### PR TITLE
fix(#1274,#1273,#1275): Consolidated audit #1123 fixes

### DIFF
--- a/servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts
@@ -7,6 +7,7 @@ import getOpenAIClient, { getEmbeddingModel, getEmbeddingDimensions } from '../o
 import { validateVectorGlobal, sanitizePayload } from './EmbeddingValidator.js';
 import { extractChunksFromTask, extractChunksFromClaudeSession, splitChunk, Chunk } from './ChunkExtractor.js';
 import { networkMetrics } from './QdrantHealthMonitor.js';
+import { GenericError, GenericErrorCode } from '../../types/errors.js';
 
 type PointStruct = Schemas['PointStruct'];
 
@@ -466,10 +467,13 @@ export async function indexTask(taskId: string, taskPath: string, source: 'roo' 
             if (success) {
                 console.log(`✅ Indexation réussie: ${pointsToIndex.length} points pour tâche ${taskId}`);
             } else {
-                console.error(`❌ Échec indexation pour tâche ${taskId} - Circuit breaker activé ou erreurs répétées`);
-                // Ne pas throw l'erreur pour éviter la boucle infernale
-                // Retourner un tableau vide pour indiquer l'échec sans crasher
-                return [];
+                // #1273: Propagate error instead of swallowing it silently
+                // Previously returned [] which caller treated as "success with 0 points"
+                throw new GenericError(
+                    `Indexation failed for task ${taskId} - circuit breaker active or repeated upsert errors`,
+                    GenericErrorCode.NETWORK_ERROR,
+                    { taskId, pointsCount: pointsToIndex.length, service: 'VectorIndexer.indexTask' }
+                );
             }
         } else {
             if (chunks.length === 0) {
@@ -485,11 +489,22 @@ export async function indexTask(taskId: string, taskPath: string, source: 'roo' 
     } catch (error) {
         console.error(`Failed to index task ${taskId}:`, error);
 
-        // 🚨 CORRECTION CRITIQUE: Ne plus re-throw l'erreur qui cause la boucle infernale
-        // À la place, log l'erreur et retourner un résultat vide
-        console.error(`🔴 ERREUR CRITIQUE INTERCEPTÉE pour tâche ${taskId}: Circuit breaker activé`);
+        // #1273: Propagate error so caller can report isError to MCP client
+        // Previously swallowed all errors and returned [], causing:
+        // - Silent data loss (caller treats [] as "success with 0 points")
+        // - Background indexer infinite retry loop (qdrantIndexedAt never set)
         recordFailure();
-        return [];
+
+        // Re-throw as GenericError if not already a typed error
+        if (error instanceof GenericError) {
+            throw error;
+        }
+        throw new GenericError(
+            `Indexation failed for task ${taskId}: ${error instanceof Error ? error.message : String(error)}`,
+            GenericErrorCode.NETWORK_ERROR,
+            { taskId, originalError: error instanceof Error ? error.message : String(error), service: 'VectorIndexer.indexTask' },
+            error instanceof Error ? error : undefined
+        );
     }
 }
 

--- a/servers/roo-state-manager/src/services/task-indexer/__tests__/VectorIndexer.test.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/__tests__/VectorIndexer.test.ts
@@ -341,7 +341,11 @@ describe('VectorIndexer', () => {
 	describe('indexTask', () => {
 		test('returns empty array when no chunks extracted', async () => {
 			const { indexTask } = await import('../VectorIndexer.js');
+			const { extractChunksFromTask } = await import('../ChunkExtractor.js');
 			const expectedCollection = process.env.QDRANT_COLLECTION_NAME || 'roo_tasks_semantic_index';
+
+			// Restore the mock after clearAllMocks
+			(extractChunksFromTask as any).mockResolvedValue([]);
 
 			mockGetCollections.mockResolvedValue({
 				collections: [{ name: expectedCollection }]
@@ -349,6 +353,21 @@ describe('VectorIndexer', () => {
 
 			const result = await indexTask('task-123', '/fake/path');
 			expect(result).toEqual([]);
+		});
+
+		test('propagates errors instead of swallowing them (#1273)', async () => {
+			const { indexTask } = await import('../VectorIndexer.js');
+			const { extractChunksFromTask } = await import('../ChunkExtractor.js');
+			const expectedCollection = process.env.QDRANT_COLLECTION_NAME || 'roo_tasks_semantic_index';
+
+			mockGetCollections.mockResolvedValue({
+				collections: [{ name: expectedCollection }]
+			});
+
+			// Simulate a real error from chunk extraction
+			(extractChunksFromTask as any).mockRejectedValue(new Error('Qdrant connection refused'));
+
+			await expect(indexTask('task-fail', '/fake/path')).rejects.toThrow('Qdrant connection refused');
 		});
 	});
 

--- a/servers/roo-state-manager/src/services/task-searcher.ts
+++ b/servers/roo-state-manager/src/services/task-searcher.ts
@@ -210,15 +210,30 @@ export async function searchTasks(
   const searchFilter = filterConditions.length > 0 ? { must: filterConditions } : options.filter;
 
   // 2. Étape 1: Recherche des Chunks Initiaux dans Qdrant
-  const searchResult = await qdrant.search(collectionName, {
+  // #1275: Add timeout to prevent hanging on large collections
+  const searchTimeoutMs = parseInt(process.env.QDRANT_SEARCH_TIMEOUT_MS || '30000', 10);
+  let searchTimeoutId;
+  const searchPromise = qdrant.search(collectionName, {
     vector,
     limit,
     filter: searchFilter,
     score_threshold: options.scoreThreshold,
     with_payload: true,
   });
+  const timeoutPromise = new Promise((_, reject) => {
+    searchTimeoutId = setTimeout(() => reject(new Error('Qdrant search timeout after ' + searchTimeoutMs + 'ms')), searchTimeoutMs);
+  });
 
-  const foundChunks = searchResult.map(result => ({
+  let searchResult: any;
+  try {
+    searchResult = await Promise.race([searchPromise, timeoutPromise]);
+  } finally {
+    if (searchTimeoutId !== undefined) {
+      clearTimeout(searchTimeoutId);
+    }
+  }
+
+  const foundChunks = searchResult.map((result: any) => ({
     chunk: result.payload as unknown as Chunk,
     score: result.score,
   }));

--- a/servers/roo-state-manager/src/tools/indexing/__tests__/reset-collection.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/indexing/__tests__/reset-collection.tool.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for reset-collection.tool.ts
  * Issue #492 - Coverage for indexing tools
+ * Issue #1274 - Confirm parameter enforcement
  *
  * @module tools/indexing/__tests__/reset-collection.tool
  */
@@ -49,7 +50,7 @@ describe('resetQdrantCollectionTool', () => {
 		const setIndexingEnabled = vi.fn();
 
 		const result = await resetQdrantCollectionTool.handler(
-			{},
+			{ confirm: true },
 			cache,
 			saveCallback,
 			indexQueue,
@@ -66,7 +67,7 @@ describe('resetQdrantCollectionTool', () => {
 		mockResetCollection.mockResolvedValue(undefined);
 
 		const result = await resetQdrantCollectionTool.handler(
-			{},
+			{ confirm: true },
 			new Map(),
 			vi.fn().mockResolvedValue(undefined),
 			new Set(),
@@ -88,7 +89,7 @@ describe('resetQdrantCollectionTool', () => {
 		const saveCallback = vi.fn().mockResolvedValue(undefined);
 
 		await resetQdrantCollectionTool.handler(
-			{},
+			{ confirm: true },
 			cache,
 			saveCallback,
 			new Set(),
@@ -109,7 +110,7 @@ describe('resetQdrantCollectionTool', () => {
 		const indexQueue = new Set<string>();
 
 		await resetQdrantCollectionTool.handler(
-			{},
+			{ confirm: true },
 			cache,
 			vi.fn().mockResolvedValue(undefined),
 			indexQueue,
@@ -127,7 +128,7 @@ describe('resetQdrantCollectionTool', () => {
 		const setEnabled = vi.fn();
 
 		await resetQdrantCollectionTool.handler(
-			{},
+			{ confirm: true },
 			new Map(),
 			vi.fn().mockResolvedValue(undefined),
 			new Set(),
@@ -141,7 +142,7 @@ describe('resetQdrantCollectionTool', () => {
 		mockResetCollection.mockRejectedValue(new Error('Qdrant down'));
 
 		const result = await resetQdrantCollectionTool.handler(
-			{},
+			{ confirm: true },
 			new Map(),
 			vi.fn().mockResolvedValue(undefined),
 			new Set(),
@@ -157,7 +158,7 @@ describe('resetQdrantCollectionTool', () => {
 		mockResetCollection.mockResolvedValue(undefined);
 
 		const result = await resetQdrantCollectionTool.handler(
-			{},
+			{ confirm: true },
 			new Map(),
 			vi.fn().mockResolvedValue(undefined),
 			new Set(),
@@ -168,5 +169,35 @@ describe('resetQdrantCollectionTool', () => {
 		expect(parsed.success).toBe(true);
 		expect(parsed.skeletonsReset).toBe(0);
 		expect(parsed.queuedForReindexing).toBe(0);
+	});
+
+	test('handler rejects without confirm', async () => {
+		const result = await resetQdrantCollectionTool.handler(
+			{},
+			new Map(),
+			vi.fn().mockResolvedValue(undefined),
+			new Set(),
+			vi.fn()
+		);
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.message).toContain('Confirmation requise');
+		expect(mockResetCollection).not.toHaveBeenCalled();
+	});
+
+	test('handler rejects with confirm: false', async () => {
+		const result = await resetQdrantCollectionTool.handler(
+			{ confirm: false },
+			new Map(),
+			vi.fn().mockResolvedValue(undefined),
+			new Set(),
+			vi.fn()
+		);
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.message).toContain('Confirmation requise');
+		expect(mockResetCollection).not.toHaveBeenCalled();
 	});
 });

--- a/servers/roo-state-manager/src/tools/indexing/index-task.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/index-task.tool.ts
@@ -100,10 +100,12 @@ export const indexTaskSemanticTool = {
             };
         } catch (error) {
             console.error('Task indexing error:', error);
+            // #1273: Set isError=true so MCP client knows indexing actually failed
             return {
+                isError: true,
                 content: [{
                     type: "text",
-                    text: `# Erreur d'indexation\n\n**Tâche:** ${args.task_id}\n**Erreur:** ${error instanceof Error ? error.stack : String(error)}\n\nL'indexation de la tâche a échoué.`
+                    text: `# Erreur d'indexation\n\n**Tâche:** ${args.task_id}\n**Erreur:** ${error instanceof Error ? error.message : String(error)}\n\nL'indexation de la tâche a échoué.`
                 }]
             };
         }

--- a/servers/roo-state-manager/src/tools/indexing/reset-collection.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/reset-collection.tool.ts
@@ -42,8 +42,19 @@ export const resetQdrantCollectionTool = {
         setQdrantIndexingEnabled: (enabled: boolean) => void
     ): Promise<CallToolResult> => {
         try {
-            console.log('🧹 Réinitialisation de la collection Qdrant...');
-            
+            // Confirmation obligatoire avant opération destructive
+            if (!args.confirm) {
+                return {
+                    content: [{
+                        type: "text",
+                        text: JSON.stringify({
+                            success: false,
+                            message: 'Confirmation requise. Passez confirm: true pour réinitialiser la collection Qdrant.'
+                        }, null, 2)
+                    }]
+                };
+            }
+
             const taskIndexer = new TaskIndexer();
             
             // Supprimer et recréer la collection Qdrant

--- a/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
@@ -92,13 +92,17 @@ export async function listWorkspaceCollections(): Promise<string[]> {
  * Separate from the task-indexer's OpenAI client to avoid config conflicts.
  */
 let codebaseEmbeddingClient: OpenAI | null = null;
+// #1275: Track last API key to detect provider switches
+let lastEmbeddingApiKey: string | undefined = undefined;
 
 function getCodebaseEmbeddingClient(): OpenAI {
-	if (!codebaseEmbeddingClient) {
-		const apiKey = process.env.EMBEDDING_API_KEY || process.env.OPENAI_API_KEY;
+	const apiKey = process.env.EMBEDDING_API_KEY || process.env.OPENAI_API_KEY;
+	// #1275: Re-create client if API key changed (e.g. after /switch-provider)
+	if (!codebaseEmbeddingClient || apiKey !== lastEmbeddingApiKey) {
 		if (!apiKey) {
 			throw new Error('No embedding API key configured. Set EMBEDDING_API_KEY or OPENAI_API_KEY.');
 		}
+		lastEmbeddingApiKey = apiKey;
 		codebaseEmbeddingClient = new OpenAI({
 			apiKey,
 			baseURL: process.env.EMBEDDING_API_BASE_URL || undefined,

--- a/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
@@ -513,32 +513,42 @@ export const searchTasksByContentTool = {
             }
 
             // #831: Add configurable timeout for large vector indexes (9.93M vectors)
+            // #1275: Fix Promise leak — clear timeout if search completes first
             const searchTimeoutMs = parseInt(process.env.QDRANT_SEARCH_TIMEOUT_MS || '30000', 10); // Default 30s
 
             // #883: Global search is now allowed (workspace auto-defaults in roosync_search)
 
             // #851: Optimized search params for 10M+ vector collection
-            // #831: Timeout wrapper for Qdrant search
-            const searchWithTimeout = Promise.race([
-                qdrant.search(collectionName, {
-                    vector: queryVector,
-                    limit: max_results || 10,
-                    filter: filter,
-                    params: {
-                        hnsw_ef: 128,
-                        exact: false,
-                        quantization: { rescore: true }
-                    },
-                    with_payload: {
-                        include: ['task_id', 'timestamp', 'chunk_type', 'content', 'content_summary', 'workspace', 'workspace_name', 'source', 'chunk_id', 'task_title', 'role', 'model']
-                    }
-                }),
-                new Promise((_, reject) =>
-                    setTimeout(() => reject(new Error(`Qdrant search timeout after ${searchTimeoutMs}ms (9.93M vectors). Tip: Provide workspace parameter to narrow search.`)), searchTimeoutMs)
-                )
-            ]);
+            // #831/#1275: Timeout wrapper with proper cleanup to avoid Promise leak
+            let timeoutId: ReturnType<typeof setTimeout> | undefined;
+            const searchPromise = qdrant.search(collectionName, {
+                vector: queryVector,
+                limit: max_results || 10,
+                filter: filter,
+                params: {
+                    hnsw_ef: 128,
+                    exact: false,
+                    quantization: { rescore: true }
+                },
+                with_payload: {
+                    include: ['task_id', 'timestamp', 'chunk_type', 'content', 'content_summary', 'workspace', 'workspace_name', 'source', 'chunk_id', 'task_title', 'role', 'model']
+                }
+            });
 
-            const searchResults = await searchWithTimeout;
+            const timeoutPromise = new Promise<never>((_, reject) => {
+                timeoutId = setTimeout(() => reject(new Error(`Qdrant search timeout after ${searchTimeoutMs}ms (9.93M vectors). Tip: Provide workspace parameter to narrow search.`)), searchTimeoutMs);
+            });
+
+            let searchResults;
+            try {
+                searchResults = await Promise.race([searchPromise, timeoutPromise]);
+            } finally {
+                // #1275: Always clear timeout to prevent leaked timer
+                if (timeoutId !== undefined) {
+                    clearTimeout(timeoutId);
+                }
+            }
+
 
             // Obtenir l'identifiant de la machine actuelle pour l'en-tête
             const currentHostId = getHostIdentifier();

--- a/servers/roo-state-manager/tests/unit/services/task-indexer/VectorIndexer.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/task-indexer/VectorIndexer.test.ts
@@ -145,12 +145,11 @@ describe('VectorIndexer', () => {
       expect(mockOpenAIClient.embeddings.create).not.toHaveBeenCalled();
     });
 
-    it('should handle errors gracefully', async () => {
+    it('should propagate errors instead of swallowing them (#1273)', async () => {
+      mockQdrantClient.getCollections.mockResolvedValue({ collections: [{ name: 'roo_tasks_semantic_index' }] });
       vi.mocked(extractChunksFromTask).mockRejectedValue(new Error('Extraction failed'));
 
-      const result = await indexTask('task-1', '/path');
-
-      expect(result).toHaveLength(0);
+      await expect(indexTask('task-1', '/path')).rejects.toThrow('Extraction failed');
     });
   });
 });


### PR DESCRIPTION
## Summary

Consolidated cherry-picks of 3 audit #1123 fixes from po-2023's stacked branches, rebased on current main.

**Original PRs closed (stale submodule base):** Parent PRs #1329, #1332, #1333 in roo-extensions.

### Changes

1. **fix(#1274)**: Enforce `confirm: true` parameter in `reset_qdrant_collection` before destructive operation. Added 2 rejection tests.
2. **fix(#1273)**: Propagate indexing errors instead of silently returning `[]`. VectorIndexer now throws `GenericError(NETWORK_ERROR)` on failure. `index-task.tool.ts` sets `isError: true`.
3. **fix(#1275)**: Fix Promise leaks in search — `Promise.race` with `setTimeout` + `clearTimeout` in `finally`. Configurable `QDRANT_SEARCH_TIMEOUT_MS` (30s default). API key change detection for embedding client.

### Not included (separate issue)

- #1269 (console.log removal) — bundled with already-merged fixes, will be handled separately
- #1284 (double-await) — already fixed by retry/backoff pattern in PR #96

## Test plan
- [x] Build passes
- [x] CI: 415 files, 7552 tests passed, 0 failures
- [x] Cherry-picks applied cleanly on current main (9736687b)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)