### PR TITLE
fix(#1244): Repair 3-layer cross-machine conversation investigation pipeline

### DIFF
--- a/servers/roo-state-manager/src/index.ts
+++ b/servers/roo-state-manager/src/index.ts
@@ -70,8 +70,9 @@ const packageJson = require('../package.json');
 let _stateManagerModule: typeof import('./services/state-manager.service.js') | null = null;
 let _serverHelpersModule: typeof import('./utils/server-helpers.js') | null = null;
 let _backgroundServicesModule: typeof import('./services/background-services.js') | null = null;
-let _rooStorageModule: typeof import('./utils/roo-storage-detector.js') | null = null;
-let _claudeStorageModule: typeof import('./utils/claude-storage-detector.js') | null = null;
+// #1244: _rooStorageModule and _claudeStorageModule removed — the synchronous
+// failsafe that loaded them is gone. Worker A in background-services handles
+// all freshness via 2-min incremental mtime scans.
 
 async function getStateManager() {
     if (!_stateManagerModule) _stateManagerModule = await import('./services/state-manager.service.js');
@@ -281,136 +282,105 @@ class RooStateManagerServer {
             }
         );
 
-        // Wrapper pour tronquer les résultats ET activer l'intercepteur de notifications
+        // Wrapper pour tronquer les résultats, mesurer la durée d'exécution,
+        // et activer l'intercepteur de notifications
         const originalCallTool = this.server['_requestHandlers'].get('tools/call');
         if (originalCallTool) {
             this.server['_requestHandlers'].set('tools/call', async (request: any) => {
+                // #1245: Measure wall-clock duration of every tool call (visible in output)
+                const startMs = Date.now();
+                const toolName: string | undefined = request?.params?.name;
+
                 // Ensure state is initialized before first tool call
                 await this.ensureInitialized();
 
                 const helpers = await getServerHelpers();
 
+                let result;
                 if (this.toolInterceptor) {
-                    const wrappedResult = await this.toolInterceptor.interceptToolCall(
+                    result = await this.toolInterceptor.interceptToolCall(
                         request.params.name,
                         request.params.arguments,
                         async () => await originalCallTool(request)
                     );
-                    return helpers.truncateResult(wrappedResult);
                 } else {
-                    const result = await originalCallTool(request);
-                    return helpers.truncateResult(result);
+                    result = await originalCallTool(request);
                 }
+
+                const durationMs = Date.now() - startMs;
+                // Inject duration AFTER truncation so the footer is never cut off.
+                return helpers.injectDuration(helpers.truncateResult(result), durationMs, toolName);
             });
         }
     }
 
     /**
-     * FAILSAFE: Ensure skeleton cache is fresh and up-to-date
+     * #1244: Fast freshness check (formerly synchronous failsafe).
+     *
+     * The actual heavy work — scanning task directories for modified files,
+     * rebuilding skeletons, regenerating the index — is done by Worker A
+     * (`startSkeletonRefreshWorker` in `services/background-services.ts`) on a
+     * 2-minute interval. Worker A is started at MCP startup via
+     * `initializeBackgroundServices()` and uses `state.lastSkeletonRefreshAt`
+     * as a checkpoint for incremental mtime-based scans (only files newer than
+     * the last tick are read).
+     *
+     * This method is now a fast no-op safety net:
+     *   - Throttled to once per minute.
+     *   - If state is not initialized yet, return immediately. The CallTool
+     *     wrapper already awaits `ensureInitialized()` before any tool runs.
+     *   - If the cache is empty (rare edge case: first run, index missing,
+     *     background load not finished), schedule a background populate via
+     *     `setImmediate`. NEVER await it.
+     *   - Otherwise, return immediately (< 5ms total).
+     *
+     * Foreground tools must NOT depend on this method to provide freshness.
+     * Freshness is guaranteed by Worker A's 2-minute periodic refresh.
      */
     private async ensureSkeletonCacheIsFresh(args?: { workspace?: string }): Promise<boolean> {
         try {
-            // #883: Throttle to avoid repeated I/O scans
+            // #883: Throttle to avoid burning cycles on repeated checks
             const checkTime = Date.now();
             if (this.lastCacheCheckAt > 0 && (checkTime - this.lastCacheCheckAt) < RooStateManagerServer.CACHE_CHECK_THROTTLE_MS) {
                 return false;
             }
             this.lastCacheCheckAt = checkTime;
 
-            const sm = await this.ensureInitialized();
+            // Do NOT await ensureInitialized() here — that's the caller's job
+            // (the CallTool wrapper already does it). We work with whatever
+            // state is currently ready, no blocking I/O on the foreground path.
+            const sm = this.stateManager;
+            if (!sm) return false;
+
             const state = sm.getState();
 
-            if (state.conversationCache.size === 0) {
-                logger.info('[FAILSAFE] Cache empty, triggering differential rebuild...');
-                const { handleBuildSkeletonCache } = await import('./tools/index.js');
-                await handleBuildSkeletonCache({
-                    force_rebuild: false,
-                    workspace_filter: args?.workspace
-                }, state.conversationCache as any);
-                return true;
-            }
-
-            // Check for new tasks
-            if (!_rooStorageModule) _rooStorageModule = await import('./utils/roo-storage-detector.js');
-            const storageLocations = await _rooStorageModule.RooStorageDetector.detectStorageLocations();
-            if (storageLocations.length === 0) {
+            // Happy path: Worker A is keeping the cache fresh. Nothing to do.
+            if (state.conversationCache.size > 0) {
                 return false;
             }
 
-            let needsUpdate = false;
-            const now = Date.now();
-            const CACHE_VALIDITY_MS = 60 * 60 * 1000; // 1 hour
-
-            const { promises: fs } = await import('fs');
-
-            for (const location of storageLocations) {
-                try {
-                    const tasksDir = path.join(location, 'tasks');
-                    const conversationDirs = await fs.readdir(tasksDir, { withFileTypes: true });
-                    for (const convDir of conversationDirs) {
-                        if (convDir.isDirectory() && convDir.name !== '.skeletons') {
-                            const metadataPath = path.join(tasksDir, convDir.name, 'task_metadata.json');
-                            try {
-                                const metadataStat = await fs.stat(metadataPath);
-                                const ageMs = now - metadataStat.mtime.getTime();
-                                if (ageMs < CACHE_VALIDITY_MS && !state.conversationCache.has(convDir.name)) {
-                                    needsUpdate = true;
-                                    break;
-                                }
-                            } catch { /* ignore stat errors */ }
-                        }
+            // Edge case: cache empty — first run, missing index, or background
+            // load still in progress. Schedule a background populate so the next
+            // tool call has data. NEVER await it.
+            logger.info('[FAILSAFE] Cache empty — scheduling background populate (non-blocking)');
+            setImmediate(() => {
+                (async () => {
+                    try {
+                        const { handleBuildSkeletonCache } = await import('./tools/index.js');
+                        await handleBuildSkeletonCache({
+                            force_rebuild: false,
+                            workspace_filter: args?.workspace
+                        }, state.conversationCache as any);
+                        logger.info('[FAILSAFE] Background populate complete');
+                    } catch (error) {
+                        logger.warn('[FAILSAFE] Background populate failed (non-blocking):', { error });
                     }
-                    if (needsUpdate) break;
-                } catch (readdirError) {
-                    logger.warn(`[FAILSAFE] Could not read directory ${location}:`, { error: readdirError });
-                }
-            }
-
-            // Check Claude Code sessions
-            if (!needsUpdate) {
-                try {
-                    if (!_claudeStorageModule) _claudeStorageModule = await import('./utils/claude-storage-detector.js');
-                    const claudeLocations = await _claudeStorageModule.ClaudeStorageDetector.detectStorageLocations();
-                    const seenProjects = new Set<string>();
-
-                    for (const location of claudeLocations) {
-                        if (seenProjects.has(location.projectPath)) continue;
-                        seenProjects.add(location.projectPath);
-
-                        try {
-                            const files = (await fs.readdir(location.projectPath)).filter((f: string) => f.endsWith('.jsonl'));
-                            for (const file of files) {
-                                try {
-                                    const taskId = `claude-${file.replace('.jsonl', '')}`;
-                                    const filePath = path.join(location.projectPath, file);
-                                    const fileStat = await fs.stat(filePath);
-                                    if ((now - fileStat.mtime.getTime()) < CACHE_VALIDITY_MS && !state.conversationCache.has(taskId)) {
-                                        needsUpdate = true;
-                                        break;
-                                    }
-                                } catch { /* skip */ }
-                            }
-                            if (needsUpdate) break;
-                        } catch { /* skip */ }
-                    }
-                } catch (claudeError) {
-                    logger.warn('[FAILSAFE] Error checking Claude sessions:', { error: claudeError });
-                }
-            }
-
-            if (needsUpdate) {
-                logger.info('[FAILSAFE] Cache outdated, triggering differential rebuild...');
-                const { handleBuildSkeletonCache: rebuildCache } = await import('./tools/index.js');
-                await rebuildCache({
-                    force_rebuild: false,
-                    workspace_filter: args?.workspace
-                }, state.conversationCache as any);
-                return true;
-            }
+                })();
+            });
 
             return false;
         } catch (error) {
-            logger.error('[FAILSAFE] Error checking skeleton cache freshness:', { error });
+            logger.error('[FAILSAFE] Error in fast freshness check:', { error });
             return false;
         }
     }

--- a/servers/roo-state-manager/src/services/__tests__/skeleton-cache.service.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/skeleton-cache.service.test.ts
@@ -32,6 +32,33 @@ vi.mock('fs', () => ({
 	}
 }));
 
+// #1244 Couche 1.1 — Mocks pour les tiers multi-source
+const {
+	mockClaudeDetectLocations,
+	mockClaudeAnalyzeConversation,
+	mockListArchivedTasks,
+	mockReadArchivedTask,
+} = vi.hoisted(() => ({
+	mockClaudeDetectLocations: vi.fn(),
+	mockClaudeAnalyzeConversation: vi.fn(),
+	mockListArchivedTasks: vi.fn(),
+	mockReadArchivedTask: vi.fn(),
+}));
+
+vi.mock('../../utils/claude-storage-detector.js', () => ({
+	ClaudeStorageDetector: {
+		detectStorageLocations: mockClaudeDetectLocations,
+		analyzeConversation: mockClaudeAnalyzeConversation,
+	}
+}));
+
+vi.mock('../task-archiver/index.js', () => ({
+	TaskArchiver: {
+		listArchivedTasks: mockListArchivedTasks,
+		readArchivedTask: mockReadArchivedTask,
+	}
+}));
+
 import { SkeletonCacheService } from '../skeleton-cache.service.js';
 
 describe('SkeletonCacheService', () => {
@@ -272,5 +299,197 @@ describe('SkeletonCacheService', () => {
 				expect(cache.size).toBe(1);
 				expect(cache.has("bom-test")).toBe(true);
 			});
+	});
+
+	// ============================================================
+	// #1244 Couche 1.1 — Multi-tier cache (Claude local + archives GDrive)
+	// ============================================================
+
+	describe('#1244 multi-tier cache', () => {
+		// Tier 1 baseline shared by all tier tests below
+		const setupTier1 = (taskIds: string[] = []) => {
+			mockDetectStorageLocations.mockResolvedValue(['/mock/storage']);
+			mockStat.mockResolvedValue({ isDirectory: () => true });
+			mockReaddir.mockResolvedValue(taskIds.map(id => `${id}.json`));
+			for (const id of taskIds) {
+				mockReadFile.mockResolvedValueOnce(JSON.stringify({ taskId: id, metadata: { source: 'roo' } }));
+			}
+		};
+
+		test('default config: neither Claude tier nor archive tier are loaded', async () => {
+			setupTier1(['roo-1']);
+			// Even if the mocks would return data, opt-in is required
+			mockClaudeDetectLocations.mockResolvedValue([{ projectPath: '/home/user/.claude/projects/proj-x' }]);
+			mockListArchivedTasks.mockResolvedValue(['archived-1']);
+
+			const service = SkeletonCacheService.getInstance();
+			await service.getCache();
+
+			expect(mockClaudeDetectLocations).not.toHaveBeenCalled();
+			expect(mockListArchivedTasks).not.toHaveBeenCalled();
+		});
+
+		test('configure({ enableClaudeTier: true }) loads Tier 2', async () => {
+			setupTier1(['roo-1']);
+			mockClaudeDetectLocations.mockResolvedValue([
+				{ projectPath: '/home/user/.claude/projects/proj-alpha' }
+			]);
+			mockClaudeAnalyzeConversation.mockResolvedValue({
+				taskId: 'claude-proj-alpha',
+				metadata: { title: 'Alpha session' },
+				sequence: [{ role: 'user', content: 'hello', timestamp: '2026-01-01T00:00:00Z' }]
+			});
+
+			SkeletonCacheService.configure({ enableClaudeTier: true });
+			const service = SkeletonCacheService.getInstance();
+			const cache = await service.getCache();
+
+			expect(mockClaudeDetectLocations).toHaveBeenCalled();
+			expect(mockClaudeAnalyzeConversation).toHaveBeenCalledWith(
+				'claude-proj-alpha',
+				'/home/user/.claude/projects/proj-alpha'
+			);
+			expect(cache.has('roo-1')).toBe(true);
+			expect(cache.has('claude-proj-alpha')).toBe(true);
+			expect(cache.get('claude-proj-alpha')!.metadata.source).toBe('claude-code');
+			expect(cache.get('claude-proj-alpha')!.metadata.dataSource).toBe('claude');
+		});
+
+		test('Tier 2 collision with Tier 1: local Roo wins', async () => {
+			// Tier 1 already has 'claude-proj-alpha' (unusual but possible if user names it that way)
+			setupTier1(['claude-proj-alpha']);
+			mockClaudeDetectLocations.mockResolvedValue([
+				{ projectPath: '/home/user/.claude/projects/proj-alpha' }
+			]);
+			// Should NOT be called because cache.has('claude-proj-alpha') is already true
+			mockClaudeAnalyzeConversation.mockResolvedValue({
+				taskId: 'claude-proj-alpha',
+				metadata: { title: 'SHOULD NOT OVERWRITE' },
+				sequence: [{ role: 'user', content: 'x', timestamp: '2026-01-01T00:00:00Z' }]
+			});
+
+			SkeletonCacheService.configure({ enableClaudeTier: true });
+			const service = SkeletonCacheService.getInstance();
+			const cache = await service.getCache();
+
+			expect(cache.has('claude-proj-alpha')).toBe(true);
+			// Tier 1 metadata preserved (source roo, not the Claude title)
+			expect(cache.get('claude-proj-alpha')!.metadata.source).toBe('roo');
+			expect(mockClaudeAnalyzeConversation).not.toHaveBeenCalled();
+		});
+
+		test('Tier 2 failure does not break Tier 1 loading', async () => {
+			setupTier1(['roo-1']);
+			mockClaudeDetectLocations.mockRejectedValue(new Error('Claude detector boom'));
+
+			SkeletonCacheService.configure({ enableClaudeTier: true });
+			const service = SkeletonCacheService.getInstance();
+			const cache = await service.getCache();
+
+			// Tier 1 still works despite Tier 2 failure
+			expect(cache.has('roo-1')).toBe(true);
+			expect(cache.size).toBe(1);
+		});
+
+		test('configure({ enableArchiveTier: true }) loads Tier 3', async () => {
+			setupTier1(['roo-1']);
+			mockListArchivedTasks.mockResolvedValue(['archived-task-A', 'archived-task-B']);
+			mockReadArchivedTask
+				.mockResolvedValueOnce({
+					version: 1,
+					taskId: 'archived-task-A',
+					machineId: 'myia-po-2025',
+					hostIdentifier: 'host-1',
+					archivedAt: '2026-04-01T12:00:00Z',
+					metadata: { title: 'Archived A', source: 'roo' },
+					messages: [{ role: 'user', content: 'archived msg', timestamp: '2026-04-01T11:59:00Z' }]
+				})
+				.mockResolvedValueOnce({
+					version: 1,
+					taskId: 'archived-task-B',
+					machineId: 'myia-web1',
+					hostIdentifier: 'host-2',
+					archivedAt: '2026-04-02T12:00:00Z',
+					metadata: { title: 'Archived B', source: 'claude-code' },
+					messages: []
+				});
+
+			SkeletonCacheService.configure({ enableArchiveTier: true });
+			const service = SkeletonCacheService.getInstance();
+			const cache = await service.getCache();
+
+			expect(mockListArchivedTasks).toHaveBeenCalled();
+			expect(mockReadArchivedTask).toHaveBeenCalledTimes(2);
+			expect(cache.has('roo-1')).toBe(true);
+			expect(cache.has('archived-task-A')).toBe(true);
+			expect(cache.has('archived-task-B')).toBe(true);
+			expect(cache.get('archived-task-A')!.metadata.dataSource).toBe('archive');
+			expect(cache.get('archived-task-A')!.metadata.machineId).toBe('myia-po-2025');
+		});
+
+		test('Tier 3 collision with Tier 1: local Roo wins, archive skipped', async () => {
+			setupTier1(['shared-id']);
+			mockListArchivedTasks.mockResolvedValue(['shared-id']);
+			// Should NOT be called because Tier 1 already has 'shared-id'
+			mockReadArchivedTask.mockResolvedValue({
+				version: 1,
+				taskId: 'shared-id',
+				machineId: 'remote-machine',
+				hostIdentifier: 'h',
+				archivedAt: '2026-04-01T00:00:00Z',
+				metadata: { title: 'SHOULD NOT OVERWRITE' },
+				messages: []
+			});
+
+			SkeletonCacheService.configure({ enableArchiveTier: true });
+			const service = SkeletonCacheService.getInstance();
+			const cache = await service.getCache();
+
+			expect(cache.has('shared-id')).toBe(true);
+			// Tier 1 entry preserved — no machineId from archive
+			expect(cache.get('shared-id')!.metadata.machineId).toBeUndefined();
+			expect(mockReadArchivedTask).not.toHaveBeenCalled();
+		});
+
+		test('Tier 3 failure (e.g. ROOSYNC_SHARED_PATH unset) does not break Tier 1', async () => {
+			setupTier1(['roo-1']);
+			mockListArchivedTasks.mockRejectedValue(new Error('ROOSYNC_SHARED_PATH not set'));
+
+			SkeletonCacheService.configure({ enableArchiveTier: true });
+			const service = SkeletonCacheService.getInstance();
+			const cache = await service.getCache();
+
+			expect(cache.has('roo-1')).toBe(true);
+			expect(cache.size).toBe(1);
+		});
+
+		test('reset() clears the static config (so next test starts clean)', async () => {
+			setupTier1([]);
+			mockClaudeDetectLocations.mockResolvedValue([]);
+
+			SkeletonCacheService.configure({ enableClaudeTier: true });
+			SkeletonCacheService.reset();
+
+			const service = SkeletonCacheService.getInstance();
+			await service.getCache();
+
+			// After reset, config is empty → Claude tier should NOT have been called
+			expect(mockClaudeDetectLocations).not.toHaveBeenCalled();
+		});
+
+		test('configure() merges flags across calls (idempotent)', async () => {
+			setupTier1(['roo-1']);
+			mockClaudeDetectLocations.mockResolvedValue([]);
+			mockListArchivedTasks.mockResolvedValue([]);
+
+			SkeletonCacheService.configure({ enableClaudeTier: true });
+			SkeletonCacheService.configure({ enableArchiveTier: true });
+			// Both flags should now be active
+			const service = SkeletonCacheService.getInstance();
+			await service.getCache();
+
+			expect(mockClaudeDetectLocations).toHaveBeenCalled();
+			expect(mockListArchivedTasks).toHaveBeenCalled();
+		});
 	});
 });

--- a/servers/roo-state-manager/src/services/archive-skeleton-builder.ts
+++ b/servers/roo-state-manager/src/services/archive-skeleton-builder.ts
@@ -1,0 +1,59 @@
+/**
+ * Archive → ConversationSkeleton conversion helper.
+ *
+ * Issue #1244 - Couche 1.1: Multi-tier skeleton cache
+ *
+ * Converts an `ArchivedTask` (cross-machine archive format on GDrive) into a
+ * `ConversationSkeleton` so it can be merged into the standard skeleton cache.
+ *
+ * The archive format is intentionally minimal (metadata + plain messages) and
+ * loses tool/action structure. We surface that by marking each message as
+ * `isTruncated: false` (the archive content is what we have) and producing zero
+ * action metadata. The `dataSource: 'archive'` marker on the metadata lets
+ * downstream tools know this skeleton came from a cold-tier source.
+ */
+
+import { ConversationSkeleton, MessageSkeleton } from '../types/conversation.js';
+import { ArchivedTask } from './task-archiver/types.js';
+
+/**
+ * Convert an `ArchivedTask` (cross-machine GDrive archive) into a `ConversationSkeleton`.
+ *
+ * Notes:
+ * - Messages keep their role/content/timestamp from the archive.
+ * - `metadata.dataSource = 'archive'` flags this skeleton as cold-tier.
+ * - `metadata.machineId` is preserved from the archive (cross-machine attribution).
+ * - `actionCount` and `totalSize` are 0 because the archive does not contain
+ *   tool/action metadata or original byte sizes.
+ */
+export function archiveToSkeleton(archive: ArchivedTask): ConversationSkeleton {
+    const sequence: MessageSkeleton[] = (archive.messages || []).map(msg => ({
+        role: msg.role,
+        content: msg.content,
+        timestamp: msg.timestamp || archive.archivedAt,
+        isTruncated: false,
+    }));
+
+    const fallbackTimestamp = archive.archivedAt;
+
+    return {
+        taskId: archive.taskId,
+        parentTaskId: archive.metadata?.parentTaskId,
+        isCompleted: archive.metadata?.isCompleted ?? false,
+        metadata: {
+            title: archive.metadata?.title,
+            workspace: archive.metadata?.workspace,
+            mode: archive.metadata?.mode,
+            createdAt: archive.metadata?.createdAt ?? fallbackTimestamp,
+            lastActivity: archive.metadata?.lastActivity ?? fallbackTimestamp,
+            messageCount: archive.metadata?.messageCount ?? sequence.length,
+            actionCount: 0,
+            totalSize: 0,
+            machineId: archive.machineId,
+            source: archive.metadata?.source ?? 'roo',
+            parentTaskId: archive.metadata?.parentTaskId,
+            dataSource: 'archive',
+        },
+        sequence,
+    };
+}

--- a/servers/roo-state-manager/src/services/skeleton-cache.service.ts
+++ b/servers/roo-state-manager/src/services/skeleton-cache.service.ts
@@ -1,6 +1,20 @@
 /**
  * Service de gestion centralisée du cache de squelettes de conversations
  * Permet un accès global au cache pour les outils externalisés
+ *
+ * Issue #1244 - Couche 1.1: Multi-tier cache
+ *  Tier 1 (Roo local)        — toujours actif (existant)
+ *  Tier 2 (Claude local)     — opt-in via configure({ enableClaudeTier: true })
+ *  Tier 3 (Archives GDrive)  — opt-in via configure({ enableArchiveTier: true })
+ *
+ * L'opt-in est volontaire pour deux raisons:
+ *  1. Eviter de polluer les tests existants qui ne mockent que `RooStorageDetector` + `fs`.
+ *     `ClaudeStorageDetector` utilise `fs/promises` (non mocké), `TaskArchiver` necessite
+ *     `ROOSYNC_SHARED_PATH` set. Sans opt-in, les tests existants resteraient verts.
+ *  2. Permettre au code de production (index.ts startup) d'activer explicitement les tiers
+ *     selon la disponibilite des dependances (ex: archives uniquement si GDrive monte).
+ *
+ * Priorite de merge en cas de collision de taskId: local (Tier 1/2) > archive (Tier 3).
  */
 
 import { ConversationSkeleton } from '../types/conversation.js';
@@ -11,16 +25,42 @@ import { promises as fs } from 'fs';
 const SKELETON_CACHE_DIR_NAME = '.skeletons';
 
 /**
+ * Configuration optionnelle pour activer les tiers cache supplementaires.
+ * Defaut: tous desactives (Tier 1 Roo local uniquement, comportement historique).
+ */
+export interface SkeletonCacheServiceConfig {
+    /** Activer le chargement des sessions Claude Code locales (~/.claude/projects/) */
+    enableClaudeTier?: boolean;
+    /** Activer le chargement des archives cross-machine depuis GDrive (.shared-state/task-archive/) */
+    enableArchiveTier?: boolean;
+}
+
+/**
  * Service singleton pour gérer le cache des squelettes de conversations
  */
 export class SkeletonCacheService {
     private static instance: SkeletonCacheService | null = null;
+    private static config: SkeletonCacheServiceConfig = {};
     private cache: Map<string, ConversationSkeleton> = new Map();
     private lastRefreshTime: number = 0;
     private readonly CACHE_VALIDITY_MS = 30 * 60 * 1000; // 30 minutes (was 5min, increased for stability)
 
     private constructor() {
         // Constructor privé pour pattern singleton
+    }
+
+    /**
+     * Configurer les tiers cache optionnels (Claude local, archives GDrive).
+     *
+     * A appeler depuis index.ts au demarrage du serveur, AVANT toute utilisation
+     * du cache. Sans appel, seul le Tier 1 (Roo local) est actif - comportement
+     * historique preserve pour la backward compatibility.
+     *
+     * Idempotent: les appels successifs fusionnent les flags (les anciens flags
+     * sont preserves sauf s'ils sont explicitement override).
+     */
+    public static configure(config: SkeletonCacheServiceConfig): void {
+        SkeletonCacheService.config = { ...SkeletonCacheService.config, ...config };
     }
 
     /**
@@ -214,6 +254,17 @@ export class SkeletonCacheService {
 
             // FIX #623: Build missing skeletons for conversations that don't have one yet
             await this.buildMissingSkeletons(tasksDir, skeletonDir);
+
+            // #1244 Couche 1.1 — Tiers optionnels (opt-in via configure())
+            // L'opt-in evite de polluer les tests existants qui ne mockent que Tier 1.
+            // En production, index.ts active explicitement les tiers selon la dispo
+            // des dependances (ROOSYNC_SHARED_PATH pour archives, etc).
+            if (SkeletonCacheService.config.enableClaudeTier) {
+                await this.loadClaudeSessionsFromDisk();
+            }
+            if (SkeletonCacheService.config.enableArchiveTier) {
+                await this.loadArchivedSkeletonsFromGDrive();
+            }
         } catch (error) {
             console.error('[SkeletonCacheService] Erreur lors du chargement des skeletons:', error);
         }
@@ -301,9 +352,124 @@ export class SkeletonCacheService {
     }
 
     /**
+     * #1244 Couche 1.1 — Tier 2: Charger les sessions Claude Code locales.
+     *
+     * Lit `~/.claude/projects/<project>/` via `ClaudeStorageDetector`, construit
+     * un squelette par projet (un seul taskId `claude-<basename(projectPath)>`),
+     * et l'insere dans le cache. Les collisions de taskId sont resolues en
+     * faveur du cache existant (Tier 1 a deja la priorite — local Roo > local Claude).
+     *
+     * Pattern de reference: `background-services.ts:loadClaudeCodeSessions()`.
+     * Marque chaque squelette avec `metadata.source = 'claude-code'` et
+     * `metadata.dataSource = 'claude'` pour permettre le filtrage downstream.
+     *
+     * No-op silencieux si le detecteur Claude echoue (non-bloquant).
+     */
+    private async loadClaudeSessionsFromDisk(): Promise<void> {
+        try {
+            const { ClaudeStorageDetector } = await import('../utils/claude-storage-detector.js');
+            const locations = await ClaudeStorageDetector.detectStorageLocations();
+
+            if (locations.length === 0) {
+                console.log('[SkeletonCacheService] Tier 2 (Claude): aucun repertoire de projets trouve');
+                return;
+            }
+
+            let loaded = 0;
+            for (const location of locations) {
+                try {
+                    const taskId = `claude-${path.basename(location.projectPath)}`;
+
+                    // Tier 1 (Roo local) a la priorite — ne pas ecraser
+                    if (this.cache.has(taskId)) continue;
+
+                    const skeleton = await ClaudeStorageDetector.analyzeConversation(
+                        taskId, location.projectPath
+                    );
+                    if (skeleton && (skeleton.sequence ?? []).length > 0) {
+                        if (!skeleton.metadata) skeleton.metadata = {} as any;
+                        skeleton.metadata.source = 'claude-code';
+                        skeleton.metadata.dataSource = 'claude';
+                        this.cache.set(taskId, skeleton);
+                        loaded++;
+                    }
+                } catch (error) {
+                    console.warn(`[SkeletonCacheService] Tier 2 (Claude): echec ${location.projectPath}:`, error);
+                }
+            }
+
+            console.log(`[SkeletonCacheService] Tier 2 (Claude): ${loaded} sessions chargees depuis ${locations.length} projets`);
+        } catch (error) {
+            console.warn('[SkeletonCacheService] Tier 2 (Claude): chargement non-bloquant a echoue:', error);
+        }
+    }
+
+    /**
+     * #1244 Couche 1.1 — Tier 3: Charger les archives cross-machine depuis GDrive.
+     *
+     * Lit `.shared-state/task-archive/<machineId>/<taskId>.json.gz` via
+     * `TaskArchiver`, convertit chaque archive en `ConversationSkeleton` via
+     * `archiveToSkeleton()`, et merge dans le cache. Les collisions sont
+     * resolues en faveur des tiers chauds (local Roo/Claude > archive remote).
+     *
+     * Necessite `ROOSYNC_SHARED_PATH` (sinon `getSharedStatePath()` throw —
+     * capture par le try/catch global, no-op silencieux).
+     *
+     * **Attention scale:** Peut charger des milliers d'archives. Activable
+     * uniquement en production via `configure({ enableArchiveTier: true })`.
+     */
+    private async loadArchivedSkeletonsFromGDrive(): Promise<void> {
+        try {
+            const { TaskArchiver } = await import('./task-archiver/index.js');
+            const { archiveToSkeleton } = await import('./archive-skeleton-builder.js');
+
+            const taskIds = await TaskArchiver.listArchivedTasks();
+
+            if (taskIds.length === 0) {
+                console.log('[SkeletonCacheService] Tier 3 (archives): aucune archive trouvee');
+                return;
+            }
+
+            let loaded = 0;
+            let skippedCollision = 0;
+            let failed = 0;
+
+            for (const taskId of taskIds) {
+                // Tiers chauds (Roo local + Claude local) ont la priorite
+                if (this.cache.has(taskId)) {
+                    skippedCollision++;
+                    continue;
+                }
+
+                try {
+                    const archive = await TaskArchiver.readArchivedTask(taskId);
+                    if (!archive) {
+                        failed++;
+                        continue;
+                    }
+                    const skeleton = archiveToSkeleton(archive);
+                    this.cache.set(skeleton.taskId, skeleton);
+                    loaded++;
+                } catch (error) {
+                    failed++;
+                    console.warn(`[SkeletonCacheService] Tier 3 (archives): echec lecture ${taskId}:`, error);
+                }
+            }
+
+            console.log(
+                `[SkeletonCacheService] Tier 3 (archives): ${loaded} chargees, ` +
+                `${skippedCollision} collisions ignorees (local prioritaire), ${failed} echecs sur ${taskIds.length} total`
+            );
+        } catch (error) {
+            console.warn('[SkeletonCacheService] Tier 3 (archives): chargement non-bloquant a echoue:', error);
+        }
+    }
+
+    /**
      * Réinitialiser le service (pour tests)
      */
     public static reset(): void {
         SkeletonCacheService.instance = null;
+        SkeletonCacheService.config = {};
     }
 }

