### PR TITLE
fix(#858): Remove stale .tags assertions in dashboard condensation test

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
@@ -662,11 +662,11 @@ describe('roosync_dashboard', () => {
       expect(messages.length).toBe(5);
 
       // First message should be the LLM summary
-      expect(messages[0].tags).toContain('CONDENSATION-SUMMARY');
+      // Note: `tags` field was removed in df56edb1 — assert on content marker only
       expect(messages[0].content).toContain('CONDENSATION-SUMMARY');
 
       // Second message should be the condensation notice
-      expect(messages[1].tags).toContain('CONDENSATION');
+      expect(messages[1].content).toContain('**CONDENSATION**');
 
       // Last 3 should be the kept messages
       expect(messages[2].content).toBe('Message 7');


### PR DESCRIPTION
## Context

Submodule `main` is currently **red**: the `roo-state-manager` CI check fails at tip (`9ba5fbd5`) because of stale `.tags` assertions in the #858 dashboard condensation test.

## Root cause (chronological)

1. `df56edb1` — `fix(dashboard): Remove unused intercom tags field` (removed `tags` from `IntercomMessage`)
2. `e7f2c3d0` — `feat(#858): Fix 5 skipped dashboard condensation tests` — this commit added new `it(...)` tests that assert `messages[0].tags.toContain('CONDENSATION-SUMMARY')`, which throws because `.tags` is `undefined`.

The #858 commit was merged even though its CI failed on `roo-state-manager`. This PR restores a green main.

## Fix

Replace both `.tags` assertions with `.content` assertions — which is the authoritative marker used by `condenseIntercom()` in [dashboard.ts:778](servers/roo-state-manager/src/tools/roosync/dashboard.ts#L778):

```typescript
content: `**CONDENSATION-SUMMARY** - ${now}\n\n${llmSummary}`
```

Line 162 of the same test file already asserts `tags` is `undefined`, confirming the field removal is intentional — it's only the #858 tests that slipped through.

## Validation

```
$ npx vitest run --config vitest.config.ci.ts src/tools/roosync/__tests__/dashboard.test.ts
 ✓ src/tools/roosync/__tests__/dashboard.test.ts (37 tests) 12495ms
 Test Files  1 passed (1)
      Tests  37 passed (37)
```

## Blocks

This blocks parent PR [jsboige/roo-extensions#1256](https://github.com/jsboige/roo-extensions/pull/1256), which bumps the submodule pointer to main tip — it cannot merge while main CI is red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)