### PR TITLE
fix(#901): Relax conversation_browser truncation defaults

### DIFF
--- a/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
+++ b/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
@@ -91,8 +91,8 @@ interface ConversationSummary {
     children: ConversationSummary[];
 }
 
-/** Max children shown inline in list output */
-const MAX_CHILDREN_SHOWN = 3;
+/** Max children shown inline in list output (was 10 before regression, 3 was too aggressive) */
+const MAX_CHILDREN_SHOWN = 10;
 
 /**
  * Strip XML wrapper tags (<user_message>, </user_message>, <task>, etc.) from message text.

--- a/servers/roo-state-manager/src/tools/view-conversation-tree.ts
+++ b/servers/roo-state-manager/src/tools/view-conversation-tree.ts
@@ -66,10 +66,10 @@ async function handleViewConversationTreeExecutionAsync(
     if (truncate === 0) {
         switch (detail_level) {
             case 'skeleton':
-                truncate = 3;
+                truncate = 20; // #901 Fix: 3→20 — 3 lines was unreadable
                 break;
             case 'summary':
-                truncate = 100; // #594 Fix: 10→100 pour éviter résumés vides sur grosses tâches Roo
+                truncate = 0; // #901 Fix: no truncation for summary — smart_truncation handles length
                 break;
             case 'full':
                 truncate = 0;
@@ -157,7 +157,7 @@ async function handleViewConversationTreeExecutionAsync(
                         output += `${indent}  [${icon} ${item.name}] → ${item.status}${timestamp ? ` (${timestamp})` : ''}\n`;
                         if (item.parameters && Object.keys(item.parameters).length > 0) {
                             const paramStr = JSON.stringify(item.parameters, null, 2);
-                            const truncatedParams = truncateMessage(paramStr, 5);
+                            const truncatedParams = truncateMessage(paramStr, 15); // #901: 5→15 lines
                             output += `${indent}    Params: ${truncatedParams}\n`;
                         }
                         break;
@@ -309,10 +309,10 @@ function handleViewConversationTreeExecution(
     if (truncate === 0) {
         switch (detail_level) {
             case 'skeleton':
-                truncate = 3;
+                truncate = 20; // #901 Fix: 3→20 — 3 lines was unreadable
                 break;
             case 'summary':
-                truncate = 100; // #594 Fix: 10→100 pour éviter résumés vides sur grosses tâches Roo
+                truncate = 0; // #901 Fix: no truncation for summary — smart_truncation handles length
                 break;
             case 'full':
                 truncate = 0;
@@ -696,7 +696,7 @@ function createFormatTaskFunction(detail_level: string, truncate: number, curren
                         output += `${indent}  [${icon} ${item.name}] → ${item.status}${timestamp ? ` (${timestamp})` : ''}\n`;
                         if (item.parameters && Object.keys(item.parameters).length > 0) {
                             const paramStr = JSON.stringify(item.parameters, null, 2);
-                            const truncatedParams = truncateMessage(paramStr, 5);
+                            const truncatedParams = truncateMessage(paramStr, 15); // #901: 5→15 lines
                             output += `${indent}    Params: ${truncatedParams}\n`;
                         }
                         break;


### PR DESCRIPTION
## Summary

Fix aggressive truncation that made conversation_browser unusable for trace analysis.

## Changes

| Parameter | Before | After | Reason |
|-----------|--------|-------|--------|
| `skeleton` truncate | 3 lines | 20 lines | 3 was unreadable |
| `summary` truncate | 100 lines | 0 (no limit) | smart_truncation handles length |
| Tool params truncate | 5 lines | 15 lines | 5 lost critical context |
| MAX_CHILDREN_SHOWN | 3 | 10 | Restore pre-regression value |

## Test plan
- [x] 255 conversation tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)