### PR TITLE
fix(#1322): Redirect debug log to outputs/debug/ instead of repo root

### DIFF
--- a/servers/roo-state-manager/src/services/RooSyncService.ts
+++ b/servers/roo-state-manager/src/services/RooSyncService.ts
@@ -9,7 +9,7 @@
  */
 
 import { existsSync, statSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { loadRooSyncConfig, RooSyncConfig, validateMachineIdUniqueness, registerMachineId } from '../config/roosync-config.js';
 import {
   type RooSyncDecision,
@@ -102,7 +102,9 @@ export class RooSyncService {
        // Écrire directement dans un fichier de log
        try {
          const fs = require('fs');
-         const logPath = process.env.ROOSYNC_LOG_PATH || join(process.cwd(), 'debug-roosync-compare.log');
+         const logPath = process.env.ROOSYNC_LOG_PATH || join(process.cwd(), 'outputs', 'debug', 'roosync-compare.log');
+         const logDir = dirname(logPath);
+         if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true });
          fs.appendFileSync(logPath, logEntry);
        } catch (e) {
          // Ignorer les erreurs de logging


### PR DESCRIPTION
## Summary
- Change `RooSyncService.ts` debug log fallback from `debug-roosync-compare.log` (repo root) to `outputs/debug/roosync-compare.log`
- Auto-creates `outputs/debug/` directory if not present
- Fixes transient file pollution at repo root (#1322)

## Test plan
- [x] `npm run build` passes (TypeScript compiles)
- [ ] Verify log file appears in `outputs/debug/` on next RooSyncService instantiation

🤖 Generated with [Claude Code](https://claude.com/claude-code)