--- a/servers/roo-state-manager/src/services/task-archiver/TaskArchiver.ts
+++ b/servers/roo-state-manager/src/services/task-archiver/TaskArchiver.ts
@@ -18,12 +18,10 @@ import { createReadStream } from 'fs';
 import { createInterface } from 'readline';
 import { getSharedStatePath } from '../../utils/shared-state-path.js';
 import { ConversationSkeleton } from '../../types/conversation.js';
-import { ArchivedTask, ArchivedTaskMessage } from './types.js';
+import { ArchivedTask, ArchivedTaskMessage, ARCHIVE_CURRENT_VERSION } from './types.js';
 
 const gzipAsync = promisify(gzip);
 const gunzipAsync = promisify(gunzip);
-
-const MAX_CONTENT_LENGTH = 10 * 1024; // 10KB - tronquer les tool results volumineux
 
 function getHostIdentifier(): string {
     return `${os.hostname()}-${os.platform()}-${os.arch()}`;
@@ -31,11 +29,6 @@ function getHostIdentifier(): string {
 
 function getMachineId(): string {
     return os.hostname().toLowerCase();
-}
-
-function truncateContent(content: string): string {
-    if (content.length <= MAX_CONTENT_LENGTH) return content;
-    return content.substring(0, MAX_CONTENT_LENGTH) + '\n[... truncated ...]';
 }
 
 interface UiMessage {
@@ -67,7 +60,7 @@ function transformUiMessages(messages: UiMessage[]): ArchivedTaskMessage[] {
         .filter(msg => msg.text && msg.text.trim().length > 0)
         .map(msg => ({
             role: (msg.author === 'agent' ? 'assistant' : 'user') as 'user' | 'assistant',
-            content: truncateContent(msg.text),
+            content: msg.text,
             timestamp: msg.timestamp,
         }));
 }
@@ -81,7 +74,7 @@ function transformApiMessages(messages: ApiMessage[]): ArchivedTaskMessage[] {
                 : JSON.stringify(msg.content);
             return {
                 role: msg.role as 'user' | 'assistant',
-                content: truncateContent(content),
+                content,
                 timestamp: msg.timestamp,
             };
         });
@@ -129,7 +122,7 @@ function transformClaudeCodeJsonl(jsonlLines: ClaudeCodeJsonlLine[]): ArchivedTa
         .filter(line => line.message && line.message.content && line.message.content.trim().length > 0)
         .map(line => ({
             role: line.message!.role as 'user' | 'assistant',
-            content: truncateContent(line.message!.content),
+            content: line.message!.content,
             timestamp: line.timestamp || new Date().toISOString(),
         }));
 }
@@ -138,10 +131,31 @@ function getArchiveBasePath(): string {
     return path.join(getSharedStatePath(), 'task-archive');
 }
 
+/**
+ * Lit la version d'un fichier d'archive existant.
+ * Retourne null si le fichier n'existe pas ou n'est pas lisible.
+ * Retourne 1 si le champ version est absent (format v1 historique).
+ */
+async function readArchiveVersion(archivePath: string): Promise<number | null> {
+    try {
+        const compressed = await fs.readFile(archivePath);
+        const decompressed = await gunzipAsync(compressed);
+        const archived = JSON.parse(decompressed.toString('utf-8')) as Partial<ArchivedTask>;
+        return typeof archived.version === 'number' ? archived.version : 1;
+    } catch {
+        return null;
+    }
+}
+
 export class TaskArchiver {
     /**
      * Archive une tache Roo complete sur GDrive.
      * Non-bloquant: les erreurs sont logguees mais ne remontent pas.
+     *
+     * Strategie upgrade-if-v1 :
+     * - Si le fichier n'existe pas : archivage normal (v2)
+     * - Si le fichier existe en v2 : skip (conserver)
+     * - Si le fichier existe en v1 : re-archiver (upgrade v1 -> v2)
      */
     static async archiveTask(
         taskId: string,
@@ -152,12 +166,10 @@ export class TaskArchiver {
         const archiveDir = path.join(getArchiveBasePath(), machineId);
         const archivePath = path.join(archiveDir, `${taskId}.json.gz`);
 
-        // Verifier si deja archive (eviter re-ecriture inutile)
-        try {
-            await fs.access(archivePath);
-            return; // Deja archive
-        } catch {
-            // Fichier n'existe pas, on continue
+        // Verifier la version existante : skip si v2, upgrade si v1
+        const existingVersion = await readArchiveVersion(archivePath);
+        if (existingVersion !== null && existingVersion >= ARCHIVE_CURRENT_VERSION) {
+            return; // Deja en v2, rien a faire
         }
 
         // Lire les messages: ui_messages.json (primaire) ou api_conversation_history.json (fallback)
@@ -185,7 +197,7 @@ export class TaskArchiver {
         }
 
         const archived: ArchivedTask = {
-            version: 1,
+            version: ARCHIVE_CURRENT_VERSION,
             taskId,
             machineId,
             hostIdentifier: getHostIdentifier(),
@@ -210,12 +222,15 @@ export class TaskArchiver {
         const compressed = await gzipAsync(Buffer.from(jsonData, 'utf-8'));
         await fs.writeFile(archivePath, compressed);
 
-        console.log(`[ARCHIVE] Task ${taskId} archived (${messages.length} msgs, ${compressed.length} bytes gz)`);
+        const verb = existingVersion === 1 ? 'upgraded v1->v2' : 'archived';
+        console.log(`[ARCHIVE] Task ${taskId} ${verb} (${messages.length} msgs, ${compressed.length} bytes gz)`);
     }
 
     /**
      * Archive une session Claude Code depuis un fichier JSONL
      * Stocke sur GDrive avec un prefixe "claude-" pour distinguer des taches Roo
+     *
+     * Meme strategie upgrade-if-v1 que archiveTask.
      */
     static async archiveClaudeCodeSession(
         sessionId: string,
@@ -226,12 +241,10 @@ export class TaskArchiver {
         const archiveDir = path.join(getArchiveBasePath(), machineId);
         const archivePath = path.join(archiveDir, `claude-${sessionId}.json.gz`);
 
-        // Verifier si deja archive
-        try {
-            await fs.access(archivePath);
-            return; // Deja archive
-        } catch {
-            // Fichier n'existe pas, on continue
+        // Verifier la version existante : skip si v2, upgrade si v1
+        const existingVersion = await readArchiveVersion(archivePath);
+        if (existingVersion !== null && existingVersion >= ARCHIVE_CURRENT_VERSION) {
+            return; // Deja en v2, rien a faire
         }
 
         // Lire le fichier JSONL
@@ -252,7 +265,7 @@ export class TaskArchiver {
         const deducedTitle = title || path.basename(path.dirname(jsonlPath));
 
         const archived: ArchivedTask = {
-            version: 1,
+            version: ARCHIVE_CURRENT_VERSION,
             taskId: sessionId,
             machineId,
             hostIdentifier: getHostIdentifier(),
@@ -272,7 +285,8 @@ export class TaskArchiver {
         const compressed = await gzipAsync(Buffer.from(jsonData, 'utf-8'));
         await fs.writeFile(archivePath, compressed);
 
-        console.log(`[ARCHIVE] Claude Code session ${sessionId} archived (${messages.length} msgs, ${compressed.length} bytes gz)`);
+        const verb = existingVersion === 1 ? 'upgraded v1->v2' : 'archived';
+        console.log(`[ARCHIVE] Claude Code session ${sessionId} ${verb} (${messages.length} msgs, ${compressed.length} bytes gz)`);
     }
 
     /**
@@ -474,5 +488,99 @@ export class TaskArchiver {
         }
 
         return taskIds;
+    }
+
+    /**
+     * Migration batch des archives v1 vers v2 sur la machine locale.
+     *
+     * Scanne le repertoire de la machine courante, identifie les fichiers en v1,
+     * et pour chaque fichier v1 : delit, decompresse, re-serialise en v2 et reecrit.
+     *
+     * La re-serialisation ne RESTAURE PAS les messages tronques (les donnees
+     * source ne sont pas disponibles ici). Pour reconstruire les messages complets,
+     * il faut passer par archiveTask()/archiveClaudeCodeSession() avec les fichiers
+     * source: cela arrive naturellement lors de la re-indexation Qdrant.
+     *
+     * Ce helper sert donc a :
+     * 1. Bumper la version dans les archives existantes (quick-fix)
+     * 2. Reporter le nombre d'archives v1 restantes (via dryRun: true)
+     *
+     * Pour une vraie reconstruction complete des messages, utiliser l'indexation
+     * Qdrant qui declenchera archiveTask() apres chaque re-indexation reussie.
+     */
+    static async migrateV1Archives(options: {
+        batchSize?: number;
+        rateLimitMs?: number;
+        dryRun?: boolean;
+        machineId?: string;
+        onProgress?: (done: number, total: number) => void;
+    } = {}): Promise<{ scanned: number; v1Found: number; upgraded: number; errors: number }> {
+        const {
+            batchSize = 50,
+            rateLimitMs = 100,
+            dryRun = false,
+            machineId = getMachineId(),
+            onProgress,
+        } = options;
+
+        const archiveBase = getArchiveBasePath();
+        const machineDir = path.join(archiveBase, machineId);
+
+        let scanned = 0;
+        let v1Found = 0;
+        let upgraded = 0;
+        let errors = 0;
+
+        let files: string[];
+        try {
+            files = (await fs.readdir(machineDir)).filter(f => f.endsWith('.json.gz'));
+        } catch {
+            return { scanned: 0, v1Found: 0, upgraded: 0, errors: 0 };
+        }
+
+        const total = files.length;
+
+        for (let i = 0; i < total; i++) {
+            const file = files[i];
+            const filePath = path.join(machineDir, file);
+            scanned++;
+
+            try {
+                const version = await readArchiveVersion(filePath);
+                if (version === null) {
+                    errors++;
+                } else if (version >= ARCHIVE_CURRENT_VERSION) {
+                    // deja en v2, rien a faire
+                } else {
+                    v1Found++;
+                    if (!dryRun) {
+                        // Upgrade : relire, patcher la version, reecrire.
+                        const compressed = await fs.readFile(filePath);
+                        const decompressed = await gunzipAsync(compressed);
+                        const archived = JSON.parse(decompressed.toString('utf-8')) as ArchivedTask;
+                        archived.version = ARCHIVE_CURRENT_VERSION;
+                        archived.archivedAt = new Date().toISOString();
+                        const newJson = JSON.stringify(archived);
+                        const newCompressed = await gzipAsync(Buffer.from(newJson, 'utf-8'));
+                        await fs.writeFile(filePath, newCompressed);
+                        upgraded++;
+                    }
+                }
+            } catch (err) {
+                console.warn(`[ARCHIVE MIGRATE] Failed on ${file}: ${err}`);
+                errors++;
+            }
+
+            if (onProgress) {
+                onProgress(i + 1, total);
+            }
+
+            // Throttle par lot
+            if ((i + 1) % batchSize === 0 && rateLimitMs > 0) {
+                await new Promise(resolve => setTimeout(resolve, rateLimitMs));
+            }
+        }
+
+        return { scanned, v1Found, upgraded, errors };
     }
 }

--- a/servers/roo-state-manager/src/services/task-archiver/__tests__/TaskArchiver.batch.test.ts
+++ b/servers/roo-state-manager/src/services/task-archiver/__tests__/TaskArchiver.batch.test.ts
@@ -197,8 +197,14 @@ describe('TaskArchiver - Additional Coverage Tests', () => {
 	// ============================================================
 
 	describe('archiveClaudeCodeSession - title handling', () => {
-		test('skips when archive already exists', async () => {
-			mockAccess.mockResolvedValue(undefined); // Archive exists
+		test('skips when archive already exists as v2', async () => {
+			// v2 archive bump: existence is detected by reading + parsing
+			// the archive (not fs.access). Provide a v2 payload so the
+			// hoisted gunzip mock (which returns its input unchanged)
+			// yields parseable JSON with version === 2.
+			mockReadFile.mockResolvedValueOnce(
+				Buffer.from(JSON.stringify({ version: 2, taskId: 'x', messages: [] }))
+			);
 			const jsonlPath = '/some/weird/path/conversations.jsonl';
 
 			await TaskArchiver.archiveClaudeCodeSession('session-123', jsonlPath, 'Custom Title');

--- a/servers/roo-state-manager/src/services/task-archiver/__tests__/TaskArchiver.test.ts
+++ b/servers/roo-state-manager/src/services/task-archiver/__tests__/TaskArchiver.test.ts
@@ -1,9 +1,10 @@
 /**
- * Tests pour TaskArchiver.ts - fonctions de transformation pure
+ * Tests pour TaskArchiver.ts
  * Issue #492 - Couverture du service d'archivage
  *
- * Teste les fonctions internes (truncateContent, transformUiMessages, transformApiMessages)
- * via le flux public archiveTask/readArchivedTask.
+ * Teste les fonctions publiques archiveTask / archiveClaudeCodeSession /
+ * readArchivedTask / listArchivedTasks / migrateV1Archives, ainsi que la
+ * strategie upgrade-if-v1 (soft transition v1 -> v2, aucune troncature).
  */
 
 import { describe, test, expect, vi, beforeEach } from 'vitest';
@@ -90,18 +91,48 @@ describe('TaskArchiver', () => {
 	// ============================================================
 
 	describe('archiveTask', () => {
-		test('skips if archive already exists', async () => {
-			mockAccess.mockResolvedValueOnce(undefined); // file exists
+		// Helpers --------------------------------------------------------
+		// The hoisted gunzip mock returns its input unchanged, so a "gzipped"
+		// archive is simulated as a raw Buffer containing the JSON payload.
+		const archiveV2 = (extra: Record<string, any> = {}) =>
+			Buffer.from(JSON.stringify({ version: 2, taskId: 'x', messages: [], ...extra }));
+		const archiveV1 = (extra: Record<string, any> = {}) =>
+			Buffer.from(JSON.stringify({ version: 1, taskId: 'x', messages: [], ...extra }));
+		const missingArchive = () => mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+
+		test('skips if archive already exists as v2', async () => {
+			mockReadFile.mockResolvedValueOnce(archiveV2()); // version check returns v2
 			await TaskArchiver.archiveTask('task-123', '/task/path', {
 				taskId: 'task-123',
 				isCompleted: true,
 			} as any);
-			// Should not try to read messages
-			expect(mockReadFile).not.toHaveBeenCalled();
+			// Only the version-check read happened; no source read, no write.
+			expect(mockReadFile).toHaveBeenCalledTimes(1);
+			expect(mockWriteFile).not.toHaveBeenCalled();
+		});
+
+		test('upgrades existing v1 archive to v2 (soft transition)', async () => {
+			mockReadFile.mockResolvedValueOnce(archiveV1()); // version check returns v1
+			const uiMessages = JSON.stringify([
+				{ author: 'user', text: 'Hello', timestamp: '2026-02-22T10:00:00Z' },
+				{ author: 'agent', text: 'Hi', timestamp: '2026-02-22T10:01:00Z' },
+			]);
+			mockReadFile.mockResolvedValueOnce(uiMessages);
+			mockMkdir.mockResolvedValueOnce(undefined);
+			mockWriteFile.mockResolvedValueOnce(undefined);
+
+			await TaskArchiver.archiveTask('task-upgrade', '/task/path', {
+				taskId: 'task-upgrade',
+				isCompleted: true,
+			} as any);
+
+			// v1 archive triggered a full re-archive (version + ui source = 2 reads)
+			expect(mockReadFile).toHaveBeenCalledTimes(2);
+			expect(mockWriteFile).toHaveBeenCalled();
 		});
 
 		test('reads ui_messages.json as primary source', async () => {
-			mockAccess.mockRejectedValueOnce(new Error('ENOENT')); // archive not exists
+			missingArchive();
 			const uiMessages = JSON.stringify([
 				{ author: 'user', text: 'Hello', timestamp: '2026-02-22T10:00:00Z' },
 				{ author: 'agent', text: 'Hi there', timestamp: '2026-02-22T10:01:00Z' },
@@ -116,13 +147,14 @@ describe('TaskArchiver', () => {
 				metadata: { title: 'Test Task' },
 			} as any);
 
-			expect(mockReadFile).toHaveBeenCalledTimes(1);
+			// 1 read for version check (failed) + 1 read for ui_messages
+			expect(mockReadFile).toHaveBeenCalledTimes(2);
 			expect(mockMkdir).toHaveBeenCalled();
 			expect(mockWriteFile).toHaveBeenCalled();
 		});
 
 		test('falls back to api_conversation_history.json', async () => {
-			mockAccess.mockRejectedValueOnce(new Error('ENOENT'));
+			missingArchive();
 			mockReadFile.mockRejectedValueOnce(new Error('ENOENT')); // ui_messages not found
 			const apiMessages = JSON.stringify([
 				{ role: 'user', content: 'Hello API', timestamp: '2026-02-22T10:00:00Z' },
@@ -137,11 +169,12 @@ describe('TaskArchiver', () => {
 				isCompleted: true,
 			} as any);
 
-			expect(mockReadFile).toHaveBeenCalledTimes(2);
+			// version check + ui_messages + api_history = 3 reads
+			expect(mockReadFile).toHaveBeenCalledTimes(3);
 		});
 
 		test('filters empty messages', async () => {
-			mockAccess.mockRejectedValueOnce(new Error('ENOENT'));
+			missingArchive();
 			const uiMessages = JSON.stringify([
 				{ author: 'user', text: '', timestamp: '2026-02-22T10:00:00Z' },
 				{ author: 'user', text: '   ', timestamp: '2026-02-22T10:01:00Z' },
@@ -160,7 +193,7 @@ describe('TaskArchiver', () => {
 		});
 
 		test('handles no message files gracefully', async () => {
-			mockAccess.mockRejectedValueOnce(new Error('ENOENT'));
+			missingArchive();
 			mockReadFile.mockRejectedValueOnce(new Error('ENOENT')); // ui_messages
 			mockReadFile.mockRejectedValueOnce(new Error('ENOENT')); // api_history
 
@@ -174,7 +207,7 @@ describe('TaskArchiver', () => {
 		});
 
 		test('filters system messages from API source', async () => {
-			mockAccess.mockRejectedValueOnce(new Error('ENOENT'));
+			missingArchive();
 			mockReadFile.mockRejectedValueOnce(new Error('ENOENT')); // ui_messages not found
 			const apiMessages = JSON.stringify([
 				{ role: 'system', content: 'System prompt' },
@@ -191,6 +224,75 @@ describe('TaskArchiver', () => {
 			} as any);
 
 			expect(mockWriteFile).toHaveBeenCalled();
+		});
+
+		test('preserves full message content without truncation', async () => {
+			missingArchive();
+			// A payload much larger than the old 10KB truncation threshold.
+			const big = 'A'.repeat(60 * 1024);
+			const uiMessages = JSON.stringify([
+				{ author: 'user', text: big, timestamp: '2026-02-22T10:00:00Z' },
+			]);
+			mockReadFile.mockResolvedValueOnce(uiMessages);
+			mockMkdir.mockResolvedValueOnce(undefined);
+
+			// Capture the serialized archive that TaskArchiver passes to gzip.
+			let capturedJson = '';
+			mockWriteFile.mockImplementationOnce(async (_p: string, _buf: Buffer) => {
+				// The hoisted gzip mock returns a fixed stub, so we instead snapshot
+				// via the JSON payload that archiveTask built before gzipping — the
+				// only observable side effect is that writeFile was called once.
+				return undefined;
+			});
+
+			// Spy on JSON.stringify to capture the archived payload the code serializes.
+			const realStringify = JSON.stringify;
+			const stringifySpy = vi.spyOn(JSON, 'stringify').mockImplementation((value: any, ...rest: any[]) => {
+				const out = (realStringify as any)(value, ...rest);
+				if (value && typeof value === 'object' && 'version' in value && 'messages' in value) {
+					capturedJson = out;
+				}
+				return out;
+			});
+
+			await TaskArchiver.archiveTask('task-big', '/task/path', {
+				taskId: 'task-big',
+				isCompleted: true,
+			} as any);
+
+			stringifySpy.mockRestore();
+
+			expect(mockWriteFile).toHaveBeenCalled();
+			const payload = JSON.parse(capturedJson);
+			expect(payload.version).toBe(2);
+			expect(payload.messages[0].content.length).toBe(big.length);
+			expect(payload.messages[0].content).not.toContain('[... truncated ...]');
+		});
+
+		test('writes archives as v2 format', async () => {
+			missingArchive();
+			const uiMessages = JSON.stringify([
+				{ author: 'user', text: 'hello', timestamp: '2026-02-22T10:00:00Z' },
+			]);
+			mockReadFile.mockResolvedValueOnce(uiMessages);
+			mockMkdir.mockResolvedValueOnce(undefined);
+			mockWriteFile.mockResolvedValueOnce(undefined);
+
+			let captured: any;
+			const realStringify = JSON.stringify;
+			const spy = vi.spyOn(JSON, 'stringify').mockImplementation((v: any, ...rest: any[]) => {
+				const out = (realStringify as any)(v, ...rest);
+				if (v && typeof v === 'object' && 'version' in v && 'messages' in v) captured = v;
+				return out;
+			});
+
+			await TaskArchiver.archiveTask('task-v2', '/task/path', {
+				taskId: 'task-v2',
+				isCompleted: true,
+			} as any);
+
+			spy.mockRestore();
+			expect(captured.version).toBe(2);
 		});
 	});
 
@@ -269,20 +371,23 @@ describe('TaskArchiver', () => {
 	// ============================================================
 
 	describe('archiveClaudeCodeSession', () => {
-		test('skips if Claude Code session already archived', async () => {
-			mockAccess.mockResolvedValueOnce(undefined); // file exists
+		test('skips if Claude Code session already archived as v2', async () => {
+			mockReadFile.mockResolvedValueOnce(
+				Buffer.from(JSON.stringify({ version: 2, taskId: 'x', messages: [] }))
+			);
 			await TaskArchiver.archiveClaudeCodeSession('session-456', '/path/to/session.jsonl');
-			// If archive exists, readFile should not be called for message parsing
-			expect(mockReadFile).not.toHaveBeenCalled();
+			// Version check returned v2 → skip path, no mkdir/writeFile.
+			expect(mockReadFile).toHaveBeenCalledTimes(1);
+			expect(mockWriteFile).not.toHaveBeenCalled();
 		});
 
 		test('handles no message files found gracefully', async () => {
-			mockAccess.mockRejectedValueOnce(new Error('ENOENT')); // archive not exists
+			mockReadFile.mockRejectedValueOnce(new Error('ENOENT')); // archive version check
 			// readJsonlFile uses createReadStream which will fail, simulating no valid JSONL
 			// The archiveClaudeCodeSession should handle this by catching and returning early
 			await TaskArchiver.archiveClaudeCodeSession('session-empty', '/path/to/session.jsonl');
 			// Should not attempt to write if parsing fails
-			// (This is implicit in the archiveClaudeCodeSession logic)
+			expect(mockWriteFile).not.toHaveBeenCalled();
 		});
 
 		test('distinguishes Claude Code archives with prefix', async () => {
@@ -328,6 +433,77 @@ describe('TaskArchiver', () => {
 			mockReaddir.mockRejectedValueOnce(new Error('ENOENT'));
 			const tasks = await TaskArchiver.listArchivedTasksBySource('roo');
 			expect(tasks).toEqual([]);
+		});
+	});
+
+	// ============================================================
+	// migrateV1Archives (soft transition batch migration)
+	// ============================================================
+
+	describe('migrateV1Archives', () => {
+		const v1Buf = () => Buffer.from(JSON.stringify({ version: 1, taskId: 't', messages: [] }));
+		const v2Buf = () => Buffer.from(JSON.stringify({ version: 2, taskId: 't', messages: [] }));
+
+		test('returns zero counts when machine dir missing', async () => {
+			mockReaddir.mockRejectedValueOnce(new Error('ENOENT'));
+			const res = await TaskArchiver.migrateV1Archives({ machineId: 'ghost' });
+			expect(res).toEqual({ scanned: 0, v1Found: 0, upgraded: 0, errors: 0 });
+		});
+
+		test('dryRun reports v1 archives without writing', async () => {
+			mockReaddir.mockResolvedValueOnce(['a.json.gz', 'b.json.gz', 'c.json.gz']);
+			mockReadFile.mockResolvedValueOnce(v1Buf());
+			mockReadFile.mockResolvedValueOnce(v2Buf());
+			mockReadFile.mockResolvedValueOnce(v1Buf());
+
+			const res = await TaskArchiver.migrateV1Archives({ dryRun: true, machineId: 'test-machine' });
+
+			expect(res.scanned).toBe(3);
+			expect(res.v1Found).toBe(2);
+			expect(res.upgraded).toBe(0);
+			expect(mockWriteFile).not.toHaveBeenCalled();
+		});
+
+		test('upgrades v1 archives and skips v2 archives', async () => {
+			mockReaddir.mockResolvedValueOnce(['a.json.gz', 'b.json.gz']);
+			// File a: v1 — first the version-check read, then the actual re-read for rewrite.
+			mockReadFile.mockResolvedValueOnce(v1Buf()); // version check a
+			mockReadFile.mockResolvedValueOnce(v1Buf()); // re-read a for upgrade
+			// File b: v2 — version check only, then skipped.
+			mockReadFile.mockResolvedValueOnce(v2Buf());
+
+			const res = await TaskArchiver.migrateV1Archives({ machineId: 'test-machine', rateLimitMs: 0 });
+
+			expect(res.scanned).toBe(2);
+			expect(res.v1Found).toBe(1);
+			expect(res.upgraded).toBe(1);
+			expect(mockWriteFile).toHaveBeenCalledTimes(1);
+		});
+
+		test('counts unreadable archives as errors', async () => {
+			mockReaddir.mockResolvedValueOnce(['corrupt.json.gz']);
+			mockReadFile.mockRejectedValueOnce(new Error('EACCES'));
+
+			const res = await TaskArchiver.migrateV1Archives({ machineId: 'test-machine', rateLimitMs: 0 });
+
+			expect(res.scanned).toBe(1);
+			expect(res.errors).toBe(1);
+			expect(res.upgraded).toBe(0);
+		});
+
+		test('invokes onProgress callback for each file', async () => {
+			mockReaddir.mockResolvedValueOnce(['a.json.gz', 'b.json.gz']);
+			mockReadFile.mockResolvedValueOnce(v2Buf());
+			mockReadFile.mockResolvedValueOnce(v2Buf());
+
+			const progress: Array<[number, number]> = [];
+			await TaskArchiver.migrateV1Archives({
+				machineId: 'test-machine',
+				rateLimitMs: 0,
+				onProgress: (done, total) => progress.push([done, total]),
+			});
+
+			expect(progress).toEqual([[1, 2], [2, 2]]);
 		});
 	});
 });

--- a/servers/roo-state-manager/src/services/task-archiver/types.ts
+++ b/servers/roo-state-manager/src/services/task-archiver/types.ts
@@ -1,7 +1,31 @@
 /**
  * Types pour l'archivage cross-machine des taches sur GDrive
  * Format agnostique Roo/Claude pour partage inter-machines
+ *
+ * Format versions
+ * ---------------
+ * v1 (deprecated — still readable):
+ *   - Messages tronques a 10KB chacun ("MAX_CONTENT_LENGTH" + "[... truncated ...]")
+ *   - Perte des tool results volumineux
+ *   - Introduit par commit 8af5dc6f (2026-03-12) sans demande utilisateur
+ *
+ * v2 (current — writers only produce this):
+ *   - Messages complets, aucune troncature
+ *   - Les tool results volumineux sont preserves integralement
+ *   - La taille sur GDrive peut etre significativement plus grande, mais l'utilisateur
+ *     a explicitement confirme ne pas avoir de contrainte d'espace sur GDrive.
+ *
+ * Soft transition
+ * ---------------
+ * Les readers tolerent v1 et v2 transparents. Les writers produisent toujours v2.
+ * Le code de skip-if-exists est remplace par upgrade-if-v1 : quand on re-archive une
+ * tache, si le fichier existant est v1, il est ecrase par v2. Si v2, il est conserve.
+ * Une migration batch (voir TaskArchiver.migrateV1Archives) permet de forcer la mise
+ * a niveau au rythme choisi par l'utilisateur.
  */
+
+export type ArchiveFormatVersion = 1 | 2;
+export const ARCHIVE_CURRENT_VERSION: ArchiveFormatVersion = 2;
 
 export interface ArchivedTaskMessage {
     role: 'user' | 'assistant';
@@ -25,7 +49,7 @@ export interface ArchivedTaskMetadata {
 }
 
 export interface ArchivedTask {
-    version: 1;
+    version: ArchiveFormatVersion;
     taskId: string;
     machineId: string;
     hostIdentifier: string;

--- a/servers/roo-state-manager/src/tools/cache/build-skeleton-cache.tool.ts
+++ b/servers/roo-state-manager/src/tools/cache/build-skeleton-cache.tool.ts
@@ -18,6 +18,20 @@ interface BuildSkeletonCacheArgs {
     force_rebuild?: boolean;
     workspace_filter?: string;
     task_ids?: string[];  // Liste des IDs de tâches à construire spécifiquement
+    /**
+     * #1244 Couche 1.4 — Sources de squelettes a charger.
+     * Defaut: ['roo'] (backward compat). Valeurs possibles:
+     *  - 'roo'     : Storages Roo locaux (Tier 1, comportement historique)
+     *  - 'claude'  : Sessions Claude Code locales (Tier 2)
+     *  - 'archive' : Archives cross-machine GDrive (Tier 3, requiert ROOSYNC_SHARED_PATH)
+     */
+    sources?: Array<'roo' | 'claude' | 'archive'>;
+    /**
+     * #1244 Couche 1.4 — Si true, force l'enqueue Qdrant pour TOUS les squelettes
+     * (Tiers 1+2+3) meme s'ils etaient deja a jour. Si false/omis, suit le comportement
+     * historique (enqueue uniquement si state.isQdrantIndexingEnabled est actif).
+     */
+    reindex?: boolean;
 }
 
 /**
@@ -131,6 +145,16 @@ export const buildSkeletonCacheDefinition = {
                 type: 'array',
                 items: { type: 'string' },
                 description: 'Liste optionnelle d\'IDs de tâches spécifiques à construire. Si fourni, seules ces tâches seront traitées (ignore workspace_filter). Active les logs verbeux.'
+            },
+            sources: {
+                type: 'array',
+                items: { type: 'string', enum: ['roo', 'claude', 'archive'] },
+                description: '#1244 Couche 1.4 — Sources de squelettes a charger. Defaut: ["roo"]. "claude" inclut les sessions Claude Code locales (Tier 2). "archive" inclut les archives cross-machine GDrive (Tier 3, requiert ROOSYNC_SHARED_PATH).'
+            },
+            reindex: {
+                type: 'boolean',
+                description: '#1244 Couche 1.4 — Si true, force l\'enqueue Qdrant pour tous les squelettes construits/charges (tous tiers). Si false/omis, suit le comportement historique (enqueue uniquement si state.isQdrantIndexingEnabled est actif).',
+                default: false
             }
         },
         required: []
@@ -148,6 +172,24 @@ export async function handleBuildSkeletonCache(
 ): Promise<CallToolResult> {
         conversationCache.clear();
         const { force_rebuild = false, workspace_filter, task_ids } = args;
+        // #1244 Couche 1.4 — Sources multi-tier (defaut: roo seul, backward compat)
+        const sources: Array<'roo' | 'claude' | 'archive'> = (args.sources && args.sources.length > 0)
+            ? args.sources
+            : ['roo'];
+        const reindex = args.reindex === true;
+        // Helper d'enqueue Qdrant — honore reindex meme si Qdrant indexing n'est pas force globalement
+        const enqueueForReindex = (taskId: string) => {
+            if (state && (state.isQdrantIndexingEnabled || reindex)) {
+                state.qdrantIndexQueue.add(taskId);
+            }
+        };
+        // #1244 Couche 1.4 — Compteurs par tier
+        let tier2Loaded = 0;
+        let tier2Skipped = 0;
+        let tier2Errors = 0;
+        let tier3Loaded = 0;
+        let tier3Skipped = 0;
+        let tier3Errors = 0;
 
         // 🚀 PROTECTION TIMEOUT ÉTENDU : 5 minutes pour permettre rebuilds complets
         const GLOBAL_TIMEOUT_MS = 300000; // 300s = 5 minutes (ancien: 50s)
@@ -174,8 +216,11 @@ export async function handleBuildSkeletonCache(
             originalConsoleLog(...args);
         };
 
-        const locations = await RooStorageDetector.detectStorageLocations(); // This returns base storage paths
-        if (locations.length === 0) {
+        const locations = sources.includes('roo')
+            ? await RooStorageDetector.detectStorageLocations()
+            : [];
+        // #1244 Couche 1.4 — Ne plus echouer si aucun storage Roo: les Tier 2/3 peuvent suffire
+        if (locations.length === 0 && sources.includes('roo') && !sources.includes('claude') && !sources.includes('archive')) {
             console.log = originalConsoleLog; // Restaurer
             return { content: [{ type: 'text', text: 'Storage not found. Cache not built.' }] };
         }
@@ -321,11 +366,8 @@ export async function handleBuildSkeletonCache(
                                         if (skeleton && skeleton.taskId) {
                                             conversationCache.set(skeleton.taskId, skeleton);
 
-                                            // 🚀 INDEXATION QDRANT: Ajouter à la queue si le state est disponible
-                                            if (state && state.isQdrantIndexingEnabled) {
-                                                state.qdrantIndexQueue.add(skeleton.taskId);
-                                                // console.log(`[INDEX-QUEUE] Added ${skeleton.taskId} to Qdrant indexing queue (from cache)`);
-                                            }
+                                            // 🚀 INDEXATION QDRANT: Ajouter à la queue si le state est disponible OU si reindex force (#1244 Couche 1.4)
+                                            enqueueForReindex(skeleton.taskId);
 
                                             // 🚀 PHASE 1: Alimenter l'index avec les préfixes de ce squelette existant
                                             if (skeleton.childTaskInstructionPrefixes && skeleton.childTaskInstructionPrefixes.length > 0) {
@@ -359,11 +401,8 @@ export async function handleBuildSkeletonCache(
                                     // BUG FIX: Utiliser skeleton.taskId et non conversationId
                                     conversationCache.set(skeleton.taskId, skeleton);
 
-                                    // 🚀 INDEXATION QDRANT: Ajouter à la queue si le state est disponible
-                                    if (state && state.isQdrantIndexingEnabled) {
-                                        state.qdrantIndexQueue.add(skeleton.taskId);
-                                        // console.log(`[INDEX-QUEUE] Added ${skeleton.taskId} to Qdrant indexing queue`);
-                                    }
+                                    // 🚀 INDEXATION QDRANT: Ajouter à la queue si le state est disponible OU si reindex force (#1244 Couche 1.4)
+                                    enqueueForReindex(skeleton.taskId);
 
                                     // 🚀 PHASE 1: Collecter les préfixes pour l'index RadixTree
                                     if (skeleton.childTaskInstructionPrefixes && skeleton.childTaskInstructionPrefixes.length > 0) {
@@ -417,6 +456,92 @@ export async function handleBuildSkeletonCache(
                         skeletonsSkipped++;
                     }
                 }
+            }
+        }
+
+        // ============================================================
+        // #1244 Couche 1.4 — PHASE 1.5: Tier 2 (Claude Code local sessions)
+        // ============================================================
+        if (sources.includes('claude') && (!task_ids || task_ids.length === 0)) {
+            console.log(`🔄 [TIER2] Loading Claude Code sessions (#1244 Couche 1.4)...`);
+            try {
+                const { ClaudeStorageDetector } = await import('../../utils/claude-storage-detector.js');
+                const claudeLocations = await ClaudeStorageDetector.detectStorageLocations();
+                console.log(`[TIER2] Found ${claudeLocations.length} Claude project locations`);
+
+                for (const location of claudeLocations) {
+                    if (checkGlobalTimeout()) break;
+                    try {
+                        const taskId = `claude-${path.basename(location.projectPath)}`;
+
+                        // Tier 1 (Roo local) a la priorite — ne pas ecraser
+                        if (conversationCache.has(taskId)) {
+                            tier2Skipped++;
+                            continue;
+                        }
+
+                        const skeleton = await ClaudeStorageDetector.analyzeConversation(
+                            taskId, location.projectPath
+                        );
+                        if (skeleton && (skeleton.sequence ?? []).length > 0) {
+                            if (!skeleton.metadata) skeleton.metadata = {} as any;
+                            (skeleton.metadata as any).source = 'claude-code';
+                            (skeleton.metadata as any).dataSource = 'claude';
+                            conversationCache.set(taskId, skeleton);
+                            enqueueForReindex(taskId);
+                            tier2Loaded++;
+                        }
+                    } catch (claudeErr) {
+                        tier2Errors++;
+                        console.warn(`[TIER2] Failed Claude location ${location.projectPath}:`, claudeErr);
+                    }
+                }
+                console.log(`[TIER2] ✅ ${tier2Loaded} Claude sessions loaded, ${tier2Skipped} collisions skipped, ${tier2Errors} errors`);
+            } catch (tier2GlobalErr) {
+                console.warn('[TIER2] Non-blocking failure:', tier2GlobalErr);
+            }
+        }
+
+        // ============================================================
+        // #1244 Couche 1.4 — PHASE 1.6: Tier 3 (Archives cross-machine GDrive)
+        // ============================================================
+        if (sources.includes('archive') && (!task_ids || task_ids.length === 0)) {
+            console.log(`🔄 [TIER3] Loading cross-machine archives from GDrive (#1244 Couche 1.4)...`);
+            try {
+                const { TaskArchiver } = await import('../../services/task-archiver/index.js');
+                const { archiveToSkeleton } = await import('../../services/archive-skeleton-builder.js');
+
+                const archivedTaskIds = await TaskArchiver.listArchivedTasks();
+                console.log(`[TIER3] Found ${archivedTaskIds.length} archived tasks`);
+
+                for (const archivedId of archivedTaskIds) {
+                    if (checkGlobalTimeout()) break;
+                    // Tiers chauds (Roo local + Claude local) ont la priorite
+                    if (conversationCache.has(archivedId)) {
+                        tier3Skipped++;
+                        continue;
+                    }
+                    try {
+                        const archive = await TaskArchiver.readArchivedTask(archivedId);
+                        if (!archive) {
+                            tier3Errors++;
+                            continue;
+                        }
+                        const skeleton = archiveToSkeleton(archive);
+                        conversationCache.set(skeleton.taskId, skeleton);
+                        enqueueForReindex(skeleton.taskId);
+                        tier3Loaded++;
+                    } catch (archiveErr) {
+                        tier3Errors++;
+                        console.warn(`[TIER3] Failed archive read ${archivedId}:`, archiveErr);
+                    }
+                }
+                console.log(
+                    `[TIER3] ✅ ${tier3Loaded} archives loaded, ` +
+                    `${tier3Skipped} collisions skipped, ${tier3Errors} errors`
+                );
+            } catch (tier3GlobalErr) {
+                console.warn('[TIER3] Non-blocking failure (likely missing ROOSYNC_SHARED_PATH):', tier3GlobalErr);
             }
         }
 
@@ -797,7 +922,18 @@ export async function handleBuildSkeletonCache(
         console.log = originalConsoleLog;
 
         // 🔍 Inclure les logs de debug dans la réponse
+        // Format historique conserve pour backward compat des tests + assertions externes
         let response = `Skeleton cache build complete (${mode}). Built: ${skeletonsBuilt}, Skipped: ${skeletonsSkipped}, Cache size: ${conversationCache.size}, Hierarchy relations found: ${hierarchyRelationsFound}`;
+        // #1244 Couche 1.4 — Per-tier stats appendues (n'apparaissent que si Tier 2 ou Tier 3 actif)
+        if (sources.includes('claude') || sources.includes('archive')) {
+            const tier2Label = sources.includes('claude')
+                ? `Tier2(claude): loaded=${tier2Loaded} skipped=${tier2Skipped} errors=${tier2Errors}`
+                : 'Tier2(claude): disabled';
+            const tier3Label = sources.includes('archive')
+                ? `Tier3(archive): loaded=${tier3Loaded} skipped=${tier3Skipped} errors=${tier3Errors}`
+                : 'Tier3(archive): disabled';
+            response += ` | sources=${sources.join('+')} reindex=${reindex} | ${tier2Label} | ${tier3Label}`;
+        }
 
         if (debugLogs.length > 0) {
             response += `\n\n🔍 DEBUG LOGS (${debugLogs.length} entries):\n${debugLogs.join('\n')}`;

--- a/servers/roo-state-manager/src/tools/conversation/__tests__/conversation-browser.test.ts
+++ b/servers/roo-state-manager/src/tools/conversation/__tests__/conversation-browser.test.ts
@@ -728,7 +728,8 @@ describe('conversation_browser', () => {
 			expect(parsed[2].taskId).toBe('task-old'); // 5 messages
 		});
 
-		test('list respects limit parameter', async () => {
+		test('list clamps limit below 10 to the floor (#1245: pages of <10 are useless)', async () => {
+			// mockCache has 3 tasks. limit=2 gets clamped to 10 → all 3 returned in sorted order.
 			const result = await handleConversationBrowser(
 				{ action: 'list', limit: 2, sortBy: 'lastActivity', sortOrder: 'desc' },
 				mockCache,
@@ -738,9 +739,10 @@ describe('conversation_browser', () => {
 			expect(result.isError).toBeFalsy();
 			const _response = JSON.parse(getTextContent(result));
 			const parsed = _response.conversations ?? _response;
-			expect(parsed.length).toBe(2);
+			expect(parsed.length).toBe(3);
 			expect(parsed[0].taskId).toBe('task-new');
 			expect(parsed[1].taskId).toBe('task-middle');
+			expect(parsed[2].taskId).toBe('task-old');
 		});
 
 		test('list filters by workspace when specified', async () => {

--- a/servers/roo-state-manager/src/tools/conversation/__tests__/list-conversations.test.ts
+++ b/servers/roo-state-manager/src/tools/conversation/__tests__/list-conversations.test.ts
@@ -256,23 +256,35 @@ describe('listConversationsTool.handler', () => {
   // ============================================================
 
   describe('limit', () => {
-    test('limite les résultats au nombre demandé', async () => {
-      const cache = makeCache(
-        makeConversation('task-1'),
-        makeConversation('task-2'),
-        makeConversation('task-3'),
-        makeConversation('task-4'),
-        makeConversation('task-5'),
-      );
+    // #1245 round 2: per_page is clamped to [10, 100] — pages of 5 are useless,
+    // pages above 100 should be opt-in file redirection. These tests exercise
+    // values LARGER than the clamp floor.
+    test('limite les résultats au nombre demandé (above floor=10)', async () => {
+      // Create 20 tasks and ask for 12 → should return 12
+      const tasks = Array.from({ length: 20 }, (_, i) => makeConversation(`task-${i + 1}`));
+      const cache = makeCache(...tasks);
+
+      const result = await listConversationsTool.handler({ limit: 12 }, cache);
+      const _response = JSON.parse((result.content[0] as any).text);
+      const parsed = _response.conversations ?? _response;
+
+      expect(parsed.length).toBe(12);
+    });
+
+    test('limit inférieur au plancher 10 → clamp à 10', async () => {
+      // Create 15 tasks and ask for 3 → should be clamped to 10
+      const tasks = Array.from({ length: 15 }, (_, i) => makeConversation(`task-${i + 1}`));
+      const cache = makeCache(...tasks);
 
       const result = await listConversationsTool.handler({ limit: 3 }, cache);
       const _response = JSON.parse((result.content[0] as any).text);
       const parsed = _response.conversations ?? _response;
 
-      expect(parsed.length).toBe(3);
+      expect(parsed.length).toBe(10);
     });
 
-    test('sans limit → retourne toutes les tâches', async () => {
+    test('sans limit → default 10 (page 1) — retourne au plus 10 tâches', async () => {
+      // Create 3 tasks — fewer than the default page size, so all 3 fit on page 1
       const cache = makeCache(
         makeConversation('task-1'),
         makeConversation('task-2'),
@@ -357,8 +369,12 @@ describe('listConversationsTool.handler', () => {
       expect(parsed[0].firstUserMessage).toBe('Initial user instruction');
     });
 
-    test('tronque le premier message à 300 caractères', async () => {
-      const longContent = 'x'.repeat(400);
+    test('tronque le premier message à 900 caractères', async () => {
+      // #1245 round 2: truncation bumped 300 → 900 for richer first-message context.
+      // The outer toConversationSummary also applies a 700-char cap; the deeper
+      // 900-char cap applies inside the sequence extractor. We assert the visible
+      // cap (what the summary actually emits).
+      const longContent = 'x'.repeat(1200);
       const task = makeConversation('task-long') as any;
       task.sequence = [{ role: 'user', content: longContent }];
       const cache = makeCache(task);
@@ -367,7 +383,8 @@ describe('listConversationsTool.handler', () => {
       const _response = JSON.parse((result.content[0] as any).text);
       const parsed = _response.conversations ?? _response;
 
-      expect(parsed[0].firstUserMessage.length).toBeLessThanOrEqual(303); // max 300 + boundary truncation
+      // toConversationSummary re-truncates to 700 chars (+ boundary slack + "...")
+      expect(parsed[0].firstUserMessage.length).toBeLessThanOrEqual(710);
       expect(parsed[0].firstUserMessage).toContain('...');
     });
 
@@ -424,7 +441,9 @@ describe('listConversationsTool.handler', () => {
       const _response = JSON.parse((result.content[0] as any).text);
       const parsed = _response.conversations ?? _response;
 
-      expect(parsed[0].isCompleted).toBe(false);
+      // #1245 UX: isCompleted is omitted when false (only emitted when true).
+      // Treat undefined as the absence of completion.
+      expect(parsed[0].isCompleted ?? false).toBe(false);
     });
 
     test('completionMessage extrait du résultat de attempt_completion', async () => {

--- a/servers/roo-state-manager/src/tools/conversation/__tests__/list-conversations.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/conversation/__tests__/list-conversations.tool.test.ts
@@ -406,9 +406,36 @@ describe('list-conversations', () => {
   });
 
   describe('handler - limit parameter', () => {
-    it('should limit number of results', async () => {
+    it('should honor limit when above the floor (#1245: clamped to [10, 100])', async () => {
+      // Create 20 tasks, ask for 15 → returns 15
       const mockCache = new Map<string, any>();
-      for (let i = 0; i < 10; i++) {
+      for (let i = 0; i < 20; i++) {
+        mockCache.set(`task${i}`, {
+          taskId: `task${i}`,
+          metadata: {
+            lastActivity: new Date(Date.now() - i * 3600000).toISOString(),
+            createdAt: '2025-01-01T12:00:00.000Z',
+            messageCount: 10,
+            actionCount: 5,
+            totalSize: 1000
+          }
+        });
+      }
+
+      const result = await listConversationsTool.handler(
+        { limit: 15 },
+        mockCache
+      );
+      const _response = JSON.parse(result.content[0].text as string);
+      const parsed = _response.conversations ?? _response;
+
+      expect(parsed).toHaveLength(15);
+    });
+
+    it('should clamp limit to floor of 10 (pages of 5 are useless)', async () => {
+      // Create 12 tasks, ask for 5 → clamped up to 10
+      const mockCache = new Map<string, any>();
+      for (let i = 0; i < 12; i++) {
         mockCache.set(`task${i}`, {
           taskId: `task${i}`,
           metadata: {
@@ -428,7 +455,7 @@ describe('list-conversations', () => {
       const _response = JSON.parse(result.content[0].text as string);
       const parsed = _response.conversations ?? _response;
 
-      expect(parsed).toHaveLength(5);
+      expect(parsed).toHaveLength(10);
     });
 
     it('should return all results when limit is not specified', async () => {

--- a/servers/roo-state-manager/src/tools/conversation/conversation-browser.ts
+++ b/servers/roo-state-manager/src/tools/conversation/conversation-browser.ts
@@ -68,6 +68,16 @@ export interface ConversationBrowserArgs {
     // ===== Arguments pour action='current' =====
     /** [current/view] Chemin du workspace (détection auto si omis) */
     workspace?: string;
+    /** [list] #1244 Couche 2.2 — Strategie de matching du workspace.
+     * 'exact' = comparaison stricte, 'normalized' (defaut) = match basename tolerant cross-machine,
+     * 'substring' = test includes pour recherches exploratoires. */
+    workspacePathMatch?: 'exact' | 'normalized' | 'substring';
+    /** [list] #1244 Couche 2.1 — Date debut (ISO 8601 ou YYYY-MM-DD). Filtre lastActivity >= startDate. */
+    startDate?: string;
+    /** [list] #1244 Couche 2.1 — Date fin (ISO 8601 ou YYYY-MM-DD). Filtre lastActivity <= endDate. */
+    endDate?: string;
+    /** [list] #1244 Couche 2.1 — Filtre par identifiant machine (cross-machine). */
+    machineId?: string;
 
     // ===== Arguments pour action='view' (via view_conversation_tree) =====
     /** [view] ID de la tâche de départ */
@@ -80,7 +90,7 @@ export interface ConversationBrowserArgs {
     truncate?: number;
     /** [view] Limite max de caractères en sortie */
     max_output_length?: number;
-    /** [view] Activer la troncature intelligente */
+    /** [view] #1244 Couche 2.5 — Troncature intelligente avec gradient. Activee PAR DEFAUT. */
     smart_truncation?: boolean;
     /** [view] Configuration troncature intelligente */
     smart_truncation_config?: {
@@ -88,6 +98,10 @@ export interface ConversationBrowserArgs {
         minPreservationRate?: number;
         maxTruncationRate?: number;
     };
+    /** [view] #1244 Couche 2.6 — Index 0-based du premier message a inclure (inclusif). */
+    messageStart?: number;
+    /** [view] #1244 Couche 2.6 — Index 0-based du dernier message a inclure (exclusif). */
+    messageEnd?: number;
     /** [view] Chemin pour sauvegarder l'arbre */
     output_file?: string;
 
@@ -144,6 +158,10 @@ export interface ConversationBrowserArgs {
     force_rebuild?: boolean;
     /** [rebuild] Liste d'IDs de tâches spécifiques à reconstruire */
     task_ids?: string[];
+    /** [rebuild] #1244 Couche 1.4 — Sources de squelettes ('roo'|'claude'|'archive'). Defaut: ['roo']. */
+    sources?: Array<'roo' | 'claude' | 'archive'>;
+    /** [rebuild] #1244 Couche 1.4 — Si true, force l'enqueue Qdrant pour tous les squelettes (tous tiers). */
+    reindex?: boolean;
 }
 
 /**
@@ -151,14 +169,14 @@ export interface ConversationBrowserArgs {
  */
 export const conversationBrowserTool: Tool = {
     name: 'conversation_browser',
-    description: 'Outil consolidé pour naviguer, visualiser et résumer les conversations. Actions: "list" (lister les conversations récentes), "tree" (arbre des tâches), "current" (tâche active), "view" (vue conversation), "summarize" (résumé/synthèse — types: "trace", "cluster", "synthesis" pour analyse LLM complète), "rebuild" (reconstruire le cache de squelettes sur disque). Commencez par "list" pour découvrir les IDs de tâches.',
+    description: 'Outil consolide pour naviguer, visualiser et resumer les conversations Roo et Claude Code (cross-machine via archives GDrive). Actions: "list" (decouvrir les conversations avec filtres), "tree" (arbre parent-enfant), "current" (tache active du workspace), "view" (zoom contenu d\'une conversation, supporte la pagination message-level), "summarize" (resume/synthese), "rebuild" (reconstruire le cache multi-tier roo+claude+archive). Pattern de zoom: list -> view(detail_level=skeleton) -> view(messageStart/messageEnd) -> summarize. Toujours commencer par "list" pour decouvrir les IDs.',
     inputSchema: {
         type: 'object',
         properties: {
             action: {
                 type: 'string',
                 enum: ['list', 'tree', 'current', 'view', 'summarize', 'rebuild'],
-                description: 'Action à effectuer. Utilisez "list" pour découvrir les conversations disponibles et leurs IDs. "rebuild" force la reconstruction du cache de squelettes.'
+                description: 'Action a effectuer. "list" = decouvrir les conversations (filtres workspace, machineId, startDate/endDate, contentPattern, source). "view" = inspecter une tache (detail_level=skeleton/summary/full, messageStart/messageEnd pour pagination). "summarize" = trace/cluster/synthesis. "tree" = arbre parent-enfant. "rebuild" = reconstruire le cache multi-tier (sources=[roo,claude,archive]).'
             },
             // --- Arguments list ---
             limit: {
@@ -224,21 +242,39 @@ export const conversationBrowserTool: Tool = {
                 type: 'string',
                 description: '[current/view] Chemin du workspace (détection auto si omis).'
             },
+            workspacePathMatch: {
+                type: 'string',
+                enum: ['exact', 'normalized', 'substring'],
+                description: '[list] #1244 Couche 2.2 — Strategie de matching du workspace. "exact": comparaison stricte (apres normalisation forward-slash). "normalized" (defaut): match par basename, tolere les variations de chemin parent (`d:/dev/CoursIA` == `d:/CoursIA`) — strategie cross-machine la plus robuste. "substring": test includes lowercase, le plus tolerant.',
+                default: 'normalized'
+            },
+            startDate: {
+                type: 'string',
+                description: '[list] #1244 Couche 2.1 — Date debut (ISO 8601 ou YYYY-MM-DD). Filtre les taches dont lastActivity >= startDate. Combinable avec endDate. Exemple: "2026-04-07".'
+            },
+            endDate: {
+                type: 'string',
+                description: '[list] #1244 Couche 2.1 — Date fin (ISO 8601 ou YYYY-MM-DD). Filtre les taches dont lastActivity <= endDate (inclusif jusqu\'a fin de journee). Exemple: "2026-04-08".'
+            },
+            machineId: {
+                type: 'string',
+                description: '[list] #1244 Couche 2.1 — Filtre par identifiant machine (cross-machine). Permet d\'isoler les conversations d\'une machine specifique parmi les archives chargees depuis GDrive. Exemple: "myia-po-2025".'
+            },
             // --- Arguments view ---
             task_id: {
                 type: 'string',
-                description: '[view] ID de la tâche de départ.'
+                description: '[view/summarize] ID de la tâche à inspecter. Decouvrir les IDs via action="list" en premier. Pour les sessions Claude Code, le prefixe peut etre "claude-" ; les taches Roo et les archives utilisent l\'UUID brut.'
             },
             view_mode: {
                 type: 'string',
                 enum: ['single', 'chain', 'cluster'],
-                description: '[view] Mode d\'affichage.',
+                description: '[view] Mode d\'affichage. "single" = une tache, "chain" (defaut) = remonte la chaine parent, "cluster" = arbre enfants.',
                 default: 'chain'
             },
             detail_level: {
                 type: 'string',
                 enum: ['skeleton', 'summary', 'full'],
-                description: '[view] Niveau de détail.',
+                description: '[view] Niveau de detail (zoom progressif). "skeleton" (defaut, ~15k chars) = vue overview ; "summary" (~50k) = contenu principal condense ; "full" (~150k) = sequence complete avec tous les outils. Combiner avec messageStart/messageEnd pour pagination message-level.',
                 default: 'skeleton'
             },
             truncate: {
@@ -248,13 +284,13 @@ export const conversationBrowserTool: Tool = {
             },
             max_output_length: {
                 type: 'number',
-                description: '[view] Limite max de caractères en sortie.',
+                description: '[view] Limite max de caractères en sortie. Un hard cap final est applique pour garantir le respect de cette limite quel que soit le mode de troncature.',
                 default: 300000
             },
             smart_truncation: {
                 type: 'boolean',
-                description: '[view] Activer la troncature intelligente avec gradient.',
-                default: false
+                description: '[view] #1244 Couche 2.5 — Algorithme de troncature intelligente (gradient temporel + priorisation par type, preserve debut/fin de conversation). Active PAR DEFAUT depuis #1244. Passer false uniquement pour debug ou comparaison avec le legacy path.',
+                default: true
             },
             smart_truncation_config: {
                 type: 'object',
@@ -264,6 +300,14 @@ export const conversationBrowserTool: Tool = {
                     minPreservationRate: { type: 'number' },
                     maxTruncationRate: { type: 'number' }
                 }
+            },
+            messageStart: {
+                type: 'number',
+                description: '[view] #1244 Couche 2.6 — Index 0-based du premier message a inclure (inclusif). Permet la pagination message-level sur les longues conversations. Defaut: 0 (debut). Pour paginer, re-appeler view avec messageStart = messageEnd precedent.'
+            },
+            messageEnd: {
+                type: 'number',
+                description: '[view] #1244 Couche 2.6 — Index 0-based du dernier message a inclure (exclusif). Si > total, est clampe a total. Defaut: jusqu\'a la fin. La reponse inclut messageRange: {start, end, total} et truncated: bool pour faciliter la navigation.'
             },
             output_file: {
                 type: 'string',
@@ -393,6 +437,16 @@ export const conversationBrowserTool: Tool = {
                 type: 'array',
                 items: { type: 'string' },
                 description: '[rebuild] Liste optionnelle d\'IDs de tâches spécifiques à reconstruire.'
+            },
+            sources: {
+                type: 'array',
+                items: { type: 'string', enum: ['roo', 'claude', 'archive'] },
+                description: '[rebuild] #1244 Couche 1.4 — Sources de squelettes a charger. Defaut: ["roo"]. "claude" inclut les sessions Claude Code locales (Tier 2). "archive" inclut les archives cross-machine GDrive (Tier 3, requiert ROOSYNC_SHARED_PATH).'
+            },
+            reindex: {
+                type: 'boolean',
+                description: '[rebuild] #1244 Couche 1.4 — Si true, force l\'enqueue Qdrant pour tous les squelettes construits/charges (tous tiers).',
+                default: false
             }
         },
         required: ['action']
@@ -523,9 +577,14 @@ export async function handleConversationBrowser(
                         sortBy: args.sortBy,
                         sortOrder: args.sortOrder,
                         workspace: args.workspace,
+                        workspacePathMatch: args.workspacePathMatch,
                         pendingSubtaskOnly: args.pendingSubtaskOnly,
                         contentPattern: args.contentPattern,
-                        source: args.source
+                        source: args.source,
+                        // #1244 Couche 2.1 — Filtres date/machine cross-machine
+                        startDate: args.startDate,
+                        endDate: args.endDate,
+                        machineId: args.machineId
                     },
                     conversationCache
                 );
@@ -575,6 +634,9 @@ export async function handleConversationBrowser(
                         max_output_length: args.max_output_length,
                         smart_truncation: args.smart_truncation,
                         smart_truncation_config: args.smart_truncation_config,
+                        // #1244 Couche 2.6 — Pagination message-level
+                        messageStart: args.messageStart,
+                        messageEnd: args.messageEnd,
                         output_file: args.output_file
                     },
                     conversationCache
@@ -638,11 +700,14 @@ export async function handleConversationBrowser(
 
             case 'rebuild': {
                 // Delegate to the existing build_skeleton_cache handler
+                // #1244 Couche 1.4 — Forward sources/reindex pour le multi-tier rebuild
                 return await handleBuildSkeletonCache(
                     {
                         force_rebuild: args.force_rebuild,
                         workspace_filter: args.workspace,
-                        task_ids: args.task_ids
+                        task_ids: args.task_ids,
+                        sources: args.sources,
+                        reindex: args.reindex
                     },
                     conversationCache,
                     serverState

--- a/servers/roo-state-manager/src/tools/conversation/conversation-browser.ts
+++ b/servers/roo-state-manager/src/tools/conversation/conversation-browser.ts
@@ -548,6 +548,17 @@ async function handleSynthesisAction(
 }
 
 /**
+ * #1262 — Timeout dur appliqué à toute exécution de conversation_browser.
+ * Si une action (list/view/tree/current/...) prend plus de CONVERSATION_BROWSER_TIMEOUT_MS,
+ * c'est un BUG à signaler : la pagination de liste ou l'affichage d'une conversation
+ * doit se terminer en moins de 30 secondes. Override via env CONVERSATION_BROWSER_TIMEOUT_MS.
+ */
+const CONVERSATION_BROWSER_TIMEOUT_MS = parseInt(
+    process.env.CONVERSATION_BROWSER_TIMEOUT_MS || '30000',
+    10
+);
+
+/**
  * Handler consolidé pour l'outil conversation_browser
  *
  * @param args Arguments de l'outil
@@ -558,6 +569,74 @@ async function handleSynthesisAction(
  * @param findChildTasks Finder de tâches enfantes (pour summarize cluster)
  */
 export async function handleConversationBrowser(
+    args: ConversationBrowserArgs,
+    conversationCache: Map<string, ConversationSkeleton>,
+    ensureSkeletonCacheIsFresh: () => Promise<void>,
+    contextWorkspace?: string,
+    getConversationSkeleton?: (id: string) => Promise<ConversationSkeleton | null>,
+    findChildTasks?: (rootId: string) => Promise<ConversationSkeleton[]>,
+    serverState?: ServerState
+): Promise<CallToolResult> {
+    // #1262 — Hard timeout (default 30s, env-overridable).
+    // The inner work runs unmodified; we just race it against a timer.
+    const startedAt = Date.now();
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const timeoutPromise = new Promise<CallToolResult>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+            reject(new Error(
+                `conversation_browser TIMEOUT after ${CONVERSATION_BROWSER_TIMEOUT_MS}ms ` +
+                `(action: ${args.action}). This is a BUG to report: list pagination or ` +
+                `conversation detail must complete in <30s. Likely culprit: blocking ` +
+                `ensureSkeletonCacheIsFresh() in src/index.ts (failsafe full rebuild or ` +
+                `disk-scan storm). Workaround: disable force_refresh and retry; if it still ` +
+                `blocks, restart the MCP server.`
+            ));
+        }, CONVERSATION_BROWSER_TIMEOUT_MS);
+        // Allow process to exit even if timer is still pending
+        if (typeof timeoutHandle?.unref === 'function') {
+            timeoutHandle.unref();
+        }
+    });
+
+    try {
+        return await Promise.race([
+            handleConversationBrowserCore(
+                args,
+                conversationCache,
+                ensureSkeletonCacheIsFresh,
+                contextWorkspace,
+                getConversationSkeleton,
+                findChildTasks,
+                serverState
+            ),
+            timeoutPromise
+        ]);
+    } catch (error) {
+        const elapsedMs = Date.now() - startedAt;
+        const errorMessage = error instanceof Error ? error.message : 'Erreur inconnue';
+        // Distinguish timeout from other errors so callers can spot the bug.
+        const isTimeout = errorMessage.includes('TIMEOUT after');
+        return {
+            content: [{
+                type: 'text',
+                text: isTimeout
+                    ? `${errorMessage} (elapsed=${elapsedMs}ms)`
+                    : `Erreur lors de conversation_browser: ${errorMessage}`
+            }],
+            isError: true
+        };
+    } finally {
+        if (timeoutHandle) {
+            clearTimeout(timeoutHandle);
+        }
+    }
+}
+
+/**
+ * #1262 — Cœur de l'implémentation, isolé pour permettre le wrapping par timeout.
+ * Ne pas exporter : le seul point d'entrée public reste handleConversationBrowser.
+ */
+async function handleConversationBrowserCore(
     args: ConversationBrowserArgs,
     conversationCache: Map<string, ConversationSkeleton>,
     ensureSkeletonCacheIsFresh: () => Promise<void>,

--- a/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
+++ b/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
@@ -6,9 +6,11 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ConversationSkeleton } from '../../types/conversation.js';
 import { SkeletonCacheService } from '../../services/skeleton-cache.service.js';
 import { normalizePath } from '../../utils/path-normalizer.js';
+import { normalizeWorkspaceId } from '../../utils/message-helpers.js';
 import { scanDiskForNewTasks } from '../task/disk-scanner.js';
 import { ClaudeStorageDetector } from '../../utils/claude-storage-detector.js';
 import { RooStorageDetector } from '../../utils/roo-storage-detector.js';
+import { parseFilterDate, isWithinDateRange } from '../../utils/date-filters.js';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -68,6 +70,10 @@ interface ApiMessage {
  */
 interface ConversationSummary {
     taskId: string;
+    /** #883 / #1244 Couche 3.2 — 'roo' or 'claude'. Prefer metadata.source over taskId prefix. */
+    source?: 'roo' | 'claude';
+    /** #1244 Couche 3.2 — 'local' (hot tier 1/2) or 'archive' (cold tier 3 GDrive). */
+    tier?: 'local' | 'archive';
     parentTaskId?: string;
     firstUserMessage?: string;
     lastUserMessage?: string;
@@ -152,7 +158,22 @@ function toConversationSummary(node: SkeletonNode, _depth = 0): Record<string, u
     // Build summary — always include key fields for readability
     const summary: Record<string, unknown> = { taskId: node.taskId };
     // #883: Always show source type (roo/claude)
-    summary.source = node.taskId.startsWith('claude-') ? 'claude' : 'roo';
+    // #1244 Couche 3.2 — Prefer metadata.source (set by SkeletonCacheService Tier 2/3)
+    // before falling back to taskId prefix detection. Allows archives to surface their
+    // ORIGINAL source ('roo' or 'claude-code') instead of being inferred from the prefix.
+    const metaSource = (node.metadata as any)?.source;
+    if (metaSource === 'claude-code' || metaSource === 'claude') {
+        summary.source = 'claude';
+    } else if (metaSource === 'roo') {
+        summary.source = 'roo';
+    } else {
+        summary.source = node.taskId.startsWith('claude-') ? 'claude' : 'roo';
+    }
+    // #1244 Couche 3.2 — Tier indicator: 'archive' (cold, cross-machine GDrive) vs 'local' (hot).
+    // Derived from metadata.dataSource set by archive-skeleton-builder / Claude tier loader.
+    // Lets agents know whether a result comes from local fast cache or remote archive.
+    const dataSource = node.metadata?.dataSource;
+    summary.tier = dataSource === 'archive' ? 'archive' : 'local';
     if (node.parentTaskId) summary.parentTaskId = node.parentTaskId;
     if (firstMsg) summary.firstUserMessage = firstMsg;
     if (lastMsg) summary.lastUserMessage = lastMsg;
@@ -303,6 +324,34 @@ function truncateSummary(summary: string, maxLength: number): string {
 }
 
 /**
+ * #1244 Couche 2.2 — Strategie de matching de workspace.
+ *
+ * - 'exact'      : equivalent strict (apres normalisation forward-slash + lowercase)
+ *                  via normalizePath. Conserve le chemin complet (`d:/dev/CoursIA` != `d:/CoursIA`).
+ * - 'normalized' : (defaut) match basename via normalizeWorkspaceId. Tolere les
+ *                  variations de chemin parent (`d:/dev/CoursIA` == `d:/CoursIA` == `CoursIA`).
+ *                  C'est la strategie cross-machine la plus robuste — un meme workspace
+ *                  ouvert depuis differents drives ou via des liens symboliques matche.
+ * - 'substring'  : test `includes` lowercase. Le plus tolerant, pour les recherches
+ *                  exploratoires (`workspace: 'CoursIA'` matche tout chemin contenant CoursIA).
+ */
+function matchesWorkspace(
+    skeletonWorkspace: string | undefined,
+    queryWorkspace: string,
+    strategy: 'exact' | 'normalized' | 'substring' = 'normalized'
+): boolean {
+    if (!skeletonWorkspace) return false;
+    if (strategy === 'exact') {
+        return normalizePath(skeletonWorkspace) === normalizePath(queryWorkspace);
+    }
+    if (strategy === 'substring') {
+        return skeletonWorkspace.toLowerCase().includes(queryWorkspace.toLowerCase());
+    }
+    // 'normalized' (default)
+    return normalizeWorkspaceId(skeletonWorkspace) === normalizeWorkspaceId(queryWorkspace);
+}
+
+/**
  * Définition de l'outil list_conversations
  */
 export const listConversationsTool = {
@@ -320,6 +369,12 @@ export const listConversationsTool = {
                 hasApiHistory: { type: 'boolean' },
                 hasUiMessages: { type: 'boolean' },
                 workspace: { type: 'string', description: 'Filtre les conversations par chemin de workspace.' },
+                workspacePathMatch: {
+                    type: 'string',
+                    enum: ['exact', 'normalized', 'substring'],
+                    description: '#1244 Couche 2.2 — Strategie de matching du workspace. "exact": comparaison stricte (apres forward-slash + lowercase). "normalized" (defaut): match par basename, tolere les variations de chemin parent (`d:/dev/CoursIA` == `d:/CoursIA`). "substring": test includes lowercase, le plus tolerant.',
+                    default: 'normalized'
+                },
                 pendingSubtaskOnly: {
                     type: 'boolean',
                     description: 'Si true, retourne uniquement les tâches ayant une instruction de sous-tâche non complétée'
@@ -327,6 +382,18 @@ export const listConversationsTool = {
                 contentPattern: {
                     type: 'string',
                     description: 'Filtre les tâches contenant ce texte dans leurs messages (recherche insensible à la casse)'
+                },
+                startDate: {
+                    type: 'string',
+                    description: '#1244 Couche 2.1 — Date debut (ISO 8601 ou YYYY-MM-DD). Filtre les taches dont lastActivity >= startDate. Combinable avec endDate pour fenetrer une periode.'
+                },
+                endDate: {
+                    type: 'string',
+                    description: '#1244 Couche 2.1 — Date fin (ISO 8601 ou YYYY-MM-DD). Filtre les taches dont lastActivity <= endDate. Combinable avec startDate.'
+                },
+                machineId: {
+                    type: 'string',
+                    description: '#1244 Couche 2.1 — Filtre par identifiant machine (cross-machine). Permet d\'isoler les conversations d\'une machine specifique (ex: "myia-po-2025") parmi les archives chargees depuis GDrive.'
                 },
             },
         },
@@ -343,9 +410,14 @@ export const listConversationsTool = {
             sortBy?: 'lastActivity' | 'messageCount' | 'totalSize',
             sortOrder?: 'asc' | 'desc',
             workspace?: string,
+            workspacePathMatch?: 'exact' | 'normalized' | 'substring',
             pendingSubtaskOnly?: boolean,
             contentPattern?: string,
-            source?: 'roo' | 'claude' | 'all'
+            source?: 'roo' | 'claude' | 'all',
+            // #1244 Couche 2.1 — Filtres date/machine cross-machine
+            startDate?: string,
+            endDate?: string,
+            machineId?: string
         },
         conversationCache: Map<string, ConversationSkeleton>
     ): Promise<CallToolResult> => {
@@ -384,12 +456,15 @@ export const listConversationsTool = {
             );
         }
 
+        // #1244 Couche 2.2 — Strategie de matching du workspace (defaut: 'normalized')
+        const workspaceMatchStrategy = args.workspacePathMatch || 'normalized';
+
         // Include Claude Code sessions
         if (includeClaude) {
             // PERF: Timeout wrapper (5s) prevents Claude session scan from blocking list responses
             // Claude sessions can be 2GB+ across 200+ JSONL files — scan must not block foreground tools
             try {
-                const claudePromise = scanClaudeSessions(args.workspace);
+                const claudePromise = scanClaudeSessions(args.workspace, workspaceMatchStrategy);
                 const claudeTimeout = new Promise<ConversationSkeleton[]>((_, reject) =>
                     setTimeout(() => reject(new Error('Claude session scan timeout (5s)')), 5000)
                 );
@@ -403,25 +478,34 @@ export const listConversationsTool = {
         // Filtrage par workspace
         let workspaceFilteredCount = 0;
         if (args.workspace) {
-            const normalizedWorkspace = normalizePath(args.workspace);
             const countBeforeFilter = allSkeletons.length;
-            
-            // 🔇 LOGS VERBEUX COMMENTÉS (explosion contexte - liste workspaces disponibles)
-            // console.log(`[DEBUG] Filtering by workspace: "${args.workspace}" -> normalized: "${normalizedWorkspace}"`);
-            // const workspaces = allSkeletons
-            //     .filter(s => s.metadata.workspace)
-            //     .map(s => `"${s.metadata.workspace!}" -> normalized: "${normalizePath(s.metadata.workspace!)}"`)
-            //     .slice(0, 5);
-            // console.log(`[DEBUG] Available workspaces (first 5):`, workspaces);
-            
             allSkeletons = allSkeletons.filter(skeleton =>
-                skeleton.metadata.workspace &&
-                normalizePath(skeleton.metadata.workspace) === normalizedWorkspace
+                matchesWorkspace(skeleton.metadata.workspace, args.workspace!, workspaceMatchStrategy)
             );
-
             workspaceFilteredCount = countBeforeFilter - allSkeletons.length;
             // 🔇 LOG VERBEUX COMMENTÉ (explosion contexte)
             // console.log(`[DEBUG] Found ${allSkeletons.length} conversations matching workspace filter`);
+        }
+
+        // #1244 Couche 2.1 — Filtre par fenetre temporelle (lastActivity dans [startDate, endDate])
+        // Les bornes acceptent ISO 8601 ou YYYY-MM-DD. endDate inclut la journee entiere.
+        const parsedStartDate = parseFilterDate(args.startDate);
+        const parsedEndDate = parseFilterDate(args.endDate);
+        if (parsedStartDate || parsedEndDate) {
+            allSkeletons = allSkeletons.filter(skeleton =>
+                isWithinDateRange(skeleton.metadata?.lastActivity, parsedStartDate, parsedEndDate)
+            );
+        }
+
+        // #1244 Couche 2.1 — Filtre par identifiant machine (cross-machine).
+        // Permet d'isoler les conversations d'une machine specifique parmi les
+        // squelettes charges depuis archive (Tier 3) ou Roo local.
+        if (args.machineId && args.machineId.trim().length > 0) {
+            const targetMachineId = args.machineId.trim().toLowerCase();
+            allSkeletons = allSkeletons.filter(skeleton => {
+                const m = (skeleton.metadata?.machineId || '').toLowerCase();
+                return m === targetMachineId;
+            });
         }
 
         // Filtre : Tâches en attente de sous-tâche
@@ -444,13 +528,13 @@ export const listConversationsTool = {
         }
 
         // Filtre : Recherche de contenu
+        // #1244 Couche 2.4 — On passe le skeleton entier pour permettre la recherche
+        // memoire sur les Tier 2/3 (sequence deja chargee) sans I/O disque inutile.
         if (args.contentPattern && args.contentPattern.trim().length > 0) {
-            const beforeCount = allSkeletons.length;
-
             const matchingTasks: ConversationSkeleton[] = [];
             for (const skeleton of allSkeletons) {
                 try {
-                    const matches = await matchesContentPattern(skeleton.taskId, args.contentPattern);
+                    const matches = await matchesContentPattern(skeleton, args.contentPattern);
                     if (matches) {
                         matchingTasks.push(skeleton);
                     }
@@ -669,21 +753,48 @@ async function hasPendingSubtask(taskId: string): Promise<boolean> {
 }
 
 /**
- * Vérifie si les messages d'une tâche contiennent un motif de texte
+ * Vérifie si les messages d'une tâche contiennent un motif de texte.
+ *
+ * #1244 Couche 2.4 — Multi-source contentPattern :
+ *  - Tier 2 (Claude) et Tier 3 (Archive) : la sequence est deja en memoire
+ *    (full skeleton dans le cache). On cherche directement dedans, sans I/O disque.
+ *  - Tier 1 (Roo local) : lecture de `api_conversation_history.json` depuis le disque
+ *    via `loadApiMessages()`. Comportement historique.
+ *
+ * Avant le fix, seules les taches Roo avec api_conversation_history sur disque etaient
+ * traversees — les sessions Claude et les archives cross-machine etaient invisibles.
  */
-async function matchesContentPattern(taskId: string, pattern: string): Promise<boolean> {
-    try {
-        const apiMessages = await loadApiMessages(taskId);
-        const normalizedPattern = pattern.toLowerCase().trim();
+async function matchesContentPattern(skeleton: ConversationSkeleton, pattern: string): Promise<boolean> {
+    const normalizedPattern = pattern.toLowerCase().trim();
+    if (normalizedPattern.length === 0) return true;
 
-        return apiMessages.some(msg => {
-            const textContent = extractTextFromMessage(msg).toLowerCase();
-            return textContent.includes(normalizedPattern);
+    // 1. Sequence deja chargee (Tier 2 Claude / Tier 3 Archive) — recherche memoire
+    const sequence = (skeleton as any).sequence;
+    if (Array.isArray(sequence) && sequence.length > 0) {
+        return sequence.some((msg: any) => {
+            if (!msg || msg.role === undefined) return false;
+            const raw = typeof msg.content === 'string' ? msg.content : '';
+            return raw.toLowerCase().includes(normalizedPattern);
         });
-    } catch (error) {
-        console.warn(`[matchesContentPattern] Error for task ${taskId}:`, error);
-        return false;
     }
+
+    // 2. Tier 1 (Roo local) — lire api_conversation_history depuis le disque
+    //    (les taches Roo n'ont pas de sequence en cache, juste un SkeletonHeader)
+    if (!skeleton.taskId.startsWith('claude-')) {
+        try {
+            const apiMessages = await loadApiMessages(skeleton.taskId);
+            return apiMessages.some(msg => {
+                const textContent = extractTextFromMessage(msg).toLowerCase();
+                return textContent.includes(normalizedPattern);
+            });
+        } catch (error) {
+            console.warn(`[matchesContentPattern] Error reading Roo task ${skeleton.taskId}:`, error);
+            return false;
+        }
+    }
+
+    // 3. Claude session without cached sequence (Tier 2 disabled / load failed) — pas de fallback fiable
+    return false;
 }
 
 /**
@@ -986,16 +1097,18 @@ let lastClaudeScanResults: ConversationSkeleton[] | null = null;
  * Full content parsing was O(n²) — analyzeConversation re-read ALL project files for each file.
  * Now: one stat per file, metadata from filename/stat only. Content available via view action.
  */
-async function scanClaudeSessions(workspaceFilter?: string): Promise<ConversationSkeleton[]> {
+async function scanClaudeSessions(
+    workspaceFilter?: string,
+    workspaceMatchStrategy: 'exact' | 'normalized' | 'substring' = 'normalized'
+): Promise<ConversationSkeleton[]> {
     const now = Date.now();
 
     // Return cached results if TTL hasn't expired
     if (lastClaudeScanResults !== null && (now - lastClaudeScanTime) < CLAUDE_SCAN_CACHE_TTL) {
         // Apply workspace filter on cached results
         if (workspaceFilter) {
-            const normalizedFilter = normalizePath(workspaceFilter);
             return lastClaudeScanResults.filter(s =>
-                s.metadata?.workspace && normalizePath(s.metadata.workspace) === normalizedFilter
+                matchesWorkspace(s.metadata?.workspace, workspaceFilter, workspaceMatchStrategy)
             );
         }
         return lastClaudeScanResults;
@@ -1100,11 +1213,10 @@ async function scanClaudeSessions(workspaceFilter?: string): Promise<Conversatio
     lastClaudeScanTime = now;
     lastClaudeScanResults = skeletons;
 
-    // Apply workspace filter
+    // Apply workspace filter (#1244 Couche 2.2 — strategy-aware)
     if (workspaceFilter) {
-        const normalizedFilter = normalizePath(workspaceFilter);
         return skeletons.filter(s =>
-            s.metadata?.workspace && normalizePath(s.metadata.workspace) === normalizedFilter
+            matchesWorkspace(s.metadata?.workspace, workspaceFilter, workspaceMatchStrategy)
         );
     }
 

--- a/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
+++ b/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
@@ -39,6 +39,10 @@ interface SkeletonNode {
     };
     firstUserMessage?: string;
     lastUserMessage?: string;
+    /** Last message of ANY role (user or assistant). Often shows the final state/result of the conversation. */
+    lastMessage?: string;
+    /** Role of the last message ('user' or 'assistant'). Helps disambiguate in output. */
+    lastMessageRole?: 'user' | 'assistant';
     lastAction?: string;
     isCompleted?: boolean;
     completionMessage?: string;
@@ -47,6 +51,9 @@ interface SkeletonNode {
         summary?: string;
         generatedAt?: string;
     };
+    /** Optional per-role message counts (when extractable) */
+    userMessageCount?: number;
+    assistantMessageCount?: number;
     children: SkeletonNode[];
 }
 
@@ -77,6 +84,8 @@ interface ConversationSummary {
     parentTaskId?: string;
     firstUserMessage?: string;
     lastUserMessage?: string;
+    lastMessage?: string;
+    lastMessageRole?: 'user' | 'assistant';
     lastAction?: string;
     isCompleted?: boolean;
     completionMessage?: string;
@@ -91,6 +100,8 @@ interface ConversationSummary {
         createdAt: string;
         mode?: string;
         messageCount: number;
+        userMessageCount?: number;
+        assistantMessageCount?: number;
         actionCount: number;
         totalSize?: number;
         workspace?: string;
@@ -99,20 +110,88 @@ interface ConversationSummary {
     children: ConversationSummary[];
 }
 
-/** Max children shown inline in list output (was 10 before regression, 3 was too aggressive) */
-const MAX_CHILDREN_SHOWN = 10;
+/** Max children shown inline in list output.
+ *  #1245 round 2: reduced from 10 → 5 to make budget room for richer root-level
+ *  firstUserMessage/lastMessage snippets while staying under 50KB total output. */
+const MAX_CHILDREN_SHOWN = 5;
 
 /**
  * Strip XML wrapper tags (<user_message>, </user_message>, <task>, etc.) from message text.
- * These are Roo internal tags that add noise to list output.
+ * Also strips leading BOM (U+FEFF) which appears in some Claude task titles and breaks
+ * downstream string comparisons (e.g. title vs firstUserMessage dedup).
+ * These are Roo/JSONL internal artifacts that add noise to list output.
  */
 function stripXmlTags(text?: string): string | undefined {
     if (!text) return undefined;
     return text
+        .replace(/^\uFEFF/, '') // Strip BOM (Claude session metadata)
         .replace(/<\/?user_message>/g, '')
         .replace(/<\/?task>/g, '')
         .replace(/^\s*\n/, '') // leading blank line after tag removal
         .trim() || undefined;
+}
+
+/**
+ * Normalize a string for content-equality comparison: strip BOM, lowercase,
+ * collapse whitespace runs to single spaces. Used to detect title vs
+ * firstUserMessage redundancy regardless of cosmetic differences.
+ */
+function normalizeForCompare(s: string | undefined): string {
+    if (!s) return '';
+    return s.replace(/^\uFEFF/, '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+/**
+ * Format a duration as a human-readable relative time.
+ * "now", "3m ago", "2h ago", "5d ago", "3w ago", "2mo ago", "1y ago".
+ * Returns undefined if the input is invalid/missing.
+ */
+function formatRelativeTime(iso: string | undefined): string | undefined {
+    if (!iso) return undefined;
+    const t = new Date(iso).getTime();
+    if (Number.isNaN(t)) return undefined;
+    const deltaMs = Date.now() - t;
+    if (deltaMs < 0) return 'in future';
+    const sec = Math.floor(deltaMs / 1000);
+    if (sec < 60) return 'now';
+    const min = Math.floor(sec / 60);
+    if (min < 60) return `${min}m ago`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `${hr}h ago`;
+    const day = Math.floor(hr / 24);
+    if (day < 7) return `${day}d ago`;
+    const wk = Math.floor(day / 7);
+    if (wk < 5) return `${wk}w ago`;
+    const mo = Math.floor(day / 30);
+    if (mo < 12) return `${mo}mo ago`;
+    const yr = Math.floor(day / 365);
+    return `${yr}y ago`;
+}
+
+/**
+ * Format a byte count as a human-readable size: "234 B", "1.2 KB", "3.4 MB", "2.5 GB".
+ */
+function formatBytes(bytes: number | undefined): string | undefined {
+    if (bytes === undefined || bytes === null || bytes < 0) return undefined;
+    if (bytes < 1024) return `${bytes} B`;
+    const kb = bytes / 1024;
+    if (kb < 1024) return `${kb.toFixed(1)} KB`;
+    const mb = kb / 1024;
+    if (mb < 1024) return `${mb.toFixed(1)} MB`;
+    const gb = mb / 1024;
+    return `${gb.toFixed(2)} GB`;
+}
+
+/**
+ * Extract the workspace basename from a full path. "d:/dev/roo-extensions" → "roo-extensions".
+ * Returns undefined for empty/invalid input.
+ */
+function getWorkspaceShort(workspace: string | undefined): string | undefined {
+    if (!workspace) return undefined;
+    const cleaned = workspace.replace(/[\\/]+$/, ''); // trim trailing slashes
+    const parts = cleaned.split(/[\\/]/);
+    const last = parts[parts.length - 1];
+    return last && last.length > 0 ? last : undefined;
 }
 
 /**
@@ -137,30 +216,45 @@ function truncateAtBoundary(text: string, maxLength: number): string {
 }
 
 /**
- * Convertit un SkeletonNode vers un objet JSON compact pour le list output.
+ * Convertit un SkeletonNode vers un objet JSON compact mais informatif pour list output.
  *
- * Compactness strategy (target: ~500 chars/root, ~100 chars/child):
- * - Strip XML tags from messages
- * - Root firstUserMessage ≤150 chars, lastUserMessage ≤120 chars
- * - Skip lastUserMessage if JSON (tool calls, not human text)
- * - Children: max 3 shown (taskId + 50-char snippet + messageCount), rest as childrenCount
- * - Omit falsy/default values (isCompleted:false, empty strings, actionCount:0)
- * - Omit title when redundant with firstUserMessage
- * - synthesis only when available
+ * UX strategy (#1245 — restoring richer output):
+ * - Strip XML tags + BOM from messages, word-boundary truncation
+ * - Title shown only when distinct from firstUserMessage (BOM-aware dedup)
+ * - Metadata enriched with: ago (relative time), sizeHuman, workspaceShort, actionCount
+ * - Noise omitted: tier when "local", isCompleted when false, lastUserMessage when == firstMsg
+ * - Children: compact format with snippet + ago + mode + completion status
  */
 function toConversationSummary(node: SkeletonNode, _depth = 0): Record<string, unknown> {
-    // Clean and truncate root messages — #1177: use word-boundary truncation for cleaner output
+    // Clean and truncate root messages — #1177: word-boundary truncation.
+    // #1245 (round 2): moderate bump (+50-100%) vs previous session, capped to keep
+    // total output under 50KB with default per_page=10 (user constraint — above 50KB
+    // Claude Code shortens the output to a file reference).
     let firstMsg = stripXmlTags(node.firstUserMessage);
-    let lastMsg = stripXmlTags(node.lastUserMessage);
-    if (firstMsg) firstMsg = truncateAtBoundary(firstMsg, 400);
-    if (lastMsg) lastMsg = truncateAtBoundary(lastMsg, 400);
+    let lastUMsg = stripXmlTags(node.lastUserMessage);
+    let lastAnyMsg = stripXmlTags(node.lastMessage);
+    if (firstMsg) firstMsg = truncateAtBoundary(firstMsg, 700);
+    if (lastUMsg) lastUMsg = truncateAtBoundary(lastUMsg, 500);
+    if (lastAnyMsg) lastAnyMsg = truncateAtBoundary(lastAnyMsg, 500);
+
+    // Drop lastUserMessage when it duplicates firstMsg (Claude tail/head collisions)
+    if (lastUMsg && normalizeForCompare(lastUMsg) === normalizeForCompare(firstMsg)) {
+        lastUMsg = undefined;
+    }
+    // Drop lastMessage (any role) when it duplicates firstMsg or lastUserMessage
+    if (lastAnyMsg && normalizeForCompare(lastAnyMsg) === normalizeForCompare(firstMsg)) {
+        lastAnyMsg = undefined;
+    }
+    if (lastAnyMsg && lastUMsg && normalizeForCompare(lastAnyMsg) === normalizeForCompare(lastUMsg)) {
+        lastAnyMsg = undefined; // already shown as lastUserMessage
+    }
 
     // Build summary — always include key fields for readability
     const summary: Record<string, unknown> = { taskId: node.taskId };
+
     // #883: Always show source type (roo/claude)
     // #1244 Couche 3.2 — Prefer metadata.source (set by SkeletonCacheService Tier 2/3)
-    // before falling back to taskId prefix detection. Allows archives to surface their
-    // ORIGINAL source ('roo' or 'claude-code') instead of being inferred from the prefix.
+    // before falling back to taskId prefix detection.
     const metaSource = (node.metadata as any)?.source;
     if (metaSource === 'claude-code' || metaSource === 'claude') {
         summary.source = 'claude';
@@ -169,51 +263,97 @@ function toConversationSummary(node: SkeletonNode, _depth = 0): Record<string, u
     } else {
         summary.source = node.taskId.startsWith('claude-') ? 'claude' : 'roo';
     }
-    // #1244 Couche 3.2 — Tier indicator: 'archive' (cold, cross-machine GDrive) vs 'local' (hot).
-    // Derived from metadata.dataSource set by archive-skeleton-builder / Claude tier loader.
-    // Lets agents know whether a result comes from local fast cache or remote archive.
+
+    // #1244 Couche 3.2 — Tier indicator. Only emitted when 'archive' (default 'local' is noise).
     const dataSource = node.metadata?.dataSource;
-    summary.tier = dataSource === 'archive' ? 'archive' : 'local';
+    if (dataSource === 'archive') {
+        summary.tier = 'archive';
+    }
+
     if (node.parentTaskId) summary.parentTaskId = node.parentTaskId;
     if (firstMsg) summary.firstUserMessage = firstMsg;
-    if (lastMsg) summary.lastUserMessage = lastMsg;
+    if (lastUMsg) summary.lastUserMessage = lastUMsg;
+    // lastMessage (any role) — often more informative than lastUserMessage because
+    // it surfaces the final assistant response / action / result of the conversation.
+    if (lastAnyMsg) {
+        summary.lastMessage = lastAnyMsg;
+        if (node.lastMessageRole) summary.lastMessageRole = node.lastMessageRole;
+    }
     if (node.lastAction) summary.lastAction = node.lastAction;
-    summary.isCompleted = node.isCompleted || false;
+    if (node.isCompleted) summary.isCompleted = true; // omit when false (default)
     if (node.completionMessage) summary.completionMessage = node.completionMessage;
     if (node.synthesis?.available) summary.synthesis = node.synthesis;
 
-    // Metadata — omit noise (actionCount) but keep useful fields
+    // Metadata — keep useful fields, drop noise.
+    // Field names preserve backward compat: workspace = full path, totalSize = raw bytes.
+    // New friendly fields added alongside: ago, sizeHuman, workspaceShort.
     const meta: Record<string, unknown> = {
         createdAt: node.metadata.createdAt,
         lastActivity: node.metadata.lastActivity,
-        messageCount: node.metadata.messageCount,
     };
-    if (node.metadata.totalSize) meta.totalSize = node.metadata.totalSize;
-    if (node.metadata.workspace) meta.workspace = node.metadata.workspace;
-    if (node.metadata.machineId) meta.machineId = node.metadata.machineId;
+    const ago = formatRelativeTime(node.metadata.lastActivity);
+    if (ago) meta.ago = ago;
+    meta.messageCount = node.metadata.messageCount;
+    // Per-role breakdown when available (extracted from Roo sequence or Claude JSONL scan).
+    if (node.userMessageCount !== undefined && node.userMessageCount >= 0) {
+        meta.userMessageCount = node.userMessageCount;
+    }
+    if (node.assistantMessageCount !== undefined && node.assistantMessageCount >= 0) {
+        meta.assistantMessageCount = node.assistantMessageCount;
+    }
+    if (node.metadata.actionCount && node.metadata.actionCount > 0) {
+        meta.actionCount = node.metadata.actionCount;
+    }
+    if (node.metadata.totalSize) {
+        meta.totalSize = node.metadata.totalSize;
+        const sizeHuman = formatBytes(node.metadata.totalSize);
+        if (sizeHuman) meta.sizeHuman = sizeHuman;
+    }
     if (node.metadata.mode) meta.mode = node.metadata.mode;
-    // Always include title as main snippet. When firstUserMessage also exists,
-    // skip title if it's just a prefix of firstUserMessage (redundant).
+    if (node.metadata.workspace) {
+        meta.workspace = node.metadata.workspace;
+        const wsShort = getWorkspaceShort(node.metadata.workspace);
+        if (wsShort && wsShort !== node.metadata.workspace) meta.workspaceShort = wsShort;
+    }
+    if (node.metadata.machineId) meta.machineId = node.metadata.machineId;
+
+    // Title: include only when distinct from firstUserMessage (BOM-aware dedup)
     if (node.metadata.title) {
-        let title = node.metadata.title;
+        let title = node.metadata.title.replace(/^\uFEFF/, ''); // strip BOM
         if (title.length > 200) title = title.substring(0, 200) + '...';
-        const titleRedundant = firstMsg && firstMsg.startsWith(title.substring(0, Math.min(50, title.length)));
+        const titleN = normalizeForCompare(title);
+        const firstMsgN = normalizeForCompare(firstMsg);
+        // Redundant if title is a prefix of (or equal to) firstMsg, OR firstMsg starts with title
+        const titleRedundant = titleN.length > 0 && firstMsgN.length > 0 && (
+            firstMsgN.startsWith(titleN) ||
+            (titleN.length >= 20 && firstMsgN.startsWith(titleN.substring(0, Math.min(60, titleN.length))))
+        );
         if (!titleRedundant) {
             meta.title = title;
         }
     }
     summary.metadata = meta;
 
-    // Children: show first N as compact objects, rest as childrenCount
+    // Children: show first N as compact objects with rich info
     if (node.children.length > 0) {
         const shown = node.children.slice(0, MAX_CHILDREN_SHOWN).map((child: SkeletonNode) => {
-            let childMsg = stripXmlTags(child.firstUserMessage) || child.metadata.title;
-            // #883: Increased from 100 to 200 chars
-            if (childMsg && childMsg.length > 200) childMsg = childMsg.substring(0, 200) + '...';
-            const c: Record<string, unknown> = { taskId: child.taskId, messageCount: child.metadata.messageCount };
+            // Prefer firstUserMessage; fall back to title (BOM-stripped)
+            let childMsg = stripXmlTags(child.firstUserMessage);
+            if (!childMsg && child.metadata.title) {
+                childMsg = child.metadata.title.replace(/^\uFEFF/, '');
+            }
+            if (childMsg && childMsg.length > 200) {
+                childMsg = childMsg.substring(0, 200) + '...';
+            }
+            const c: Record<string, unknown> = {
+                taskId: child.taskId,
+                messageCount: child.metadata.messageCount,
+            };
             if (childMsg) c.firstUserMessage = childMsg;
             if (child.metadata.mode) c.mode = child.metadata.mode;
-            c.isCompleted = child.isCompleted || false;
+            const childAgo = formatRelativeTime(child.metadata.lastActivity);
+            if (childAgo) c.ago = childAgo;
+            if (child.isCompleted) c.isCompleted = true; // omit when false
             return c;
         });
         summary.children = shown;
@@ -361,9 +501,9 @@ export const listConversationsTool = {
         inputSchema: {
             type: 'object',
             properties: {
-                limit: { type: 'number', description: 'Alias for per_page (backward compat). Max results per page.' },
+                limit: { type: 'number', description: 'Alias for per_page (backward compat). Clamped to [10, 100].' },
                 page: { type: 'number', description: 'Page number (1-based). Default: 1.' },
-                per_page: { type: 'number', description: 'Results per page. Default: 20. Max: 50.' },
+                per_page: { type: 'number', description: 'Results per page. Default: 10 (keeps output <50KB so Claude Code displays inline). Min: 10. Max: 100 (opt-in large pages — above ~50KB the host redirects output to a file).' },
                 sortBy: { type: 'string', enum: ['lastActivity', 'messageCount', 'totalSize'] },
                 sortOrder: { type: 'string', enum: ['asc', 'desc'] },
                 hasApiHistory: { type: 'boolean' },
@@ -569,10 +709,14 @@ export const listConversationsTool = {
         // Créer les SkeletonNode SANS la propriété sequence MAIS avec toutes les infos importantes
         const skeletonMap = new Map<string, SkeletonNode>(allSkeletons.map(s => {
             const sequence = (s as any).sequence;
-            
+
             // Variables pour les informations à extraire
             let firstUserMessage: string | undefined = undefined;
             let lastUserMessage: string | undefined = undefined;
+            let lastMessage: string | undefined = undefined;
+            let lastMessageRole: 'user' | 'assistant' | undefined = undefined;
+            let userMessageCount: number | undefined = undefined;
+            let assistantMessageCount: number | undefined = undefined;
             let lastAction: string | undefined = undefined;
             let isCompleted = false;
             let completionMessage: string | undefined = undefined;
@@ -580,19 +724,47 @@ export const listConversationsTool = {
             // Extraire les informations de la sequence si elle existe (Roo tasks)
             if (sequence && Array.isArray(sequence) && sequence.length > 0) {
                 // 1. Premier message utilisateur — #1177: strip XML, truncate at word boundary
+                //    #1245 round 2: bump 300 → 900 chars for richer context
                 const firstUserMsg = sequence.find((msg: any) => msg.role === 'user');
                 if (firstUserMsg && firstUserMsg.content) {
                     const cleaned = stripXmlTags(firstUserMsg.content) || firstUserMsg.content;
-                    firstUserMessage = truncateAtBoundary(cleaned, 300);
+                    firstUserMessage = truncateAtBoundary(cleaned, 900);
                 }
 
-                // 2. Dernier message utilisateur (permet de voir la fin de la conversation)
+                // 2. Dernier message utilisateur — #1245: bump 200 → 500 chars
                 const userMessages = sequence.filter((msg: any) => msg.role === 'user');
+                userMessageCount = userMessages.length;
                 if (userMessages.length > 0) {
                     const lastUserMsg = userMessages[userMessages.length - 1];
                     if (lastUserMsg && lastUserMsg.content) {
                         const cleaned = stripXmlTags(lastUserMsg.content) || lastUserMsg.content;
-                        lastUserMessage = truncateAtBoundary(cleaned, 200);
+                        lastUserMessage = truncateAtBoundary(cleaned, 500);
+                    }
+                }
+
+                // 2b. #1245 round 2: dernier message de TOUT rôle (user OR assistant)
+                //     Scan en arrière dans la sequence brute pour capturer le dernier message
+                //     réel (souvent un assistant, qui porte la réponse/action finale).
+                //     On garde lastMessageRole pour désambiguïser l'affichage.
+                const assistantMessages = sequence.filter((msg: any) => msg.role === 'assistant');
+                assistantMessageCount = assistantMessages.length;
+                for (let i = sequence.length - 1; i >= 0; i--) {
+                    const m = sequence[i];
+                    if (!m || (m.role !== 'user' && m.role !== 'assistant')) continue;
+                    // Extract text content (may be string or array of blocks)
+                    let textContent: string | undefined;
+                    if (typeof m.content === 'string') {
+                        textContent = m.content;
+                    } else if (Array.isArray(m.content)) {
+                        // Find first text block
+                        const textBlock = m.content.find((c: any) => c.type === 'text' && c.text);
+                        if (textBlock) textContent = textBlock.text;
+                    }
+                    if (textContent) {
+                        const cleaned = stripXmlTags(textContent) || textContent;
+                        lastMessage = truncateAtBoundary(cleaned, 500);
+                        lastMessageRole = m.role;
+                        break;
                     }
                 }
 
@@ -622,7 +794,7 @@ export const listConversationsTool = {
                     }
                 }
 
-                // 3. Détecter si la conversation est terminée (dernier message de type attempt_completion)
+                // 4. Détecter si la conversation est terminée (dernier message de type attempt_completion)
                 const lastAssistantMessages = sequence
                     .filter((msg: any) => msg.role === 'assistant')
                     .slice(-3); // Prendre les 3 derniers messages assistant pour chercher attempt_completion
@@ -653,7 +825,8 @@ export const listConversationsTool = {
                 firstUserMessage = s.metadata.title;
             }
 
-            // #666: Fallback for Claude sessions — use pre-extracted JSONL metadata
+            // #666 + #1245 round 2: Fallback for Claude sessions — use pre-extracted JSONL metadata.
+            // These dynamic fields are set by scanClaudeSessions on the skeleton.
             const claudeAny = s as any;
             if (!firstUserMessage && claudeAny._claudeFirstUserMessage) {
                 firstUserMessage = claudeAny._claudeFirstUserMessage;
@@ -661,11 +834,28 @@ export const listConversationsTool = {
             if (!lastUserMessage && claudeAny._claudeLastUserMessage) {
                 lastUserMessage = claudeAny._claudeLastUserMessage;
             }
+            if (!lastMessage && claudeAny._claudeLastMessage) {
+                lastMessage = claudeAny._claudeLastMessage;
+                if (claudeAny._claudeLastMessageRole) {
+                    lastMessageRole = claudeAny._claudeLastMessageRole;
+                }
+            }
+            if (userMessageCount === undefined && typeof claudeAny._claudeUserCount === 'number') {
+                userMessageCount = claudeAny._claudeUserCount;
+            }
+            if (assistantMessageCount === undefined && typeof claudeAny._claudeAssistantCount === 'number') {
+                assistantMessageCount = claudeAny._claudeAssistantCount;
+            }
 
             // Deduplicate: skip lastUserMessage if identical to firstUserMessage
             // (happens with Claude sessions where tail chunk finds same message as head)
             if (lastUserMessage && lastUserMessage === firstUserMessage) {
                 lastUserMessage = undefined;
+            }
+            // Deduplicate: skip lastMessage if it just mirrors firstUserMessage (tiny task)
+            if (lastMessage && lastMessage === firstUserMessage) {
+                lastMessage = undefined;
+                lastMessageRole = undefined;
             }
 
             // Créer explicitement un SkeletonNode avec SEULEMENT les propriétés nécessaires
@@ -676,6 +866,10 @@ export const listConversationsTool = {
                 metadata: s.metadata,
                 firstUserMessage,
                 lastUserMessage,
+                lastMessage,
+                lastMessageRole,
+                userMessageCount,
+                assistantMessageCount,
                 lastAction,
                 isCompleted,
                 completionMessage,
@@ -712,7 +906,14 @@ export const listConversationsTool = {
         });
 
         // --- Pagination ---
-        const perPage = Math.min(args.per_page || args.limit || 20, 50); // Cap at 50
+        // #1245 round 2: clamp to [10, 100].
+        //   - floor 10: user explicit ("pas moins de 10 éléments par page, des pages de 5 ça n'a jamais été utile")
+        //   - cap 100: an agent may deliberately want a large page (it will be redirected to a file
+        //     above ~50KB — that's fine as an opt-in, just not the default behaviour).
+        //   - default 10: keeps the default output comfortably under 50KB so Claude Code displays
+        //     content inline; agents can pass per_page=50/100 when they want everything in a file.
+        const rawPerPage = args.per_page || args.limit || 10;
+        const perPage = Math.min(Math.max(rawPerPage, 10), 100);
         const page = Math.max(args.page || 1, 1);
         const totalCount = forest.length;
         const totalPages = Math.ceil(totalCount / perPage);
@@ -858,11 +1059,20 @@ function extractTextFromMessage(message: ApiMessage): string {
 interface ClaudeSessionMeta {
     firstUserMessage?: string;
     lastUserMessage?: string;
+    /** Last message of ANY role (user or assistant) — final state of the conversation. */
+    lastMessage?: string;
+    lastMessageRole?: 'user' | 'assistant';
     messageCount: number;
+    /** Sampled counts from head+tail chunks (under-counts for big files, exact for small ones). */
+    sampledUserCount?: number;
+    sampledAssistantCount?: number;
+    sampledCountsAreExact?: boolean;
 }
 
 async function extractClaudeSessionMeta(filePath: string, fileSize: number): Promise<ClaudeSessionMeta> {
-    const CHUNK = 16384; // 16KB
+    // #1245 round 2: bump 16KB → 48KB so we capture enough first-message content
+    // and more accurate counts. 48KB * 2 = 96KB max I/O per file, acceptable for list.
+    const CHUNK = 49152; // 48KB
     const result: ClaudeSessionMeta = { messageCount: 0 };
     let handle: import('fs/promises').FileHandle | undefined;
 
@@ -876,22 +1086,26 @@ async function extractClaudeSessionMeta(filePath: string, fileSize: number): Pro
         const headLines = headText.split('\n').filter(l => l.trim());
 
         let lineCount = 0;
+        let sampledUser = 0;
+        let sampledAssistant = 0;
         for (const line of headLines) {
             lineCount++;
             try {
                 const entry = JSON.parse(line);
+                if (entry.type === 'user') sampledUser++;
+                else if (entry.type === 'assistant') sampledAssistant++;
                 // Claude Code JSONL format: type="user" with message.content (string or array)
-                if (entry.type === 'user' && entry.message) {
+                if (!result.firstUserMessage && entry.type === 'user' && entry.message) {
                     const text = extractClaudeMessageText(entry.message.content);
                     if (text && text.length > 0) {
-                        result.firstUserMessage = truncateAtBoundary(text, 300);
-                        break;
+                        result.firstUserMessage = truncateAtBoundary(text, 900);
                     }
                 }
             } catch { /* skip malformed lines */ }
         }
 
-        // --- Read last chunk for last user message ---
+        // --- Read last chunk for last user message + last message (any role) ---
+        const fileFullyRead = fileSize <= CHUNK;
         if (fileSize > CHUNK) {
             const tailOffset = Math.max(0, fileSize - CHUNK);
             const tailBuf = Buffer.alloc(Math.min(CHUNK, fileSize - tailOffset));
@@ -900,25 +1114,71 @@ async function extractClaudeSessionMeta(filePath: string, fileSize: number): Pro
             const tailLines = tailText.split('\n').filter(l => l.trim());
             lineCount += tailLines.length;
 
-            // Scan backwards for last user message
+            // Also accumulate per-role counts from the tail (still sampled — may double-count
+            // the one boundary line but that's one line of error in large files).
+            for (const line of tailLines) {
+                try {
+                    const entry = JSON.parse(line);
+                    if (entry.type === 'user') sampledUser++;
+                    else if (entry.type === 'assistant') sampledAssistant++;
+                } catch { /* skip */ }
+            }
+
+            // Scan backwards for last USER message + last message (any role)
             for (let i = tailLines.length - 1; i >= 0; i--) {
                 try {
                     const entry = JSON.parse(tailLines[i]);
-                    if (entry.type === 'user' && entry.message) {
+                    if (!result.lastMessage && (entry.type === 'user' || entry.type === 'assistant') && entry.message) {
                         const text = extractClaudeMessageText(entry.message.content);
                         if (text && text.length > 0) {
-                            result.lastUserMessage = truncateAtBoundary(text, 200);
-                            break;
+                            result.lastMessage = truncateAtBoundary(text, 500);
+                            result.lastMessageRole = entry.type as 'user' | 'assistant';
                         }
                     }
+                    if (!result.lastUserMessage && entry.type === 'user' && entry.message) {
+                        const text = extractClaudeMessageText(entry.message.content);
+                        if (text && text.length > 0) {
+                            result.lastUserMessage = truncateAtBoundary(text, 500);
+                        }
+                    }
+                    if (result.lastUserMessage && result.lastMessage) break;
+                } catch { /* skip */ }
+            }
+        } else {
+            // Small file: head chunk has everything, scan backwards through headLines for last messages
+            for (let i = headLines.length - 1; i >= 0; i--) {
+                try {
+                    const entry = JSON.parse(headLines[i]);
+                    if (!result.lastMessage && (entry.type === 'user' || entry.type === 'assistant') && entry.message) {
+                        const text = extractClaudeMessageText(entry.message.content);
+                        if (text && text.length > 0) {
+                            result.lastMessage = truncateAtBoundary(text, 500);
+                            result.lastMessageRole = entry.type as 'user' | 'assistant';
+                        }
+                    }
+                    if (!result.lastUserMessage && entry.type === 'user' && entry.message) {
+                        const text = extractClaudeMessageText(entry.message.content);
+                        if (text && text.length > 0) {
+                            result.lastUserMessage = truncateAtBoundary(text, 500);
+                        }
+                    }
+                    if (result.lastUserMessage && result.lastMessage) break;
                 } catch { /* skip */ }
             }
         }
 
-        // Estimate message count: use line count from chunks as sample,
-        // extrapolate to full file based on avg bytes/line
-        const avgBytesPerLine = Math.max(100, (CHUNK * 2) / Math.max(lineCount, 1));
-        result.messageCount = Math.max(1, Math.round(fileSize / avgBytesPerLine));
+        // Message count: exact if the whole file fit in the head chunk, extrapolated otherwise.
+        if (fileFullyRead) {
+            result.messageCount = sampledUser + sampledAssistant;
+            result.sampledCountsAreExact = true;
+        } else {
+            // Extrapolate from avg bytes/line across sampled chunks
+            const avgBytesPerLine = Math.max(100, (CHUNK * 2) / Math.max(lineCount, 1));
+            result.messageCount = Math.max(1, Math.round(fileSize / avgBytesPerLine));
+            result.sampledCountsAreExact = false;
+        }
+        result.sampledUserCount = sampledUser;
+        result.sampledAssistantCount = sampledAssistant;
 
     } catch {
         // Fallback — return empty meta
@@ -988,17 +1248,31 @@ interface ClaudeJsonlMetadata {
     cwd?: string;
     firstUserMessage?: string;
     lastUserMessage?: string;
+    /** Last message of ANY role (user or assistant) — often the final state/result. */
+    lastMessage?: string;
+    lastMessageRole?: 'user' | 'assistant';
     approxMessageCount: number;
     title?: string;
+    /** Sampled per-role counts from head+tail chunks (exact when file fully scanned). */
+    userCount?: number;
+    assistantCount?: number;
+    countsAreExact?: boolean;
 }
 
 /**
- * Extract metadata from a Claude JSONL file by reading only the first and last 8KB.
- * This provides cwd, first/last user messages, and an approximate message count
- * without parsing the entire file (which can be many MB).
+ * Extract metadata from a Claude JSONL file by reading only the first and last chunks.
+ * This provides cwd, first/last messages (per-role + any-role), and an approximate
+ * message count without parsing the entire file (which can be many MB).
+ *
+ * #1245 round 2:
+ *   - CHUNK_SIZE bumped 8KB → 48KB (more content in first message, more accurate counts)
+ *   - Added lastMessage (any role) + lastMessageRole
+ *   - Added userCount/assistantCount with countsAreExact flag
+ *   - Truncation 300 → 900 (first), 200 → 500 (last user + last any)
  *
  * JSONL format: each line is a JSON object with { type, message?, cwd?, timestamp? }
  * User messages have type="user" with message.role="user" and message.content (string or array).
+ * Assistant messages have type="assistant" with message.role="assistant" and message.content.
  */
 async function extractClaudeJsonlMetadata(filePath: string, fileSize: number): Promise<ClaudeJsonlMetadata> {
     const result: ClaudeJsonlMetadata = { approxMessageCount: 0 };
@@ -1006,9 +1280,13 @@ async function extractClaudeJsonlMetadata(filePath: string, fileSize: number): P
 
     try {
         handle = await fs.open(filePath, 'r');
-        const CHUNK_SIZE = 8192;
+        const CHUNK_SIZE = 49152; // 48KB — enough to capture richer first messages and more accurate counts
 
-        // --- Read first chunk (first 8KB) ---
+        let sampledUser = 0;
+        let sampledAssistant = 0;
+        let fileFullyRead = false;
+
+        // --- Read first chunk (first 48KB) ---
         const headBuf = Buffer.alloc(Math.min(CHUNK_SIZE, fileSize));
         const { bytesRead: headRead } = await handle.read(headBuf, 0, headBuf.length, 0);
         const headText = headBuf.toString('utf-8', 0, headRead);
@@ -1023,11 +1301,17 @@ async function extractClaudeJsonlMetadata(filePath: string, fileSize: number): P
                 if (!result.cwd && entry.cwd) {
                     result.cwd = entry.cwd.replace(/\\/g, '/');
                 }
+                // Count messages by role (sampled from head chunk)
+                if (entry.type === 'user' && entry.message?.role === 'user') {
+                    sampledUser++;
+                } else if (entry.type === 'assistant' && entry.message?.role === 'assistant') {
+                    sampledAssistant++;
+                }
                 // Extract first user message
                 if (!result.firstUserMessage && entry.type === 'user' && entry.message?.role === 'user') {
                     const content = extractClaudeMessageText(entry.message.content);
                     if (content) {
-                        result.firstUserMessage = truncateAtBoundary(content, 300);
+                        result.firstUserMessage = truncateAtBoundary(content, 900);
                         // Derive title from first user message (skip command invocations)
                         const titleText = content.replace(/<[^>]+>/g, '').trim();
                         if (titleText.length > 3) {
@@ -1040,7 +1324,7 @@ async function extractClaudeJsonlMetadata(filePath: string, fileSize: number): P
             }
         }
 
-        // --- Read last chunk (last 8KB) ---
+        // --- Read last chunk (last 48KB) ---
         if (fileSize > CHUNK_SIZE) {
             const tailOffset = Math.max(0, fileSize - CHUNK_SIZE);
             const tailBuf = Buffer.alloc(Math.min(CHUNK_SIZE, fileSize - tailOffset));
@@ -1048,30 +1332,95 @@ async function extractClaudeJsonlMetadata(filePath: string, fileSize: number): P
             const tailText = tailBuf.toString('utf-8', 0, tailRead);
             const tailLines = tailText.split('\n');
 
-            // Walk backwards to find the last user message
+            // Accumulate per-role counts from tail (note: head+tail may overlap on small files,
+            // but we already guarded fileSize > CHUNK_SIZE above, so no overlap here)
+            let tailUser = 0;
+            let tailAssistant = 0;
+
+            // Walk backwards to find the last message (any role) and the last user message
+            let foundLastAny = false;
+            let foundLastUser = false;
             for (let i = tailLines.length - 1; i >= 0; i--) {
                 const trimmed = tailLines[i].trim();
                 if (!trimmed) continue;
                 try {
                     const entry = JSON.parse(trimmed);
-                    if (entry.type === 'user' && entry.message?.role === 'user') {
+                    const isUser = entry.type === 'user' && entry.message?.role === 'user';
+                    const isAssistant = entry.type === 'assistant' && entry.message?.role === 'assistant';
+                    if (isUser) tailUser++;
+                    if (isAssistant) tailAssistant++;
+
+                    if (!foundLastAny && (isUser || isAssistant)) {
                         const content = extractClaudeMessageText(entry.message.content);
                         if (content) {
-                            result.lastUserMessage = truncateAtBoundary(content, 200);
-                            break;
+                            result.lastMessage = truncateAtBoundary(content, 500);
+                            result.lastMessageRole = isUser ? 'user' : 'assistant';
+                            foundLastAny = true;
                         }
                     }
+                    if (!foundLastUser && isUser) {
+                        const content = extractClaudeMessageText(entry.message.content);
+                        if (content) {
+                            result.lastUserMessage = truncateAtBoundary(content, 500);
+                            foundLastUser = true;
+                        }
+                    }
+                    // Keep scanning so per-role counts are accumulated across the whole tail chunk
                 } catch {
                     // Skip truncated lines at chunk boundary
                 }
             }
+
+            sampledUser += tailUser;
+            sampledAssistant += tailAssistant;
+        } else {
+            // Small file: entire file was in head chunk. Scan backwards through headLines
+            // for lastMessage/lastUserMessage.
+            fileFullyRead = true;
+            let foundLastAny = false;
+            let foundLastUser = false;
+            for (let i = headLines.length - 1; i >= 0; i--) {
+                const trimmed = headLines[i].trim();
+                if (!trimmed) continue;
+                try {
+                    const entry = JSON.parse(trimmed);
+                    const isUser = entry.type === 'user' && entry.message?.role === 'user';
+                    const isAssistant = entry.type === 'assistant' && entry.message?.role === 'assistant';
+                    if (!foundLastAny && (isUser || isAssistant)) {
+                        const content = extractClaudeMessageText(entry.message.content);
+                        if (content) {
+                            result.lastMessage = truncateAtBoundary(content, 500);
+                            result.lastMessageRole = isUser ? 'user' : 'assistant';
+                            foundLastAny = true;
+                        }
+                    }
+                    if (!foundLastUser && isUser) {
+                        const content = extractClaudeMessageText(entry.message.content);
+                        if (content) {
+                            result.lastUserMessage = truncateAtBoundary(content, 500);
+                            foundLastUser = true;
+                        }
+                    }
+                    if (foundLastAny && foundLastUser) break;
+                } catch {
+                    // Skip unparseable lines
+                }
+            }
         }
 
-        // --- Approximate message count from file size ---
-        // Claude JSONL lines average ~500-2000 bytes. Use 1000 as middle ground.
-        // Only user+assistant messages matter, roughly 60% of lines.
-        const approxTotalLines = Math.max(1, Math.round(fileSize / 1000));
-        result.approxMessageCount = Math.max(1, Math.round(approxTotalLines * 0.6));
+        // --- Per-role counts + approximate total message count ---
+        result.userCount = sampledUser;
+        result.assistantCount = sampledAssistant;
+        result.countsAreExact = fileFullyRead;
+
+        if (fileFullyRead) {
+            result.approxMessageCount = sampledUser + sampledAssistant;
+        } else {
+            // Claude JSONL lines average ~500-2000 bytes. Use 1000 as middle ground.
+            // Only user+assistant messages matter, roughly 60% of lines.
+            const approxTotalLines = Math.max(1, Math.round(fileSize / 1000));
+            result.approxMessageCount = Math.max(1, Math.round(approxTotalLines * 0.6));
+        }
 
     } catch {
         // Return whatever we have so far
@@ -1166,6 +1515,16 @@ async function scanClaudeSessions(
                     const wsName = (fileWorkspace || derivedWorkspace) ? path.basename(fileWorkspace || derivedWorkspace || '') : 'unknown';
                     const claudeTitle = jsonlMeta.title || `[Claude] ${wsName} — ${sessionId.substring(0, 8)}`;
 
+                    // #1245 round 2: prefer sessionMeta's richer fields, fall back to jsonlMeta
+                    const mergedFirstUser = sessionMeta.firstUserMessage || jsonlMeta.firstUserMessage;
+                    const mergedLastUser = sessionMeta.lastUserMessage || jsonlMeta.lastUserMessage;
+                    const mergedLastAny = sessionMeta.lastMessage || jsonlMeta.lastMessage;
+                    const mergedLastRole = sessionMeta.lastMessageRole || jsonlMeta.lastMessageRole;
+
+                    // Per-role counts: prefer sessionMeta sampled counts, fall back to jsonlMeta
+                    const userCount = sessionMeta.sampledUserCount ?? jsonlMeta.userCount;
+                    const assistantCount = sessionMeta.sampledAssistantCount ?? jsonlMeta.assistantCount;
+
                     const skeleton: ConversationSkeleton = {
                         taskId,
                         sequence: [], // Content loaded on-demand via view action
@@ -1180,21 +1539,38 @@ async function scanClaudeSessions(
                             machineId: os.hostname(),
                             dataSource: 'claude',
                         },
-                        // #666: Store extracted messages for SkeletonNode enrichment (fallback)
-                        _claudeFirstUserMessage: jsonlMeta.firstUserMessage,
-                        _claudeLastUserMessage: jsonlMeta.lastUserMessage,
-                    } as ConversationSkeleton & { _claudeFirstUserMessage?: string; _claudeLastUserMessage?: string };
+                        // #666 + #1245: Store extracted messages + per-role counts for SkeletonNode enrichment (fallback)
+                        _claudeFirstUserMessage: mergedFirstUser,
+                        _claudeLastUserMessage: mergedLastUser,
+                        _claudeLastMessage: mergedLastAny,
+                        _claudeLastMessageRole: mergedLastRole,
+                        _claudeUserCount: userCount,
+                        _claudeAssistantCount: assistantCount,
+                    } as ConversationSkeleton & {
+                        _claudeFirstUserMessage?: string;
+                        _claudeLastUserMessage?: string;
+                        _claudeLastMessage?: string;
+                        _claudeLastMessageRole?: 'user' | 'assistant';
+                        _claudeUserCount?: number;
+                        _claudeAssistantCount?: number;
+                    };
 
                     // Inject first/last messages into sequence for toConversationSummary
-                    const firstMsg = sessionMeta.firstUserMessage || jsonlMeta.firstUserMessage;
-                    const lastMsg = sessionMeta.lastUserMessage || jsonlMeta.lastUserMessage;
-                    if (firstMsg || lastMsg) {
+                    // #1245 round 2: also inject lastMessage (any role) as the FINAL synthetic entry,
+                    // so the Roo sequence-extraction code path in the skeletonMap build picks it up
+                    // via a reverse scan. Use role='assistant' for non-user last messages so the
+                    // existing "last assistant" logic surfaces it.
+                    if (mergedFirstUser || mergedLastUser || mergedLastAny) {
                         const seq: any[] = [];
-                        if (firstMsg) {
-                            seq.push({ role: 'user', content: firstMsg });
+                        if (mergedFirstUser) {
+                            seq.push({ role: 'user', content: mergedFirstUser });
                         }
-                        if (lastMsg && lastMsg !== firstMsg) {
-                            seq.push({ role: 'user', content: lastMsg });
+                        if (mergedLastUser && mergedLastUser !== mergedFirstUser) {
+                            seq.push({ role: 'user', content: mergedLastUser });
+                        }
+                        // Final entry = last message of any role, so reverse scans pick it up
+                        if (mergedLastAny && mergedLastAny !== mergedLastUser && mergedLastAny !== mergedFirstUser) {
+                            seq.push({ role: mergedLastRole || 'assistant', content: mergedLastAny });
                         }
                         (skeleton as any).sequence = seq;
                     }

--- a/servers/roo-state-manager/src/tools/indexing/__tests__/roosync-indexing.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/indexing/__tests__/roosync-indexing.tool.test.ts
@@ -190,7 +190,28 @@ describe('roosyncIndexingTool', () => {
 			cache, ensureFresh, saveSkeleton, indexQueue, setEnabled, mockRebuildHandler
 		);
 
-		expect(mockDiagnoseHandler).toHaveBeenCalledWith(cache);
+		expect(mockDiagnoseHandler).toHaveBeenCalledWith(cache, {
+			deep: undefined,
+			sample_size: undefined,
+			top_n_workspaces: undefined,
+		});
+		expect(result).toBe(expected);
+	});
+
+	test('diagnose action with deep=true forwards options to handleDiagnoseSemanticIndex', async () => {
+		const expected = { content: [{ type: 'text', text: 'diagnosed deep' }] };
+		mockDiagnoseHandler.mockResolvedValue(expected);
+
+		const result = await handleRooSyncIndexing(
+			{ action: 'diagnose', deep: true, sample_size: 500, top_n_workspaces: 10 },
+			cache, ensureFresh, saveSkeleton, indexQueue, setEnabled, mockRebuildHandler
+		);
+
+		expect(mockDiagnoseHandler).toHaveBeenCalledWith(cache, {
+			deep: true,
+			sample_size: 500,
+			top_n_workspaces: 10,
+		});
 		expect(result).toBe(expected);
 	});
 

--- a/servers/roo-state-manager/src/tools/indexing/diagnose-index.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/diagnose-index.tool.ts
@@ -1,5 +1,15 @@
 /**
  * Diagnostic de l'index sémantique Qdrant
+ *
+ * #1244 — Extended diagnostics:
+ *  - Embedding dimension match (collection vs vLLM live test)
+ *  - Payload sample (detect missing fields)
+ *  - Source distribution (roo / claude-code / unknown)
+ *  - Workspace distribution (top N workspace_name)
+ *  - Payload field coverage on a sampled slice
+ *
+ * Backward compatible: callers passing only `conversationCache` get the same
+ * baseline diagnostics as before. Deep diagnostics opt-in via `options.deep`.
  */
 
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
@@ -8,12 +18,41 @@ import { getQdrantClient } from '../../services/qdrant.js';
 import getOpenAIClient, { getEmbeddingModel } from '../../services/openai.js';
 
 /**
+ * Options for the diagnose tool. All optional — preserves backward compatibility.
+ */
+export interface DiagnoseIndexOptions {
+    /** Enable deep diagnostics (scroll sample, source/workspace distribution). Default: false. */
+    deep?: boolean;
+    /** Sample size for scroll-based stats. Default: 1000 points. */
+    sample_size?: number;
+    /** Number of top workspace_name values to report. Default: 20. */
+    top_n_workspaces?: number;
+}
+
+interface PayloadSample {
+    id: string | number;
+    payload_keys: string[];
+    workspace_name?: string;
+    source?: string;
+    chunk_type?: string;
+    timestamp?: string;
+}
+
+/**
  * Diagnostique l'état de l'index sémantique
+ *
+ * @param conversationCache Cache des squelettes (passé pour cohérence avec les autres handlers)
+ * @param options Options de diagnostic. Si `deep: true`, exécute scroll + agrégations.
  */
 export async function handleDiagnoseSemanticIndex(
-    conversationCache: Map<string, ConversationSkeleton>
+    conversationCache: Map<string, ConversationSkeleton>,
+    options: DiagnoseIndexOptions = {}
 ): Promise<CallToolResult> {
     const collectionName = process.env.QDRANT_COLLECTION_NAME || 'roo_tasks_semantic_index';
+    const deep = options.deep === true;
+    const sampleSize = Math.max(1, Math.min(options.sample_size ?? 1000, 5000));
+    const topNWorkspaces = Math.max(1, Math.min(options.top_n_workspaces ?? 20, 100));
+
     const diagnostics: any = {
         timestamp: new Date().toISOString(),
         collection_name: collectionName,
@@ -21,6 +60,8 @@ export async function handleDiagnoseSemanticIndex(
         errors: [],
         details: {},
     };
+
+    let collectionDimension: number | undefined;
 
     try {
         // Test de connectivité à Qdrant
@@ -55,13 +96,16 @@ export async function handleDiagnoseSemanticIndex(
             // Obtenir des informations sur la collection
             try {
                 const collectionInfo = await qdrant.getCollection(collectionName);
+                const dimVal = (collectionInfo.config?.params?.vectors as any)?.size;
+                collectionDimension = typeof dimVal === 'number' ? dimVal : undefined;
+
                 diagnostics.details.collection_info = {
                     vectors_count: (collectionInfo as any).vectors_count,
                     indexed_vectors_count: collectionInfo.indexed_vectors_count || 0,
                     points_count: collectionInfo.points_count,
                     config: {
-                        distance: collectionInfo.config?.params?.vectors?.distance || 'unknown',
-                        size: collectionInfo.config?.params?.vectors?.size || 'unknown',
+                        distance: (collectionInfo.config?.params?.vectors as any)?.distance || 'unknown',
+                        size: dimVal ?? 'unknown',
                     },
                 };
 
@@ -88,17 +132,53 @@ export async function handleDiagnoseSemanticIndex(
         diagnostics.errors.push(`Impossible de se connecter à Qdrant: ${connectionError.message}`);
     }
 
-    // Test de connectivité à OpenAI (always run, even if Qdrant fails)
+    // Test de connectivité à OpenAI/vLLM (always run, even if Qdrant fails)
+    // #1244: capture the actual returned dimension to compare with collection dimension
+    let embeddingLiveDimension: number | undefined;
     try {
         const openai = getOpenAIClient();
         const testEmbedding = await openai.embeddings.create({
             model: getEmbeddingModel(),
             input: 'test connectivity',
         });
-        diagnostics.details.openai_connection = testEmbedding.data[0].embedding.length > 0 ? 'success' : 'failed';
+        const embeddingLength = testEmbedding.data[0].embedding.length;
+        embeddingLiveDimension = embeddingLength;
+        diagnostics.details.openai_connection = embeddingLength > 0 ? 'success' : 'failed';
+        diagnostics.details.embedding_live_dimension = embeddingLength;
     } catch (openaiError: any) {
         diagnostics.errors.push(`Erreur OpenAI: ${openaiError.message}`);
         diagnostics.details.openai_connection = 'failed';
+    }
+
+    // #1244: Dimension mismatch detection (Hypothesis A from plan)
+    const expectedDimensionEnv = process.env.EMBEDDING_DIMENSIONS
+        ? parseInt(process.env.EMBEDDING_DIMENSIONS, 10)
+        : undefined;
+    if (collectionDimension !== undefined) {
+        diagnostics.details.dimension_check = {
+            collection_dimension: collectionDimension,
+            embedding_env_dimension: expectedDimensionEnv,
+            embedding_live_dimension: embeddingLiveDimension,
+            collection_matches_env: expectedDimensionEnv !== undefined
+                ? collectionDimension === expectedDimensionEnv
+                : null,
+            collection_matches_live: embeddingLiveDimension !== undefined
+                ? collectionDimension === embeddingLiveDimension
+                : null,
+        };
+
+        if (embeddingLiveDimension !== undefined && collectionDimension !== embeddingLiveDimension) {
+            diagnostics.errors.push(
+                `Dimension mismatch: collection=${collectionDimension}, embedding live=${embeddingLiveDimension}. ` +
+                `Searches will return 0 results until the index is rebuilt with matching dimensions.`
+            );
+        }
+        if (expectedDimensionEnv !== undefined && collectionDimension !== expectedDimensionEnv) {
+            diagnostics.errors.push(
+                `Dimension drift: collection=${collectionDimension}, EMBEDDING_DIMENSIONS env=${expectedDimensionEnv}. ` +
+                `One of the two is stale.`
+            );
+        }
     }
 
     // Vérifier les variables d'environnement nécessaires (always run, even if Qdrant fails)
@@ -121,6 +201,101 @@ export async function handleDiagnoseSemanticIndex(
         diagnostics.errors.push(`Variables d'environnement manquantes: ${missingEnvVars.join(', ')}`);
     }
 
+    // #1244: Deep diagnostics — scroll a sample, aggregate by source/workspace_name, detect field coverage
+    if (deep && diagnostics.status === 'healthy') {
+        try {
+            const qdrant = getQdrantClient();
+
+            const scrollResult: any = await qdrant.scroll(collectionName, {
+                limit: sampleSize,
+                with_payload: true,
+                with_vector: false,
+            });
+
+            const points: any[] = Array.isArray(scrollResult)
+                ? scrollResult
+                : (scrollResult?.points || scrollResult?.result?.points || []);
+
+            const sourceCounts: Record<string, number> = {};
+            const workspaceCounts: Record<string, number> = {};
+            const fieldPresence: Record<string, number> = {};
+            const samples: PayloadSample[] = [];
+
+            for (const point of points) {
+                const payload = point?.payload || {};
+
+                // source distribution
+                const src = (payload.source ?? '__unknown__') as string;
+                sourceCounts[src] = (sourceCounts[src] || 0) + 1;
+
+                // workspace_name distribution
+                const ws = payload.workspace_name;
+                if (typeof ws === 'string' && ws.length > 0) {
+                    workspaceCounts[ws] = (workspaceCounts[ws] || 0) + 1;
+                } else {
+                    workspaceCounts['__missing__'] = (workspaceCounts['__missing__'] || 0) + 1;
+                }
+
+                // field coverage — count payloads where each essential field is populated
+                for (const f of ['task_id', 'workspace', 'workspace_name', 'source', 'timestamp', 'chunk_type', 'role', 'host_os', 'task_title', 'model']) {
+                    if (payload[f] !== undefined && payload[f] !== null && payload[f] !== '') {
+                        fieldPresence[f] = (fieldPresence[f] || 0) + 1;
+                    }
+                }
+
+                // sample first 5
+                if (samples.length < 5) {
+                    samples.push({
+                        id: point.id,
+                        payload_keys: Object.keys(payload).sort(),
+                        workspace_name: payload.workspace_name,
+                        source: payload.source,
+                        chunk_type: payload.chunk_type,
+                        timestamp: payload.timestamp,
+                    });
+                }
+            }
+
+            const sampledCount = points.length;
+            const sortedWorkspaces = Object.entries(workspaceCounts)
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, topNWorkspaces)
+                .map(([name, count]) => ({ name, count, pct: sampledCount > 0 ? +(count / sampledCount * 100).toFixed(1) : 0 }));
+
+            const fieldCoveragePct: Record<string, number> = {};
+            for (const [f, count] of Object.entries(fieldPresence)) {
+                fieldCoveragePct[f] = sampledCount > 0 ? +(count / sampledCount * 100).toFixed(1) : 0;
+            }
+
+            diagnostics.details.deep_diagnostics = {
+                sample_size_requested: sampleSize,
+                sample_size_actual: sampledCount,
+                source_distribution: sourceCounts,
+                workspace_distribution_top: sortedWorkspaces,
+                workspace_distribution_distinct: Object.keys(workspaceCounts).filter(k => k !== '__missing__').length,
+                field_coverage_pct: fieldCoveragePct,
+                payload_samples: samples,
+            };
+
+            // #1244: Hypothesis B / D — detect critical field gaps
+            if ((fieldCoveragePct.workspace_name ?? 0) < 50) {
+                diagnostics.errors.push(
+                    `workspace_name populated in only ${fieldCoveragePct.workspace_name ?? 0}% of sampled points. ` +
+                    `Filter by workspace_name will return few/no results.`
+                );
+            }
+            if ((fieldCoveragePct.timestamp ?? 0) < 50) {
+                diagnostics.errors.push(
+                    `timestamp populated in only ${fieldCoveragePct.timestamp ?? 0}% of sampled points. ` +
+                    `Date range filters will be unreliable.`
+                );
+            }
+        } catch (deepError: any) {
+            diagnostics.errors.push(`Deep diagnostics failed: ${deepError.message}`);
+            diagnostics.details.deep_diagnostics = { error: deepError.message };
+        }
+    }
+
     // Recommandations basées sur le diagnostic
     const recommendations: string[] = [];
     if (diagnostics.status === 'missing_collection') {
@@ -135,8 +310,35 @@ export async function handleDiagnoseSemanticIndex(
     if (diagnostics.details.qdrant_connection === 'failed') {
         recommendations.push('Vérifiez la configuration Qdrant (URL, clé API, connectivité réseau)');
     }
-
+    if (diagnostics.details.dimension_check?.collection_matches_live === false) {
+        recommendations.push(
+            'Dimension mismatch détectée. Reset la collection Qdrant ' +
+            '(roosync_indexing action=reset) puis rebuild avec rebuild_task_index.'
+        );
+    }
+    if (deep && diagnostics.details.deep_diagnostics && !diagnostics.details.deep_diagnostics.error) {
+        const dd = diagnostics.details.deep_diagnostics;
+        if ((dd.field_coverage_pct?.workspace_name ?? 0) < 50) {
+            recommendations.push(
+                'workspace_name peu populé. Vérifiez ChunkExtractor.ts ' +
+                '(populate workspace_name = path.basename(workspace) systématiquement).'
+            );
+        }
+        if (dd.source_distribution && (dd.source_distribution['__unknown__'] ?? 0) > sampleSize * 0.5) {
+            recommendations.push(
+                'Beaucoup de points sans champ `source`. Le ChunkExtractor Roo ne le fixe pas — ' +
+                'à corriger pour permettre le filtrage source=roo vs source=claude-code.'
+            );
+        }
+    }
     diagnostics.recommendations = recommendations;
+
+    // Discoverability hint (not a recommendation — kept separate to preserve "healthy = 0 recommendations" contract)
+    if (!deep && diagnostics.status === 'healthy') {
+        diagnostics.info = [
+            'Pour un diagnostic approfondi (sample payloads, distribution source/workspace), passez deep=true.'
+        ];
+    }
 
     return {
         content: [{

--- a/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
@@ -52,6 +52,15 @@ export interface RooSyncIndexingArgs {
 
     /** #604: Source de la conversation (pour action=index, détermine l'extracteur de chunks) */
     source?: 'roo' | 'claude-code';
+
+    /** #1244: Activer le diagnostic approfondi (scroll sample, distribution source/workspace) — pour action=diagnose */
+    deep?: boolean;
+
+    /** #1244: Taille de l'échantillon scroll (pour action=diagnose avec deep=true). Défaut 1000, max 5000 */
+    sample_size?: number;
+
+    /** #1244: Nombre de top workspaces à reporter (pour action=diagnose avec deep=true). Défaut 20, max 100 */
+    top_n_workspaces?: number;
 }
 
 /**
@@ -109,6 +118,21 @@ export const roosyncIndexingTool: Tool = {
                 type: 'string',
                 enum: ['roo', 'claude-code'],
                 description: "#604: Source de la conversation (pour action=index). 'roo' = tâche Roo standard, 'claude-code' = session Claude Code JSONL. Par défaut: 'roo'"
+            },
+            deep: {
+                type: 'boolean',
+                description: "#1244: Pour action=diagnose. Active le diagnostic approfondi (scroll d'un échantillon, distribution source/workspace_name, field coverage, payload samples). Permet de détecter les bugs d'indexation (champs manquants, dimension mismatch).",
+                default: false
+            },
+            sample_size: {
+                type: 'number',
+                description: "#1244: Pour action=diagnose avec deep=true. Taille de l'échantillon Qdrant à scroll. Défaut 1000, max 5000.",
+                default: 1000
+            },
+            top_n_workspaces: {
+                type: 'number',
+                description: "#1244: Pour action=diagnose avec deep=true. Nombre de top workspace_name à reporter dans la distribution. Défaut 20, max 100.",
+                default: 20
             }
         },
         required: ['action']
@@ -192,7 +216,11 @@ export async function handleRooSyncIndexing(
         }
 
         case 'diagnose': {
-            return await handleDiagnoseSemanticIndex(conversationCache);
+            return await handleDiagnoseSemanticIndex(conversationCache, {
+                deep: args.deep,
+                sample_size: args.sample_size,
+                top_n_workspaces: args.top_n_workspaces,
+            });
         }
 
         case 'archive': {

--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -91,10 +91,21 @@ export function registerCallToolHandler(
                     async () => { await ensureSkeletonCacheIsFresh(); },
                     CACHE_CONFIG.DEFAULT_WORKSPACE,  // contextWorkspace: utilise process.cwd() ou WORKSPACE_PATH
                     async (id: string) => {
-                        // 1. Try RAM cache first (cache holds SkeletonHeader, no sequence)
+                        // 1. Try RAM cache first
                         const cached = cache.get(id);
                         if (cached) {
-                            // #1110: Cache holds headers only — load full skeleton on demand
+                            // #1244 Couche 2.3 — Source unifiee : Tier 2 (Claude) et Tier 3 (Archive)
+                            // stockent des squelettes COMPLETS (avec sequence) directement dans le cache.
+                            // Seul Tier 1 (Roo local) stocke des SkeletonHeader et necessite loadFullSkeleton.
+                            // On detecte la presence d'un sequence non-vide pour court-circuiter loadFullSkeleton
+                            // sur les tiers chauds — sinon les archives etaient perdues car loadFullSkeleton
+                            // ne lit que `<storage>/tasks/.skeletons/<id>.json` (Tier 1 disk).
+                            const cachedAny = cached as any;
+                            const hasFullSequence = Array.isArray(cachedAny.sequence) && cachedAny.sequence.length > 0;
+                            if (hasFullSequence) {
+                                return cached as any;
+                            }
+                            // #1110: Cache holds headers only (Tier 1 Roo) — load full skeleton on demand
                             if (cached.metadata.messageCount > 0) {
                                 const full = await loadFullSkeleton(id, cache);
                                 if (full) return full;

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
@@ -46,7 +46,7 @@ describe('get-status (Option B)', () => {
       overallStatus: 'synced',
       lastUpdate: new Date().toISOString(),
       machines: {
-        'ai-01': { status: 'online', lastSync: '2026-04-08', pendingDecisions: 0, diffsCount: 0 }
+        'ai-01': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 }
       }
     });
     mockGetHeartbeatService.mockReturnValue({
@@ -131,7 +131,7 @@ describe('get-status (Option B)', () => {
         overallStatus: 'synced',
         lastUpdate: new Date().toISOString(),
         machines: {
-          'ai-01': { status: 'online', lastSync: '2026-04-08', pendingDecisions: 0, diffsCount: 0 }
+          'ai-01': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 }
         }
       });
 
@@ -222,7 +222,7 @@ describe('get-status (Option B)', () => {
       mockLoadDashboard.mockResolvedValue({
         overallStatus: 'synced',
         lastUpdate: new Date().toISOString(),
-        machines: { 'ai-01': { status: 'online', lastSync: '2026-04-08', pendingDecisions: 0, diffsCount: 0 } }
+        machines: { 'ai-01': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 } }
       });
 
       const result = await roosyncGetStatus({ machineFilter: 'ai-01' });

--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -197,7 +197,8 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
     let status: 'HEALTHY' | 'WARNING' | 'CRITICAL' = 'HEALTHY';
     if (offlineMachines.length > 0 || inboxStats.urgent > 0) {
       status = 'CRITICAL';
-    } else if (offlineMachines.length === 0 && (flags.length > 0 || inboxStats.unread > 5)) {
+    } else if (inboxStats.unread > 5 || (heartbeatState?.warningMachines?.length ?? 0) > 0) {
+      // WARNING if: high unread count OR heartbeat warning machines (but no offline)
       status = 'WARNING';
     }
 

--- a/servers/roo-state-manager/src/tools/search/__tests__/search-semantic.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-semantic.tool.test.ts
@@ -492,6 +492,61 @@ describe('searchTasksByContentTool', () => {
 			expect(parsed.results[0].chunks).toHaveLength(2);
 			expect(parsed.results[0].best_score).toBe(0.9);
 		});
+
+		// ========================================================
+		// #1244 Couche 1.3 — Push date filters into Qdrant directly
+		// ========================================================
+		test('[#1244 1.3] pushes start_date and end_date as Qdrant range filter on timestamp', async () => {
+			mockQdrantClient.search.mockResolvedValue([]);
+
+			await searchTasksByContentTool.handler(
+				{
+					search_query: 'work',
+					start_date: '2026-04-07',
+					end_date: '2026-04-08',
+				} as any,
+				makeCache(),
+				mockEnsureCache,
+				defaultFallback
+			);
+
+			const searchCall = mockQdrantClient.search.mock.calls[0][1];
+			expect(searchCall.filter).toBeDefined();
+			expect(searchCall.filter.must).toBeDefined();
+
+			// Should contain a range filter on the `timestamp` key.
+			const timestampFilter = searchCall.filter.must.find(
+				(c: any) => c && c.key === 'timestamp' && c.range
+			);
+			expect(timestampFilter).toBeDefined();
+
+			// gte must use start-of-day at UTC
+			expect(timestampFilter.range.gte).toBe('2026-04-07T00:00:00.000Z');
+			// lte must be expanded to end-of-day at UTC (pure date → 23:59:59.999)
+			expect(timestampFilter.range.lte).toBe('2026-04-08T23:59:59.999Z');
+		});
+
+		test('[#1244 1.3] pushes start_date only as Qdrant range filter (no lte)', async () => {
+			mockQdrantClient.search.mockResolvedValue([]);
+
+			await searchTasksByContentTool.handler(
+				{
+					search_query: 'work',
+					start_date: '2026-04-07',
+				} as any,
+				makeCache(),
+				mockEnsureCache,
+				defaultFallback
+			);
+
+			const searchCall = mockQdrantClient.search.mock.calls[0][1];
+			const timestampFilter = searchCall.filter.must.find(
+				(c: any) => c && c.key === 'timestamp' && c.range
+			);
+			expect(timestampFilter).toBeDefined();
+			expect(timestampFilter.range.gte).toBe('2026-04-07T00:00:00.000Z');
+			expect(timestampFilter.range.lte).toBeUndefined();
+		});
 	});
 
 	// ============================================================

--- a/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
@@ -9,6 +9,7 @@ import { getQdrantClient } from '../../services/qdrant.js';
 import getOpenAIClient, { getEmbeddingModel } from '../../services/openai.js';
 import { handleSearchTasksSemanticFallback } from './search-fallback.tool.js';
 import { getHostIdentifier } from '../../services/task-indexer/ChunkExtractor.js';
+import { parseFilterDate, isWithinDateRange } from '../../utils/date-filters.js';
 
 export interface SearchTasksByContentArgs {
     conversation_id?: string;
@@ -116,45 +117,9 @@ function formatRelativeTime(timestamp: string | undefined): string {
     }
 }
 
-/**
- * Parse a date string (ISO 8601 or YYYY-MM-DD) into a Date object.
- * Returns null if parsing fails.
- */
-function parseFilterDate(dateStr: string | undefined): Date | null {
-    if (!dateStr) return null;
-    try {
-        // Support YYYY-MM-DD by appending T00:00:00Z for start, or use as-is for ISO
-        const d = new Date(dateStr.includes('T') ? dateStr : `${dateStr}T00:00:00Z`);
-        return isNaN(d.getTime()) ? null : d;
-    } catch {
-        return null;
-    }
-}
-
-/**
- * Check if a timestamp falls within the [startDate, endDate] range.
- * Both bounds are inclusive. Null bounds mean no constraint.
- */
-function isWithinDateRange(timestamp: string | undefined, startDate: Date | null, endDate: Date | null): boolean {
-    if (!startDate && !endDate) return true;
-    if (!timestamp) return false;
-    try {
-        const ts = new Date(timestamp);
-        if (isNaN(ts.getTime())) return false;
-        if (startDate && ts < startDate) return false;
-        if (endDate) {
-            // For end_date given as YYYY-MM-DD, include the entire day
-            const endOfDay = new Date(endDate.getTime());
-            if (endOfDay.getHours() === 0 && endOfDay.getMinutes() === 0) {
-                endOfDay.setUTCHours(23, 59, 59, 999);
-            }
-            if (ts > endOfDay) return false;
-        }
-        return true;
-    } catch {
-        return false;
-    }
-}
+// #1244 Couche 2.1 — parseFilterDate / isWithinDateRange factorises dans
+// `src/utils/date-filters.ts` pour reutilisation par list-conversations,
+// conversation-browser, summarize, etc. Importes en haut du fichier.
 
 interface RawSearchResult {
     taskId: string;
@@ -470,6 +435,31 @@ export const searchTasksByContentTool = {
                 });
             }
 
+            // #1244 Couche 1.3 — Push date filter INTO Qdrant (range on timestamp field)
+            // Avant ce fix, le filtre etait applique APRES retrieval (lignes 548-553) :
+            // si un match etait en position 20 et max_results=10, l'utilisateur voyait 0 resultats.
+            // Les timestamps sont stockes comme strings ISO 8601 (lexicographiquement comparables).
+            const parsedStartDateForQdrant = parseFilterDate(start_date);
+            const parsedEndDateForQdrant = parseFilterDate(end_date);
+            if (parsedStartDateForQdrant || parsedEndDateForQdrant) {
+                const rangeFilter: any = {};
+                if (parsedStartDateForQdrant) {
+                    rangeFilter.gte = parsedStartDateForQdrant.toISOString();
+                }
+                if (parsedEndDateForQdrant) {
+                    // Pour YYYY-MM-DD, inclure la journee entiere
+                    const endOfDay = new Date(parsedEndDateForQdrant.getTime());
+                    if (endOfDay.getUTCHours() === 0 && endOfDay.getUTCMinutes() === 0) {
+                        endOfDay.setUTCHours(23, 59, 59, 999);
+                    }
+                    rangeFilter.lte = endOfDay.toISOString();
+                }
+                filterConditions.push({
+                    key: "timestamp",
+                    range: rangeFilter
+                });
+            }
+
             if (filterConditions.length > 0) {
                 filter = { must: filterConditions };
             } else {
@@ -545,11 +535,15 @@ export const searchTasksByContentTool = {
                 };
             });
 
-            // #636 Phase 2: Temporal post-filtering (Qdrant stores timestamps as strings)
-            const parsedStartDate = parseFilterDate(start_date);
-            const parsedEndDate = parseFilterDate(end_date);
-            const filteredResults = (parsedStartDate || parsedEndDate)
-                ? results.filter(r => isWithinDateRange(r.metadata.timestamp, parsedStartDate, parsedEndDate))
+            // #1244 Couche 1.3 — Filtre temporel : double-couche
+            //   (a) Push dans Qdrant en amont (range filter sur 'timestamp', cf. l. 477-495)
+            //       → fait l'essentiel du travail, evite de transferer des resultats hors plage.
+            //   (b) Filet de securite client-side : si Qdrant n'honore pas le filtre
+            //       (timestamp non indexe, schema mismatch, mock de tests), on filtre ici aussi.
+            //   Avant ce double-niveau, le filtre etait UNIQUEMENT post-Qdrant et apres `limit`,
+            //   ce qui pouvait masquer des matches en position > max_results (bug originel #1244).
+            const filteredResults = (parsedStartDateForQdrant || parsedEndDateForQdrant)
+                ? results.filter(r => isWithinDateRange(r.metadata.timestamp, parsedStartDateForQdrant, parsedEndDateForQdrant))
                 : results;
 
             // Group by task_id: deduplicate multiple chunks from the same conversation
@@ -583,8 +577,10 @@ export const searchTasksByContentTool = {
                     query: search_query,
                     results_count: filteredResults.length,
                     unique_tasks: groupedResults.length,
-                    // #636 Phase 2: temporal filter info
-                    ...(parsedStartDate || parsedEndDate ? {
+                    // #636 Phase 2 + #1244 Couche 1.3: temporal filter info
+                    // Le filtre est pousse en amont dans Qdrant (range filter sur 'timestamp')
+                    // ET applique en defense-in-depth client-side (cf. filteredResults plus haut).
+                    ...(parsedStartDateForQdrant || parsedEndDateForQdrant ? {
                         temporal_filter: {
                             start_date: start_date || null,
                             end_date: end_date || null,

--- a/servers/roo-state-manager/src/tools/smart-truncation/content-truncator.ts
+++ b/servers/roo-state-manager/src/tools/smart-truncation/content-truncator.ts
@@ -11,10 +11,51 @@ import { TaskTruncationPlan, ElementTruncationPlan } from './types.js';
  */
 export class ContentTruncator {
     /**
+     * #1244 Couche 2.5 — Hard cap final pour garantir une borne stricte sur la sortie.
+     *
+     * Tronque le milieu d'une chaine de caracteres tout en preservant le debut
+     * (header / metadata) et la fin (resume / dernier message). Ce filet de
+     * securite est invoque en sortie de chaque handler view/list/summarize quand
+     * le moteur principal de troncature n'a pas suffi a respecter `max_output_length`.
+     *
+     * Caracteristiques :
+     *  - Operation char-level (pas line-level), donc applicable a n'importe quelle
+     *    sortie textuelle deja formattee.
+     *  - Reserve `headerKeepChars` au debut (par defaut 2000) pour conserver
+     *    metadata, titre, breakdown, etc.
+     *  - Le reste du budget va a la fin pour preserver le dernier contexte utile.
+     *  - Insere un marqueur lisible `[... N chars tronques par hard cap ...]`.
+     *  - No-op si `content.length <= maxChars`.
+     */
+    static hardCapString(
+        content: string,
+        maxChars: number,
+        options: { headerKeepChars?: number } = {}
+    ): string {
+        if (content.length <= maxChars) return content;
+
+        const headerKeepChars = Math.max(0, options.headerKeepChars ?? 2000);
+        const marker = `\n\n[... TRUNCATED chars by hard cap ...]\n\n`;
+
+        // Si headerKeepChars + marker depasse deja maxChars, fallback sur une simple coupe en fin
+        if (headerKeepChars + marker.length >= maxChars) {
+            const safeSize = Math.max(0, maxChars - marker.length);
+            return content.substring(0, safeSize) + marker;
+        }
+
+        const tailBudget = maxChars - headerKeepChars - marker.length;
+        const head = content.substring(0, headerKeepChars);
+        const tail = content.substring(content.length - tailBudget);
+        const removed = content.length - headerKeepChars - tailBudget;
+
+        return `${head}${marker.replace('TRUNCATED chars', `${removed} chars`)}${tail}`;
+    }
+
+    /**
      * Applique les plans de troncature aux tâches
      */
     static applyTruncationPlans(
-        tasks: ConversationSkeleton[], 
+        tasks: ConversationSkeleton[],
         taskPlans: TaskTruncationPlan[]
     ): ConversationSkeleton[] {
         const planMap = new Map(taskPlans.map(plan => [plan.taskId, plan]));

--- a/servers/roo-state-manager/src/tools/smart-truncation/types.ts
+++ b/servers/roo-state-manager/src/tools/smart-truncation/types.ts
@@ -113,4 +113,8 @@ export interface ViewConversationTreeArgs {
     smart_truncation_config?: Partial<SmartTruncationConfig>;
     /** Chemin optionnel pour sauvegarder l'arbre dans un fichier markdown */
     output_file?: string;
+    /** #1244 Couche 2.6 — Index 0-based du premier message a inclure (inclusif). Defaut: 0 (debut). */
+    messageStart?: number;
+    /** #1244 Couche 2.6 — Index 0-based du dernier message a inclure (exclusif). Defaut: jusqu'a la fin. */
+    messageEnd?: number;
 }

--- a/servers/roo-state-manager/src/tools/view-conversation-tree.ts
+++ b/servers/roo-state-manager/src/tools/view-conversation-tree.ts
@@ -29,6 +29,71 @@ function truncateMessage(message: string, truncate: number): string {
 }
 
 /**
+ * #1244 Couche 2.5 — Hard cap final sur la sortie complete d'un handler view.
+ *
+ * Filet de securite : applique `ContentTruncator.hardCapString` au texte du
+ * premier item de contenu si sa taille depasse `maxChars`. Garantit le respect
+ * strict de `max_output_length` peu importe les fuites du legacy path,
+ * les bugs d'estimation, ou les depassements du gradient engine.
+ *
+ * Preserve les autres items de contenu tels quels (cas sauvegarde fichier,
+ * messages d'erreur multi-content, etc).
+ */
+function applyHardCap(result: CallToolResult, maxChars: number): CallToolResult {
+    if (!result.content || result.content.length === 0) return result;
+    const first = result.content[0];
+    if (first.type !== 'text' || typeof first.text !== 'string') return result;
+    if (first.text.length <= maxChars) return result;
+
+    const capped = ContentTruncator.hardCapString(first.text, maxChars, { headerKeepChars: 2000 });
+    return {
+        ...result,
+        content: [
+            { ...first, text: capped },
+            ...result.content.slice(1)
+        ]
+    };
+}
+
+/**
+ * #1244 Couche 2.6 — Injecte un en-tete messageRange en debut de sortie.
+ *
+ * Permet a l'agent de savoir combien de messages existent au total et comment
+ * paginer (re-appel avec messageStart: end precedent). Indique explicitement
+ * si la fenetre courante est une troncature.
+ *
+ * Pas besoin d'un bloc navigation verbeux : le schema MCP documente clairement
+ * messageStart/messageEnd. Cet en-tete suffit pour rendre la pagination evidente.
+ */
+function injectMessageRangeMetadata(
+    result: CallToolResult,
+    range: { start: number; end: number; total: number; truncated: boolean }
+): CallToolResult {
+    if (!result.content || result.content.length === 0) return result;
+    const first = result.content[0];
+    if (first.type !== 'text' || typeof first.text !== 'string') return result;
+
+    const lines: string[] = [
+        `messageRange: { start: ${range.start}, end: ${range.end}, total: ${range.total}, truncated: ${range.truncated} }`,
+    ];
+    if (range.truncated && range.end < range.total) {
+        lines.push(`  -> Pour la suite: re-appeler view avec messageStart: ${range.end} (page suivante)`);
+    }
+    if (range.truncated && range.start > 0) {
+        lines.push(`  -> Pour le debut: re-appeler view avec messageStart: 0, messageEnd: ${range.start}`);
+    }
+    const header = lines.join('\n') + '\n\n';
+
+    return {
+        ...result,
+        content: [
+            { ...first, text: header + first.text },
+            ...result.content.slice(1)
+        ]
+    };
+}
+
+/**
   * Trouve la tâche la plus récente dans le cache, optionnellement filtrée par workspace
   */
 function findLatestTask(conversationCache: Map<string, ConversationSkeleton>, workspace?: string): ConversationSkeleton | undefined {
@@ -218,55 +283,132 @@ async function handleViewConversationTreeExecutionAsync(
     // FIX #584: Lazy load full skeleton if sequence is empty but messageCount suggests content exists
     // This happens when scanDiskForNewTasks creates minimal skeletons for discovery
     // FIX #594: Throw explicit error instead of failing silently when lazy loading fails
+    // #1244 Couche 2.7: Dispatch Roo vs Claude selon le prefix taskId / metadata.source
     if ((!mainTask.sequence || mainTask.sequence.length === 0) && mainTask.metadata.messageCount > 0) {
         console.log(`[view] Lazy loading full skeleton for ${task_id} (messageCount: ${mainTask.metadata.messageCount})`);
 
-        // Find the task path by checking all storage locations
-        const storageLocations = await RooStorageDetector.detectStorageLocations();
-        let taskPath: string | null = null;
-        let locationsChecked: string[] = [];
+        const isClaudeTask = task_id.startsWith('claude-')
+            || (mainTask.metadata as any)?.source === 'claude-code'
+            || (mainTask.metadata as any)?.dataSource === 'claude';
 
-        for (const locationPath of storageLocations) {
-            const potentialPath = path.join(locationPath, 'tasks', task_id);
-            locationsChecked.push(potentialPath);
-            try {
-                const stats = await fs.stat(potentialPath);
-                if (stats.isDirectory()) {
-                    taskPath = potentialPath;
+        if (isClaudeTask) {
+            // #1244 Couche 2.7 — Claude path: utiliser ClaudeStorageDetector
+            const { ClaudeStorageDetector } = await import('../utils/claude-storage-detector.js');
+            const claudeLocations = await ClaudeStorageDetector.detectStorageLocations();
+            const projectBasename = task_id.replace(/^claude-/, '');
+            let claudeProjectPath: string | null = null;
+            const locationsChecked: string[] = [];
+
+            for (const loc of claudeLocations) {
+                locationsChecked.push(loc.projectPath);
+                if (path.basename(loc.projectPath) === projectBasename) {
+                    claudeProjectPath = loc.projectPath;
                     break;
                 }
-            } catch {
-                // Location doesn't have this task, continue to next
             }
-        }
 
-        if (taskPath) {
-            const fullSkeleton = await RooStorageDetector.analyzeConversation(task_id, taskPath);
-            if (fullSkeleton && (fullSkeleton.sequence ?? []).length > 0) {
-                // Update the cache with complete skeleton
-                conversationCache.set(task_id, fullSkeleton);
-                // Refresh mainTask reference
-                mainTask = fullSkeleton;
-                console.log(`[view] Successfully loaded ${(fullSkeleton.sequence ?? []).length} sequence items for ${task_id}`);
-            } else {
-                // Task found but analyzeConversation returned null/empty
+            if (!claudeProjectPath) {
                 throw new GenericError(
-                    `Task '${task_id}' found at path but analysis failed. ` +
-                    `The task files may be corrupted or in an unexpected format. ` +
-                    `Checked ${locationsChecked.length} storage locations.`,
+                    `Claude task '${task_id}' has ${mainTask.metadata.messageCount} messages but no matching Claude project directory was found. ` +
+                    `Searched basename '${projectBasename}' in ${locationsChecked.length} location(s). ` +
+                    `The Claude session may have been deleted or moved.`,
                     GenericErrorCode.INVALID_ARGUMENT,
-                    { taskId: task_id, locationsChecked, taskPath }
+                    { taskId: task_id, projectBasename, locationsChecked }
+                );
+            }
+
+            const fullSkeleton = await ClaudeStorageDetector.analyzeConversation(task_id, claudeProjectPath);
+            if (fullSkeleton && (fullSkeleton.sequence ?? []).length > 0) {
+                // Preserver les marqueurs source ajoutes par SkeletonCacheService Tier 2
+                if (!fullSkeleton.metadata) fullSkeleton.metadata = {} as any;
+                (fullSkeleton.metadata as any).source = 'claude-code';
+                (fullSkeleton.metadata as any).dataSource = 'claude';
+                conversationCache.set(task_id, fullSkeleton);
+                mainTask = fullSkeleton;
+                console.log(`[view] Successfully loaded Claude session ${task_id} (${(fullSkeleton.sequence ?? []).length} sequence items)`);
+            } else {
+                throw new GenericError(
+                    `Claude task '${task_id}' found at '${claudeProjectPath}' but analysis returned empty. ` +
+                    `The JSONL files may be corrupted or empty.`,
+                    GenericErrorCode.INVALID_ARGUMENT,
+                    { taskId: task_id, projectPath: claudeProjectPath }
                 );
             }
         } else {
-            // Task path not found in any storage location
-            throw new GenericError(
-                `Task '${task_id}' has ${mainTask.metadata.messageCount} messages but the task directory was not found in any storage location. ` +
-                `Checked ${locationsChecked.length} location(s): ${storageLocations.slice(0, 3).join(', ')}${storageLocations.length > 3 ? '...' : ''}. ` +
-                `The task may have been deleted or the storage locations may be misconfigured.`,
-                GenericErrorCode.INVALID_ARGUMENT,
-                { taskId: task_id, messageCount: mainTask.metadata.messageCount, locationsChecked, storageLocations }
-            );
+            // Roo path (existant)
+            const storageLocations = await RooStorageDetector.detectStorageLocations();
+            let taskPath: string | null = null;
+            let locationsChecked: string[] = [];
+
+            for (const locationPath of storageLocations) {
+                const potentialPath = path.join(locationPath, 'tasks', task_id);
+                locationsChecked.push(potentialPath);
+                try {
+                    const stats = await fs.stat(potentialPath);
+                    if (stats.isDirectory()) {
+                        taskPath = potentialPath;
+                        break;
+                    }
+                } catch {
+                    // Location doesn't have this task, continue to next
+                }
+            }
+
+            if (taskPath) {
+                const fullSkeleton = await RooStorageDetector.analyzeConversation(task_id, taskPath);
+                if (fullSkeleton && (fullSkeleton.sequence ?? []).length > 0) {
+                    // Update the cache with complete skeleton
+                    conversationCache.set(task_id, fullSkeleton);
+                    // Refresh mainTask reference
+                    mainTask = fullSkeleton;
+                    console.log(`[view] Successfully loaded ${(fullSkeleton.sequence ?? []).length} sequence items for ${task_id}`);
+                } else {
+                    // Task found but analyzeConversation returned null/empty
+                    throw new GenericError(
+                        `Task '${task_id}' found at path but analysis failed. ` +
+                        `The task files may be corrupted or in an unexpected format. ` +
+                        `Checked ${locationsChecked.length} storage locations.`,
+                        GenericErrorCode.INVALID_ARGUMENT,
+                        { taskId: task_id, locationsChecked, taskPath }
+                    );
+                }
+            } else {
+                // Task path not found in any storage location
+                throw new GenericError(
+                    `Task '${task_id}' has ${mainTask.metadata.messageCount} messages but the task directory was not found in any storage location. ` +
+                    `Checked ${locationsChecked.length} location(s): ${storageLocations.slice(0, 3).join(', ')}${storageLocations.length > 3 ? '...' : ''}. ` +
+                    `The task may have been deleted or the storage locations may be misconfigured.`,
+                    GenericErrorCode.INVALID_ARGUMENT,
+                    { taskId: task_id, messageCount: mainTask.metadata.messageCount, locationsChecked, storageLocations }
+                );
+            }
+        }
+    }
+
+    // #1244 Couche 2.6 — Pagination message-level sur la tache focale
+    // Applique avant le dispatch view_mode pour que chain/cluster voient la version paginee.
+    const totalMessages = (mainTask.sequence ?? []).length;
+    const hasPagingArgs = typeof args.messageStart === 'number' || typeof args.messageEnd === 'number';
+    let effectiveMessageStart = 0;
+    let effectiveMessageEnd = totalMessages;
+    let isPaged = false;
+
+    if (hasPagingArgs) {
+        effectiveMessageStart = Math.max(0, args.messageStart ?? 0);
+        effectiveMessageEnd = Math.min(totalMessages, args.messageEnd ?? totalMessages);
+        if (effectiveMessageStart > effectiveMessageEnd) {
+            effectiveMessageStart = effectiveMessageEnd;
+        }
+        isPaged = effectiveMessageStart > 0 || effectiveMessageEnd < totalMessages;
+
+        if (isPaged) {
+            const pagedMainTask: ConversationSkeleton = {
+                ...mainTask,
+                sequence: (mainTask.sequence ?? []).slice(effectiveMessageStart, effectiveMessageEnd),
+            };
+            // Substituer la version paginee dans la map et la reference principale
+            skeletonMap.set(task_id, pagedMainTask);
+            mainTask = pagedMainTask;
         }
     }
 
@@ -295,15 +437,30 @@ async function handleViewConversationTreeExecutionAsync(
             }
             break;
     }
-    
+
     // 🎯 POINT D'AIGUILLAGE : Smart Truncation vs Legacy
-    if (args.smart_truncation === true) {
-        // ✨ NOUVEAU : Algorithme de troncature intelligente avec gradient
-        return handleSmartTruncationAsync(tasksToDisplay, args, view_mode, detail_level, max_output_length, currentTaskId);
-    } else {
-        // 🔄 LEGACY : Comportement original préservé (par défaut)
-        return handleLegacyTruncationAsync(tasksToDisplay, args, view_mode, detail_level, max_output_length, truncate, currentTaskId);
+    // #1244 Couche 2.5 — Defaut inverse: smart_truncation est ON sauf opt-out explicite (false).
+    // Le legacy path reste accessible pour debug/comparaison via smart_truncation: false.
+    const useSmart = args.smart_truncation !== false;
+    const result = useSmart
+        ? await handleSmartTruncationAsync(tasksToDisplay, args, view_mode, detail_level, max_output_length, currentTaskId)
+        : await handleLegacyTruncationAsync(tasksToDisplay, args, view_mode, detail_level, max_output_length, truncate, currentTaskId);
+
+    // #1244 Couche 2.5 — Hard cap final: filet de securite pour garantir max_output_length
+    // independamment des estimations en amont. Couvre les bugs d'estimation, les fuites du
+    // legacy path, et les depassements occasionnels du gradient engine.
+    const cappedResult = applyHardCap(result, max_output_length);
+
+    // #1244 Couche 2.6 — Injecter messageRange metadata si pagination explicite
+    if (hasPagingArgs) {
+        return injectMessageRangeMetadata(cappedResult, {
+            start: effectiveMessageStart,
+            end: effectiveMessageEnd,
+            total: totalMessages,
+            truncated: effectiveMessageEnd < totalMessages || effectiveMessageStart > 0,
+        });
     }
+    return cappedResult;
 }
 
 /**
@@ -370,9 +527,34 @@ function handleViewConversationTreeExecution(
     };
 
     let tasksToDisplay: ConversationSkeleton[] = [];
-    const mainTask = skeletonMap.get(task_id);
+    let mainTask = skeletonMap.get(task_id);
     if (!mainTask) {
         throw new GenericError(`Task with ID '${task_id}' not found in cache.`, GenericErrorCode.INVALID_ARGUMENT);
+    }
+
+    // #1244 Couche 2.6 — Pagination message-level (version synchrone)
+    const totalMessages = (mainTask.sequence ?? []).length;
+    const hasPagingArgs = typeof args.messageStart === 'number' || typeof args.messageEnd === 'number';
+    let effectiveMessageStart = 0;
+    let effectiveMessageEnd = totalMessages;
+    let isPaged = false;
+
+    if (hasPagingArgs) {
+        effectiveMessageStart = Math.max(0, args.messageStart ?? 0);
+        effectiveMessageEnd = Math.min(totalMessages, args.messageEnd ?? totalMessages);
+        if (effectiveMessageStart > effectiveMessageEnd) {
+            effectiveMessageStart = effectiveMessageEnd;
+        }
+        isPaged = effectiveMessageStart > 0 || effectiveMessageEnd < totalMessages;
+
+        if (isPaged) {
+            const pagedMainTask: ConversationSkeleton = {
+                ...mainTask,
+                sequence: (mainTask.sequence ?? []).slice(effectiveMessageStart, effectiveMessageEnd),
+            };
+            skeletonMap.set(task_id, pagedMainTask);
+            mainTask = pagedMainTask;
+        }
     }
 
     switch (view_mode) {
@@ -399,13 +581,27 @@ function handleViewConversationTreeExecution(
             }
             break;
     }
-    
+
     // Version synchrone sans sauvegarde fichier
-    if (args.smart_truncation === true) {
-        return handleSmartTruncation(tasksToDisplay, args, view_mode, detail_level, max_output_length, currentTaskId);
-    } else {
-        return handleLegacyTruncation(tasksToDisplay, args, view_mode, detail_level, max_output_length, truncate, currentTaskId);
+    // #1244 Couche 2.5 — Defaut inverse: smart_truncation ON sauf opt-out explicite (false)
+    const useSmart = args.smart_truncation !== false;
+    const result = useSmart
+        ? handleSmartTruncation(tasksToDisplay, args, view_mode, detail_level, max_output_length, currentTaskId)
+        : handleLegacyTruncation(tasksToDisplay, args, view_mode, detail_level, max_output_length, truncate, currentTaskId);
+
+    // #1244 Couche 2.5 — Hard cap final
+    const cappedResult = applyHardCap(result, max_output_length);
+
+    // #1244 Couche 2.6 — Injecter messageRange metadata si pagination explicite
+    if (hasPagingArgs) {
+        return injectMessageRangeMetadata(cappedResult, {
+            start: effectiveMessageStart,
+            end: effectiveMessageEnd,
+            total: totalMessages,
+            truncated: effectiveMessageEnd < totalMessages || effectiveMessageStart > 0,
+        });
     }
+    return cappedResult;
 }
 
 /**
@@ -761,7 +957,7 @@ export const viewConversationTree = {
             detail_level: { type: 'string', enum: ['skeleton', 'summary', 'full'], default: 'skeleton', description: 'Niveau de détail: skeleton (métadonnées seulement), summary (résumé), full (complet).' },
             truncate: { type: 'number', default: 0, description: 'Nombre de lignes à conserver au début et à la fin de chaque message. 0 pour vue complète (défaut intelligent).' },
             max_output_length: { type: 'number', default: 300000, description: 'Limite maximale de caractères en sortie. Au-delà, force la troncature. (AUGMENTÉ: 300K vs 150K)' },
-            smart_truncation: { type: 'boolean', default: false, description: '🧠 Activer l\'algorithme de troncature intelligente avec gradient (NOUVEAU)' },
+            smart_truncation: { type: 'boolean', default: true, description: '#1244 Couche 2.5 — Algorithme de troncature intelligente avec gradient (gradient temporel + priorisation par type, preserve debut/fin de conversation). Active PAR DEFAUT (defaut inverse depuis #1244). Passer false uniquement pour debug ou comparaison avec le legacy path. Un hard cap final est applique en sortie pour garantir le respect de max_output_length quel que soit le mode.' },
             smart_truncation_config: {
                 type: 'object',
                 description: '⚙️ Configuration avancée pour la troncature intelligente (NOUVEAU)',
@@ -771,7 +967,9 @@ export const viewConversationTree = {
                     maxTruncationRate: { type: 'number', description: 'Taux maximum de troncature pour le centre (défaut: 0.7)' }
                 }
             },
-            output_file: { type: 'string', description: 'Chemin optionnel pour sauvegarder l\'arbre dans un fichier markdown' }
+            output_file: { type: 'string', description: 'Chemin optionnel pour sauvegarder l\'arbre dans un fichier markdown' },
+            messageStart: { type: 'number', description: '#1244 Couche 2.6 — Index 0-based du premier message a inclure dans la vue (inclusif). Permet la pagination message-level pour les longues conversations. Defaut: 0 (debut).' },
+            messageEnd: { type: 'number', description: '#1244 Couche 2.6 — Index 0-based du dernier message a inclure (exclusif). Combiner avec messageStart pour fenetrer la conversation. Si > total, est clampe a total. Defaut: jusqu\'a la fin.' }
         },
     },
     handler: async (args: any, conversationCache: Map<string, ConversationSkeleton>): Promise<CallToolResult> => {

--- a/servers/roo-state-manager/src/utils/date-filters.ts
+++ b/servers/roo-state-manager/src/utils/date-filters.ts
@@ -1,0 +1,59 @@
+/**
+ * Date filtering helpers shared across MCP tools.
+ *
+ * #1244 Couche 2.1 — Factorise les helpers de date originellement co-localises
+ * dans search-semantic.tool.ts pour reutilisation par list-conversations,
+ * conversation-browser, summarize, etc.
+ *
+ * Politique :
+ *  - Accepte ISO 8601 complet (`2026-04-08T12:34:56Z`) ou raccourci YYYY-MM-DD.
+ *  - Pour `endDate`, etend implicitement a fin de journee si l'heure est minuit
+ *    (afin que `endDate: "2026-04-08"` inclue toute la journee du 8 avril).
+ */
+
+/**
+ * Parse une chaine de date (ISO 8601 ou YYYY-MM-DD) en objet Date.
+ * Retourne null si le parsing echoue.
+ */
+export function parseFilterDate(dateStr: string | undefined | null): Date | null {
+    if (!dateStr) return null;
+    try {
+        // Support YYYY-MM-DD by appending T00:00:00Z; otherwise use as-is
+        const d = new Date(dateStr.includes('T') ? dateStr : `${dateStr}T00:00:00Z`);
+        return isNaN(d.getTime()) ? null : d;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Verifie qu'un timestamp tombe dans la fenetre [startDate, endDate].
+ * Bornes inclusives. Une borne null = pas de contrainte de ce cote.
+ *
+ * Si timestamp est absent / invalide ET qu'au moins une borne est fournie,
+ * retourne false (filtrage strict). Si aucune borne, retourne true.
+ */
+export function isWithinDateRange(
+    timestamp: string | undefined | null,
+    startDate: Date | null,
+    endDate: Date | null
+): boolean {
+    if (!startDate && !endDate) return true;
+    if (!timestamp) return false;
+    try {
+        const ts = new Date(timestamp);
+        if (isNaN(ts.getTime())) return false;
+        if (startDate && ts < startDate) return false;
+        if (endDate) {
+            // For end_date given as YYYY-MM-DD, include the entire day
+            const endOfDay = new Date(endDate.getTime());
+            if (endOfDay.getUTCHours() === 0 && endOfDay.getUTCMinutes() === 0) {
+                endOfDay.setUTCHours(23, 59, 59, 999);
+            }
+            if (ts > endOfDay) return false;
+        }
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/servers/roo-state-manager/src/utils/server-helpers.ts
+++ b/servers/roo-state-manager/src/utils/server-helpers.ts
@@ -39,9 +39,68 @@ export function getSharedStatePath(): string {
 export function truncateResult(result: CallToolResult): CallToolResult {
     for (const item of result.content) {
         if (item.type === 'text' && item.text.length > OUTPUT_CONFIG.MAX_OUTPUT_LENGTH) {
-            item.text = item.text.substring(0, OUTPUT_CONFIG.MAX_OUTPUT_LENGTH) + 
+            item.text = item.text.substring(0, OUTPUT_CONFIG.MAX_OUTPUT_LENGTH) +
                 `\n\n[...]\n\n--- OUTPUT TRUNCATED AT ${OUTPUT_CONFIG.MAX_OUTPUT_LENGTH} CHARACTERS ---`;
         }
+    }
+    return result;
+}
+
+/**
+ * Format a millisecond duration as a compact human-readable string.
+ *  - <1000 ms : "142ms"
+ *  - <60 s    : "2.4s"
+ *  - <60 m    : "1m23s"
+ *  - else     : "1h05m"
+ */
+export function formatDurationMs(ms: number): string {
+    if (ms < 1000) return `${ms}ms`;
+    if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+    const totalSec = Math.floor(ms / 1000);
+    if (totalSec < 3600) {
+        const m = Math.floor(totalSec / 60);
+        const s = totalSec % 60;
+        return `${m}m${s.toString().padStart(2, '0')}s`;
+    }
+    const h = Math.floor(totalSec / 3600);
+    const m = Math.floor((totalSec % 3600) / 60);
+    return `${h}h${m.toString().padStart(2, '0')}m`;
+}
+
+/**
+ * Inject execution duration into a tool result so callers can see how long
+ * each MCP tool took. Sets `result._meta.durationMs` (MCP spec field) AND
+ * appends a compact footer line to the first text content for human visibility.
+ *
+ * Footer format: `\n\n[⏱ <toolName> 142ms]`
+ *
+ * Safe by design:
+ *  - Footer is appended (never inserted), so JSON-text consumers that read
+ *    `content[0].text` will get the footer at the end. Existing convention
+ *    (cf. truncateResult) already appends non-JSON markers.
+ *  - When the result has no text content, only `_meta.durationMs` is set.
+ *  - errors during injection are swallowed — the original result is returned.
+ */
+export function injectDuration(
+    result: CallToolResult,
+    durationMs: number,
+    toolName?: string
+): CallToolResult {
+    try {
+        // Always set MCP spec _meta field
+        const meta = (result as any)._meta || {};
+        meta.durationMs = durationMs;
+        meta.toolName = toolName;
+        (result as any)._meta = meta;
+
+        // Append a compact footer to the first text item for visibility
+        const first = result.content && result.content[0];
+        if (first && first.type === 'text' && typeof first.text === 'string') {
+            const label = toolName ? `${toolName} ` : '';
+            first.text = `${first.text}\n\n[⏱ ${label}${formatDurationMs(durationMs)}]`;
+        }
+    } catch {
+        // Never fail tool calls because of instrumentation
     }
     return result;
 }

--- a/servers/roo-state-manager/tests/unit/services/task-archiver/TaskArchiver.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/task-archiver/TaskArchiver.test.ts
@@ -77,6 +77,17 @@ describe('TaskArchiver', () => {
     });
 
     describe('archiveTask', () => {
+        // Since the archive format bump v1 -> v2, existence check is done by
+        // reading the archive (gunzip + JSON parse) and inspecting .version,
+        // NOT fs.access. The hoisted gunzip mock strips the 'compressed-' prefix,
+        // so a v2 archive is simulated as Buffer.from('compressed-' + JSON.stringify({version: 2, ...})).
+        const missingArchive = () =>
+            vi.mocked(fs.readFile).mockRejectedValueOnce(new Error('ENOENT'));
+        const existingV2Archive = () =>
+            vi.mocked(fs.readFile).mockResolvedValueOnce(
+                Buffer.from('compressed-' + JSON.stringify({ version: 2, taskId: 'x', messages: [] })) as any
+            );
+
         it('should archive a task from ui_messages.json', async () => {
             const skeleton = createMockSkeleton();
             const uiMessages = [
@@ -84,9 +95,7 @@ describe('TaskArchiver', () => {
                 { author: 'agent', text: 'Hi there!', timestamp: '2026-02-13T10:00:05Z' },
             ];
 
-            // File doesn't exist yet (no prior archive)
-            vi.mocked(fs.access).mockRejectedValueOnce(new Error('ENOENT'));
-            // ui_messages.json is readable
+            missingArchive(); // version check fails -> no prior archive
             vi.mocked(fs.readFile).mockResolvedValueOnce(JSON.stringify(uiMessages));
             vi.mocked(fs.mkdir).mockResolvedValueOnce(undefined);
             vi.mocked(fs.writeFile).mockResolvedValueOnce(undefined);
@@ -103,16 +112,33 @@ describe('TaskArchiver', () => {
             );
         });
 
-        it('should skip if already archived', async () => {
+        it('should skip if already archived as v2', async () => {
             const skeleton = createMockSkeleton();
-
-            // File already exists
-            vi.mocked(fs.access).mockResolvedValueOnce(undefined);
+            existingV2Archive();
 
             await TaskArchiver.archiveTask('test-task-123', '/task/path', skeleton);
 
-            expect(fs.readFile).not.toHaveBeenCalled();
+            // Only the version-check read happens; no source read and no write.
+            expect(vi.mocked(fs.readFile).mock.calls.length).toBe(1);
             expect(fs.writeFile).not.toHaveBeenCalled();
+        });
+
+        it('should upgrade existing v1 archive to v2', async () => {
+            const skeleton = createMockSkeleton();
+            const uiMessages = [
+                { author: 'user', text: 'Hello', timestamp: '2026-02-13T10:00:00Z' },
+            ];
+            // Version check returns v1 -> triggers re-archive
+            vi.mocked(fs.readFile).mockResolvedValueOnce(
+                Buffer.from('compressed-' + JSON.stringify({ version: 1, taskId: 'x', messages: [] })) as any
+            );
+            vi.mocked(fs.readFile).mockResolvedValueOnce(JSON.stringify(uiMessages));
+            vi.mocked(fs.mkdir).mockResolvedValueOnce(undefined);
+            vi.mocked(fs.writeFile).mockResolvedValueOnce(undefined);
+
+            await TaskArchiver.archiveTask('test-task-123', '/task/path', skeleton);
+
+            expect(fs.writeFile).toHaveBeenCalled();
         });
 
         it('should fallback to api_conversation_history.json if ui_messages absent', async () => {
@@ -122,11 +148,8 @@ describe('TaskArchiver', () => {
                 { role: 'assistant', content: 'Response', timestamp: '2026-02-13T10:00:05Z' },
             ];
 
-            // Not already archived
-            vi.mocked(fs.access).mockRejectedValueOnce(new Error('ENOENT'));
-            // ui_messages.json fails
+            missingArchive();
             vi.mocked(fs.readFile).mockRejectedValueOnce(new Error('ENOENT'));
-            // api_conversation_history.json works
             vi.mocked(fs.readFile).mockResolvedValueOnce(JSON.stringify(apiMessages));
             vi.mocked(fs.mkdir).mockResolvedValueOnce(undefined);
             vi.mocked(fs.writeFile).mockResolvedValueOnce(undefined);
@@ -139,9 +162,7 @@ describe('TaskArchiver', () => {
         it('should silently return if no message files exist', async () => {
             const skeleton = createMockSkeleton();
 
-            // Not already archived
-            vi.mocked(fs.access).mockRejectedValueOnce(new Error('ENOENT'));
-            // Both files fail
+            missingArchive();
             vi.mocked(fs.readFile).mockRejectedValueOnce(new Error('ENOENT'));
             vi.mocked(fs.readFile).mockRejectedValueOnce(new Error('ENOENT'));
 
@@ -150,29 +171,30 @@ describe('TaskArchiver', () => {
             expect(fs.writeFile).not.toHaveBeenCalled();
         });
 
-        it('should truncate content exceeding 10KB', async () => {
+        it('should preserve full content without truncation (v2 format)', async () => {
+            // Regression guard: commit 8af5dc6f silently introduced a 10KB
+            // per-message truncation without user request. v2 removes it.
             const skeleton = createMockSkeleton();
-            const longContent = 'x'.repeat(15000);
+            const longContent = 'x'.repeat(60 * 1024); // 60KB, well beyond the old 10KB cap
             const uiMessages = [
                 { author: 'user', text: longContent, timestamp: '2026-02-13T10:00:00Z' },
             ];
 
-            vi.mocked(fs.access).mockRejectedValueOnce(new Error('ENOENT'));
+            missingArchive();
             vi.mocked(fs.readFile).mockResolvedValueOnce(JSON.stringify(uiMessages));
             vi.mocked(fs.mkdir).mockResolvedValueOnce(undefined);
             vi.mocked(fs.writeFile).mockResolvedValueOnce(undefined);
 
             await TaskArchiver.archiveTask('test-task-123', '/task/path', skeleton);
 
-            // Verify the written data has truncated content
             const writeCall = vi.mocked(fs.writeFile).mock.calls[0];
             expect(writeCall).toBeDefined();
-            // The data is gzipped, but our mock just prepends 'compressed-'
             const compressedStr = (writeCall[1] as Buffer).toString();
             const jsonStr = compressedStr.replace('compressed-', '');
             const archived = JSON.parse(jsonStr);
-            expect(archived.messages[0].content.length).toBeLessThan(15000);
-            expect(archived.messages[0].content).toContain('[... truncated ...]');
+            expect(archived.version).toBe(2);
+            expect(archived.messages[0].content.length).toBe(longContent.length);
+            expect(archived.messages[0].content).not.toContain('[... truncated ...]');
         });
 
         it('should map agent author to assistant role', async () => {
@@ -181,7 +203,7 @@ describe('TaskArchiver', () => {
                 { author: 'agent', text: 'I am the assistant', timestamp: '2026-02-13T10:00:00Z' },
             ];
 
-            vi.mocked(fs.access).mockRejectedValueOnce(new Error('ENOENT'));
+            missingArchive();
             vi.mocked(fs.readFile).mockResolvedValueOnce(JSON.stringify(uiMessages));
             vi.mocked(fs.mkdir).mockResolvedValueOnce(undefined);
             vi.mocked(fs.writeFile).mockResolvedValueOnce(undefined);
@@ -203,7 +225,7 @@ describe('TaskArchiver', () => {
                 { author: 'user', text: '  ', timestamp: '2026-02-13T10:00:10Z' },
             ];
 
-            vi.mocked(fs.access).mockRejectedValueOnce(new Error('ENOENT'));
+            missingArchive();
             vi.mocked(fs.readFile).mockResolvedValueOnce(JSON.stringify(uiMessages));
             vi.mocked(fs.mkdir).mockResolvedValueOnce(undefined);
             vi.mocked(fs.writeFile).mockResolvedValueOnce(undefined);

--- a/servers/roo-state-manager/tests/unit/tools/conversation/list-conversations.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/conversation/list-conversations.test.ts
@@ -155,8 +155,82 @@ describe('list_conversations tool', () => {
         const result = await listConversationsTool.handler({ contentPattern: 'specific pattern' }, mockCache);
         const _response = JSON.parse(result.content[0].text as string);
         const content = _response.conversations ?? _response;
-        
+
         expect(content).toHaveLength(1);
         expect(content[0].taskId).toBe('task-2');
+    });
+
+    // ======================================================================
+    // #1244 — pipeline repair (couches 2.1 / 2.2 / 3.2)
+    // Regression guards for the CoursIA postmortem fixes.
+    // ======================================================================
+    describe('#1244 — pipeline repair', () => {
+        it('[#1244 2.1] startDate filter keeps only tasks with lastActivity >= startDate', async () => {
+            // task-1 lastActivity = 2023-01-02, task-2 lastActivity = 2023-01-01
+            const result = await listConversationsTool.handler({ startDate: '2023-01-02' }, mockCache);
+            const _response = JSON.parse(result.content[0].text as string);
+            const content = _response.conversations ?? _response;
+
+            expect(content).toHaveLength(1);
+            expect(content[0].taskId).toBe('task-1');
+        });
+
+        it('[#1244 2.1] endDate filter keeps only tasks with lastActivity <= endDate (end of day expanded)', async () => {
+            // endDate "2023-01-01" is expanded to end-of-day (23:59:59.999Z) by isWithinDateRange,
+            // so task-2 (2023-01-01T00:00:00Z) matches while task-1 (2023-01-02T00:00:00Z) is excluded.
+            const result = await listConversationsTool.handler({ endDate: '2023-01-01' }, mockCache);
+            const _response = JSON.parse(result.content[0].text as string);
+            const content = _response.conversations ?? _response;
+
+            expect(content).toHaveLength(1);
+            expect(content[0].taskId).toBe('task-2');
+        });
+
+        it('[#1244 2.1] machineId filter isolates a single machine cross-machine', async () => {
+            mockCache.get('task-1')!.metadata.machineId = 'myia-po-2025';
+            mockCache.get('task-2')!.metadata.machineId = 'myia-ai-01';
+
+            const result = await listConversationsTool.handler({ machineId: 'myia-po-2025' }, mockCache);
+            const _response = JSON.parse(result.content[0].text as string);
+            const content = _response.conversations ?? _response;
+
+            expect(content).toHaveLength(1);
+            expect(content[0].taskId).toBe('task-1');
+        });
+
+        it('[#1244 2.2] workspacePathMatch "normalized" (default) matches different parent paths via basename', async () => {
+            // Override task workspaces to two different parent trees sharing a basename.
+            mockCache.get('task-1')!.metadata.workspace = 'd:/dev/CoursIA';
+            mockCache.get('task-2')!.metadata.workspace = 'c:/other/Project';
+
+            // Query uses a shorter path ("d:/CoursIA") — with 'normalized' (default) both
+            // resolve to basename "coursia" and match. Before #1244 this failed (exact match only).
+            const result = await listConversationsTool.handler({ workspace: 'd:/CoursIA' }, mockCache);
+            const _response = JSON.parse(result.content[0].text as string);
+            const content = _response.conversations ?? _response;
+
+            expect(content).toHaveLength(1);
+            expect(content[0].taskId).toBe('task-1');
+        });
+
+        it('[#1244 3.2] toConversationSummary exposes source/tier/machineId from metadata', async () => {
+            const t1 = mockCache.get('task-1')!;
+            t1.metadata.source = 'claude-code';
+            t1.metadata.dataSource = 'archive';
+            t1.metadata.machineId = 'myia-po-2025';
+
+            const result = await listConversationsTool.handler({}, mockCache);
+            const _response = JSON.parse(result.content[0].text as string);
+            const content = _response.conversations ?? _response;
+
+            const task1Summary = content.find((c: any) => c.taskId === 'task-1');
+            expect(task1Summary).toBeDefined();
+            // Couche 3.2 — source flows from metadata.source (not taskId prefix)
+            expect(task1Summary.source).toBe('claude');
+            // Couche 3.2 — tier derived from metadata.dataSource ('archive' vs 'local')
+            expect(task1Summary.tier).toBe('archive');
+            // Cross-machine dimension surfaced in meta
+            expect(task1Summary.metadata.machineId).toBe('myia-po-2025');
+        });
     });
 });

--- a/servers/roo-state-manager/tests/unit/tools/conversation/list-conversations.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/conversation/list-conversations.test.ts
@@ -66,6 +66,13 @@ describe('list_conversations tool', () => {
         mockCache.set('task-2', task2);
 
         vi.mocked(path.join).mockImplementation((...args) => args.join('/'));
+        // #1244 Couche 2.2 — list-conversations now uses normalizeWorkspaceId() which calls path.basename
+        vi.mocked(path.basename).mockImplementation((p: string) => {
+            if (!p) return '';
+            const normalized = p.replace(/\\/g, '/');
+            const parts = normalized.split('/').filter(Boolean);
+            return parts[parts.length - 1] || '';
+        });
     });
 
     it('should have correct definition', () => {

--- a/servers/roo-state-manager/tests/unit/tools/conversation/list-conversations.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/conversation/list-conversations.test.ts
@@ -112,12 +112,13 @@ describe('list_conversations tool', () => {
         expect(content[1].taskId).toBe('task-1'); // 10 messages
     });
 
-    it('should limit results', async () => {
+    it('should clamp limit below floor to 10 (#1245: pages of <10 are useless)', async () => {
+        // mockCache has only 2 tasks. limit=1 gets clamped to 10, so we get all 2 back.
         const result = await listConversationsTool.handler({ limit: 1 }, mockCache);
         const _response = JSON.parse(result.content[0].text as string);
         const content = _response.conversations ?? _response;
-        
-        expect(content).toHaveLength(1);
+
+        expect(content).toHaveLength(2);
     });
 
     // Test for pendingSubtaskOnly filter

--- a/servers/roo-state-manager/tests/unit/tools/indexing/diagnose-index.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/indexing/diagnose-index.test.ts
@@ -79,8 +79,10 @@ function createMockOpenAI(overrides: Partial<{
 }> = {}) {
     return {
         embeddings: {
+            // Default healthy embedding: matches the default collection dimension (1536)
+            // so the dimension_check added by #1244 Couche 1.2 doesn't flag a mismatch.
             create: overrides.create ?? vi.fn().mockResolvedValue({
-                data: [{ embedding: [0.1, 0.2, 0.3] }]
+                data: [{ embedding: new Array(1536).fill(0.1) }]
             })
         }
     };

--- a/servers/roo-state-manager/tests/unit/tools/view-conversation-tree.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/view-conversation-tree.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { viewConversationTree } from '../../../src/tools/view-conversation-tree.js';
 import { ConversationSkeleton } from '../../../src/types/conversation.js';
+import { ClaudeStorageDetector } from '../../../src/utils/claude-storage-detector.js';
 
 // Mock fs (promises as fs) - use vi.hoisted to create mock references before mock definition
 const { mockWriteFile, mockMkdir } = vi.hoisted(() => ({
@@ -68,13 +69,16 @@ describe('view_conversation_tree Tool', () => {
         expect(textContent).toContain('Task: Child 2');
     });
 
-    it('should truncate long content when max_output_length is exceeded', async () => {
+    it('should truncate long content via legacy path when smart_truncation is explicitly disabled', async () => {
         // #901: skeleton snippet increased from 50→300 chars, so content must exceed 300 chars
-        // to trigger the '...' ellipsis in skeleton mode
+        // #1244 Couche 2.5: smart_truncation now defaults to true; this test explicitly opts into
+        // the legacy path via smart_truncation: false to preserve coverage of its 'Sortie estimée'
+        // marker. max_output_length must be large enough to fit within the hard-cap header window
+        // (2000 chars preserved) so the legacy marker is not clipped by the final safety net.
         const longContent = 'This is a long line of content for testing truncation behavior.\n'.repeat(50);
         mockCache.set('long_task', createMockSkeleton('long_task', undefined, 'Long Task', '2025-01-02T00:00:00Z', longContent));
 
-        const result = await viewConversationTree.handler({ task_id: 'long_task', max_output_length: 50 }, mockCache);
+        const result = await viewConversationTree.handler({ task_id: 'long_task', max_output_length: 1500, smart_truncation: false }, mockCache);
         const textContent = result.content[0].type === 'text' ? result.content[0].text : '';
 
         // Mode skeleton uses substring(0, 300) + '...' for content > 300 chars
@@ -185,12 +189,177 @@ describe('view_conversation_tree Tool', () => {
 
     it('should throw error when cache is empty and no task_id provided', async () => {
         const emptyCache = new Map<string, ConversationSkeleton>();
-        
+
         try {
             await viewConversationTree.handler({}, emptyCache);
             throw new Error('Expected error to be thrown');
         } catch (error: any) {
             expect(error.message).toContain("Cache is empty and no task_id was provided. Cannot determine latest task.");
         }
+    });
+
+    // =========================================================================
+    // #1244 — Pipeline repair (couches 2.5, 2.6, 2.7)
+    // =========================================================================
+    describe('#1244 — pipeline repair', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        // --- Couche 2.5: smart_truncation defaults to true --------------------
+        it('[#1244 2.5] smart_truncation defaults to true (no Sortie estimée marker from smart path)', async () => {
+            const longContent = 'Line of detailed content for default-smart-path assertion.\n'.repeat(200);
+            mockCache.set('smart_default_task', createMockSkeleton(
+                'smart_default_task',
+                undefined,
+                'Smart Default Task',
+                '2025-01-02T00:00:00Z',
+                longContent,
+            ));
+
+            // No explicit smart_truncation flag → should go through smart path
+            const result = await viewConversationTree.handler(
+                { task_id: 'smart_default_task', max_output_length: 8000 },
+                mockCache,
+            );
+            const textContent = result.content[0].type === 'text' ? result.content[0].text : '';
+
+            // Legacy marker MUST NOT be present
+            expect(textContent).not.toContain('Sortie estimée');
+            // Task header should still be present
+            expect(textContent).toContain('Smart Default Task');
+        });
+
+        // --- Couche 2.5: hard cap enforces max_output_length ------------------
+        it('[#1244 2.5] hard cap enforces max_output_length even with long content', async () => {
+            // Build a very long skeleton that would otherwise blow past 8 KB
+            const hugeContent = 'word '.repeat(30_000); // ~150 KB of content
+            mockCache.set('huge_task', createMockSkeleton(
+                'huge_task',
+                undefined,
+                'Huge Task',
+                '2025-01-02T00:00:00Z',
+                hugeContent,
+            ));
+
+            const MAX = 8_000;
+            const result = await viewConversationTree.handler(
+                { task_id: 'huge_task', max_output_length: MAX, detail_level: 'full' },
+                mockCache,
+            );
+            const textContent = result.content[0].type === 'text' ? result.content[0].text : '';
+
+            // Hard cap should clamp total length at or below max_output_length
+            // (applyHardCap uses ContentTruncator.hardCapString with headerKeepChars, which
+            // guarantees the final string length ≤ max_output_length).
+            expect(textContent.length).toBeLessThanOrEqual(MAX);
+        });
+
+        // --- Couche 2.6: pagination → messageRange header ---------------------
+        it('[#1244 2.6] messageStart/messageEnd return messageRange header with navigation hints', async () => {
+            const paginatedTask: ConversationSkeleton = {
+                taskId: 'paged_task',
+                parentTaskId: undefined,
+                metadata: {
+                    title: 'Paged Task',
+                    lastActivity: '2025-01-02T00:00:00Z',
+                    createdAt: '2025-01-02T00:00:00Z',
+                    messageCount: 5,
+                    actionCount: 0,
+                    totalSize: 500,
+                },
+                sequence: [
+                    { role: 'user',      content: 'msg 0', timestamp: '2025-01-02T00:00:00Z', isTruncated: false },
+                    { role: 'assistant', content: 'msg 1', timestamp: '2025-01-02T00:01:00Z', isTruncated: false },
+                    { role: 'user',      content: 'msg 2', timestamp: '2025-01-02T00:02:00Z', isTruncated: false },
+                    { role: 'assistant', content: 'msg 3', timestamp: '2025-01-02T00:03:00Z', isTruncated: false },
+                    { role: 'user',      content: 'msg 4', timestamp: '2025-01-02T00:04:00Z', isTruncated: false },
+                ],
+            };
+            mockCache.set('paged_task', paginatedTask);
+
+            const result = await viewConversationTree.handler(
+                { task_id: 'paged_task', messageStart: 1, messageEnd: 3, view_mode: 'single' },
+                mockCache,
+            );
+            const textContent = result.content[0].type === 'text' ? result.content[0].text : '';
+
+            // Should include the messageRange metadata header from injectMessageRangeMetadata
+            expect(textContent).toContain('messageRange:');
+            expect(textContent).toContain('start: 1');
+            expect(textContent).toContain('end: 3');
+            expect(textContent).toContain('total: 5');
+            expect(textContent).toContain('truncated: true');
+
+            // And at least one of the navigation hints (next page or previous page)
+            const hasNavHint =
+                textContent.includes('messageStart: 3') || // page suivante
+                textContent.includes('messageStart: 0');   // debut
+            expect(hasNavHint).toBe(true);
+        });
+
+        // --- Couche 2.7: Claude task_id dispatches to ClaudeStorageDetector ----
+        it('[#1244 2.7] Claude task_id dispatches to ClaudeStorageDetector.analyzeConversation', async () => {
+            // Mock Claude storage discovery + conversation loading. Production code uses
+            // `await import('../utils/claude-storage-detector.js')` which goes through the
+            // Node module cache, so spying on the statically-imported ClaudeStorageDetector
+            // intercepts the dynamic-import result as well.
+            const detectSpy = vi.spyOn(ClaudeStorageDetector, 'detectStorageLocations').mockResolvedValue([
+                {
+                    path: '/home/user/.claude/projects/myproject-abc',
+                    projectPath: '/home/user/.claude/projects/myproject-abc',
+                    globalPath: '/home/user/.claude',
+                    sessionFiles: ['session.jsonl'],
+                } as any,
+            ]);
+
+            const analyzeSpy = vi.spyOn(ClaudeStorageDetector, 'analyzeConversation').mockResolvedValue({
+                taskId: 'claude-myproject-abc',
+                parentTaskId: undefined,
+                metadata: {
+                    title: 'Claude Dispatched Task',
+                    lastActivity: '2025-01-02T00:00:00Z',
+                    createdAt: '2025-01-02T00:00:00Z',
+                    messageCount: 1,
+                    actionCount: 0,
+                    totalSize: 42,
+                    source: 'claude-code',
+                    dataSource: 'claude',
+                } as any,
+                sequence: [
+                    { role: 'user', content: 'hello from claude session', timestamp: '2025-01-02T00:00:00Z', isTruncated: false },
+                ],
+            } as any);
+
+            // Inject a shell skeleton in cache with empty sequence but messageCount > 0
+            // so the lazy-load branch fires on first handler call.
+            const claudeShell: ConversationSkeleton = {
+                taskId: 'claude-myproject-abc',
+                parentTaskId: undefined,
+                metadata: {
+                    title: 'Claude Dispatched Task (shell)',
+                    lastActivity: '2025-01-02T00:00:00Z',
+                    createdAt: '2025-01-02T00:00:00Z',
+                    messageCount: 5, // > 0 → triggers lazy load
+                    actionCount: 0,
+                    totalSize: 0,
+                    source: 'claude-code',
+                    dataSource: 'claude',
+                } as any,
+                sequence: [], // empty → triggers lazy load
+            };
+            mockCache.set('claude-myproject-abc', claudeShell);
+
+            await viewConversationTree.handler(
+                { task_id: 'claude-myproject-abc', view_mode: 'single' },
+                mockCache,
+            );
+
+            expect(detectSpy).toHaveBeenCalled();
+            expect(analyzeSpy).toHaveBeenCalledWith(
+                'claude-myproject-abc',
+                '/home/user/.claude/projects/myproject-abc',
+            );
+        });
     });
 });

--- a/servers/roo-state-manager/vitest.config.ci.ts
+++ b/servers/roo-state-manager/vitest.config.ci.ts
@@ -59,7 +59,10 @@ export default mergeConfig(baseConfig, defineConfig({
       'tests/unit/services/RooSyncService.test.ts',
       'tests/unit/services/task-indexer-vector-validation.test.ts',
       'tests/unit/services/task-indexer.test.ts',
-      'tests/unit/tools/view-conversation-tree.test.ts',
+      // #1244 Couche 2.5/2.6/2.7 — Re-enabled in CI after repair: legacy test was
+      // fixed to accommodate the new hard-cap and smart_truncation default, and the
+      // file now contains regression guards for the pipeline repair (#1244).
+      // 'tests/unit/tools/view-conversation-tree.test.ts',
 
       // ===== CI-excluded: POWERSHELL (requires Windows PowerShell) =====
       'src/services/__tests__/PowerShellExecutor.test.ts',


### PR DESCRIPTION
## Summary

Implements the full 3-layer plan from roo-extensions issue [jsboige/roo-extensions#1244](https://github.com/jsboige/roo-extensions/issues/1244) — postmortem CoursIA revealed the conversation harness was architecturally incomplete: skeleton cache only knew Roo local storage (ignoring Claude sessions and 11 562 cross-machine archives), `max_output_length` was ignored on the legacy truncation path (93 022 chars on 8 000 requested), `view` failed on Claude tasks with `Task directory not found`, and `list`/`view`/`summarize` used different cache sources.

## What changed

### Layer 1 — Construction
- **Multi-tier skeleton cache** (`skeleton-cache.service.ts`): Tier 1 Roo local headers, Tier 2 Claude sessions (full skeletons), Tier 3 GDrive archives (full skeletons). `metadata.dataSource` and `metadata.source` set on Tier 2/3 entries for UI surfacing.
- **`archive-skeleton-builder.ts`** (new): Converts archived task JSON into `ConversationSkeleton`, preserving original `source` and `machineId`.
- **Diagnose-index extended**: collection dimensions, payload sample, vLLM health, source/workspace breakdown via scroll.
- **Search-semantic temporal fix**: `start_date`/`end_date` pushed as Qdrant range filter on `timestamp` instead of post-filtering memory results.
- **Build-skeleton-cache** new params `sources` and `reindex` for orchestrated multi-tier rebuild.

### Layer 2 — Query/Navigation
- **`date-filters.ts`** (new): Shared `parseFilterDate` / `isWithinDateRange` helpers (factored from search-semantic).
- **List filters**: `startDate`/`endDate`/`machineId` + `workspacePathMatch` strategy (`exact`|`normalized`|`substring`).
- **Multi-source `contentPattern`**: in-memory search for Tier 2/3 cached sequences, disk read for Tier 1 Roo `api_conversation_history.json`.
- **Cache unification (Couche 2.3)**: `getConversationSkeleton` callback in `registry.ts` short-circuits `loadFullSkeleton` (Tier 1 only) when the cache already holds a full skeleton. Fixes archives being unreachable from `summarize`.
- **`smart_truncation` default INVERTED to `true`** (Couche 2.5). The legacy path remains accessible via explicit `false` for debug/comparison. Hard cap final via `ContentTruncator.truncateMiddle` in every handler exit guarantees `max_output_length` is respected.
- **Message-level pagination** (Couche 2.6): `messageStart`/`messageEnd` with `messageRange: {start, end, total}` and `truncated` metadata in response.
- **Claude view dispatch** (Couche 2.7): `view` detects `claude-` prefix (or Claude metadata) and routes to `ClaudeStorageDetector.analyzeConversation`, fixing `Task directory not found` on Claude Code sessions.

### Layer 3 — UI surface
- **List entries** always include `machineId`, `source` (preferring `metadata.source` over taskId prefix), and `tier` (`local` vs `archive`).
- **Schema descriptions enriched**: action enum, `task_id`, `detail_level` (with character budgets per level), `smart_truncation`, `messageStart`/`messageEnd` — zoom progression discoverable from tool definition alone.

## Test plan

- [x] `npm run build` — clean (tsc)
- [x] `npx vitest run --config vitest.config.ci.ts` — **7396 pass / 22 skipped (412 files)**
- [ ] Real CoursIA investigation post-merge (oracle for the calibration phase)
- [ ] Cross-machine verification from po-2025 after rebuild

## Stats

```
17 files changed, 1493 insertions(+), 167 deletions(-)
+ 2 new files: archive-skeleton-builder.ts, date-filters.ts
```

## Calibration note

All numeric values (`per_page`, `previewChars`, snippet lengths per level, cache TTLs) in the plan are **starting points**, not fixed targets. The post-merge CoursIA investigation will validate or invalidate them. Final values to be documented in MEMORY.md.

Refs: jsboige/roo-extensions#1244

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>