### PR TITLE
fix(ci): Add maxRetries to flaky machines.smoke.test.ts cleanup

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/machines.smoke.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/machines.smoke.test.ts
@@ -97,9 +97,9 @@ describe('SMOKE: roosync_machines', () => {
   });
 
   afterEach(() => {
-    // Cleanup test files
+    // Cleanup test files (maxRetries for CI where ENOTEMPTY can occur transiently)
     if (fs.existsSync(testSharedStatePath)) {
-      fs.rmSync(testSharedStatePath, { recursive: true, force: true });
+      fs.rmSync(testSharedStatePath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
     }
 
     // Reset RooSyncService singleton to restore original state


### PR DESCRIPTION
## Summary
- Adds `maxRetries: 3` and `retryDelay: 100` to the `afterEach` `rmSync` call in `machines.smoke.test.ts`
- Fixes intermittent CI failures with `ENOTEMPTY: directory not empty` during test cleanup

## Problem
The `fs.rmSync` in afterEach occasionally fails in GitHub Actions CI with:
```
Error: ENOTEMPTY: directory not empty, rmdir '.shared-state-test-machines'
```
This is a known Node.js issue where file handles aren't released immediately.

## Test plan
- [x] All 3 tests pass locally
- [x] Node.js 18+ supports `maxRetries`/`retryDelay` options

🤖 Generated with [Claude Code](https://claude.com/claude-code)