### PR TITLE
perf(#883): static import getHostIdentifier

### DIFF
--- a/servers/roo-state-manager/src/tools/search/__tests__/search-semantic.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-semantic.tool.test.ts
@@ -53,6 +53,10 @@ vi.mock('../../../services/task-indexer.js', () => ({
 	getHostIdentifier: () => mockGetHostIdentifier()
 }));
 
+vi.mock('../../../services/task-indexer/ChunkExtractor.js', () => ({
+	getHostIdentifier: () => mockGetHostIdentifier()
+}));
+
 vi.mock('../search-fallback.tool.js', () => ({
 	handleSearchTasksSemanticFallback: mockFallbackHandler
 }));

--- a/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
@@ -8,6 +8,7 @@ import { ConversationSkeleton } from '../../types/conversation.js';
 import { getQdrantClient } from '../../services/qdrant.js';
 import getOpenAIClient, { getEmbeddingModel } from '../../services/openai.js';
 import { handleSearchTasksSemanticFallback } from './search-fallback.tool.js';
+import { getHostIdentifier } from '../../services/task-indexer/ChunkExtractor.js';
 
 export interface SearchTasksByContentArgs {
     conversation_id?: string;
@@ -504,7 +505,6 @@ export const searchTasksByContentTool = {
             const searchResults = await searchWithTimeout;
 
             // Obtenir l'identifiant de la machine actuelle pour l'en-tête
-            const { TaskIndexer, getHostIdentifier } = await import('../../services/task-indexer.js');
             const currentHostId = getHostIdentifier();
 
             // Normalisation de la réponse Qdrant (supporte format tableau direct ou objet { result/points: [...] })


### PR DESCRIPTION
## Summary
- Replace dynamic `await import('task-indexer.js')` with static import of `getHostIdentifier` from `ChunkExtractor.js`
- Eliminates module loading overhead on every search call
- Follow-up to PR #14 based on qdrant workspace perf report (12-19s vs 1.2s direct)

## Test plan
- [x] 56 search-semantic tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)