### PR TITLE
fix(#881): Add Compact mode and rename NoTools → NoToolParams

### DIFF
--- a/servers/roo-state-manager/src/services/reporting/DetailLevelStrategyFactory.ts
+++ b/servers/roo-state-manager/src/services/reporting/DetailLevelStrategyFactory.ts
@@ -3,6 +3,8 @@
  *
  * Implémente le pattern Factory pour instancier la bonne stratégie selon DetailLevel
  * Version complète avec tous les 6 niveaux selon script PowerShell référence
+ *
+ * #881: Ajout de 'Compact' et 'NoToolParams', alias NoTools → Compact
  */
 
 import { IReportingStrategy } from './IReportingStrategy.js';
@@ -11,6 +13,8 @@ import { FullReportingStrategy } from './strategies/FullReportingStrategy.js';
 import { MessagesReportingStrategy } from './strategies/MessagesReportingStrategy.js';
 import { SummaryReportingStrategy } from './strategies/SummaryReportingStrategy.js';
 import { NoToolsReportingStrategy } from './strategies/NoToolsReportingStrategy.js';
+import { NoToolParamsReportingStrategy } from './strategies/NoToolParamsReportingStrategy.js';
+import { CompactReportingStrategy } from './strategies/CompactReportingStrategy.js';
 import { NoResultsReportingStrategy } from './strategies/NoResultsReportingStrategy.js';
 import { UserOnlyReportingStrategy } from './strategies/UserOnlyReportingStrategy.js';
 import { StateManagerError } from '../../types/errors.js';
@@ -23,7 +27,12 @@ export class DetailLevelStrategyFactory {
         ['Full', () => new FullReportingStrategy()],
         ['Messages', () => new MessagesReportingStrategy()],
         ['Summary', () => new SummaryReportingStrategy()],
-        ['NoTools', () => new NoToolsReportingStrategy()],
+        // #881: NoTools maintenant alias vers Compact (filtre params + résume résultats)
+        ['NoTools', () => new CompactReportingStrategy()],
+        // Nouveau: NoToolParams = ancien comportement NoTools (masque params, garde résultats)
+        ['NoToolParams', () => new NoToolParamsReportingStrategy()],
+        // Nouveau: Compact = filtre params + résume résultats
+        ['Compact', () => new CompactReportingStrategy()],
         ['NoResults', () => new NoResultsReportingStrategy()],
         ['UserOnly', () => new UserOnlyReportingStrategy()]
     ]);

