### PR TITLE
test(coverage): extend qdrant + add shared-state-path tests

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/qdrant.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/qdrant.test.ts
@@ -1,57 +1,75 @@
 /**
  * Tests for qdrant.ts
  * Issue #492 - Coverage for singleton QdrantClient factory
+ * Extended: getCollectionSize, isLargeCollection, timeout config
  *
  * @module services/__tests__/qdrant
  */
 
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 
-// Mock QdrantClient
-const mockQdrantClient = { getCollections: vi.fn() };
+// Mock QdrantClient — use vi.fn(impl) not vi.fn().mockImplementation(impl)
+// vitest auto-clears mockImplementation between tests (even without clearAllMocks)
+// but vi.fn(impl) captures the implementation in the constructor, surviving auto-clear.
+const mockQdrantClient = { getCollection: vi.fn() };
 
 vi.mock('@qdrant/js-client-rest', () => ({
-	QdrantClient: vi.fn().mockImplementation(() => mockQdrantClient)
+	QdrantClient: vi.fn(() => mockQdrantClient)
 }));
 
 describe('qdrant', () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-		vi.resetModules();
-		// Clean env vars
-		delete process.env.QDRANT_URL;
-		delete process.env.QDRANT_API_KEY;
-	});
+	let getQdrantClient: () => any;
+	let resetQdrantClient: () => void;
+	let getCollectionSize: () => Promise<number>;
+	let isLargeCollection: () => Promise<boolean>;
+	let MockedQdrantClient: ReturnType<typeof vi.fn>;
 
