### PR TITLE
fix(#1350): Dashboard atomicity — mutex + visible LLM failure

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
@@ -165,6 +165,8 @@ describe('roosync_dashboard', () => {
   // === Test 11: Condensation manuelle (annulée sans LLM) ===
   // #864: Sans LLM configuré, la condensation est annulée
   // #858: Fixed — mock properly resets via beforeEach
+  // Atomicity fix: Condensation cancelled now persists a visible [ERROR] system
+  // message (deduplicated within 5 min), so LLM outages are visible instead of silent.
   it('condense is cancelled without LLM configured', async () => {
     // S'assurer qu'aucun LLM n'est configuré
     delete process.env.OPENAI_API_KEY;
@@ -187,10 +189,10 @@ describe('roosync_dashboard', () => {
     expect(condenseResult.condensed).toBe(false);
     expect(condenseResult.archivedCount).toBe(0);
 
-    // Tous les messages sont conservés (pas de condensation)
-    // write ne crée PAS de message intercom, seulement 10 (append)
+    // Tous les messages user sont conservés (pas de condensation) + 1 message system [ERROR]
+    // write ne crée PAS de message intercom, 10 (append) + 1 (ERROR) = 11
     const readResult = await roosyncDashboard({ action: 'read', type: 'global', section: 'intercom' });
-    expect(readResult.data?.intercom?.messages?.length).toBe(10);
+    expect(readResult.data?.intercom?.messages?.length).toBe(11);
   });
 
   // === Test 12: Read dashboard inexistant ===
@@ -451,9 +453,9 @@ describe('roosync_dashboard', () => {
     const readResult = await roosyncDashboard({ action: 'read', type: 'global', section: 'intercom' });
     const messages = readResult.data?.intercom?.messages;
 
-    // Tous les messages sont conservés (pas de condensation)
-    // write ne crée PAS de message intercom, seulement 10 (append)
-    expect(messages?.length).toBe(10);
+    // Tous les messages user conservés + 1 message system [ERROR] persisté pour visibilité
+    // write ne crée PAS de message intercom, 10 (append) + 1 (ERROR) = 11
+    expect(messages?.length).toBe(11);
   });
 
   // === Test 28: Condensation annulée sans LLM préserve tous les messages ===
@@ -480,12 +482,19 @@ describe('roosync_dashboard', () => {
     const readResult = await roosyncDashboard({ action: 'read', type: 'global', section: 'intercom' });
     const msgs = readResult.data?.intercom?.messages;
 
-    // Tous les messages conservés: write ne crée PAS de message intercom, seulement 10 (append)
-    expect(msgs?.length).toBe(10);
+    // 10 messages user (append) + 1 message system [ERROR] = 11
+    expect(msgs?.length).toBe(11);
 
-    // Les derniers messages sont dans l'ordre original
-    const lastMessage = msgs?.[msgs.length - 1]?.content;
-    expect(lastMessage).toBe('Message 9');
+    // Les 10 messages user sont dans l'ordre original
+    for (let i = 0; i < 10; i++) {
+      expect(msgs?.[i]?.content).toBe(`Message ${i}`);
+      expect(msgs?.[i]?.author?.machineId).not.toBe('system');
+    }
+
+    // Le dernier message est le système [ERROR] CONDENSATION CANCELLED
+    const lastMessage = msgs?.[msgs.length - 1];
+    expect(lastMessage?.author?.machineId).toBe('system');
+    expect(lastMessage?.content).toContain('[ERROR] CONDENSATION CANCELLED');
   });
 
   // === Test 30: Size-based auto-condensation triggers on large dashboards ===
@@ -505,8 +514,8 @@ describe('roosync_dashboard', () => {
     const result = await roosyncDashboard({ action: 'read', type: 'global', section: 'intercom' });
     const messageCount = result.data?.intercom?.messages?.length ?? 0;
 
-    // All 25 messages preserved since LLM is unavailable (condensation cancelled)
-    expect(messageCount).toBe(25);
+    // All 25 user messages preserved + 1 system [ERROR] (visibility fix) = 26
+    expect(messageCount).toBe(26);
   });
 
   // === Test 31: Small messages don't trigger condensation even with many messages ===

--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -57,6 +57,46 @@ const MAX_SUMMARY_SIZE_BYTES = 5 * 1024;  // 5 KB
 const LLM_MAX_RETRIES = 3;
 const LLM_INITIAL_BACKOFF_MS = 2000; // 2s, doubles each retry
 
+// Dedup window for [ERROR] CONDENSATION CANCELLED system messages (prevent loop
+// when LLM is down and every append re-triggers a failed condensation).
+const CONDENSATION_ERROR_DEDUP_MS = 5 * 60 * 1000; // 5 minutes
+
+// === Per-key mutex ===
+//
+// Prevents concurrent condensations/writes on the same dashboard key within
+// this process. Without this, two concurrent append() calls that both detect
+// the 50KB threshold will:
+//   1. Both run condenseIntercom in parallel (two 3-min LLM calls)
+//   2. Each write its own archive file (same source messages, different
+//      timestamp) — producing duplicate archives
+//   3. Race on writeDashboardFile, the second overwriting the first
+//
+// Cross-process / cross-machine races on GDrive are NOT solved here (that
+// would require a file-based lock with stale detection, tracked separately).
+const perKeyLocks = new Map<string, Promise<unknown>>();
+
+/**
+ * Serialize async operations per key.
+ * Callers with the same key run one-at-a-time in arrival order.
+ * Errors don't poison the chain: the next caller proceeds regardless.
+ */
+async function withKeyLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const previous = perKeyLocks.get(key) ?? Promise.resolve();
+  // Chain: run fn() whether `previous` resolved or rejected
+  const current = previous.then(() => fn(), () => fn());
+  // Best-effort cleanup: remove from map once settled, if we're still the tail
+  const stored = current.then(
+    () => undefined,
+    () => undefined
+  ).finally(() => {
+    if (perKeyLocks.get(key) === stored) {
+      perKeyLocks.delete(key);
+    }
+  });
+  perKeyLocks.set(key, stored);
+  return current;
+}
+
 // === Schemas Zod ===
 
 export const AuthorSchema = z.object({
@@ -717,7 +757,50 @@ async function condenseIntercom(
       summaryOk: !!llmSummary,
       statusOk: !!newStatus
     });
-    return dashboard; // Retourner le dashboard inchangé
+
+    // Inject a visible [ERROR] system message so next readers see the failure.
+    // Deduped over CONDENSATION_ERROR_DEDUP_MS to avoid filling the dashboard
+    // when LLM stays down across multiple append() triggers.
+    const existing = dashboard.intercom.messages;
+    const lastErrorIdx = [...existing].reverse().findIndex(
+      m => m.author.machineId === 'system'
+        && m.content.includes('[ERROR] CONDENSATION CANCELLED')
+    );
+    const recentErrorExists = lastErrorIdx !== -1
+      && (Date.now() - new Date(
+           existing[existing.length - 1 - lastErrorIdx].timestamp
+         ).getTime()) < CONDENSATION_ERROR_DEDUP_MS;
+
+    if (recentErrorExists) {
+      return dashboard; // Déjà signalé récemment, pas de spam
+    }
+
+    const errorTimestamp = new Date().toISOString();
+    const statusOkLabel = newStatus ? 'OK' : 'FAILED';
+    const summaryOkLabel = llmSummary ? 'OK' : 'FAILED';
+    const errorMessage: IntercomMessage = {
+      id: generateMessageId(),
+      timestamp: errorTimestamp,
+      author: { machineId: 'system', workspace: 'system' },
+      content: `**[ERROR] CONDENSATION CANCELLED** - ${errorTimestamp}\n\n`
+        + `LLM calls failed after ${LLM_MAX_RETRIES} retries (backoff 2s/4s/8s):\n`
+        + `- Status update: ${statusOkLabel}\n`
+        + `- Summary generation: ${summaryOkLabel}\n\n`
+        + `Dashboard left unchanged (${dashboard.intercom.messages.length} messages). `
+        + `Verify LLM endpoint (OPENAI_CHAT_API_BASE / OPENAI_CHAT_MODEL_ID) and retry. `
+        + `Next condensation attempt will occur on the next append exceeding the `
+        + `${Math.round(MAX_DASHBOARD_SIZE_BYTES / 1024)}KB threshold.`
+    };
+
+    return {
+      ...dashboard,
+      lastModified: errorTimestamp,
+      intercom: {
+        ...dashboard.intercom,
+        messages: [...dashboard.intercom.messages, errorMessage],
+        totalMessages: dashboard.intercom.totalMessages + 1
+      }
+    };
   }
 
   // Both operations succeeded — now auto-condense if outputs exceed size limits
@@ -890,13 +973,20 @@ export async function roosyncDashboard(args: DashboardArgs): Promise<DashboardRe
     case 'read':
       return handleRead(key, args, resolvedMachineId, resolvedWorkspace);
     case 'write':
-      return handleWrite(key, args, createIfNotExists, resolvedMachineId, resolvedWorkspace);
+      // Serialized: read-modify-write races can overwrite concurrent updates
+      return withKeyLock(key, () =>
+        handleWrite(key, args, createIfNotExists, resolvedMachineId, resolvedWorkspace)
+      );
     case 'append':
-      return handleAppend(key, args, createIfNotExists, resolvedMachineId, resolvedWorkspace);
+      // Serialized: prevents concurrent condensations producing duplicate archives
+      return withKeyLock(key, () =>
+        handleAppend(key, args, createIfNotExists, resolvedMachineId, resolvedWorkspace)
+      );
     case 'condense':
-      return handleCondense(key, args);
+      // Serialized: manual condense must not race with auto-condense from append
+      return withKeyLock(key, () => handleCondense(key, args));
     case 'delete':
-      return handleDelete(key, args);
+      return withKeyLock(key, () => handleDelete(key, args));
     case 'read_archive':
       return handleReadArchive(key, args);
     default:
@@ -1141,8 +1231,12 @@ async function handleCondense(
   const condensedDashboard = await condenseIntercom(key, dashboard, keepCount);
   const condenseElapsed = Date.now() - condenseStart;
   const actuallyCondensed = condensedDashboard.intercom.messages.length < beforeCount;
+  // Persist whenever the dashboard changed — either condensation succeeded
+  // (count decreased) or LLM failed and an ERROR system message was injected
+  // (count increased). writeDashboardFile is atomic (tmp+rename).
+  const dashboardChanged = condensedDashboard.intercom.messages.length !== beforeCount;
 
-  if (actuallyCondensed) {
+  if (dashboardChanged) {
     await writeDashboardFile(key, condensedDashboard);
   }
 


### PR DESCRIPTION
## Summary

Parent repo issue: jsboige/roo-extensions#1350

Fixes two dashboard reliability bugs:

1. **Race condition** causing duplicate archives (4 confirmed in `workspace-roo-extensions` GDrive archive history — pairs of identical-sized archives 2 min apart)
2. **Silent LLM failure** — condensation was cancelled silently, leaving frozen status invisible to agents

## Changes

### `dashboard.ts` (+103 / -6)

**Mutex in-process par clé**
- New `withKeyLock<T>(key, fn)` serializes `append`/`condense`/`write`/`delete` for the same dashboard key within one Node process
- Map<string, Promise> chain, self-cleaning on completion
- Switch dispatcher wraps relevant actions

**Visibilité des échecs LLM**
- On `condenseIntercom` LLM failure (after 3 retries with 2s/4s/8s backoff), inject a `[ERROR] CONDENSATION CANCELLED` system message in the dashboard
- Deduplicated within 5 min (new `CONDENSATION_ERROR_DEDUP_MS` constant) to avoid spam
- Includes retry count, status/summary OK flags, and next-trigger info

**`handleCondense` write condition**
- Was: `actuallyCondensed = messages.length < beforeCount` → only wrote on success
- Now: writes whenever dashboard changed (decrease OR increase from ERROR inject)

### `dashboard.test.ts` (+22 / -13)

4 tests updated to reflect new ERROR system message presence:
- Test 11: "condense is cancelled without LLM configured" → 10 → 11 messages
- Test 27: "condense without LLM service is cancelled" → 10 → 11
- Test 28: "condense cancelled without LLM preserves all messages" → 10 → 11 + last message is now the system ERROR
- Test 30: "auto-condensation triggers based on size" → 25 → 26

## Limitations

- In-process mutex **does not** solve cross-process or cross-machine races on GDrive. To be monitored via archive duplicate counter.
- LLM atomicity (status + summary) was already correct (verified lines 712-721) — no change.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run src/tools/roosync/__tests__/dashboard.test.ts` — 37/37 pass
- [ ] Observe production: absence of new duplicate archives over 7-day window
- [ ] Observe production: `[ERROR] CONDENSATION CANCELLED` messages appear in dashboard if/when LLM endpoint is down

🤖 Generated with [Claude Code](https://claude.com/claude-code)