### PR TITLE
fix(#1269): Remove debug console.log from diagnose.ts

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/debug-reset.ts
+++ b/servers/roo-state-manager/src/tools/roosync/debug-reset.ts
@@ -91,26 +91,18 @@ async function handleDebugAction(
   timestamp: string,
   config: any
 ): Promise<DebugResetResult> {
-  console.log('[DEBUG] debugDashboard - FORCAGE NOUVELLE INSTANCE');
-  
   // Forcer la réinitialisation complète du singleton
-  await await RooSyncService.resetInstance();
-  
+  await RooSyncService.resetInstance();
+
   // Attendre un peu pour s'assurer que l'instance est bien nettoyée
   await new Promise(resolve => setTimeout(resolve, 100));
-  
+
   // Créer une nouvelle instance avec cache désactivé
-  const service = await await RooSyncService.getInstance({ enabled: false });
-  
-  console.log('[DEBUG] debugDashboard - NOUVELLE INSTANCE CRÉÉE');
-  
+  const service = await RooSyncService.getInstance({ enabled: false });
+
   // Appeler loadDashboard directement
   const dashboard = await service.loadDashboard();
-  
-  if (args.verbose) {
-    console.log('[DEBUG] debugDashboard - RÉSULTAT BRUT:', JSON.stringify(dashboard, null, 2));
-  }
-  
+
   return {
     action: 'debug',
     success: true,
@@ -143,18 +135,14 @@ async function handleResetAction(
     };
   }
   
-  console.log('[RESET] Réinitialisation de l\'instance RooSyncService...');
-  
   // Réinitialiser l'instance singleton
-  await await RooSyncService.resetInstance();
-  
+  await RooSyncService.resetInstance();
+
   // Vider le cache si demandé
   if (args.clearCache) {
     const service = await getRooSyncService();
     service.clearCache();
   }
-  
-  console.log('[RESET] Instance réinitialisée avec succès');
   
   return {
     action: 'reset',

--- a/servers/roo-state-manager/src/tools/roosync/diagnose.ts
+++ b/servers/roo-state-manager/src/tools/roosync/diagnose.ts
@@ -181,8 +181,6 @@ async function handleDebugAction(
   args: DiagnoseArgs,
   timestamp: string
 ): Promise<DiagnoseResult> {
-  console.log('[DEBUG] debugDashboard - FORCAGE NOUVELLE INSTANCE');
-
   // Forcer la réinitialisation complète du singleton
   await await RooSyncService.resetInstance();
 
@@ -192,14 +190,8 @@ async function handleDebugAction(
   // Créer une nouvelle instance avec cache désactivé
   const service = await await RooSyncService.getInstance({ enabled: false });
 
-  console.log('[DEBUG] debugDashboard - NOUVELLE INSTANCE CRÉÉE');
-
   // Appeler loadDashboard directement
   const dashboard = await service.loadDashboard();
-
-  if (args.verbose) {
-    console.log('[DEBUG] debugDashboard - RÉSULTAT BRUT:', JSON.stringify(dashboard, null, 2));
-  }
 
   const config = service.getConfig();
 
@@ -236,8 +228,6 @@ async function handleResetAction(
     };
   }
 
-  console.log('[RESET] Réinitialisation de l\'instance RooSyncService...');
-
   // Réinitialiser l'instance singleton
   await await RooSyncService.resetInstance();
 
@@ -246,8 +236,6 @@ async function handleResetAction(
     const service = await getRooSyncService();
     service.clearCache();
   }
-
-  console.log('[RESET] Instance réinitialisée avec succès');
 
   const service = await getRooSyncService();
   const config = service.getConfig();
@@ -277,8 +265,6 @@ async function handleTestAction(
   timestamp: string
 ): Promise<DiagnoseResult> {
   const message = args.message || 'Test minimal OK';
-
-  console.log(`[minimal-test] 🧪 Exécution du test minimal: ${message}`);
 
   return {
     success: true,


### PR DESCRIPTION
## Summary
- Remove 6 `console.log` debug statements from `diagnose.ts` that pollute VS Code Extension Host output
- Fix 3 `await await` anti-pattern occurrences in `debug-reset.ts` (#1284)
- Remove 5 additional `console.log` debug statements from `debug-reset.ts`

## Changes

### diagnose.ts (Issue #1269)
- Removed 6 console.log from handleDebugAction, handleResetAction, handleTestAction
- One of these (verbose mode) could leak full dashboard JSON in logs

### debug-reset.ts (Issue #1284)
- Fixed `await await RooSyncService.resetInstance()` (lines 97, 149)
- Fixed `await await RooSyncService.getInstance(...)` (line 103)
- Removed 5 console.log debug statements (same pattern as diagnose.ts)
- **Note:** get-status.ts was already clean (no console.log found)

## Test plan
- [x] Build passes
- [x] 7464/7465 tests pass (1 pre-existing flaky timeout on tool-discoverability, same on main)
- [ ] No console.log pollution in Extension Host after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>