### PR TITLE
fix(#982): Restore full content in semantic search snippets

### DIFF
--- a/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
@@ -494,7 +494,7 @@ export const searchTasksByContentTool = {
                         quantization: { rescore: true }
                     },
                     with_payload: {
-                        include: ['task_id', 'timestamp', 'chunk_type', 'content_summary', 'workspace', 'workspace_name', 'source', 'chunk_id', 'task_title', 'role', 'model']
+                        include: ['task_id', 'timestamp', 'chunk_type', 'content', 'content_summary', 'workspace', 'workspace_name', 'source', 'chunk_id', 'task_title', 'role', 'model']
                     }
                 }),
                 new Promise((_, reject) =>
@@ -514,13 +514,15 @@ export const searchTasksByContentTool = {
 
             // Phase 2: Enriched results with snippets, score interpretation, deduplication
             const results: RawSearchResult[] = rawPoints.map((result: any) => {
+                // #982 FIX: Prefer full content for snippet extraction (content_summary is only 200 chars)
+                const fullContent = String(result.payload?.content || result.payload?.content_summary || '');
                 const content = String(result.payload?.content_summary || result.payload?.content || '');
                 const score = result.score || 0;
                 return {
                     taskId: result.payload?.task_id || 'unknown',
                     score,
                     content: truncateMessage(content, 5),
-                    snippet: extractSnippet(content, search_query),
+                    snippet: extractSnippet(fullContent, search_query),
                     relevance: interpretScore(score),
                     metadata: {
                         chunk_id: result.payload?.chunk_id,


### PR DESCRIPTION
## Summary
- Add `content` back to `with_payload.include` so `extractSnippet()` gets full indexed text (~1000 chars) instead of `content_summary` (200 chars)
- Prefer full `content` for snippet extraction, keep `content_summary` for the display content field
- Root cause: triple truncation chain — `content_summary` capped at 200 chars at indexing time, `content` excluded from Qdrant payload, `extractSnippet` `maxChars=300` was irrelevant on 200-char input

## Test plan
- [x] Build passes (0 errors)
- [x] 7231/7253 tests pass (22 skipped, 0 failures)
- [ ] Verify snippets are readable after VS Code restart

Fixes jsboige/roo-extensions#982

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>