### PR TITLE
feat(#941): Add modeApiConfigs to SYNC_SAFE_KEYS

### DIFF
--- a/servers/roo-state-manager/src/services/RooSettingsService.ts
+++ b/servers/roo-state-manager/src/services/RooSettingsService.ts
@@ -59,6 +59,7 @@ const SYNC_SAFE_KEYS = new Set([
   'currentApiConfigName',
   'listApiConfigMeta',
   'profileThresholds',
+  'modeApiConfigs',
   // Behavior settings
   'autoApprovalEnabled',
   'alwaysAllowReadOnly',


### PR DESCRIPTION
## Summary
- Add `modeApiConfigs` to `SYNC_SAFE_KEYS` in RooSettingsService to enable sync of mode→profile mappings across machines
- This prevents config drift when users customize profiles via Roo UI (VS Code stores in state.vscdb, diverges from model-configs.json)

## Test plan
- [ ] Verify `modeApiConfigs` appears in synced settings
- [ ] Run drift detection script: `roo-config/scripts/check-mode-api-configs-drift.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>