### PR TITLE
fix(#1123): Dashboard parsing hardening + skeleton-cache BOM fix

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/skeleton-cache.service.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/skeleton-cache.service.test.ts
@@ -256,6 +256,21 @@ describe('SkeletonCacheService', () => {
 			const service = SkeletonCacheService.getInstance();
 			const cache = await service.getCache();
 			expect(cache.size).toBe(0);
-		});
+			});
+
+			// FIX #1123: BOM in skeleton file should be stripped before JSON.parse
+			test("loads skeleton files with UTF-8 BOM prefix", async () => {
+				mockDetectStorageLocations.mockResolvedValue(["/mock/storage"]);
+				mockStat.mockResolvedValue({ isDirectory: () => true });
+				mockReaddir.mockResolvedValue(["bom-skeleton.json"]);
+				// BOM char (0xFEFF) + valid JSON
+				const bomJson = "﻿" + JSON.stringify({ taskId: "bom-test", metadata: { mode: "code-simple" } });
+				mockReadFile.mockResolvedValue(bomJson);
+
+				const service = SkeletonCacheService.getInstance();
+				const cache = await service.getCache();
+				expect(cache.size).toBe(1);
+				expect(cache.has("bom-test")).toBe(true);
+			});
 	});
 });

--- a/servers/roo-state-manager/src/services/skeleton-cache.service.ts
+++ b/servers/roo-state-manager/src/services/skeleton-cache.service.ts
@@ -191,7 +191,11 @@ export class SkeletonCacheService {
                 for (const file of jsonFiles) {
                     try {
                         const filePath = path.join(skeletonDir, file);
-                        const content = await fs.readFile(filePath, 'utf-8');
+                        let content = await fs.readFile(filePath, 'utf-8');
+                        // FIX #1123: Strip UTF-8 BOM if present (Windows editors can add it)
+                        if (content.charCodeAt(0) === 0xFEFF) {
+                            content = content.slice(1);
+                        }
                         const skeleton: ConversationSkeleton = JSON.parse(content);
 
                         if (skeleton.taskId) {

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
@@ -521,4 +521,75 @@ describe('roosync_dashboard', () => {
     const hasCondensationTag = messages?.some(m => m.tags?.includes('CONDENSATION'));
     expect(hasCondensationTag).toBe(false);
   });
+
+  // === Test 32: Content with ### [ prefix doesn't break parsing (#1123) ===
+  it('preserves message content containing ### [ at line start', async () => {
+    await roosyncDashboard({ action: 'write', type: 'global', content: '# Init', createIfNotExists: true });
+
+    // Message with ### [ in content — this used to cause false message splits
+    const maliciousContent = 'Normal text\n\n### [This looks like a header]\n\nMore text';
+    await roosyncDashboard({
+      action: 'append',
+      type: 'global',
+      content: maliciousContent,
+      tags: ['INFO']
+    });
+
+    // Add a second message to verify split didn't corrupt
+    await roosyncDashboard({
+      action: 'append',
+      type: 'global',
+      content: 'Second message'
+    });
+
+    const result = await roosyncDashboard({ action: 'read', type: 'global', section: 'intercom' });
+    const messages = result.data?.intercom?.messages;
+
+    expect(messages.length).toBe(2);
+    // First message should preserve the ### [ content exactly
+    expect(messages[0].content).toBe(maliciousContent);
+    expect(messages[1].content).toBe('Second message');
+  });
+
+  // === Test 33: Content with --- separator doesn't break parsing ===
+  it('preserves message content containing --- separator', async () => {
+    await roosyncDashboard({ action: 'write', type: 'global', content: '# Init', createIfNotExists: true });
+
+    const contentWithDashes = 'Some text\n---\nMore text after dash separator';
+    await roosyncDashboard({
+      action: 'append',
+      type: 'global',
+      content: contentWithDashes
+    });
+
+    await roosyncDashboard({
+      action: 'append',
+      type: 'global',
+      content: 'After'
+    });
+
+    const result = await roosyncDashboard({ action: 'read', type: 'global', section: 'intercom' });
+    const messages = result.data?.intercom?.messages;
+
+    expect(messages.length).toBe(2);
+    expect(messages[0].content).toBe(contentWithDashes);
+  });
+
+  // === Test 34: Content with pipe | in body preserves correctly ===
+  it('preserves message content containing pipe characters', async () => {
+    await roosyncDashboard({ action: 'write', type: 'global', content: '# Init', createIfNotExists: true });
+
+    const contentWithPipes = 'Column A | Column B | Column C\n--- | --- | ---\n1 | 2 | 3';
+    await roosyncDashboard({
+      action: 'append',
+      type: 'global',
+      content: contentWithPipes
+    });
+
+    const result = await roosyncDashboard({ action: 'read', type: 'global', section: 'intercom' });
+    const messages = result.data?.intercom?.messages;
+
+    expect(messages.length).toBe(1);
+    expect(messages[0].content).toBe(contentWithPipes);
+  });
 });

--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -239,11 +239,13 @@ async function readDashboardFile(key: string): Promise<Dashboard | null> {
           const [, timestamp, machineId, workspace, , tagsStr, content] = headerMatch;
           // tagsStr (groupe 5) contient déjà les tags sans les crochets: "WARN, SYSTEM"
           const tags = tagsStr ? tagsStr.split(', ').map(t => t.trim()) : [];
+          // FIX #1123: Unescape "### [" that was escaped during write to prevent false splits
+          const unescapedContent = content.trim().replace(/^\\#\\#\\# \[/gm, '### [');
           messages.push({
             id: generateMessageId(), // ID regénéré (pas stocké dans le format markdown)
             timestamp,
             author: { machineId: machineId.trim(), workspace: workspace.trim() },
-            content: content.trim(),
+            content: unescapedContent,
             tags: tags.length > 0 ? tags : undefined
           });
         }
@@ -294,10 +296,13 @@ async function writeDashboardFile(key: string, dashboard: Dashboard): Promise<vo
   const statusSection = dashboard.status.markdown || '*Aucun contenu.*';
 
   // Construire la section intercom (messages en markdown)
+  // FIX #1123: Escape "### [" at line start in content to prevent false message splits
+  const escapeContent = (text: string): string =>
+    text.replace(/^### \[/gm, '\\#\\#\\# [');
   const intercomSection = dashboard.intercom.messages.length > 0
     ? dashboard.intercom.messages.map(msg => {
         const tags = msg.tags?.length ? ` [${msg.tags.join(', ')}]` : '';
-        return `### [${msg.timestamp}] ${msg.author.machineId}|${msg.author.workspace}${tags}\n\n${msg.content}`;
+        return `### [${msg.timestamp}] ${msg.author.machineId}|${msg.author.workspace}${tags}\n\n${escapeContent(msg.content)}`;
       }).join('\n\n---\n\n')
     : '*Aucun message.*';
 


### PR DESCRIPTION
## Summary
- **Dashboard**: Escape `### [` in message content during write to prevent false message splits when content contains markdown headers. Unescape on read to preserve original.
- **Skeleton-cache**: Strip UTF-8 BOM before `JSON.parse` — inconsistency with other readers that already strip BOM (list-conversations.tool.ts, build-skeleton-cache.tool.ts).

## Test plan
- [x] 3 new dashboard tests: `### [` in content, `---` separator, `|` pipe characters
- [x] 1 new skeleton-cache test: BOM-prefixed skeleton file
- [x] Build passes
- [x] All CI tests pass (414 files, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)