### PR TITLE
fix(#1354,#1356): ToolUsageInterceptor inbox check fire-and-forget

### DIFF
--- a/servers/roo-state-manager/src/notifications/ToolUsageInterceptor.ts
+++ b/servers/roo-state-manager/src/notifications/ToolUsageInterceptor.ts
@@ -49,6 +49,10 @@ export class ToolUsageInterceptor {
   private messageManager: MessageManager;
   private conversationCache: Map<string, SkeletonHeader>;
   private config: InterceptorConfig;
+
+  // FIX #1356: prevent pile-up of background inbox scans when tool calls
+  // arrive faster than the GDrive scan completes. One at a time is enough.
+  private inboxCheckInFlight = false;
   
   /**
    * Constructeur de l'intercepteur
@@ -107,10 +111,15 @@ export class ToolUsageInterceptor {
       });
     }
     
-    // 2. Vérifier la boîte de réception RooSync (non-bloquant avec timeout)
-    // FIX: Previously this was `await`-ed, blocking ALL tool calls if Google Drive was slow
-    if (this.config.checkInbox) {
-      const inboxCheckPromise = this.checkForNewMessages()
+    // 2. Vérifier la boîte de réception RooSync (FIRE-AND-FORGET)
+    // FIX #1356: The previous `Promise.race(3s)` did NOT fire under heavy GDrive I/O
+    // because the event-loop timer was starved by libuv threadpool saturation
+    // (1345+ sequential fs.readFile calls on FUSE-mounted GDrive).
+    // Solution: never await the inbox check. Let it run in the background.
+    // Any notifications will still be emitted, just asynchronously after the tool returns.
+    if (this.config.checkInbox && !this.inboxCheckInFlight) {
+      this.inboxCheckInFlight = true;
+      this.checkForNewMessages()
         .then(async (newMessages) => {
           if (newMessages.length > 0) {
             console.error(`📬 [ToolUsageInterceptor] Found ${newMessages.length} new messages`);
@@ -119,11 +128,10 @@ export class ToolUsageInterceptor {
         })
         .catch(error => {
           console.error('⚠️ [ToolUsageInterceptor] Error checking inbox:', error);
+        })
+        .finally(() => {
+          this.inboxCheckInFlight = false;
         });
-
-      // Race with a 3-second timeout: don't block tool execution
-      const timeoutPromise = new Promise<void>(resolve => setTimeout(resolve, 3000));
-      await Promise.race([inboxCheckPromise, timeoutPromise]);
     }
     
     // 4. Exécuter l'outil original

--- a/servers/roo-state-manager/src/notifications/__tests__/ToolUsageInterceptor.test.ts
+++ b/servers/roo-state-manager/src/notifications/__tests__/ToolUsageInterceptor.test.ts
@@ -307,9 +307,10 @@ describe('ToolUsageInterceptor', () => {
 
       await interceptor.interceptToolCall('tool', {}, async () => 'ok');
 
-      expect(notifySpy).toHaveBeenCalledWith(
+      // FIX #1356: inbox check is fire-and-forget; wait for background notification
+      await vi.waitFor(() => expect(notifySpy).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'new_message' })
-      );
+      ));
     });
 
     test('message en dessous du seuil minPriority : pas de notification', async () => {
@@ -445,9 +446,10 @@ describe('ToolUsageInterceptor', () => {
 
       await interceptor.interceptToolCall('tool', {}, async () => 'ok');
 
-      expect(notifySpy).toHaveBeenCalledWith(
+      // FIX #1356: inbox check is fire-and-forget; wait for background notification
+      await vi.waitFor(() => expect(notifySpy).toHaveBeenCalledWith(
         expect.objectContaining({ priority: 'URGENT' })
-      );
+      ));
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes root cause of #1354 (nanoclaw docker bridge tools/call timeouts) and #1356 (inbox scan design flaw).

- Make `ToolUsageInterceptor` inbox check truly fire-and-forget (no `await`)
- Add `inboxCheckInFlight` guard to prevent pile-up on rapid tool calls

## Root cause

Every tool call triggered a synchronous scan of 1345+ inbox files on GDrive FUSE mount.

The existing `Promise.race(3s)` guard did NOT fire in practice — live trace on ai-01 showed the setTimeout callback delayed 50s+. The libuv threadpool (4 threads) saturates on sequential `fs.readFile` against GDrive, which starves Node's event loop timer queue.

## Verification

On ai-01 with 1345 inbox files:

| State | `tools/call get_mcp_best_practices` |
|-------|------|
| Before (main) | 50s+ hang, never returns |
| Env workaround `NOTIFICATIONS_CHECK_INBOX=false` | 304 ms |
| **This patch (production config, inbox check enabled)** | **190 ms** |

Live trace confirmed `▶️ Executing tool` now appears immediately, not after a 50s timer starvation.

## Remaining work (tracked in #1356)

The fire-and-forget fix stops the blocking. The underlying O(n) sequential GDrive scan on every tool call is still wasteful — the proper long-term fix is to move inbox scanning to a background worker with a cached result read by `beforeTool`. That's the scope of #1356 follow-up.

## Test plan

- [x] Build clean (tsc)
- [x] Manual verification via curl against production proxy config
- [ ] CI (vitest) — pending auto-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)