### PR TITLE
fix(#1269,#1284): Remove debug console.log from diagnose + debug-reset

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/debug-reset.ts
+++ b/servers/roo-state-manager/src/tools/roosync/debug-reset.ts
@@ -91,12 +91,8 @@ async function handleDebugAction(
   timestamp: string,
   config: any
 ): Promise<DebugResetResult> {
-  console.log('[DEBUG] debugDashboard - FORCAGE NOUVELLE INSTANCE');
-  
-  // Forcer la réinitialisation complète du singleton
   await RooSyncService.resetInstance();
 
-  // Attendre que l'instance soit bien nettoyée (retry avec backoff)
   let service: Awaited<ReturnType<typeof RooSyncService.getInstance>> | null = null;
   for (let attempt = 0; attempt < 5; attempt++) {
     service = await RooSyncService.getInstance({ enabled: false });
@@ -107,15 +103,8 @@ async function handleDebugAction(
   if (!service) {
     throw new RooSyncServiceError('debug-reset', 'Failed to create new RooSyncService instance after reset');
   }
-  
-  console.log('[DEBUG] debugDashboard - NOUVELLE INSTANCE CRÉÉE');
-  
-  // Appeler loadDashboard directement
-  const dashboard = await service.loadDashboard();
-  
-  if (args.verbose) {
-    console.log('[DEBUG] debugDashboard - RÉSULTAT BRUT:', JSON.stringify(dashboard, null, 2));
-  }
+
+  await service.loadDashboard();
   
   return {
     action: 'debug',
@@ -149,18 +138,12 @@ async function handleResetAction(
     };
   }
   
-  console.log('[RESET] Réinitialisation de l\'instance RooSyncService...');
-  
-  // Réinitialiser l'instance singleton
   await RooSyncService.resetInstance();
-  
-  // Vider le cache si demandé
+
   if (args.clearCache) {
     const service = await getRooSyncService();
     service.clearCache();
   }
-  
-  console.log('[RESET] Instance réinitialisée avec succès');
   
   return {
     action: 'reset',

--- a/servers/roo-state-manager/src/tools/roosync/diagnose.ts
+++ b/servers/roo-state-manager/src/tools/roosync/diagnose.ts
@@ -210,22 +210,11 @@ async function handleDebugAction(
   args: DiagnoseArgs,
   timestamp: string
 ): Promise<DiagnoseResult> {
-  console.log('[DEBUG] debugDashboard - FORCAGE NOUVELLE INSTANCE');
-
-  // Forcer la réinitialisation complète du singleton
   await RooSyncService.resetInstance();
 
-  // #1267: Retry polling instead of fixed 100ms sleep
   const service = await getInstanceWithRetry({ enabled: false });
 
-  console.log('[DEBUG] debugDashboard - NOUVELLE INSTANCE CRÉÉE');
-
-  // Appeler loadDashboard directement
   const dashboard = await service.loadDashboard();
-
-  if (args.verbose) {
-    console.log('[DEBUG] debugDashboard - RÉSULTAT BRUT:', JSON.stringify(dashboard, null, 2));
-  }
 
   const config = service.getConfig();
 
@@ -262,18 +251,12 @@ async function handleResetAction(
     };
   }
 
-  console.log('[RESET] Réinitialisation de l\'instance RooSyncService...');
-
-  // Réinitialiser l'instance singleton
   await RooSyncService.resetInstance();
 
-  // Vider le cache si demandé
   if (args.clearCache) {
     const service = await getRooSyncService();
     service.clearCache();
   }
-
-  console.log('[RESET] Instance réinitialisée avec succès');
 
   const service = await getRooSyncService();
   const config = service.getConfig();
@@ -303,8 +286,6 @@ async function handleTestAction(
   timestamp: string
 ): Promise<DiagnoseResult> {
   const message = args.message || 'Test minimal OK';
-
-  console.log(`[minimal-test] 🧪 Exécution du test minimal: ${message}`);
 
   return {
     success: true,


### PR DESCRIPTION
## Summary

Re-submits the console.log cleanup that was part of the closed PR #98.

- `diagnose.ts`: 6 console.log removed (handleDebug/Reset/Test actions)
- `debug-reset.ts`: 5 console.log removed (handleDebug/Reset actions)
- Verbose dashboard-JSON leak removed

## Context

PR #98 ([closed 2026-04-11](https://github.com/jsboige/jsboige-mcp-servers/pull/98)) bundled this cleanup with other work but was never merged — verified via:
- `git branch --contains ee8a40b0 567926a2` → orphan commits
- Main branch still had 6+5 console.log present

## Test plan
- [x] Build passes (`npm run build`)
- [x] No `console.log` remaining in target files (grep verified)
- [x] `await await` pattern already clean on main (not re-done here)

Fixes #1269
Fixes #1284 (partial — console.log only)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>