### PR TITLE
test: Update skepticism-protocol tests for v3.0 condensed format

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/skepticism-protocol.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/skepticism-protocol.test.ts
@@ -1,10 +1,10 @@
 /**
  * Tests for skepticism-protocol.md validation
- * Issue #567 Section 5 - Assigned to myia-po-2024
+ * Issue #567 Section 5 - Updated for v3.0.0 condensed format
  *
  * These tests verify:
  * 1. The skepticism-protocol.md file exists and has valid format
- * 2. The anti-patterns documented are covered by guards
+ * 2. Core skepticism principles are documented
  */
 
 import { describe, it, expect } from 'vitest'
@@ -24,56 +24,39 @@ describe('Skepticism Protocol - File Validation', () => {
     expect(fs.existsSync(ROO_RULES_PATH)).toBe(true)
   })
 
-  it('skepticism-protocol.md has valid markdown structure', () => {
+  it('skepticism-protocol.md has valid markdown structure (v3.0 condensed)', () => {
     const content = fs.readFileSync(CLAUDE_RULES_PATH, 'utf-8')
 
-    // Check for required sections
+    // Check for required sections in v3.0 condensed format
     expect(content).toContain('# Protocole de Scepticisme Raisonnable')
     expect(content).toContain('## Principe')
-    expect(content).toContain('## Declencheurs de Scepticisme')
-    expect(content).toContain('## Protocole de Verification')
+    expect(content).toContain('## Declencheurs')
+    expect(content).toContain('## Verification')
     expect(content).toContain('## Regles Anti-Propagation')
-    expect(content).toContain('## Anti-Patterns Documentes')
   })
 
   it('skepticism-protocol.md contains version metadata', () => {
     const content = fs.readFileSync(CLAUDE_RULES_PATH, 'utf-8')
 
     expect(content).toContain('**Version:**')
-    expect(content).toContain('**Cree:**')
   })
 
-  it('skepticism-protocol.md documents GPU anti-pattern', () => {
+  it('skepticism-protocol.md documents GPU trigger', () => {
     const content = fs.readFileSync(CLAUDE_RULES_PATH, 'utf-8')
 
     expect(content).toContain('GPU insuffisante')
-    expect(content).toContain('GPU Fleet')
   })
 
-  it('skepticism-protocol.md documents machine silence anti-pattern', () => {
+  it('skepticism-protocol.md documents verification levels', () => {
     const content = fs.readFileSync(CLAUDE_RULES_PATH, 'utf-8')
 
-    expect(content).toContain('machine "silencieuse"')
-    expect(content).toContain('Verifier inbox complet')
-  })
-
-  it('skepticism-protocol.md documents duplicate work anti-pattern', () => {
-    const content = fs.readFileSync(CLAUDE_RULES_PATH, 'utf-8')
-
-    expect(content).toContain('Dupliquer le travail')
-    expect(content).toContain('Claim protocol')
+    expect(content).toContain('Rapide')
+    expect(content).toContain('Active')
+    expect(content).toContain('Croisee')
   })
 })
 
 describe('Skepticism Protocol - Guards Coverage', () => {
-  it('verifies verification levels are defined (Niveau 1-3)', () => {
-    const content = fs.readFileSync(CLAUDE_RULES_PATH, 'utf-8')
-
-    expect(content).toContain('Niveau 1')
-    expect(content).toContain('Niveau 2')
-    expect(content).toContain('Niveau 3')
-  })
-
   it('verifies claim qualification labels are defined', () => {
     const content = fs.readFileSync(CLAUDE_RULES_PATH, 'utf-8')
 
@@ -85,7 +68,6 @@ describe('Skepticism Protocol - Guards Coverage', () => {
   it('verifies reference sources are documented', () => {
     const content = fs.readFileSync(CLAUDE_RULES_PATH, 'utf-8')
 
-    expect(content).toContain('GPU Fleet')
     expect(content).toContain('CLAUDE.md')
     expect(content).toContain('MEMORY.md')
   })
@@ -98,27 +80,12 @@ describe('Skepticism Protocol - Guards Coverage', () => {
     expect(content).toContain('vLLM ou z.ai')
     expect(content).toContain('pas localement sur les executeurs')
   })
-})
 
-describe('Skepticism Protocol - Integration Points', () => {
-  it('documents integration with /coordinate command', () => {
+  it('verifies anti-propagation rules for coordinator and executor', () => {
     const content = fs.readFileSync(CLAUDE_RULES_PATH, 'utf-8')
 
-    expect(content).toContain('/coordinate')
-    expect(content).toContain('Verifier les rapports AVANT de dispatcher')
-  })
-
-  it('documents integration with /executor command', () => {
-    const content = fs.readFileSync(CLAUDE_RULES_PATH, 'utf-8')
-
-    expect(content).toContain('/executor')
-    expect(content).toContain('Verifier les premisses des instructions recues')
-  })
-
-  it('documents integration with roosync-hub agent', () => {
-    const content = fs.readFileSync(CLAUDE_RULES_PATH, 'utf-8')
-
-    expect(content).toContain('roosync-hub')
-    expect(content).toContain('Croiser rapports avec git/GitHub')
+    expect(content).toContain('Coordinateur')
+    expect(content).toContain('Executeur')
+    expect(content).toContain('JAMAIS')
   })
 })


### PR DESCRIPTION
## Summary
- Update skepticism-protocol.test.ts to match v3.0 condensed format of the rule file
- Old tests expected verbose v2.0 sections (Anti-Patterns Documentes, Integration Points, etc.) that were removed during harness reduction
- 10 tests were failing, all 10 now pass with updated assertions

## Test plan
- [x] `npx vitest run src/services/__tests__/skepticism-protocol.test.ts` — 10/10 pass
- [x] Full CI suite: 7317/7317 pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>