--- a/servers/roo-state-manager/src/services/reporting/strategies/CompactReportingStrategy.ts
+++ b/servers/roo-state-manager/src/services/reporting/strategies/CompactReportingStrategy.ts
@@ -1,0 +1,243 @@
+/**
+ * CompactReportingStrategy - Stratégie pour le mode Compact
+ *
+ * Nouveau mode introduit pour fix #881:
+ * - Affiche les messages conversationnels (user/assistant) de façon complète
+ * - Résume les tool calls (nom + statut, pas de params)
+ * - Résume les tool results (type + taille, pas le contenu complet)
+ * - Garde les réflexions thinking en details collapsibles
+ *
+ * Ce mode remplace le comportement attendu de "NoTools" qui était trompeur.
+ */
+
+import { BaseReportingStrategy, FormattedMessage } from '../IReportingStrategy.js';
+import { ClassifiedContent, EnhancedSummaryOptions } from '../../../types/enhanced-conversation.js';
+
+export class CompactReportingStrategy extends BaseReportingStrategy {
+    readonly detailLevel = 'Compact';
+    readonly description = 'Messages complets avec outils résumés (nom + statut uniquement)';
+
+    /**
+     * Le mode Compact n'est pas "TOC Only" - il affiche tous les contenus avec résumé des outils
+     */
+    isTocOnlyMode(): boolean {
+        return false;
+    }
+
+    /**
+     * Formate le contenu d'un message en résumant les outils
+     */
+    formatMessageContent(
+        content: ClassifiedContent,
+        messageIndex: number,
+        options: EnhancedSummaryOptions
+    ): FormattedMessage {
+        const anchor = this.generateAnchor(content, messageIndex);
+        const title = this.generateMessageTitle(content, messageIndex);
+        const cssClass = this.getCssClass(content);
+
+        // Essayer le formatage avancé Phase 4 si activé
+        const advancedFormatted = this.formatWithAdvancedFormatterIfEnabled(
+            content, messageIndex, options
+        );
+
+        if (advancedFormatted) {
+            return {
+                content: advancedFormatted,
+                cssClass: this.getCssClass(content),
+                shouldRender: true,
+                messageType: this.getMessageType(content),
+                anchor,
+                metadata: {
+                    messageIndex,
+                    contentLength: content.content.length,
+                    hasToolDetails: false,
+                    title,
+                    cssClass,
+                    anchor,
+                    shouldDisplay: true,
+                    messageType: this.getMessageType(content)
+                },
+                processingNotes: [`Mode Compact: outils résumés (nom + statut)`, 'Phase 4 CSS avancé activé']
+            };
+        }
+
+        // Formatage classique (fallback)
+        let formattedContent: string[] = [];
+
+        // En-tête du message avec ancre
+        const firstLine = this.getTruncatedFirstLine(content.content, 200);
+        formattedContent.push(`### ${title} - ${firstLine} {#${anchor}}`);
+        formattedContent.push('');
+
+        // Div avec classe CSS
+        formattedContent.push(`<div class="${cssClass}">`);
+
+        if (content.subType === 'UserMessage') {
+            // Messages utilisateur nettoyés mais complets
+            const cleanedContent = this.cleanUserMessage(content.content);
+            formattedContent.push(cleanedContent);
+        } else if (content.subType === 'ToolResult') {
+            // Résultats d'outils RÉSUMÉS (pas de contenu complet)
+            formattedContent.push(this.formatToolResultSummary(content));
+        } else if (content.type === 'Assistant') {
+            // Messages assistant avec outils résumés
+            formattedContent.push(this.formatAssistantMessageCompact(content));
+        } else {
+            // Autres types de contenu
+            formattedContent.push(content.content);
+        }
+
+        formattedContent.push('</div>');
+        formattedContent.push('');
+        formattedContent.push('<div style="text-align: right; font-size: 0.9em; color: #666;"><a href="#table-des-matieres">^ Table des matières</a></div>');
+        formattedContent.push('');
+
+        return {
+            content: formattedContent.join('\n'),
+            cssClass,
+            shouldRender: true,
+            messageType: this.getMessageType(content),
+            anchor,
+            metadata: {
+                messageIndex,
+                contentLength: content.content.length,
+                hasToolDetails: false,
+                title,
+                cssClass,
+                anchor,
+                shouldDisplay: true,
+                messageType: this.getMessageType(content)
+            },
+            processingNotes: [`Mode Compact: outils résumés (nom + statut)`]
+        };
+    }
+
+    /**
+     * Formate un résultat d'outil en RÉSUMÉ (pas de contenu complet)
+     */
+    private formatToolResultSummary(content: ClassifiedContent): string {
+        const parts: string[] = [];
+
+        // Extraire le nom de l'outil et le résultat
+        const toolResultMatch = content.content.match(/\[([^\]]+)\] Result:\s*(.*)/s);
+        if (toolResultMatch) {
+            const toolName = toolResultMatch[1];
+            const result = toolResultMatch[2].trim();
+
+            // En-tête compact
+            const resultType = this.detectResultType(result);
+            const resultSize = this.formatContentSize(result.length);
+            const success = !result.toLowerCase().includes('error') && !result.toLowerCase().includes('failed');
+            const statusIcon = success ? '✅' : '❌';
+
+            parts.push(`**${statusIcon} Outil :** \`\`${toolName}\`\` — ${resultType} (${resultSize})`);
+
+            // Si erreur, afficher un extrait
+            if (!success && result.length > 0) {
+                const errorPreview = result.substring(0, 200);
+                parts.push('');
+                parts.push(`> ⚠️ **Erreur:** ${errorPreview}${result.length > 200 ? '...' : ''}`);
+            }
+        } else {
+            // Format de résultat non reconnu - afficher type uniquement
+            const size = this.formatContentSize(content.content.length);
+            parts.push(`**📦 Résultat d'outil** (${size})`);
+        }
+
+        return parts.join('\n');
+    }
+
+    /**
+     * Formate un message assistant en mode compact
+     */
+    private formatAssistantMessageCompact(content: ClassifiedContent): string {
+        const parts: string[] = [];
+
+        let textContent = content.content;
+        const toolCalls: Array<{tag: string; content: string}> = [];
+        const thinkingBlocks: string[] = [];
+
+        // Extraction des blocs <thinking>
+        const thinkingMatches = textContent.match(/<thinking>.*?<\/thinking>/gs);
+        if (thinkingMatches) {
+            thinkingMatches.forEach(match => {
+                thinkingBlocks.push(match);
+                textContent = textContent.replace(match, '');
+            });
+        }
+
+        // Extraction des blocs d'outils XML
+        const toolMatches = textContent.match(/<([a-zA-Z_][a-zA-Z0-9_\-:]+)(?:\s+[^>]*)?>.*?<\/\1>/gs);
+        if (toolMatches) {
+            toolMatches.forEach(match => {
+                const tagMatch = match.match(/<([a-zA-Z_][a-zA-Z0-9_\-:]+)/);
+                const tagName = tagMatch ? tagMatch[1] : 'outil';
+                if (tagName !== 'thinking') {
+                    toolCalls.push({tag: tagName, content: match});
+                    textContent = textContent.replace(match, '');
+                }
+            });
+        }
+
+        textContent = textContent.trim();
+
+        // Affichage du contenu textuel principal
+        if (textContent) {
+            parts.push(textContent);
+            parts.push('');
+        }
+
+        // Liste compacte des appels d'outils
+        if (toolCalls.length > 0) {
+            parts.push(`**🔧 Outils appelés (${toolCalls.length}) :**`);
+            toolCalls.forEach(call => {
+                parts.push(`- \`\`${call.tag}\`\``);
+            });
+            parts.push('');
+        }
+
+        // Réflexions en details (compact)
+        if (thinkingBlocks.length > 0) {
+            parts.push('<details>');
+            parts.push(`<summary>💭 Réflexions (${thinkingBlocks.length})</summary>`);
+            parts.push('');
+            thinkingBlocks.forEach((block, i) => {
+                // Extraire le contenu sans les balises
+                const content = block.replace(/<\/?thinking>/g, '').trim();
+                const preview = content.substring(0, 300);
+                parts.push(`**Réflexion ${i + 1}:** ${preview}${content.length > 300 ? '...' : ''}`);
+            });
+            parts.push('</details>');
+            parts.push('');
+        }
+
+        return parts.join('\n');
+    }
+
+    /**
+     * Détecte le type de résultat d'outil
+     */
+    private detectResultType(result: string): string {
+        if (result.includes('<files>')) return 'Liste fichiers';
+        if (result.includes('<file_write_result>')) return 'Écriture fichier';
+        if (result.includes('Command executed')) return 'Exécution commande';
+        if (result.includes('Browser') && result.includes('action')) return 'Navigation web';
+        if (result.includes('<environment_details>')) return 'Détails environnement';
+        if (result.match(/error|failed|unable/i)) return 'Erreur';
+        if (result.includes('Todo list updated')) return 'Mise à jour todo';
+        return 'Résultat';
+    }
+
+    /**
+     * Formate une taille de contenu de façon lisible
+     */
+    private formatContentSize(bytes: number): string {
+        if (bytes < 1024) return `${bytes} B`;
+        if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+        return `${Math.round(bytes / (1024 * 1024) * 10) / 10} MB`;
+    }
+
+    // Les méthodes generateMessageTitle, getCssClass, generateAnchor et getMessageType
+    // sont héritées de BaseReportingStrategy
+}

