### PR TITLE
fix(tests): Fix ENOTEMPTY in machines.smoke.test.ts on CI

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/machines.smoke.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/machines.smoke.test.ts
@@ -96,14 +96,17 @@ describe('SMOKE: roosync_machines', () => {
     }
   });
 
-  afterEach(() => {
-    // Cleanup test files (maxRetries for CI where ENOTEMPTY can occur transiently)
-    if (fs.existsSync(testSharedStatePath)) {
-      fs.rmSync(testSharedStatePath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
-    }
-
-    // Reset RooSyncService singleton to restore original state
+  afterEach(async () => {
+    // Reset RooSyncService singleton FIRST to stop any pending async file writes
     RooSyncService.resetInstance();
+
+    // Wait briefly for any in-flight async operations to complete before cleanup
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // Cleanup test files
+    if (fs.existsSync(testSharedStatePath)) {
+      fs.rmSync(testSharedStatePath, { recursive: true, force: true });
+    }
 
     // Restore original environment
     process.env = originalEnv;


### PR DESCRIPTION
## Summary
- Fixes `ENOTEMPTY: directory not empty, rmdir` error in `machines.smoke.test.ts` on CI (Node 22)
- Root cause: `afterEach` was calling `fs.rmSync` BEFORE `RooSyncService.resetInstance()`, leaving service's pending async file writes racing with cleanup
- Fix: Reset singleton first, add 50ms delay for in-flight ops, then cleanup

## Test plan
- [ ] Run `npx vitest run src/tools/roosync/__tests__/machines.smoke.test.ts` locally
- [ ] CI should pass on Node 20 and Node 22

Closes issue blocking CI in parent repo `jsboige/roo-extensions` (multiple PRs failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)