### PR TITLE
fix(ci): add ChunkExtractor mock for search-by-content test

### DIFF
--- a/servers/roo-state-manager/tests/unit/tools/search/search-by-content.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/search/search-by-content.test.ts
@@ -33,6 +33,10 @@ vi.mock('../../../../src/services/task-indexer.js', () => ({
   getHostIdentifier: vi.fn(() => 'test-host-os')
 }));
 
+vi.mock('../../../../src/services/task-indexer/ChunkExtractor.js', () => ({
+  getHostIdentifier: vi.fn(() => 'test-host-os')
+}));
+
 describe('🔍 search_tasks_by_content', () => {
   let conversationCache: Map<string, any>;
   let ensureCacheFreshCallback: any;


### PR DESCRIPTION
Fix CI failure from PR #15 — missing mock for new static import path.