### PR TITLE
fix(test): InventoryCollector mock path mismatch

### DIFF
--- a/servers/roo-state-manager/tests/unit/services/InventoryCollector.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/InventoryCollector.test.ts
@@ -34,7 +34,7 @@ const { mockGetSharedStatePath } = vi.hoisted(() => ({
     mockGetSharedStatePath: vi.fn()
 }));
 
-vi.mock('../../../src/utils/server-helpers.js', () => ({
+vi.mock('../../../src/utils/shared-state-path.js', () => ({
     getSharedStatePath: mockGetSharedStatePath
 }));
 


### PR DESCRIPTION
## Summary
- Fix mock import path in `InventoryCollector.test.ts`: `server-helpers.js` → `shared-state-path.js`
- The source code was refactored in #1110 to extract `getSharedStatePath` into its own module (breaking ESM circular deps), but the test mock path was not updated
- This caused the `forceRefresh` cache bypass test to fail (28→28 tests pass now)

## Test plan
- [x] `npx vitest run tests/unit/services/InventoryCollector.test.ts` — 28/28 pass
- [x] `npm run build` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)