--- a/servers/roo-state-manager/src/services/reporting/strategies/NoToolParamsReportingStrategy.ts
+++ b/servers/roo-state-manager/src/services/reporting/strategies/NoToolParamsReportingStrategy.ts
@@ -1,0 +1,245 @@
+/**
+ * NoToolParamsReportingStrategy - Stratégie pour le mode NoToolParams
+ *
+ * Anciennement "NoTools" - renommé pour clarifier le comportement réel (#881)
+ *
+ * MODE NOTOOLPARAMS :
+ * - Affiche tous les messages avec résultats d'outils complets
+ * - Masque SEULEMENT les paramètres d'appels d'outils
+ * - Garde les réflexions et détails techniques
+ * - Table des matières avec liens internes
+ *
+ * NOTE: Pour filtrer les résultats d'outils, utiliser le mode "Compact" ou "NoResults"
+ */
+
+import { BaseReportingStrategy, FormattedMessage } from '../IReportingStrategy.js';
+import { ClassifiedContent, EnhancedSummaryOptions } from '../../../types/enhanced-conversation.js';
+
+export class NoToolParamsReportingStrategy extends BaseReportingStrategy {
+    readonly detailLevel = 'NoToolParams';
+    readonly description = 'Messages complets avec résultats mais paramètres d\'outils masqués (anciennement NoTools)';
+
+    /**
+     * Le mode NoTools n'est pas "TOC Only" - il affiche tous les contenus avec filtrage
+     */
+    isTocOnlyMode(): boolean {
+        return false;
+    }
+
+    /**
+     * Formate le contenu d'un message en masquant SEULEMENT les paramètres d'outils
+     */
+    formatMessageContent(
+        content: ClassifiedContent,
+        messageIndex: number,
+        options: EnhancedSummaryOptions
+    ): FormattedMessage {
+        const anchor = this.generateAnchor(content, messageIndex);
+        const title = this.generateMessageTitle(content, messageIndex);
+        const cssClass = this.getCssClass(content);
+        
+        // Essayer le formatage avancé Phase 4 si activé
+        const advancedFormatted = this.formatWithAdvancedFormatterIfEnabled(
+            content, messageIndex, options
+        );
+        
+        if (advancedFormatted) {
+            return {
+                content: advancedFormatted,
+                cssClass: this.getCssClass(content),
+                shouldRender: true,
+                messageType: this.getMessageType(content),
+                anchor,
+                metadata: {
+                    messageIndex,
+                    contentLength: content.content.length,
+                    hasToolDetails: false,
+                    title,
+                    cssClass,
+                    anchor,
+                    shouldDisplay: true,
+                    messageType: this.getMessageType(content)
+                },
+                processingNotes: [`Mode NoTools: paramètres outils masqués, résultats complets`, 'Phase 4 CSS avancé activé']
+            };
+        }
+        
+        // Formatage classique (fallback)
+        let formattedContent: string[] = [];
+        
+        // En-tête du message avec ancre
+        const firstLine = this.getTruncatedFirstLine(content.content, 200);
+        formattedContent.push(`### ${title} - ${firstLine} {#${anchor}}`);
+        formattedContent.push('');
+        
+        // Div avec classe CSS
+        formattedContent.push(`<div class="${cssClass}">`);
+        
+        if (content.subType === 'UserMessage') {
+            // Messages utilisateur nettoyés mais complets
+            const cleanedContent = this.cleanUserMessage(content.content);
+            formattedContent.push(cleanedContent);
+        } else if (content.subType === 'ToolResult') {
+            // Résultats d'outils avec TOUS les détails (pas masqués en mode NoTools)
+            formattedContent.push(this.formatToolResult(content));
+        } else if (content.type === 'Assistant') {
+            // Messages assistant avec SEULEMENT paramètres d'outils masqués
+            formattedContent.push(this.formatAssistantMessage(content));
+        } else {
+            // Autres types de contenu
+            formattedContent.push(content.content);
+        }
+        
+        formattedContent.push('</div>');
+        formattedContent.push('');
+        formattedContent.push('<div style="text-align: right; font-size: 0.9em; color: #666;"><a href="#table-des-matieres">^ Table des matières</a></div>');
+        formattedContent.push('');
+        
+        return {
+            content: formattedContent.join('\n'),
+            cssClass,
+            shouldRender: true,
+            messageType: this.getMessageType(content),
+            anchor,
+            metadata: {
+                messageIndex,
+                contentLength: content.content.length,
+                hasToolDetails: false,
+                title,
+                cssClass,
+                anchor,
+                shouldDisplay: true,
+                messageType: this.getMessageType(content)
+            },
+            processingNotes: [`Mode NoTools: paramètres outils masqués, résultats complets`]
+        };
+    }
+
+    /**
+     * Formate un résultat d'outil avec TOUS les détails (pas masqués en mode NoTools)
+     */
+    private formatToolResult(content: ClassifiedContent): string {
+        const parts: string[] = [];
+        
+        // Extraire le nom de l'outil et le résultat
+        const toolResultMatch = content.content.match(/\[([^\]]+)\] Result:\s*(.*)/s);
+        if (toolResultMatch) {
+            const toolName = toolResultMatch[1];
+            const result = toolResultMatch[2].trim();
+            
+            parts.push(`**Résultat d'outil :** \`\`${toolName}\`\``);
+            parts.push('');
+            
+            // Contexte avant le résultat (s'il existe)
+            const beforeResult = content.content.substring(0, content.content.indexOf('[' + toolName + '] Result:'));
+            if (beforeResult.trim()) {
+                const cleanedBefore = this.cleanUserMessage(beforeResult);
+                parts.push('**Contexte :**');
+                parts.push(cleanedBefore);
+                parts.push('');
+            }
+            
+            // Résultat COMPLET avec tous les détails (mode NoTools garde les résultats)
+            if (result) {
+                const resultType = this.detectResultType(result);
+                parts.push('<details>');
+                parts.push(`<summary>**${resultType} :** Cliquez pour afficher</summary>`);
+                parts.push('');
+                parts.push('```');
+                parts.push(result);
+                parts.push('```');
+                parts.push('</details>');
+            }
+        } else {
+            // Format de résultat non reconnu - afficher tel quel
+            parts.push('**Résultat d\'outil**');
+            parts.push('');
+            parts.push('```');
+            parts.push(content.content);
+            parts.push('```');
+        }
+        
+        return parts.join('\n');
+    }
+
+    /**
+     * Formate un message assistant en masquant SEULEMENT les paramètres d'outils
+     */
+    private formatAssistantMessage(content: ClassifiedContent): string {
+        const parts: string[] = [];
+        
+        let textContent = content.content;
+        const technicalBlocks: Array<{type: string; content: string; tag?: string}> = [];
+        
+        // Extraction des blocs <thinking> (gardés complets en mode NoTools)
+        const thinkingMatches = textContent.match(/<thinking>.*?<\/thinking>/gs);
+        if (thinkingMatches) {
+            thinkingMatches.forEach(match => {
+                technicalBlocks.push({type: 'Reflexion', content: match});
+                textContent = textContent.replace(match, '');
+            });
+        }
+        
+        // Extraction des blocs d'outils XML (paramètres masqués)
+        const toolMatches = textContent.match(/<([a-zA-Z_][a-zA-Z0-9_\-:]+)(?:\s+[^>]*)?>.*?<\/\1>/gs);
+        if (toolMatches) {
+            toolMatches.forEach(match => {
+                const tagMatch = match.match(/<([a-zA-Z_][a-zA-Z0-9_\-:]+)/);
+                const tagName = tagMatch ? tagMatch[1] : 'outil';
+                if (tagName !== 'thinking') {
+                    technicalBlocks.push({type: 'Outil', content: match, tag: tagName});
+                    textContent = textContent.replace(match, '');
+                }
+            });
+        }
+        
+        textContent = textContent.trim();
+        
+        // Affichage du contenu textuel principal
+        if (textContent) {
+            parts.push(textContent);
+            parts.push('');
+        }
+        
+        // Traitement des blocs techniques selon mode NoTools
+        technicalBlocks.forEach(block => {
+            if (block.type === 'Outil' && block.tag) {
+                // Mode NoTools : masquer les paramètres d'outils mais garder les sections collapsibles
+                parts.push('<details>');
+                parts.push(`<summary>OUTIL - ${block.tag} [Paramètres masqués en mode NoTools]</summary>`);
+                parts.push('');
+                parts.push('*Contenu des paramètres d\'outil masqué - utilisez -DetailLevel Full pour afficher*');
+                parts.push('</details>');
+            } else {
+                // Réflexions et autres détails techniques : affichés complets en mode NoTools
+                parts.push('<details>');
+                parts.push(`<summary>DETAILS TECHNIQUE - ${block.type}</summary>`);
+                parts.push('');
+                parts.push('```xml');
+                parts.push(block.content);
+                parts.push('```');
+                parts.push('</details>');
+            }
+            parts.push('');
+        });
+        
+        return parts.join('\n');
+    }
+
+    /**
+     * Détecte le type de résultat d'outil
+     */
+    private detectResultType(result: string): string {
+        if (result.includes('<files>')) return 'fichiers';
+        if (result.includes('<file_write_result>')) return 'écriture fichier';
+        if (result.includes('Command executed')) return 'exécution commande';
+        if (result.includes('Browser') && result.includes('action')) return 'navigation web';
+        if (result.includes('<environment_details>')) return 'détails environnement';
+        if (result.match(/error|failed|unable/i)) return 'erreur';
+        if (result.includes('Todo list updated')) return 'mise à jour todo';
+        return 'résultat';
+    }
+
+    // Les méthodes generateMessageTitle, getCssClass, generateAnchor et getMessageType
+    // sont maintenant héritées de BaseReportingStrategy
+}

