### PR TITLE
fix(#788): Block synthesis at routing level

### DIFF
--- a/servers/roo-state-manager/src/tools/conversation/__tests__/conversation-browser.test.ts
+++ b/servers/roo-state-manager/src/tools/conversation/__tests__/conversation-browser.test.ts
@@ -383,36 +383,26 @@ describe('conversation_browser', () => {
 	// ============================================================
 
 	describe('action: summarize (synthesis)', () => {
-		test('delegates to handleGetConversationSynthesis with correct args', async () => {
-			mockHandleGetConversationSynthesis.mockResolvedValue({
-				taskId: 'task-synth',
-				analysisEngineVersion: '3.0.0-phase3'
+			test('synthesis is disabled and returns SYNTHESIS_DISABLED error', async () => {
+				const result = await handleConversationBrowser(
+					{
+						action: 'summarize',
+						summarize_type: 'synthesis',
+						taskId: 'task-synth'
+					} as ConversationBrowserArgs,
+					mockCache,
+					mockEnsureCache,
+					undefined,
+					mockGetSkeleton,
+					mockFindChildren
+				);
+
+				expect(result.isError).toBe(true);
+				expect(getTextContent(result)).toContain('SYNTHESIS_DISABLED');
+				expect(mockHandleGetConversationSynthesis).not.toHaveBeenCalled();
 			});
 
-			const result = await handleConversationBrowser(
-				{
-					action: 'summarize',
-					summarize_type: 'synthesis',
-					taskId: 'task-synth'
-				} as ConversationBrowserArgs,
-				mockCache,
-				mockEnsureCache,
-				undefined,
-				mockGetSkeleton,
-				mockFindChildren
-			);
-
-			expect(mockHandleGetConversationSynthesis).toHaveBeenCalledWith(
-				expect.objectContaining({
-					taskId: 'task-synth',
-					outputFormat: 'json'
-				}),
-				mockGetSkeleton
-			);
-			expect(result.isError).toBeFalsy();
-		});
-
-		test('synthesis returns error when getConversationSkeleton is missing', async () => {
+		test('synthesis disabled even when getConversationSkeleton is missing', async () => {
 			const result = await handleConversationBrowser(
 				{
 					action: 'summarize',
@@ -427,10 +417,10 @@ describe('conversation_browser', () => {
 			);
 
 			expect(result.isError).toBe(true);
-			expect(getTextContent(result)).toContain('getConversationSkeleton');
+			expect(getTextContent(result)).toContain('SYNTHESIS_DISABLED');
 		});
 
-		test('synthesis handles LLM errors gracefully', async () => {
+		test('synthesis disabled — does not reach LLM error handling', async () => {
 			mockHandleGetConversationSynthesis.mockRejectedValue(
 				new Error('LLM API connection refused')
 			);
@@ -449,7 +439,9 @@ describe('conversation_browser', () => {
 			);
 
 			expect(result.isError).toBe(true);
-			expect(getTextContent(result)).toContain('LLM API connection refused');
+			expect(getTextContent(result)).toContain('SYNTHESIS_DISABLED');
+			// Verify the LLM error handler is never reached
+			expect(mockHandleGetConversationSynthesis).not.toHaveBeenCalled();
 		});
 
 		test('synthesis is listed in the summarize_type schema enum', async () => {

--- a/servers/roo-state-manager/src/tools/conversation/conversation-browser.ts
+++ b/servers/roo-state-manager/src/tools/conversation/conversation-browser.ts
@@ -585,15 +585,17 @@ export async function handleConversationBrowser(
                 // Résoudre taskId depuis taskId ou task_id
                 const resolvedTaskId = (args.taskId || args.task_id)!;
 
-                // === Synthesis: LLM pipeline via SynthesisOrchestratorService ===
-                // Enrichment methods implemented algorithmically (Phase 2, issue #767)
+                // === Synthesis: DISABLED — LLM pipeline not yet implemented (#788) ===
+                // Synthesis requires real LLM integration (Phase 3). Stub services return
+                // null/error. Block early to prevent unnecessary service instantiation.
                 if (args.summarize_type === 'synthesis') {
-                    return await handleSynthesisAction(
-                        resolvedTaskId,
-                        args.synthesis_output_format || 'json',
-                        args.filePath,
-                        getConversationSkeleton
-                    );
+                    return {
+                        content: [{
+                            type: 'text' as const,
+                            text: 'SYNTHESIS_DISABLED: summarize_type "synthesis" requires LLM integration not yet available. Use "trace" or "cluster" instead. See issue #788.'
+                        }],
+                        isError: true
+                    };
                 }
 
                 // Resolve source for summarize: 'all' not supported, auto-detect from taskId prefix


### PR DESCRIPTION
## Summary
- Block `summarize_type: "synthesis"` at routing level in `conversation_browser`, returning `SYNTHESIS_DISABLED` immediately
- Previously, the synthesis path would instantiate `NarrativeContextBuilderService` and `SynthesisOrchestratorService` (both stubs) before failing inside their methods
- 3 tests updated to verify early guard behavior

## Context
Issue #788 Phase 1 was incomplete — synthesis was "disabled" but the routing still called through to stub services. This fix ensures zero service instantiation when synthesis is requested.

## Test plan
- [x] Build passes (`tsc` clean)
- [x] 7373 CI tests pass, 0 fail
- [x] `conversation_browser(summarize_type="synthesis")` returns `SYNTHESIS_DISABLED` immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)