### PR TITLE
feat(#814): Recover rebuild-task-index with SQLite write-back

### DIFF
--- a/servers/roo-state-manager/src/tools/maintenance/__tests__/rebuild-task-index.test.ts
+++ b/servers/roo-state-manager/src/tools/maintenance/__tests__/rebuild-task-index.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Tests for rebuild-task-index.ts
+ * Issue #814 — Recovery of SQLite write-back for orphaned tasks
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+// Shared mock DB instance — all Database() calls return this
+const mockDb = {
+	get: vi.fn(),
+	run: vi.fn(),
+	close: vi.fn((cb: Function) => cb(null))
+};
+
+const { mockExistsSync, mockCopyFileSync } = vi.hoisted(() => ({
+	mockExistsSync: vi.fn(),
+	mockCopyFileSync: vi.fn()
+}));
+
+const { mockReaddir, mockStat, mockUnlink } = vi.hoisted(() => ({
+	mockReaddir: vi.fn(),
+	mockStat: vi.fn(),
+	mockUnlink: vi.fn().mockResolvedValue(undefined)
+}));
+
+const { mockAnalyzeConversation } = vi.hoisted(() => ({
+	mockAnalyzeConversation: vi.fn()
+}));
+
+vi.mock('fs', async () => {
+	const actual = await vi.importActual<typeof import('fs')>('fs');
+	return {
+		...actual,
+		default: { ...actual, existsSync: mockExistsSync, copyFileSync: mockCopyFileSync },
+		existsSync: mockExistsSync,
+		copyFileSync: mockCopyFileSync,
+		promises: {
+			readdir: mockReaddir,
+			stat: mockStat,
+			unlink: mockUnlink,
+			writeFile: vi.fn()
+		}
+	};
+});
+
+vi.mock('sqlite3', () => {
+	// The Database constructor must call cb ASYNCHRONOUSLY to avoid TDZ
+	// (the source code does `const db = new Database(path, mode, (err) => resolve(db))`)
+	const DatabaseMock = vi.fn((_path: string, _mode: number, cb: (err: Error | null) => void) => {
+		if (cb) queueMicrotask(() => cb(null));
+		return mockDb;
+	});
+	return {
+		default: {
+			Database: DatabaseMock,
+			OPEN_READONLY: 0x00000001,
+			OPEN_READWRITE: 0x00000002
+		},
+		Database: DatabaseMock,
+		OPEN_READONLY: 0x00000001,
+		OPEN_READWRITE: 0x00000002
+	};
+});
+
+vi.mock('../../../utils/roo-storage-detector.js', () => ({
+	RooStorageDetector: {
+		analyzeConversation: mockAnalyzeConversation
+	}
+}));
+
+vi.mock('../../../utils/logger.js', () => ({
+	createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+	Logger: class {}
+}));
+
+vi.mock('../../../utils/workspace-detector.js', () => ({
+	WorkspaceDetector: class {
+		constructor() {}
+		async detect() { return { workspace: 'D:\\Dev\\test-workspace' }; }
+	}
+}));
+
+import { handleRebuildTaskIndex } from '../rebuild-task-index.js';
+
+describe('rebuild-task-index', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockExistsSync.mockReturnValue(true);
+		mockUnlink.mockResolvedValue(undefined);
+
+		// Default: empty state
+		mockDb.get.mockImplementation((_sql: string, _params: unknown[], cb: Function) => {
+			cb(null, { value: JSON.stringify({ taskHistory: [] }) });
+		});
+		mockDb.close.mockImplementation((cb: Function) => cb(null));
+		mockDb.run.mockImplementation((_sql: string, _params: unknown[], cb: Function) => {
+			if (cb) cb(null);
+		});
+	});
+
+	describe('error handling', () => {
+		test('returns error when state.vscdb not found', async () => {
+			mockExistsSync.mockReturnValue(false);
+
+			const result = await handleRebuildTaskIndex({ dry_run: true });
+
+			expect(result.isError).toBe(true);
+			expect((result.content[0] as any).text).toContain('state.vscdb not found');
+		});
+
+		test('returns error when tasks directory not accessible', async () => {
+			mockReaddir.mockRejectedValue(new Error('ENOENT: no such file or directory'));
+
+			const result = await handleRebuildTaskIndex({ dry_run: true });
+
+			expect(result.isError).toBe(true);
+			expect((result.content[0] as any).text).toContain('Error reading tasks directory');
+		});
+	});
+
+	describe('dry-run mode', () => {
+		test('defaults to dry-run when not specified', async () => {
+			mockDb.get.mockImplementation((_sql: string, _params: unknown[], cb: Function) => {
+				cb(null, { value: JSON.stringify({ taskHistory: [
+					{ ts: 1000, task: 'existing', workspace: 'ws', id: 'existing-id' }
+				] }) });
+			});
+
+			mockReaddir
+				.mockResolvedValueOnce(['existing-id', 'orphan-id'])
+				.mockResolvedValueOnce(['api_conversation_history.json'])
+				.mockResolvedValueOnce(['api_conversation_history.json']);
+
+			mockStat.mockResolvedValue({
+				isDirectory: () => true,
+				mtime: new Date('2026-01-01'),
+				birthtime: new Date('2026-01-01')
+			});
+
+			mockAnalyzeConversation.mockResolvedValue({
+				metadata: { title: 'Orphan Task', workspace: 'D:\\Dev\\test' }
+			});
+
+			const result = await handleRebuildTaskIndex({});
+
+			const text = (result.content[0] as any).text;
+			expect(text).toContain('SIMULATION');
+			expect(text).toContain('**Orphaned tasks (total):** 1');
+			// No SQLite write in dry-run
+			expect(mockDb.run).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('orphan detection', () => {
+		test('correctly identifies orphaned tasks', async () => {
+			mockDb.get.mockImplementation((_sql: string, _params: unknown[], cb: Function) => {
+				cb(null, { value: JSON.stringify({ taskHistory: [
+					{ ts: 1000, task: 'indexed-task', workspace: 'ws', id: 'task-a' }
+				] }) });
+			});
+
+			mockReaddir
+				.mockResolvedValueOnce(['task-a', 'task-b', 'task-c'])
+				.mockResolvedValueOnce(['file.json'])
+				.mockResolvedValueOnce(['file.json'])
+				.mockResolvedValueOnce(['file.json']);
+
+			mockStat.mockResolvedValue({
+				isDirectory: () => true,
+				mtime: new Date('2026-01-01'),
+				birthtime: new Date('2026-01-01')
+			});
+
+			mockAnalyzeConversation.mockResolvedValue(null);
+
+			const result = await handleRebuildTaskIndex({ dry_run: true });
+			const text = (result.content[0] as any).text;
+
+			expect(text).toContain('**Tasks in SQLite index:** 1');
+			expect(text).toContain('**Tasks on disk:** 3');
+			expect(text).toContain('**Orphaned tasks (total):** 2');
+		});
+
+		test('skips .skeletons directory', async () => {
+			mockReaddir
+				.mockResolvedValueOnce(['.skeletons', 'real-task'])
+				.mockResolvedValueOnce(['file.json']);
+
+			mockStat.mockResolvedValue({
+				isDirectory: () => true,
+				mtime: new Date('2026-01-01'),
+				birthtime: new Date('2026-01-01')
+			});
+
+			mockAnalyzeConversation.mockResolvedValue(null);
+
+			const result = await handleRebuildTaskIndex({ dry_run: true });
+			const text = (result.content[0] as any).text;
+
+			expect(text).toContain('**Tasks on disk:** 1');
+		});
+
+		test('skips empty task directories', async () => {
+			mockReaddir
+				.mockResolvedValueOnce(['task-empty', 'task-with-files'])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce(['api_conversation_history.json']);
+
+			mockStat.mockResolvedValue({
+				isDirectory: () => true,
+				mtime: new Date('2026-01-01'),
+				birthtime: new Date('2026-01-01')
+			});
+
+			mockAnalyzeConversation.mockResolvedValue(null);
+
+			const result = await handleRebuildTaskIndex({ dry_run: true });
+			const text = (result.content[0] as any).text;
+
+			expect(text).toContain('**Tasks on disk:** 1');
+		});
+	});
+
+	describe('filters', () => {
+		test('workspace_filter limits results', async () => {
+			mockReaddir
+				.mockResolvedValueOnce(['task-1', 'task-2'])
+				.mockResolvedValueOnce(['file.json'])
+				.mockResolvedValueOnce(['file.json']);
+
+			mockStat.mockResolvedValue({
+				isDirectory: () => true,
+				mtime: new Date('2026-01-01'),
+				birthtime: new Date('2026-01-01')
+			});
+
+			const result = await handleRebuildTaskIndex({
+				dry_run: true,
+				workspace_filter: 'test-workspace'
+			});
+			const text = (result.content[0] as any).text;
+
+			expect(text).toContain('**Workspace filter:** test-workspace');
+		});
+
+		test('max_tasks limits processing', async () => {
+			mockReaddir
+				.mockResolvedValueOnce(['task-1', 'task-2', 'task-3'])
+				.mockResolvedValueOnce(['file.json'])
+				.mockResolvedValueOnce(['file.json'])
+				.mockResolvedValueOnce(['file.json']);
+
+			mockStat.mockResolvedValue({
+				isDirectory: () => true,
+				mtime: new Date('2026-01-01'),
+				birthtime: new Date('2026-01-01')
+			});
+
+			mockAnalyzeConversation.mockResolvedValue(null);
+
+			const result = await handleRebuildTaskIndex({
+				dry_run: true,
+				max_tasks: 1
+			});
+			const text = (result.content[0] as any).text;
+
+			expect(text).toContain('**Max tasks limit:** 1');
+			expect(text).toContain('**Tasks to process:** 1');
+		});
+	});
+
+	describe('metadata enrichment', () => {
+		test('uses RooStorageDetector title when available', async () => {
+			mockReaddir
+				.mockResolvedValueOnce(['task-1'])
+				.mockResolvedValueOnce(['file.json']);
+
+			mockStat.mockResolvedValue({
+				isDirectory: () => true,
+				mtime: new Date('2026-01-01'),
+				birthtime: new Date('2026-01-01')
+			});
+
+			mockAnalyzeConversation.mockResolvedValue({
+				metadata: { title: 'My Rich Task Title', workspace: 'D:\\Projects\\myapp' }
+			});
+
+			const result = await handleRebuildTaskIndex({ dry_run: true });
+			const text = (result.content[0] as any).text;
+
+			expect(text).toContain('My Rich Task Title');
+			expect(text).toContain('**Rich metadata available:** 1');
+		});
+
+		test('falls back to task ID when RooStorageDetector fails', async () => {
+			mockReaddir
+				.mockResolvedValueOnce(['task-fallback'])
+				.mockResolvedValueOnce(['file.json']);
+
+			mockStat.mockResolvedValue({
+				isDirectory: () => true,
+				mtime: new Date('2026-01-01'),
+				birthtime: new Date('2026-01-01')
+			});
+
+			mockAnalyzeConversation.mockRejectedValue(new Error('Parse error'));
+
+			const result = await handleRebuildTaskIndex({ dry_run: true });
+			const text = (result.content[0] as any).text;
+
+			expect(text).toContain('task-fallback');
+			expect(text).toContain('**Rich metadata available:** 0');
+		});
+	});
+
+	describe('no orphans', () => {
+		test('reports cleanly when all tasks are indexed', async () => {
+			mockDb.get.mockImplementation((_sql: string, _params: unknown[], cb: Function) => {
+				cb(null, { value: JSON.stringify({ taskHistory: [
+					{ ts: 1000, task: 'task-a', workspace: 'ws', id: 'task-a' },
+					{ ts: 2000, task: 'task-b', workspace: 'ws', id: 'task-b' }
+				] }) });
+			});
+
+			mockReaddir
+				.mockResolvedValueOnce(['task-a', 'task-b'])
+				.mockResolvedValueOnce(['file.json'])
+				.mockResolvedValueOnce(['file.json']);
+
+			mockStat.mockResolvedValue({
+				isDirectory: () => true,
+				mtime: new Date('2026-01-01'),
+				birthtime: new Date('2026-01-01')
+			});
+
+			const result = await handleRebuildTaskIndex({ dry_run: true });
+			const text = (result.content[0] as any).text;
+
+			expect(text).toContain('No orphaned tasks found');
+			expect(text).toContain('Index is in sync with disk');
+		});
+	});
+
+	describe('anti-stub checks', () => {
+		test('orphan count varies with input data', async () => {
+			// First call: 1 indexed task, 3 on disk → 2 orphans
+			mockDb.get.mockImplementation((_sql: string, _params: unknown[], cb: Function) => {
+				cb(null, { value: JSON.stringify({ taskHistory: [
+					{ ts: 1000, task: 'indexed', workspace: 'ws', id: 'task-a' }
+				] }) });
+			});
+
+			mockReaddir
+				.mockResolvedValueOnce(['task-a', 'task-b', 'task-c'])
+				.mockResolvedValueOnce(['f.json'])
+				.mockResolvedValueOnce(['f.json'])
+				.mockResolvedValueOnce(['f.json']);
+
+			mockStat.mockResolvedValue({
+				isDirectory: () => true,
+				mtime: new Date('2026-01-01'),
+				birthtime: new Date('2026-01-01')
+			});
+			mockAnalyzeConversation.mockResolvedValue(null);
+
+			const result1 = await handleRebuildTaskIndex({ dry_run: true });
+			const text1 = (result1.content[0] as any).text;
+
+			// Reset mocks for second call
+			mockReaddir.mockReset();
+			mockStat.mockReset();
+
+			// Second call: 3 indexed, 3 on disk → 0 orphans
+			mockDb.get.mockImplementation((_sql: string, _params: unknown[], cb: Function) => {
+				cb(null, { value: JSON.stringify({ taskHistory: [
+					{ ts: 1000, task: 'a', workspace: 'ws', id: 'task-a' },
+					{ ts: 2000, task: 'b', workspace: 'ws', id: 'task-b' },
+					{ ts: 3000, task: 'c', workspace: 'ws', id: 'task-c' }
+				] }) });
+			});
+
+			mockReaddir
+				.mockResolvedValueOnce(['task-a', 'task-b', 'task-c'])
+				.mockResolvedValueOnce(['f.json'])
+				.mockResolvedValueOnce(['f.json'])
+				.mockResolvedValueOnce(['f.json']);
+
+			mockStat.mockResolvedValue({
+				isDirectory: () => true,
+				mtime: new Date('2026-01-01'),
+				birthtime: new Date('2026-01-01')
+			});
+
+			const result2 = await handleRebuildTaskIndex({ dry_run: true });
+			const text2 = (result2.content[0] as any).text;
+
+			// Anti-stub: different inputs produce different orphan counts
+			expect(text1).toContain('**Orphaned tasks (total):** 2');
+			expect(text2).toContain('No orphaned tasks found');
+		});
+	});
+});

--- a/servers/roo-state-manager/src/tools/maintenance/index.ts
+++ b/servers/roo-state-manager/src/tools/maintenance/index.ts
@@ -4,3 +4,5 @@
 
 export { maintenanceToolDefinition, handleMaintenance } from './maintenance.js';
 export type { MaintenanceArgs, MaintenanceAction } from './maintenance.js';
+export { handleRebuildTaskIndex } from './rebuild-task-index.js';
+export type { RebuildTaskIndexArgs } from './rebuild-task-index.js';

--- a/servers/roo-state-manager/src/tools/maintenance/maintenance.ts
+++ b/servers/roo-state-manager/src/tools/maintenance/maintenance.ts
@@ -18,11 +18,12 @@ import { ServerState } from '../../services/state-manager.service.js';
 import { handleBuildSkeletonCache } from '../cache/build-skeleton-cache.tool.js';
 import { diagnoseConversationBomTool } from '../repair/diagnose-conversation-bom.tool.js';
 import { repairConversationBomTool } from '../repair/repair-conversation-bom.tool.js';
+import { handleRebuildTaskIndex } from './rebuild-task-index.js';
 
 /**
  * Actions supportées par maintenance
  */
-export type MaintenanceAction = 'cache_rebuild' | 'diagnose_bom' | 'repair_bom';
+export type MaintenanceAction = 'cache_rebuild' | 'diagnose_bom' | 'repair_bom' | 'rebuild_index';
 
 /**
  * Arguments consolidés du tool maintenance
@@ -42,8 +43,12 @@ export interface MaintenanceArgs {
     // BOM-specific options
     /** Si true, répare automatiquement les fichiers trouvés (action=diagnose_bom) */
     fix_found?: boolean;
-    /** Si true, simule la réparation sans modifier les fichiers (action=repair_bom) */
+    /** Si true, simule la réparation sans modifier les fichiers (action=repair_bom, rebuild_index) */
     dry_run?: boolean;
+
+    // Rebuild-index-specific options
+    /** Nombre maximum de tâches à traiter (action=rebuild_index) */
+    max_tasks?: number;
 }
 
 /**
@@ -57,8 +62,8 @@ export const maintenanceToolDefinition = {
         properties: {
             action: {
                 type: 'string',
-                enum: ['cache_rebuild', 'diagnose_bom', 'repair_bom'],
-                description: 'Action: cache_rebuild, diagnose_bom, ou repair_bom.'
+                enum: ['cache_rebuild', 'diagnose_bom', 'repair_bom', 'rebuild_index'],
+                description: 'Action: cache_rebuild, diagnose_bom, repair_bom, ou rebuild_index (reconstruit l\'index SQLite des tâches VS Code).'
             },
             force_rebuild: {
                 type: 'boolean',
@@ -81,8 +86,13 @@ export const maintenanceToolDefinition = {
             },
             dry_run: {
                 type: 'boolean',
-                description: 'Simuler la réparation sans modifier les fichiers (action=repair_bom).',
+                description: 'Simuler la réparation sans modifier les fichiers (action=repair_bom, rebuild_index).',
                 default: false
+            },
+            max_tasks: {
+                type: 'number',
+                description: 'Nombre maximum de tâches à traiter (action=rebuild_index). 0 = toutes.',
+                default: 0
             }
         },
         required: ['action']
@@ -124,11 +134,18 @@ export async function handleMaintenance(
                 dry_run: args.dry_run
             });
 
+        case 'rebuild_index':
+            return handleRebuildTaskIndex({
+                workspace_filter: args.workspace_filter,
+                max_tasks: args.max_tasks,
+                dry_run: args.dry_run ?? true
+            });
+
         default:
             return {
                 content: [{
                     type: 'text',
-                    text: `Action inconnue: '${action}'. Actions valides: cache_rebuild, diagnose_bom, repair_bom.`
+                    text: `Action inconnue: '${action}'. Actions valides: cache_rebuild, diagnose_bom, repair_bom, rebuild_index.`
                 }],
                 isError: true
             };

--- a/servers/roo-state-manager/src/tools/maintenance/rebuild-task-index.ts
+++ b/servers/roo-state-manager/src/tools/maintenance/rebuild-task-index.ts
@@ -1,0 +1,356 @@
+/**
+ * Rebuild Task Index — Recovered from destroyed vscode-global-state.ts (438L)
+ *
+ * Issue #814: Recovers the SQLite write-back functionality that was lost when
+ * vscode-global-state.ts was deleted in commit fcd44db (2026-03-10).
+ *
+ * This module detects orphaned tasks (present on disk but missing from VS Code's
+ * SQLite task index) and writes them back so they appear in Roo's task panel.
+ *
+ * Uses SQLite patterns from RooSettingsService but operates on taskHistory
+ * within the Roo extension's global state blob.
+ *
+ * @module tools/maintenance/rebuild-task-index
+ * @version 1.0.0
+ * @since Recovery #814
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { existsSync, copyFileSync } from 'fs';
+import sqlite3 from 'sqlite3';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { RooStorageDetector } from '../../utils/roo-storage-detector.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('rebuild-task-index');
+
+/**
+ * The key VS Code uses to store Roo extension state in SQLite.
+ * Must match the extension's actual key (case-sensitive in SQLite).
+ */
+const VSCDB_KEY = 'RooVeterinaryInc.roo-cline';
+
+const VSCDB_RELATIVE_PATH = path.join('AppData', 'Roaming', 'Code', 'User', 'globalStorage', 'state.vscdb');
+
+interface HistoryItem {
+	ts: number;
+	task: string;
+	workspace: string;
+	id?: string;
+}
+
+interface VSCodeRooState {
+	taskHistory?: HistoryItem[];
+	[key: string]: unknown;
+}
+
+export interface RebuildTaskIndexArgs {
+	workspace_filter?: string;
+	max_tasks?: number;
+	dry_run?: boolean;
+}
+
+// ── SQLite helpers (adapted from RooSettingsService patterns) ──
+
+function getStateDbPath(): string {
+	return path.join(os.homedir(), VSCDB_RELATIVE_PATH);
+}
+
+function openDatabase(filePath: string, mode: number): Promise<sqlite3.Database> {
+	return new Promise((resolve, reject) => {
+		const db = new sqlite3.Database(filePath, mode, (err) => {
+			if (err) reject(new Error(`Cannot open state.vscdb: ${err.message}`));
+			else resolve(db);
+		});
+	});
+}
+
+function closeDatabase(db: sqlite3.Database): Promise<void> {
+	return new Promise((resolve, reject) => {
+		db.close((err) => {
+			if (err) reject(err);
+			else resolve();
+		});
+	});
+}
+
+function dbGet(db: sqlite3.Database, sql: string, params: unknown[]): Promise<{ value: string | Buffer } | undefined> {
+	return new Promise((resolve, reject) => {
+		db.get(sql, params, (err: Error | null, row: { value: string | Buffer } | undefined) => {
+			if (err) reject(err);
+			else resolve(row);
+		});
+	});
+}
+
+function dbRun(db: sqlite3.Database, sql: string, params: unknown[]): Promise<void> {
+	return new Promise((resolve, reject) => {
+		db.run(sql, params, (err: Error | null) => {
+			if (err) reject(err);
+			else resolve();
+		});
+	});
+}
+
+// ── State read/write (with temp copy for reads, backup for writes) ──
+
+async function readRooState(): Promise<VSCodeRooState> {
+	const dbPath = getStateDbPath();
+	if (!existsSync(dbPath)) {
+		throw new Error(`state.vscdb not found at: ${dbPath}`);
+	}
+
+	// Copy to temp to avoid locking conflicts with VS Code
+	const tmpPath = dbPath + '.rebuild-tmp';
+	try {
+		copyFileSync(dbPath, tmpPath);
+		const db = await openDatabase(tmpPath, sqlite3.OPEN_READONLY);
+		try {
+			const row = await dbGet(db, 'SELECT value FROM ItemTable WHERE key = ?', [VSCDB_KEY]);
+			if (!row) {
+				return {};
+			}
+			let value = typeof row.value === 'string' ? row.value : row.value.toString('utf-8');
+			// Strip BOM if present
+			if (value.charCodeAt(0) === 0xFEFF) {
+				value = value.slice(1);
+			}
+			return JSON.parse(value);
+		} finally {
+			await closeDatabase(db);
+		}
+	} finally {
+		try { await fs.unlink(tmpPath); } catch { /* ignore cleanup errors */ }
+	}
+}
+
+async function writeRooState(state: VSCodeRooState): Promise<void> {
+	const dbPath = getStateDbPath();
+
+	// Create backup before writing
+	const backupPath = dbPath + '.rebuild-backup';
+	copyFileSync(dbPath, backupPath);
+	logger.info(`Backup created: ${backupPath}`);
+
+	const db = await openDatabase(dbPath, sqlite3.OPEN_READWRITE);
+	try {
+		const value = JSON.stringify(state);
+		await dbRun(db, 'UPDATE ItemTable SET value = ? WHERE key = ?', [value, VSCDB_KEY]);
+		logger.info('taskHistory written to state.vscdb');
+	} finally {
+		await closeDatabase(db);
+	}
+}
+
+// ── Main handler ──
+
+export async function handleRebuildTaskIndex(args: RebuildTaskIndexArgs): Promise<CallToolResult> {
+	const { workspace_filter, max_tasks = 0, dry_run = true } = args;
+
+	try {
+		// 1. Read current VS Code state
+		const state = await readRooState();
+		const indexedTasks = new Set<string>();
+		const currentHistory: HistoryItem[] = [];
+
+		if (state.taskHistory && Array.isArray(state.taskHistory)) {
+			currentHistory.push(...state.taskHistory);
+			for (const item of state.taskHistory) {
+				if (item.id) {
+					indexedTasks.add(item.id);
+				}
+			}
+		}
+
+		// 2. Scan tasks on disk
+		const tasksDir = path.join(
+			os.homedir(), 'AppData', 'Roaming', 'Code', 'User',
+			'globalStorage', 'rooveterinaryinc.roo-cline', 'tasks'
+		);
+
+		let diskTasks: Array<{ id: string; workspace?: string; lastActivity: Date }> = [];
+
+		try {
+			const entries = await fs.readdir(tasksDir);
+			for (const entry of entries) {
+				const taskPath = path.join(tasksDir, entry);
+				const stats = await fs.stat(taskPath);
+				if (!stats.isDirectory() || entry === '.skeletons') continue;
+
+				// Verify the directory has files (not empty)
+				const files = await fs.readdir(taskPath);
+				if (files.length === 0) continue;
+
+				// Detect workspace
+				let workspace: string | undefined;
+				try {
+					const { WorkspaceDetector } = await import('../../utils/workspace-detector.js');
+					const detector = new WorkspaceDetector({
+						enableCache: true,
+						validateExistence: false,
+						normalizePaths: true
+					});
+					const result = await detector.detect(taskPath);
+					if (result.workspace) {
+						workspace = result.workspace;
+					}
+				} catch {
+					// Keep workspace undefined
+				}
+
+				diskTasks.push({
+					id: entry,
+					workspace,
+					lastActivity: stats.mtime
+				});
+			}
+		} catch (error) {
+			return {
+				content: [{
+					type: 'text',
+					text: `Error reading tasks directory: ${error}`
+				}],
+				isError: true
+			};
+		}
+
+		// 3. Identify orphans
+		let orphans = diskTasks.filter(t => !indexedTasks.has(t.id));
+
+		if (workspace_filter) {
+			orphans = orphans.filter(t =>
+				t.workspace && t.workspace.toLowerCase().includes(workspace_filter.toLowerCase())
+			);
+		}
+
+		if (max_tasks > 0) {
+			orphans = orphans.slice(0, max_tasks);
+		}
+
+		// 4. Build report
+		let report = `# Rebuild Task Index\n\n`;
+		report += `**Mode:** ${dry_run ? 'SIMULATION (dry-run)' : 'LIVE REBUILD'}\n`;
+		report += `**Tasks in SQLite index:** ${indexedTasks.size}\n`;
+		report += `**Tasks on disk:** ${diskTasks.length}\n`;
+		report += `**Orphaned tasks (total):** ${diskTasks.filter(t => !indexedTasks.has(t.id)).length}\n`;
+
+		if (workspace_filter) {
+			report += `**Workspace filter:** ${workspace_filter}\n`;
+		}
+		if (max_tasks > 0) {
+			report += `**Max tasks limit:** ${max_tasks}\n`;
+		}
+		report += `**Tasks to process:** ${orphans.length}\n\n`;
+
+		if (orphans.length === 0) {
+			report += `No orphaned tasks found. Index is in sync with disk.\n`;
+			return { content: [{ type: 'text', text: report }] };
+		}
+
+		// 5. Generate history items for orphans
+		const newItems: HistoryItem[] = [];
+		let addedCount = 0;
+		let metadataCount = 0;
+		let errorCount = 0;
+		const errors: string[] = [];
+
+		for (const orphan of orphans) {
+			try {
+				const taskPath = path.join(tasksDir, orphan.id);
+				let title = orphan.id;
+
+				// Try to generate rich metadata via RooStorageDetector
+				try {
+					const skeleton = await RooStorageDetector.analyzeConversation(orphan.id, taskPath);
+					if (skeleton?.metadata?.title) {
+						title = skeleton.metadata.title;
+					}
+					if (skeleton?.metadata?.workspace) {
+						orphan.workspace = skeleton.metadata.workspace;
+					}
+					metadataCount++;
+				} catch {
+					// Fall back to basic title
+				}
+
+				// Normalize workspace path
+				let normalizedWorkspace = orphan.workspace || 'unknown';
+				if (normalizedWorkspace !== 'unknown') {
+					normalizedWorkspace = normalizedWorkspace.replace(/\//g, '\\').replace(/\\+$/, '');
+				}
+
+				newItems.push({
+					ts: orphan.lastActivity.getTime(),
+					task: title,
+					workspace: normalizedWorkspace,
+					id: orphan.id
+				});
+				addedCount++;
+			} catch (error) {
+				errorCount++;
+				errors.push(`${orphan.id}: ${error}`);
+			}
+		}
+
+		// 6. Write back to SQLite (unless dry-run)
+		if (!dry_run && newItems.length > 0) {
+			const allTasks = [...currentHistory, ...newItems].sort((a, b) => b.ts - a.ts);
+			const updatedState = { ...state, taskHistory: allTasks };
+			await writeRooState(updatedState);
+
+			report += `## Result: INDEX UPDATED\n\n`;
+			report += `**Tasks added:** ${addedCount}\n`;
+			report += `**Rich metadata generated:** ${metadataCount}\n`;
+			report += `**Total after update:** ${allTasks.length}\n`;
+			if (errorCount > 0) {
+				report += `**Errors:** ${errorCount}\n`;
+			}
+			report += `\n**Next steps:**\n`;
+			report += `1. Restart VS Code completely\n`;
+			report += `2. Verify tasks appear in the Roo panel\n`;
+			report += `3. Validate tasks are functional\n`;
+		} else {
+			report += `## Result: SIMULATION\n\n`;
+			report += `**Tasks that would be added:** ${addedCount}\n`;
+			report += `**Rich metadata available:** ${metadataCount}\n`;
+			report += `**New total after rebuild:** ${currentHistory.length + addedCount}\n`;
+			if (errorCount > 0) {
+				report += `**Potential errors:** ${errorCount}\n`;
+			}
+			report += `\nRe-run with \`dry_run: false\` to apply changes.\n`;
+		}
+
+		// Sample of tasks
+		if (newItems.length > 0) {
+			report += `\n## Sample (first 5):\n\n`;
+			for (const item of newItems.slice(0, 5)) {
+				report += `- **${item.id}** — ${item.task}\n`;
+				report += `  Workspace: ${item.workspace} | ${new Date(item.ts).toISOString()}\n`;
+			}
+		}
+
+		// Errors detail
+		if (errors.length > 0) {
+			report += `\n## Errors:\n\n`;
+			for (const err of errors.slice(0, 10)) {
+				report += `- ${err}\n`;
+			}
+			if (errors.length > 10) {
+				report += `... and ${errors.length - 10} more.\n`;
+			}
+		}
+
+		return { content: [{ type: 'text', text: report }] };
+
+	} catch (error) {
+		return {
+			content: [{
+				type: 'text',
+				text: `Error during task index rebuild: ${error instanceof Error ? error.message : String(error)}`
+			}],
+			isError: true
+		};
+	}
+}


### PR DESCRIPTION
## Summary
- Recovers the critical SQLite write-back functionality lost when `vscode-global-state.ts` (438L) was deleted in commit `fcd44db`
- The existing replacement only generates metadata JSON — does NOT fix tasks invisible in Roo's UI
- New `rebuild-task-index.ts` integrated into `maintenance(action: "rebuild_index")`
- 12 tests with anti-stub checks, all 7898 existing tests still pass

## Changes
- `src/tools/maintenance/rebuild-task-index.ts` — New file (recovered + adapted)
- `src/tools/maintenance/maintenance.ts` — Added `rebuild_index` action
- `src/tools/maintenance/index.ts` — Export new module
- `src/tools/maintenance/__tests__/rebuild-task-index.test.ts` — 12 tests

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 7898 tests pass (`npx vitest run`)
- [x] 12 new tests cover: error handling, dry-run, orphan detection, filters, metadata enrichment, anti-stub

Generated with [Claude Code](https://claude.com/claude-code)