-	test('getQdrantClient returns a client instance', async () => {
+	beforeEach(async () => {
+		// Clear only the spies we control (not the constructor mock)
+		mockQdrantClient.getCollection.mockReset();
+
+		// Reset env vars to safe defaults
 		process.env.QDRANT_URL = 'https://qdrant.example.com';
 		process.env.QDRANT_API_KEY = 'test-key';
+		delete process.env.QDRANT_TIMEOUT_MS;
+		delete process.env.QDRANT_COLLECTION_NAME;
 
-		const { getQdrantClient } = await import('../qdrant.js');
+		// Import all once
+		const qdrantModule = await import('../qdrant.js');
+		const qdrantClientModule = await import('@qdrant/js-client-rest');
+		getQdrantClient = qdrantModule.getQdrantClient;
+		resetQdrantClient = qdrantModule.resetQdrantClient;
+		getCollectionSize = qdrantModule.getCollectionSize;
+		isLargeCollection = qdrantModule.isLargeCollection;
+		MockedQdrantClient = qdrantClientModule.QdrantClient;
+
+		// Reset singleton + clear constructor call tracking
+		resetQdrantClient();
+		(MockedQdrantClient as ReturnType<typeof vi.fn>).mockClear();
+	});
+
+	// ---- getQdrantClient / resetQdrantClient ----
+
+	test('getQdrantClient returns a client instance', () => {
 		const client = getQdrantClient();
 		expect(client).toBeDefined();
 		expect(client).toBe(mockQdrantClient);
 	});
 
-	test('getQdrantClient returns singleton on repeated calls', async () => {
-		process.env.QDRANT_URL = 'https://qdrant.example.com';
-		process.env.QDRANT_API_KEY = 'test-key';
-
-		const { getQdrantClient } = await import('../qdrant.js');
+	test('getQdrantClient returns singleton on repeated calls', () => {
 		const client1 = getQdrantClient();
 		const client2 = getQdrantClient();
 		expect(client1).toBe(client2);
 	});
 
-	test('getQdrantClient uses QDRANT_URL from env', async () => {
+	test('getQdrantClient uses QDRANT_URL from env', () => {
 		process.env.QDRANT_URL = 'https://custom-qdrant.example.com';
 		process.env.QDRANT_API_KEY = 'api-key-123';
+		resetQdrantClient();
 
-		const { QdrantClient } = await import('@qdrant/js-client-rest');
-		const { getQdrantClient } = await import('../qdrant.js');
 		getQdrantClient();
 
-		expect(QdrantClient).toHaveBeenCalledWith(expect.objectContaining({
+		expect(MockedQdrantClient).toHaveBeenCalledWith(expect.objectContaining({
 			url: 'https://custom-qdrant.example.com',
 			apiKey: 'api-key-123',
 			port: 443,
@@ -59,31 +77,116 @@ describe('qdrant', () => {
 		}));
 	});
 
-	test('getQdrantClient handles undefined env vars', async () => {
-		// No env vars set
-		const { getQdrantClient } = await import('../qdrant.js');
+	test('getQdrantClient handles undefined env vars', () => {
+		delete process.env.QDRANT_URL;
+		delete process.env.QDRANT_API_KEY;
+		resetQdrantClient();
+
 		const client = getQdrantClient();
 		expect(client).toBeDefined();
 	});
 
-	test('resetQdrantClient clears the singleton', async () => {
-		process.env.QDRANT_URL = 'https://qdrant.example.com';
-		process.env.QDRANT_API_KEY = 'test-key';
-
-		const { QdrantClient } = await import('@qdrant/js-client-rest');
-		const { getQdrantClient, resetQdrantClient } = await import('../qdrant.js');
-
+	test('resetQdrantClient clears the singleton', () => {
 		getQdrantClient();
-		expect(QdrantClient).toHaveBeenCalledTimes(1);
+		expect(MockedQdrantClient).toHaveBeenCalledTimes(1);
 
 		resetQdrantClient();
-
 		getQdrantClient();
-		expect(QdrantClient).toHaveBeenCalledTimes(2);
+		expect(MockedQdrantClient).toHaveBeenCalledTimes(2);
 	});
 
-	test('resetQdrantClient is safe to call without prior init', async () => {
-		const { resetQdrantClient } = await import('../qdrant.js');
+	test('resetQdrantClient is safe to call without prior init', () => {
 		expect(() => resetQdrantClient()).not.toThrow();
+	});
+
+	test('getQdrantClient uses QDRANT_TIMEOUT_MS from env', () => {
+		process.env.QDRANT_TIMEOUT_MS = '30000';
+		resetQdrantClient();
+		getQdrantClient();
+
+		expect(MockedQdrantClient).toHaveBeenCalledWith(expect.objectContaining({
+			timeout: 30000
+		}));
+	});
+
+	test('getQdrantClient defaults timeout to 15000ms', () => {
+		resetQdrantClient();
+		getQdrantClient();
+
+		expect(MockedQdrantClient).toHaveBeenCalledWith(expect.objectContaining({
+			timeout: 15000
+		}));
+	});
+
+	// ---- getCollectionSize ----
+
+	test('getCollectionSize returns points_count from collection', async () => {
+		mockQdrantClient.getCollection.mockResolvedValue({
+			points_count: 12345
+		});
+
+		const size = await getCollectionSize();
+		expect(size).toBe(12345);
+	});
+
+	test('getCollectionSize returns 0 when points_count is undefined', async () => {
+		mockQdrantClient.getCollection.mockResolvedValue({});
+
+		const size = await getCollectionSize();
+		expect(size).toBe(0);
+	});
+
+	test('getCollectionSize returns 1 on error (graceful degradation)', async () => {
+		mockQdrantClient.getCollection.mockRejectedValue(new Error('connection refused'));
+
+		const size = await getCollectionSize();
+		expect(size).toBe(1);
+	});
+
+	test('getCollectionSize uses default collection name when env not set', async () => {
+		mockQdrantClient.getCollection.mockResolvedValue({ points_count: 50 });
+
+		await getCollectionSize();
+
+		expect(mockQdrantClient.getCollection).toHaveBeenCalledWith('roo_tasks_semantic_index');
+	});
+
+	test('getCollectionSize uses QDRANT_COLLECTION_NAME from env when set', async () => {
+		process.env.QDRANT_COLLECTION_NAME = 'custom_collection';
+		mockQdrantClient.getCollection.mockResolvedValue({ points_count: 42 });
+
+		const size = await getCollectionSize();
+
+		expect(mockQdrantClient.getCollection).toHaveBeenCalledWith('custom_collection');
+		expect(size).toBe(42);
+	});
+
+	// ---- isLargeCollection ----
+
+	test('isLargeCollection returns true for collections > 5M vectors', async () => {
+		mockQdrantClient.getCollection.mockResolvedValue({
+			points_count: 6_000_000
+		});
+
+		const result = await isLargeCollection();
+		expect(result).toBe(true);
+	});
+
+	test('isLargeCollection returns false for collections <= 5M vectors', async () => {
+		mockQdrantClient.getCollection.mockResolvedValue({
+			points_count: 4_999_999
+		});
+
+		const result = await isLargeCollection();
+		expect(result).toBe(false);
+	});
+
+	test('isLargeCollection returns false for exactly 5M vectors', async () => {
+		mockQdrantClient.getCollection.mockResolvedValue({
+			points_count: 5_000_000
+		});
+
+		const result = await isLargeCollection();
+		expect(result).toBe(false);
 	});
 });

--- a/servers/roo-state-manager/src/utils/__tests__/shared-state-path.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/shared-state-path.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for shared-state-path.ts
+ * Coverage improvement - #1110 ESM cycle fix helper
+ *
+ * @module utils/__tests__/shared-state-path
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+
+describe('getSharedStatePath', () => {
+	const originalEnv = process.env.ROOSYNC_SHARED_PATH;
+
+	beforeEach(() => {
+		delete process.env.ROOSYNC_SHARED_PATH;
+	});
+
+	afterEach(() => {
+		if (originalEnv !== undefined) {
+			process.env.ROOSYNC_SHARED_PATH = originalEnv;
+		} else {
+			delete process.env.ROOSYNC_SHARED_PATH;
+		}
+	});
+
+	test('returns ROOSYNC_SHARED_PATH when set', async () => {
+		process.env.ROOSYNC_SHARED_PATH = '/some/shared/path';
+		const { getSharedStatePath } = await import('../shared-state-path.js');
+		expect(getSharedStatePath()).toBe('/some/shared/path');
+	});
+
+	test('throws descriptive error when ROOSYNC_SHARED_PATH is not set', async () => {
+		const { getSharedStatePath } = await import('../shared-state-path.js');
+		expect(() => getSharedStatePath()).toThrow('ROOSYNC_SHARED_PATH environment variable is not set');
+	});
+
+	test('throws error mentioning Google Drive for user guidance', async () => {
+		const { getSharedStatePath } = await import('../shared-state-path.js');
+		expect(() => getSharedStatePath()).toThrow(/Google Drive/);
+	});
+
+	test('returns different paths when env changes between imports', async () => {
+		process.env.ROOSYNC_SHARED_PATH = '/path/one';
+		const { getSharedStatePath } = await import('../shared-state-path.js');
+		expect(getSharedStatePath()).toBe('/path/one');
+
+		process.env.ROOSYNC_SHARED_PATH = '/path/two';
+		expect(getSharedStatePath()).toBe('/path/two');
+	});
+});


### PR DESCRIPTION
## Summary

- Extended `qdrant.test.ts` from 6→16 tests: added `getCollectionSize` (5 tests), `isLargeCollection` (3 tests), timeout config (2 tests)
- Added new `shared-state-path.test.ts` (4 tests, 100% coverage of throw + return paths)

### Key finding: vitest mockImplementation gotcha

Vitest **auto-clears `mockImplementation` between tests** (even without explicit `clearAllMocks`). The fix is to use `vi.fn(impl)` instead of `vi.fn().mockImplementation(impl)` — the constructor-captured implementation survives auto-clear.

## Coverage improvement

| Module | Before | After (estimated) |
|--------|--------|-------------------|
| `qdrant.ts` | 40% (20/50 stmts) | ~85% |
| `shared-state-path.ts` | 50% (4/8 stmts) | 100% |

## Test plan

- [x] All 20 new/extended tests pass
- [x] CI suite: 7369 passed, 0 failed
- [x] Build: clean (`tsc` no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)