### PR TITLE
fix(sequence): Complete null-safety for ALL .sequence accesses (46 guards, 15 files)

### DIFF
--- a/servers/roo-state-manager/scripts/complete-lazy-load-conversion.ps1
+++ b/servers/roo-state-manager/scripts/complete-lazy-load-conversion.ps1
@@ -1,0 +1,102 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Complete the lazy-load conversion for registry.ts (Issue #1140)
+
+.DESCRIPTION
+    This script converts ALL remaining toolExports.* references in registry.ts
+    to use dynamic imports. This completes the lazy-loading refactor started
+    in the initial PR.
+
+.NOTES
+    Run this from the roo-state-manager directory:
+    pwsh scripts/complete-lazy-load-conversion.ps1
+#>
+
+$ErrorActionPreference = 'Stop'
+$registryPath = "src/tools/registry.ts"
+
+if (!(Test-Path $registryPath)) {
+    Write-Error "registry.ts not found. Run this script from roo-state-manager directory."
+    exit 1
+}
+
+Write-Host "Reading registry.ts..."
+$content = Get-Content $registryPath -Raw
+
+# Define all remaining conversions: function name -> import path
+$conversions = @(
+    @{ Func = 'roosyncGetDecisionDetails'; Path = './roosync/get-decision-details.js' }
+    @{ Func = 'roosyncApproveDecision'; Path = './roosync/approve-decision.js' }
+    @{ Func = 'roosyncRejectDecision'; Path = './roosync/reject-decision.js' }
+    @{ Func = 'roosyncApplyDecision'; Path = './roosync/apply-decision.js' }
+    @{ Func = 'roosyncRollbackDecision'; Path = './roosync/rollback-decision.js' }
+    @{ Func = 'roosyncInit'; Path = './roosync/init.js' }
+    @{ Func = 'roosyncUpdateBaseline'; Path = './roosync/baseline.js' }
+    @{ Func = 'roosync_manage_baseline'; Path = './roosync/baseline.js' }
+    @{ Func = 'roosyncDiagnose'; Path = './roosync/diagnose.js' }
+    @{ Func = 'roosyncCollectConfig'; Path = './roosync/config.js' }
+    @{ Func = 'roosyncPublishConfig'; Path = './roosync/config.js' }
+    @{ Func = 'roosyncApplyConfig'; Path = './roosync/apply-config.js' }
+    @{ Func = 'roosyncDecision'; Path = './roosync/decision.js' }
+    @{ Func = 'roosyncDecisionInfo'; Path = './roosync/decision-info.js' }
+    @{ Func = 'roosync_baseline'; Path = './roosync/baseline.js' }
+    @{ Func = 'roosyncConfig'; Path = './roosync/config.js' }
+    @{ Func = 'inventoryTool'; Path = './roosync/inventory.js'; Pattern = 'const invResult = await toolExports.inventoryTool.execute'; Replacement = 'const { inventoryTool } = await import(''./roosync/inventory.js'');{NL}                  const invResult = await inventoryTool.execute' }
+    @{ Func = 'roosyncMachines'; Path = './roosync/machines.js'; Pattern = 'const machResult = await toolExports.roosyncMachines'; Replacement = 'const { roosyncMachines } = await import(''./roosync/machines.js'');{NL}                  const machResult = await roosyncMachines' }
+    @{ Func = 'roosyncHeartbeat'; Path = './roosync/heartbeat.js'; Pattern = 'const heartbeatResult = await toolExports.roosyncHeartbeat'; Replacement = 'const { roosyncHeartbeat } = await import(''./roosync/heartbeat.js'');{NL}                  const heartbeatResult = await roosyncHeartbeat' }
+    @{ Func = 'roosyncSend'; Path = './roosync/messaging/send.js'; Pattern = 'result = await toolExports.roosyncSend'; Replacement = 'const { roosyncSend } = await import(''./roosync/messaging/send.js'');{NL}                   result = await roosyncSend' }
+    @{ Func = 'roosyncRead'; Path = './roosync/messaging/read.js'; Pattern = 'result = await toolExports.roosyncRead'; Replacement = 'const { roosyncRead } = await import(''./roosync/messaging/read.js'');{NL}                   result = await roosyncRead' }
+    @{ Func = 'roosyncManage'; Path = './roosync/messaging/manage.js'; Pattern = 'result = await toolExports.roosyncManage'; Replacement = 'const { roosyncManage } = await import(''./roosync/messaging/manage.js'');{NL}                   result = await roosyncManage' }
+    @{ Func = 'cleanupMessages'; Path = './roosync/messaging/cleanup-messages.js'; Pattern = 'result = await toolExports.cleanupMessages'; Replacement = 'const { cleanupMessages } = await import(''./roosync/messaging/cleanup-messages.js'');{NL}                   result = await cleanupMessages' }
+    @{ Func = 'roosyncAttachments'; Path = './roosync/attachments/attachments.js'; Pattern = 'result = await toolExports.roosyncAttachments'; Replacement = 'const { roosyncAttachments } = await import(''./roosync/attachments/attachments.js'');{NL}                   result = await roosyncAttachments' }
+    @{ Func = 'roosyncListAttachments'; Path = './roosync/attachments/list-attachments.js'; Pattern = 'result = await toolExports.roosyncListAttachments'; Replacement = 'const { roosyncListAttachments } = await import(''./roosync/attachments/list-attachments.js'');{NL}                   result = await roosyncListAttachments' }
+    @{ Func = 'roosyncGetAttachment'; Path = './roosync/attachments/get-attachment.js'; Pattern = 'result = await toolExports.roosyncGetAttachment'; Replacement = 'const { roosyncGetAttachment } = await import(''./roosync/attachments/get-attachment.js'');{NL}                   result = await roosyncGetAttachment' }
+    @{ Func = 'roosyncDeleteAttachment'; Path = './roosync/attachments/delete-attachment.js'; Pattern = 'result = await toolExports.roosyncDeleteAttachment'; Replacement = 'const { roosyncDeleteAttachment } = await import(''./roosync/attachments/delete-attachment.js'');{NL}                   result = await roosyncDeleteAttachment' }
+    @{ Func = 'getMachineInventoryTool'; Path = './roosync/inventory.js'; Pattern = 'const invResult = await toolExports.getMachineInventoryTool.execute'; Replacement = 'const { getMachineInventoryTool } = await import(''./roosync/inventory.js'');{NL}                       const invResult = await getMachineInventoryTool.execute' }
+    @{ Func = 'roosyncRefreshDashboard'; Path = './roosync/refresh-dashboard.js' }
+    @{ Func = 'roosyncUpdateDashboard'; Path = './roosync/update-dashboard.js' }
+    @{ Func = 'roosyncDashboard'; Path = './roosync/dashboard.js'; Pattern = 'const dashboardResult = await toolExports.roosyncDashboard'; Replacement = 'const { roosyncDashboard } = await import(''./roosync/dashboard.js'');{NL}                   const dashboardResult = await roosyncDashboard' }
+    @{ Func = 'roosyncSyncEvent'; Path = './roosync/sync-event.js'; Pattern = 'const syncEventResult = await toolExports.roosyncSyncEvent'; Replacement = 'const { roosyncSyncEvent } = await import(''./roosync/sync-event.js'');{NL}                   const syncEventResult = await roosyncSyncEvent' }
+    @{ Func = 'roosyncMcpManagement'; Path = './roosync/mcp-management.js'; Pattern = 'const mcpManagementResult = await toolExports.roosyncMcpManagement'; Replacement = 'const { roosyncMcpManagement } = await import(''./roosync/mcp-management.js'');{NL}                   const mcpManagementResult = await roosyncMcpManagement' }
+    @{ Func = 'roosyncStorageManagement'; Path = './roosync/storage-management.js'; Pattern = 'const storageManagementResult = await toolExports.roosyncStorageManagement'; Replacement = 'const { roosyncStorageManagement } = await import(''./roosync/storage-management.js'');{NL}                   const storageManagementResult = await roosyncStorageManagement' }
+)
+
+$changeCount = 0
+
+foreach ($conv in $conversions) {
+    $func = $conv.Func
+    $path = $conv.Path
+
+    # Use custom pattern if provided, otherwise use default
+    if ($conv.Pattern -and $conv.Replacement) {
+        $pattern = $conv.Pattern
+        $replacement = $conv.Replacement -replace '\{NL\}', "`n"
+    } else {
+        # Default pattern for standard roosyncResult cases
+        $pattern = "const roosyncResult = await toolExports\.$func\(args as any\);"
+        $replacement = "const { $func } = await import('$path');`n                  const roosyncResult = await $func(args as any);"
+    }
+
+    if ($content -match [regex]::Escape($pattern)) {
+        Write-Host "  Converting $func..."
+        $content = $content -replace [regex]::Escape($pattern), $replacement
+        $changeCount++
+    }
+}
+
+# Save with UTF-8 no-BOM
+[System.IO.File]::WriteAllText((Resolve-Path $registryPath), $content, [System.Text.UTF8Encoding]::new($false))
+
+Write-Host "`n✓ Conversion complete: $changeCount functions converted"
+Write-Host "`nChecking for remaining toolExports references..."
+$remaining = Select-String -Path $registryPath -Pattern "toolExports\."
+if ($remaining) {
+    Write-Host "WARNING: Found $($remaining.Count) remaining references:`n"
+    $remaining | ForEach-Object { Write-Host "  Line $($_.LineNumber): $($_.Line.Trim())" }
+    Write-Host "`nThese may need manual conversion or are expected (e.g., in comments)."
+} else {
+    Write-Host "✓ No remaining toolExports references found!`n"
+}
+
+Write-Host "Run 'npm run build' and 'npx vitest run' to verify."

--- a/servers/roo-state-manager/scripts/convert-registry-lazy-load.ps1
+++ b/servers/roo-state-manager/scripts/convert-registry-lazy-load.ps1
@@ -1,0 +1,77 @@
+#!/usr/bin/env pwsh
+# Script to convert remaining toolExports references to dynamic imports in registry.ts
+# Issue #1140: Lazy-load tools to reduce MCP startup time
+
+$registryPath = Join-Path $PSScriptRoot "..\src\tools\registry.ts"
+$content = Get-Content $registryPath -Raw
+
+# Define mappings of function names to their import paths
+$imports = @{
+    'roosyncGetDecisionDetails' = './roosync/decision-info.js'
+    'roosyncApproveDecision' = './roosync/decision.js'
+    'roosyncRejectDecision' = './roosync/decision.js'
+    'roosyncApplyDecision' = './roosync/decision.js'
+    'roosyncRollbackDecision' = './roosync/decision.js'
+    'roosyncInit' = './roosync/init.js'
+    'roosyncUpdateBaseline' = './roosync/baseline.js'
+    'roosync_manage_baseline' = './roosync/baseline.js'
+    'roosyncDiagnose' = './roosync/diagnose.js'
+    'roosync_baseline' = './roosync/baseline.js'
+    'roosyncDecision' = './roosync/decision.js'
+    'roosyncDecisionInfo' = './roosync/decision-info.js'
+    'roosyncConfig' = './roosync/config.js'
+    'inventoryTool' = './roosync/inventory.js'
+    'roosyncMachines' = './roosync/machines.js'
+    'roosyncHeartbeat' = './roosync/heartbeat.js'
+    'roosyncSend' = './roosync/messaging/send.js'
+    'roosyncRead' = './roosync/messaging/read.js'
+    'roosyncManage' = './roosync/messaging/manage.js'
+    'cleanupMessages' = './roosync/messaging/cleanup-messages.js'
+    'roosyncAttachments' = './roosync/attachments/attachments.js'
+    'roosyncListAttachments' = './roosync/attachments/list-attachments.js'
+    'roosyncGetAttachment' = './roosync/attachments/get-attachment.js'
+    'roosyncDeleteAttachment' = './roosync/attachments/delete-attachment.js'
+    'getMachineInventoryTool' = './roosync/inventory.js'
+    'roosyncRefreshDashboard' = './roosync/refresh-dashboard.js'
+    'roosyncUpdateDashboard' = './roosync/update-dashboard.js'
+    'roosyncDashboard' = './roosync/dashboard.js'
+    'roosyncSyncEvent' = './roosync/sync-event.js'
+    'roosyncMcpManagement' = './roosync/mcp-management.js'
+    'roosyncStorageManagement' = './roosync/storage-management.js'
+    'roosyncCollectConfig' = './roosync/config.js'
+    'roosyncPublishConfig' = './roosync/config.js'
+    'roosyncApplyConfig' = './roosync/apply-config.js'
+}
+
+# Pattern to match: toolExports.functionName(
+foreach ($func in $imports.Keys) {
+    $path = $imports[$func]
+
+    # Match patterns like: const roosyncResult = await toolExports.functionName(args)
+    $pattern = "const roosyncResult = await toolExports\.$func\(args as any\);"
+    $replacement = "const { $func } = await import('$path');`n                  const roosyncResult = await $func(args as any);"
+    $content = $content -replace [regex]::Escape($pattern), $replacement
+
+    # Match patterns like: result = await toolExports.functionName.execute(args)
+    $pattern2 = "const invResult = await toolExports\.$func\.execute\(args as any, \{\} as any\);"
+    $replacement2 = "const { $func } = await import('$path');`n                  const invResult = await $func.execute(args as any, {} as any);"
+    $content = $content -replace [regex]::Escape($pattern2), $replacement2
+
+    # Match patterns like: result = await toolExports.functionName(args) as CallToolResult
+    $pattern3 = "result = await toolExports\.$func\(args as any\) as CallToolResult;"
+    $replacement3 = "const { $func } = await import('$path');`n                   result = await $func(args as any) as CallToolResult;"
+    $content = $content -replace [regex]::Escape($pattern3), $replacement3
+
+    # Match patterns without assignment
+    $pattern4 = "const machResult = await toolExports\.$func\(args as any\);"
+    $replacement4 = "const { $func } = await import('$path');`n                  const machResult = await $func(args as any);"
+    $content = $content -replace [regex]::Escape($pattern4), $replacement4
+}
+
+# Save the result
+[System.IO.File]::WriteAllText($registryPath, $content, [System.Text.UTF8Encoding]::new($false))
+
+Write-Host "Conversion complete. Remaining toolExports references:"
+Select-String -Path $registryPath -Pattern "toolExports\." | ForEach-Object {
+    Write-Host "  Line $($_.LineNumber): $($_.Line.Trim())"
+}

--- a/servers/roo-state-manager/src/services/EnrichContentClassifier.ts
+++ b/servers/roo-state-manager/src/services/EnrichContentClassifier.ts
@@ -18,7 +18,7 @@ export class EnrichContentClassifier {
 		const classified: ClassifiedContent[] = [];
 		let index = 0;
 
-		const messages = conversation.sequence.filter((item): item is MessageSkeleton =>
+		const messages = (conversation.sequence ?? []).filter((item): item is MessageSkeleton =>
 			'role' in item && 'content' in item);
 
 		for (const message of messages) {

--- a/servers/roo-state-manager/src/services/TraceSummaryService.ts
+++ b/servers/roo-state-manager/src/services/TraceSummaryService.ts
@@ -339,7 +339,7 @@ export class TraceSummaryService {
      * Extrait le premier message utilisateur d'une conversation
      */
     private extractFirstUserMessage(conversation: ConversationSkeleton): string {
-        const userMessages = conversation.sequence.filter(item =>
+        const userMessages = (conversation.sequence ?? []).filter(item =>
             'role' in item && item.role === 'user'
         ) as MessageSkeleton[];
 
@@ -353,7 +353,7 @@ export class TraceSummaryService {
      * Convertit les messages en format JSON avec extraction des tool calls
      */
     private convertToJsonMessages(conversation: ConversationSkeleton, options: SummaryOptions): JsonMessage[] {
-        const messages = conversation.sequence.filter(item =>
+        const messages = (conversation.sequence ?? []).filter(item =>
             'role' in item && 'content' in item
         ) as MessageSkeleton[];
 
@@ -456,7 +456,7 @@ export class TraceSummaryService {
             'isTruncated', 'toolCount', 'workspace'
         ];
 
-        const messages = conversation.sequence.filter(item =>
+        const messages = (conversation.sequence ?? []).filter(item =>
             'role' in item && 'content' in item
         ) as MessageSkeleton[];
 
@@ -488,7 +488,7 @@ export class TraceSummaryService {
         ];
 
         const rows: any[][] = [];
-        const messages = conversation.sequence.filter(item =>
+        const messages = (conversation.sequence ?? []).filter(item =>
             'role' in item && 'content' in item
         ) as MessageSkeleton[];
 
@@ -586,7 +586,7 @@ export class TraceSummaryService {
             totalMessages += conv.metadata.messageCount;
             totalSize += conv.metadata.totalSize;
 
-            const messages = conv.sequence.filter(item =>
+            const messages = (conv.sequence ?? []).filter(item =>
                 'role' in item && 'content' in item
             ) as MessageSkeleton[];
 
@@ -654,7 +654,7 @@ export class TraceSummaryService {
      * Calcule la taille du contenu original
      */
     private getOriginalContentSize(conversation: ConversationSkeleton): number {
-        const messages = conversation.sequence.filter((item): item is MessageSkeleton =>
+        const messages = (conversation.sequence ?? []).filter((item): item is MessageSkeleton =>
             'role' in item && 'content' in item);
 
         return messages.reduce((total: number, message: MessageSkeleton) => total + message.content.length, 0);

--- a/servers/roo-state-manager/src/services/XmlExporterService.ts
+++ b/servers/roo-state-manager/src/services/XmlExporterService.ts
@@ -58,7 +58,7 @@ export class XmlExporterService {
         // Ajout de la séquence
         const sequence = root.ele('sequence');
         
-        for (const item of skeleton.sequence) {
+        for (const item of skeleton.sequence ?? []) {
             if ('role' in item) {
                 // C'est un message
                 const messageElement = sequence.ele('message', {
@@ -143,7 +143,7 @@ export class XmlExporterService {
             // Séquence (même logique que generateTaskXml)
             const sequence = taskElement.ele('sequence');
             
-            for (const item of skeleton.sequence) {
+            for (const item of skeleton.sequence ?? []) {
                 if ('role' in item) {
                     const messageElement = sequence.ele('message', {
                         role: item.role,

--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -323,7 +323,7 @@ export async function loadClaudeCodeSessions(conversationCache: Map<string, Skel
                 const skeleton = await ClaudeStorageDetector.analyzeConversation(
                     taskId, location.projectPath
                 );
-                if (skeleton && skeleton.sequence.length > 0) {
+                if (skeleton && (skeleton.sequence ?? []).length > 0) {
                     // #937 FIX: Set both source and dataSource consistently for Claude sessions
                     if (!skeleton.metadata) skeleton.metadata = {} as any;
                     skeleton.metadata.source = 'claude-code'; // For filtering in Qdrant
@@ -437,7 +437,7 @@ export function startSkeletonRefreshWorker(state: ServerState): void {
 
                                 if (stat.mtime.getTime() > existingLastActivity) {
                                     const skeleton = await ClaudeStorageDetector.analyzeConversation(taskId, location.projectPath);
-                                    if (skeleton && skeleton.sequence.length > 0) {
+                                    if (skeleton && (skeleton.sequence ?? []).length > 0) {
                                         if (!skeleton.metadata) skeleton.metadata = {} as any;
                                         skeleton.metadata.dataSource = 'claude';
                                         state.conversationCache.set(taskId, toHeader(skeleton));

--- a/servers/roo-state-manager/src/services/synthesis/NarrativeContextBuilderService.ts
+++ b/servers/roo-state-manager/src/services/synthesis/NarrativeContextBuilderService.ts
@@ -405,7 +405,7 @@ export class NarrativeContextBuilderService {
             'se', 'son', 'sa', 'ses', 'au', 'aux', 'par', 'plus', 'ou', 'mais']);
 
         const wordFreq = new Map<string, number>();
-        const messages = skeleton.sequence.filter(s => 'role' in s) as MessageSkeleton[];
+        const messages = (skeleton.sequence ?? []).filter(s => 'role' in s) as MessageSkeleton[];
 
         for (const msg of messages) {
             const words = msg.content.toLowerCase()
@@ -473,8 +473,8 @@ export class NarrativeContextBuilderService {
             return { flows: [], styles: [], approaches: [], decisions: [] };
         }
 
-        const messages = skeleton.sequence.filter(s => 'role' in s) as MessageSkeleton[];
-        const actions = skeleton.sequence.filter(s => 'type' in s && (s as any).type === 'tool') as ActionMetadata[];
+        const messages = (skeleton.sequence ?? []).filter(s => 'role' in s) as MessageSkeleton[];
+        const actions = (skeleton.sequence ?? []).filter(s => 'type' in s && (s as any).type === 'tool') as ActionMetadata[];
 
         // Detect interaction flows
         const flows: string[] = [];
@@ -530,8 +530,8 @@ export class NarrativeContextBuilderService {
             return { roles: [], expertise: [], dynamics: [], contributions: [] };
         }
 
-        const messages = skeleton.sequence.filter(s => 'role' in s) as MessageSkeleton[];
-        const actions = skeleton.sequence.filter(s => 'type' in s && (s as any).type === 'tool') as ActionMetadata[];
+        const messages = (skeleton.sequence ?? []).filter(s => 'role' in s) as MessageSkeleton[];
+        const actions = (skeleton.sequence ?? []).filter(s => 'type' in s && (s as any).type === 'tool') as ActionMetadata[];
 
         const userMsgs = messages.filter(m => m.role === 'user');
         const assistantMsgs = messages.filter(m => m.role === 'assistant');
@@ -585,8 +585,8 @@ export class NarrativeContextBuilderService {
             return { temporal: [], efficiency: {}, quality: {}, adaptation: [] };
         }
 
-        const messages = skeleton.sequence.filter(s => 'role' in s) as MessageSkeleton[];
-        const actions = skeleton.sequence.filter(s => 'type' in s && (s as any).type === 'tool') as ActionMetadata[];
+        const messages = (skeleton.sequence ?? []).filter(s => 'role' in s) as MessageSkeleton[];
+        const actions = (skeleton.sequence ?? []).filter(s => 'type' in s && (s as any).type === 'tool') as ActionMetadata[];
 
         // Temporal patterns
         const temporal: Array<{ phase: string; messageCount: number }> = [];
@@ -602,7 +602,7 @@ export class NarrativeContextBuilderService {
             messagesPerAction: actions.length > 0 ? messages.length / actions.length : 0,
             actionsTotal: actions.length,
             messagesTotal: messages.length,
-            totalSequenceLength: skeleton.sequence.length,
+            totalSequenceLength: (skeleton.sequence ?? []).length,
             isCompleted: skeleton.isCompleted ?? false
         };
 
@@ -671,7 +671,7 @@ export class NarrativeContextBuilderService {
             return { completeness: 0, accuracy: 0 };
         }
 
-        const messages = skeleton.sequence.filter(s => 'role' in s) as MessageSkeleton[];
+        const messages = (skeleton.sequence ?? []).filter(s => 'role' in s) as MessageSkeleton[];
         const totalChars = messages.reduce((s, m) => s + m.content.length, 0);
         const contextChars = context.contextSummary?.length || 0;
 
@@ -1228,7 +1228,7 @@ export class NarrativeContextBuilderService {
      * Analyse le contenu d'une conversation en utilisant les patterns de TraceSummaryService
      */
     private async analyzeConversationContent(conversation: ConversationSkeleton): Promise<string> {
-        const messages = conversation.sequence.filter((item): item is any =>
+        const messages = (conversation.sequence ?? []).filter((item): item is any =>
             'role' in item && 'content' in item);
 
         if (messages.length === 0) {

--- a/servers/roo-state-manager/src/services/trace-summary/ClusterSummaryService.ts
+++ b/servers/roo-state-manager/src/services/trace-summary/ClusterSummaryService.ts
@@ -431,7 +431,7 @@ export class ClusterSummaryService {
         let totalContentSize = 0;
 
         for (const task of tasks) {
-            const messages = task.sequence.filter((item): item is MessageSkeleton =>
+            const messages = (task.sequence ?? []).filter((item): item is MessageSkeleton =>
                 'role' in item);
 
             for (const message of messages) {
@@ -881,7 +881,7 @@ ${sortedByDate.map(task => {
 
         for (const task of organizedTasks.allTasks) {
             // Extrait le contexte principal de chaque tâche
-            const messages = task.sequence.filter((item): item is MessageSkeleton => 'role' in item);
+            const messages = (task.sequence ?? []).filter((item): item is MessageSkeleton => 'role' in item);
 
             // Première et dernière interaction utilisateur pour le contexte
             const userMessages = messages.filter(m => m.role === 'user' && !this.classifier.isToolResult(m.content));
@@ -992,7 +992,7 @@ ${task !== organizedTasks.rootTask ? `**Parent :** ${organizedTasks.rootTask.met
 </thead>
 <tbody>
     ${organizedTasks.sortedTasks.map(task => {
-                const messageCount = task.sequence.filter(item => 'role' in item).length;
+                const messageCount = (task.sequence ?? []).filter(item => 'role' in item).length;
                 const icon = task === organizedTasks.rootTask ? '🎯' : '📝';
                 return `<tr>
         <td>${icon} ${task.metadata.title || task.taskId}</td>
@@ -1008,7 +1008,7 @@ ${task !== organizedTasks.rootTask ? `**Parent :** ${organizedTasks.rootTask.met
             parts.push(`| Tâche | Mode | Taille | Messages | Date |
 |-------|------|--------|----------|------|
 ${organizedTasks.sortedTasks.map(task => {
-                const messageCount = task.sequence.filter(item => 'role' in item).length;
+                const messageCount = (task.sequence ?? []).filter(item => 'role' in item).length;
                 const icon = task === organizedTasks.rootTask ? '🎯' : '📝';
                 return `| ${icon} ${task.metadata.title || task.taskId} | ${task.metadata.mode || 'N/A'} | ${this.formatBytes(task.metadata.totalSize)} | ${messageCount} | ${new Date(task.metadata.createdAt).toLocaleDateString('fr-FR')} |`;
             }).join('\n')}`);
@@ -1037,7 +1037,7 @@ ${organizedTasks.sortedTasks.map(task => {
             const tools = new Set<string>();
             const contentTypes = { user: 0, assistant: 0, tools: 0 };
 
-            const messages = task.sequence.filter((item): item is MessageSkeleton => 'role' in item);
+            const messages = (task.sequence ?? []).filter((item): item is MessageSkeleton => 'role' in item);
 
             for (const message of messages) {
                 if (message.role === 'user') {

--- a/servers/roo-state-manager/src/services/trace-summary/ContentClassifier.ts
+++ b/servers/roo-state-manager/src/services/trace-summary/ContentClassifier.ts
@@ -27,7 +27,7 @@ export class ContentClassifier {
         let index = 0;
 
         // Filtrer seulement les MessageSkeleton de la sequence
-        let messages = conversation.sequence.filter((item): item is MessageSkeleton =>
+        let messages = (conversation.sequence ?? []).filter((item): item is MessageSkeleton =>
             'role' in item && 'content' in item);
 
         // Appliquer le filtrage par plage si spécifié
@@ -41,7 +41,7 @@ export class ContentClassifier {
                 // Log pour debugging
                 console.log(`[Range Filter] Processing messages ${startIdx + 1} to ${endIdx} (${messages.length} messages)`);
             } else {
-                console.warn(`[Range Filter] Invalid range: start=${options.startIndex}, end=${options.endIndex}, total=${conversation.sequence.length}`);
+                console.warn(`[Range Filter] Invalid range: start=${options.startIndex}, end=${options.endIndex}, total=${(conversation.sequence ?? []).length}`);
             }
         }
 

--- a/servers/roo-state-manager/src/services/trace-summary/JsonCsvExporter.ts
+++ b/servers/roo-state-manager/src/services/trace-summary/JsonCsvExporter.ts
@@ -215,7 +215,7 @@ export class JsonCsvExporter {
     }
 
     private extractFirstUserMessage(conversation: ConversationSkeleton): string {
-        const userMessages = conversation.sequence.filter(item =>
+        const userMessages = (conversation.sequence ?? []).filter(item =>
             'role' in item && item.role === 'user'
         ) as MessageSkeleton[];
 
@@ -233,7 +233,7 @@ export class JsonCsvExporter {
             isContentTruncated: (content: string, maxChars: number) => boolean;
         }
     ): JsonMessageInternal[] {
-        const messages = conversation.sequence.filter(item =>
+        const messages = (conversation.sequence ?? []).filter(item =>
             'role' in item && 'content' in item
         ) as MessageSkeleton[];
 
@@ -338,7 +338,7 @@ export class JsonCsvExporter {
             'isTruncated', 'toolCount', 'workspace'
         ];
 
-        const messages = conversation.sequence.filter(item =>
+        const messages = (conversation.sequence ?? []).filter(item =>
             'role' in item && 'content' in item
         ) as MessageSkeleton[];
 
@@ -367,7 +367,7 @@ export class JsonCsvExporter {
         ];
 
         const rows: any[][] = [];
-        const messages = conversation.sequence.filter(item =>
+        const messages = (conversation.sequence ?? []).filter(item =>
             'role' in item && 'content' in item
         ) as MessageSkeleton[];
 
@@ -440,7 +440,7 @@ export class JsonCsvExporter {
             totalMessages += conv.metadata.messageCount;
             totalSize += conv.metadata.totalSize;
 
-            const messages = conv.sequence.filter(item =>
+            const messages = (conv.sequence ?? []).filter(item =>
                 'role' in item && 'content' in item
             ) as MessageSkeleton[];
 

--- a/servers/roo-state-manager/src/services/trace-summary/SummaryGenerator.ts
+++ b/servers/roo-state-manager/src/services/trace-summary/SummaryGenerator.ts
@@ -199,7 +199,7 @@ export class SummaryGenerator {
      * Calcule la taille du contenu original
      */
     public getOriginalContentSize(conversation: ConversationSkeleton): number {
-        const messages = conversation.sequence.filter((item): item is MessageSkeleton =>
+        const messages = (conversation.sequence ?? []).filter((item): item is MessageSkeleton =>
             'role' in item && 'content' in item);
 
         return messages.reduce((total: number, message: MessageSkeleton) => total + message.content.length, 0);

--- a/servers/roo-state-manager/src/tools/__tests__/view-conversation-tree.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/view-conversation-tree.test.ts
@@ -279,4 +279,66 @@ describe('viewConversationTree.handler', () => {
       expect(result.content[0].text).toContain('5');
     });
   });
+
+  // ============================================================
+  // Regression: undefined sequence (SkeletonHeader without sequence)
+  // ============================================================
+
+  describe('regression: undefined sequence (#73 incomplete fix)', () => {
+    test('does not crash when skeleton has undefined sequence', async () => {
+      // SkeletonHeaders stored in cache lack the sequence field.
+      // This must not cause "task.sequence is not iterable".
+      const skeletonWithoutSequence = {
+        taskId: 'no-seq',
+        metadata: {
+          title: 'Task without sequence',
+          messageCount: 0,
+          lastActivity: '2026-01-01T10:00:00.000Z',
+          workspace: '/test/workspace',
+          firstActivity: '2026-01-01T09:00:00.000Z',
+          actionCount: 0,
+          totalSize: 0,
+        },
+        // sequence is deliberately MISSING (undefined)
+      } as unknown as ConversationSkeleton;
+
+      const cache = makeCache([skeletonWithoutSequence]);
+
+      // Should not throw "task.sequence is not iterable"
+      const result = await viewConversationTree.handler(
+        { task_id: 'no-seq', view_mode: 'single' },
+        cache
+      );
+
+      expect(result).toBeDefined();
+      expect(result.content[0].text).toContain('no-seq');
+    });
+
+    test('does not crash with chain view when parent has no sequence', async () => {
+      const parentNoSeq = {
+        taskId: 'parent-no-seq',
+        metadata: {
+          title: 'Parent without sequence',
+          messageCount: 0,
+          lastActivity: '2026-01-01T09:00:00.000Z',
+          workspace: '/test/workspace',
+          firstActivity: '2026-01-01T08:00:00.000Z',
+          actionCount: 0,
+          totalSize: 0,
+        },
+        // no sequence
+      } as unknown as ConversationSkeleton;
+
+      const child = makeSkeleton({ taskId: 'child-with-seq', parentTaskId: 'parent-no-seq' });
+      const cache = makeCache([parentNoSeq, child]);
+
+      const result = await viewConversationTree.handler(
+        { task_id: 'child-with-seq', view_mode: 'chain' },
+        cache
+      );
+
+      expect(result).toBeDefined();
+      expect(result.content[0].text).toContain('child-with-seq');
+    });
+  });
 });

--- a/servers/roo-state-manager/src/tools/conversation/view-details.tool.ts
+++ b/servers/roo-state-manager/src/tools/conversation/view-details.tool.ts
@@ -119,7 +119,7 @@ export const viewTaskDetailsTool = {
             output += `Dernière activité: ${skeleton.metadata.lastActivity}\n\n`;
 
             // Filtrer pour ne garder que les actions (pas les messages)
-            const actions = skeleton.sequence.filter((item: any) => !('role' in item));
+            const actions = (skeleton.sequence ?? []).filter((item: any) => !('role' in item));
             
             if (actions.length === 0) {
                 output += "ℹ️ Aucune action technique trouvée dans cette tâche.\n";

--- a/servers/roo-state-manager/src/tools/search-fallback.tool.ts
+++ b/servers/roo-state-manager/src/tools/search-fallback.tool.ts
@@ -89,7 +89,7 @@ export async function handleSearchTasksSemanticFallback(
             let hasMatch = false;
             let matchText = '';
             
-            for (const item of skeleton.sequence) {
+            for (const item of skeleton.sequence ?? []) {
                 if ('content' in item && typeof item.content === 'string') {
                     const content = item.content.toLowerCase();
                     const queryLower = query.toLowerCase();
@@ -160,7 +160,7 @@ export async function handleSearchTasksSemanticFallback(
     const query = search_query.toLowerCase();
     const results: any[] = [];
 
-    for (const item of skeleton.sequence) {
+    for (const item of skeleton.sequence ?? []) {
         if (results.length >= max_results) {
             break;
         }

--- a/servers/roo-state-manager/src/tools/search/search-fallback.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-fallback.tool.ts
@@ -63,7 +63,7 @@ export async function searchFallbackTool(
       // Chercher aussi dans les messages de la séquence
       let messageMatch = false;
       if (skeleton.sequence && Array.isArray(skeleton.sequence)) {
-        messageMatch = skeleton.sequence.some((msg: any) =>
+        messageMatch = (skeleton.sequence ?? []).some((msg: any) =>
           (msg.content || msg.text) && (msg.content || msg.text).toLowerCase().includes(searchText)
 
         );

--- a/servers/roo-state-manager/src/tools/smart-truncation/content-truncator.ts
+++ b/servers/roo-state-manager/src/tools/smart-truncation/content-truncator.ts
@@ -38,7 +38,7 @@ export class ContentTruncator {
     ): ConversationSkeleton {
         const elementPlanMap = new Map(plan.elementPlans.map(ep => [ep.sequenceIndex, ep]));
         
-        const truncatedSequence = task.sequence.map((item, index) => {
+        const truncatedSequence = (task.sequence ?? []).map((item, index) => {
             const elementPlan = elementPlanMap.get(index);
             if (!elementPlan) {
                 return item; // Pas de troncature pour cet élément

--- a/servers/roo-state-manager/src/tools/smart-truncation/engine.ts
+++ b/servers/roo-state-manager/src/tools/smart-truncation/engine.ts
@@ -75,7 +75,7 @@ class SizeCalculator {
         totalSize += 200; // Approximation pour l'en-tête
         
         // Contenu de la séquence
-        for (const item of skeleton.sequence) {
+        for (const item of skeleton.sequence ?? []) {
             if ('role' in item) {
                 // Message utilisateur/assistant
                 totalSize += item.content.length + 100; // Contenu + formatage
@@ -264,7 +264,7 @@ export class SmartTruncationEngine {
         let remainingBudget = truncationBudget;
 
         // Identifier les éléments candidats à la troncature (messages centraux prioritairement)
-        const elements = task.sequence.map((item, index) => ({
+        const elements = (task.sequence ?? []).map((item, index) => ({
             index,
             item,
             size: SizeCalculator.calculateElementSize(item),

--- a/servers/roo-state-manager/src/tools/view-conversation-tree.ts
+++ b/servers/roo-state-manager/src/tools/view-conversation-tree.ts
@@ -127,7 +127,7 @@ async function handleViewConversationTreeExecutionAsync(
         output += `${indent}  Parent: ${skeleton.parentTaskId || 'None'}\n`;
         output += `${indent}  Messages: ${skeleton.metadata.messageCount}\n`;
         
-        skeleton.sequence.forEach(item => {
+        (skeleton.sequence ?? []).forEach(item => {
             if ('role' in item) { // Message user/assistant
                 const role = item.role === 'user' ? '👤 User' : '🤖 Assistant';
 
@@ -242,12 +242,12 @@ async function handleViewConversationTreeExecutionAsync(
 
         if (taskPath) {
             const fullSkeleton = await RooStorageDetector.analyzeConversation(task_id, taskPath);
-            if (fullSkeleton && fullSkeleton.sequence.length > 0) {
+            if (fullSkeleton && (fullSkeleton.sequence ?? []).length > 0) {
                 // Update the cache with complete skeleton
                 conversationCache.set(task_id, fullSkeleton);
                 // Refresh mainTask reference
                 mainTask = fullSkeleton;
-                console.log(`[view] Successfully loaded ${fullSkeleton.sequence.length} sequence items for ${task_id}`);
+                console.log(`[view] Successfully loaded ${(fullSkeleton.sequence ?? []).length} sequence items for ${task_id}`);
             } else {
                 // Task found but analyzeConversation returned null/empty
                 throw new GenericError(
@@ -499,7 +499,7 @@ function handleLegacyTruncation(
     // Utilisation du SizeCalculator du module smart-truncation pour cohérence
     const estimatedSize = tasksToDisplay.reduce((sum, task) => {
         let taskSize = 200; // En-tête de tâche
-        for (const item of task.sequence) {
+        for (const item of task.sequence ?? []) {
             if ('role' in item) {
                 taskSize += item.content.length + 100; // Message + formatage
             } else {
@@ -678,7 +678,7 @@ function createFormatTaskFunction(detail_level: string, truncate: number, curren
         output += `${indent}  Parent: ${skeleton.parentTaskId || 'None'}\n`;
         output += `${indent}  Messages: ${skeleton.metadata.messageCount}\n`;
         
-        skeleton.sequence.forEach(item => {
+        (skeleton.sequence ?? []).forEach(item => {
             if ('role' in item) { // Message user/assistant
                 const role = item.role === 'user' ? '👤 User' : '🤖 Assistant';
 


### PR DESCRIPTION
## Summary

- Adds `?? []` null-safety guards to **ALL 46** unguarded `.sequence` accesses across **15 production files**
- PR #73 only fixed 1 of 30+ occurrences, leaving `conversation_browser` crashing with `task.sequence is not iterable` when SkeletonHeaders (which lack the sequence field) are passed where ConversationSkeletons are expected
- Adds 2 regression tests that would have caught the incomplete fix

## Files changed

| File | Guards |
|------|--------|
| view-conversation-tree.ts | 5 |
| NarrativeContextBuilderService.ts | 9 |
| TraceSummaryService.ts | 6 |
| ClusterSummaryService.ts | 5 |
| JsonCsvExporter.ts | 5 |
| search-fallback.tool.ts | 3 |
| background-services.ts | 2 |
| XmlExporterService.ts | 2 |
| smart-truncation/engine.ts | 2 |
| ContentClassifier.ts | 2 |
| EnrichContentClassifier.ts | 1 |
| SummaryGenerator.ts | 1 |
| content-truncator.ts | 1 |
| view-details.tool.ts | 1 |
| search/search-fallback.tool.ts | 1 |

## Test plan

- [x] Build clean (tsc)
- [x] 7369 tests passed, 0 failed (vitest CI config)
- [x] 2 new regression tests for undefined sequence scenarios
- [x] Verified via grep: no remaining unguarded .sequence. access in production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)