--- a/servers/roo-state-manager/src/types/enhanced-conversation.ts
+++ b/servers/roo-state-manager/src/types/enhanced-conversation.ts
@@ -5,8 +5,10 @@
 
 /**
  * Niveaux de détail pour l'export Markdown selon script PowerShell référence
+ *
+ * #881: Ajout de 'Compact' (filtre params + résume résultats) et 'NoToolParams' (anciennement NoTools)
  */
-export type DetailLevel = 'Full' | 'NoTools' | 'NoResults' | 'Messages' | 'Summary' | 'UserOnly';
+export type DetailLevel = 'Full' | 'NoTools' | 'NoToolParams' | 'Compact' | 'NoResults' | 'Messages' | 'Summary' | 'UserOnly';
 
 /**
  * Détails structurés d'un appel d'outil parsé depuis XML
@@ -158,7 +160,7 @@ export interface TruncatedContent {
  * Options étendues pour la génération de résumés
  */
 export interface EnhancedSummaryOptions {
-    detailLevel?: 'Full' | 'NoTools' | 'NoResults' | 'Messages' | 'Summary' | 'UserOnly';
+    detailLevel?: 'Full' | 'NoTools' | 'NoToolParams' | 'Compact' | 'NoResults' | 'Messages' | 'Summary' | 'UserOnly';
     outputFormat?: 'markdown' | 'html' | 'text';
     truncationChars?: number;
     compactStats?: boolean;


### PR DESCRIPTION
## Summary
- Add new `Compact` mode that filters tool params + summarizes results
- Rename `NoTools` to `NoToolParams` for clarity
- Make `NoTools` an alias to `Compact` (intuitive behavior)

## Problem
`detailLevel: 'NoTools'` was misleading - it only filtered tool parameters but kept full tool results (300KB+ output for 23 messages).

## Solution
1. **CompactReportingStrategy**: New strategy that summarizes tools (name + status + size)
2. **NoToolParamsReportingStrategy**: Old NoTools behavior (backward compat)
3. **NoTools → Compact alias**: Intuitive behavior by default

## Test plan
- [x] 198 tests pass
- [x] Build succeeds
- [ ] Manual test with `conversation_browser(summarize, detailLevel='Compact')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)