### PR TITLE
test(coverage): Add tests for gateway and interfaces - idle worker coverage improvement

### DIFF
--- a/servers/roo-state-manager/src/gateway/__tests__/unified-api-gateway.test.ts
+++ b/servers/roo-state-manager/src/gateway/__tests__/unified-api-gateway.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Tests unitaires pour UnifiedApiGateway
+ *
+ * Couvre les fonctionnalités principales du Gateway unifié
+ * qui orchestre les 32 outils MCP roo-state-manager
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  UnifiedApiGateway,
+  createUnifiedApiGateway,
+  DisplayPreset,
+  INTELLIGENT_PRESETS
+} from '../UnifiedApiGateway.js';
+import { ToolCategory, ProcessingLevel } from '../../interfaces/UnifiedToolInterface.js';
+import { GenericErrorCode } from '../../types/errors.js';
+
+describe('UnifiedApiGateway', () => {
+  let gateway: UnifiedApiGateway;
+
+  beforeEach(() => {
+    gateway = new UnifiedApiGateway({ debugMode: false });
+  });
+
+  describe('Constructor', () => {
+    it('should create instance with default config', () => {
+      expect(gateway).toBeDefined();
+      expect(gateway.getMetrics().totalRequests).toBe(0);
+    });
+
+    it('should accept custom config', () => {
+      const customGateway = new UnifiedApiGateway({
+        debugMode: true,
+        immediateProcessingTimeout: 10000
+      });
+      expect(customGateway).toBeDefined();
+    });
+
+    it('should initialize metrics correctly', async () => {
+      // Add small delay to ensure uptime is measurable
+      await new Promise(resolve => setTimeout(resolve, 1));
+      const metrics = gateway.getMetrics();
+      expect(metrics.totalRequests).toBe(0);
+      expect(metrics.immediateProcessingCount).toBe(0);
+      expect(metrics.backgroundProcessingCount).toBe(0);
+      expect(metrics.uptime).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('execute - QUICK_OVERVIEW preset', () => {
+    it('should execute quick overview preset successfully', async () => {
+      const result = await gateway.execute(DisplayPreset.QUICK_OVERVIEW);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.data?.results).toBeInstanceOf(Array);
+    });
+
+    it('should merge options with preset defaults', async () => {
+      const customOptions = {
+        truncate: 100,
+        maxResults: 50
+      };
+
+      const result = await gateway.execute(DisplayPreset.QUICK_OVERVIEW, customOptions);
+
+      expect(result.success).toBe(true);
+      expect(result.metadata?.processingLevel).toBeDefined();
+    });
+
+    it('should increment immediate processing count', async () => {
+      const beforeMetrics = gateway.getMetrics();
+      await gateway.execute(DisplayPreset.QUICK_OVERVIEW);
+      const afterMetrics = gateway.getMetrics();
+
+      expect(afterMetrics.totalRequests).toBe(beforeMetrics.totalRequests + 1);
+      expect(afterMetrics.immediateProcessingCount).toBeGreaterThan(beforeMetrics.immediateProcessingCount);
+    });
+  });
+
+  describe('execute - DETAILED_ANALYSIS preset', () => {
+    it('should execute detailed analysis preset successfully', async () => {
+      const result = await gateway.execute(DisplayPreset.DETAILED_ANALYSIS);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+    });
+
+    it('should use background processing level', async () => {
+      const result = await gateway.execute(DisplayPreset.DETAILED_ANALYSIS);
+
+      expect(result.success).toBe(true);
+      // Background processing returns a job ID
+      expect(result.data?.jobId).toBeDefined();
+      expect(result.data?.status).toBe('processing');
+    });
+  });
+
+  describe('execute - SEARCH_RESULTS preset', () => {
+    it('should execute search results preset successfully', async () => {
+      const result = await gateway.execute(DisplayPreset.SEARCH_RESULTS, {
+        maxResults: 20
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate search-specific options', async () => {
+      const result = await gateway.execute(DisplayPreset.SEARCH_RESULTS, {
+        maxResults: 10
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('execute - EXPORT_FORMAT preset', () => {
+    it('should execute export format preset successfully', async () => {
+      const result = await gateway.execute(DisplayPreset.EXPORT_FORMAT, {
+        outputFormat: 'json'
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate export formats', async () => {
+      const result = await gateway.execute(DisplayPreset.EXPORT_FORMAT, {
+        outputFormat: 'csv'
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('execute - TREE_NAVIGATION preset', () => {
+    it('should execute tree navigation preset successfully', async () => {
+      const result = await gateway.execute(DisplayPreset.TREE_NAVIGATION);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should handle mixed processing level', async () => {
+      const result = await gateway.execute(DisplayPreset.TREE_NAVIGATION, {
+        forceRebuild: false
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Validation', () => {
+    it('should reject invalid preset', async () => {
+      await expect(gateway.execute('invalid' as any)).rejects.toThrow();
+    });
+
+    it('should validate truncate option for display category', async () => {
+      await expect(gateway.execute(DisplayPreset.QUICK_OVERVIEW, {
+        truncate: -1
+      })).rejects.toThrow('Validation failed');
+    });
+
+    it('should validate maxResults option for search category', async () => {
+      await expect(gateway.execute(DisplayPreset.SEARCH_RESULTS, {
+        maxResults: 0
+      })).rejects.toThrow('Validation failed');
+    });
+
+    it('should validate outputFormat for export category', async () => {
+      await expect(gateway.execute(DisplayPreset.EXPORT_FORMAT, {
+        outputFormat: 'invalid' as any
+      })).rejects.toThrow('Validation failed');
+    });
+  });
+
+  describe('INTELLIGENT_PRESETS', () => {
+    it('should have all required presets', () => {
+      expect(INTELLIGENT_PRESETS).toBeDefined();
+      expect(INTELLIGENT_PRESETS[DisplayPreset.QUICK_OVERVIEW]).toBeDefined();
+      expect(INTELLIGENT_PRESETS[DisplayPreset.DETAILED_ANALYSIS]).toBeDefined();
+      expect(INTELLIGENT_PRESETS[DisplayPreset.SEARCH_RESULTS]).toBeDefined();
+      expect(INTELLIGENT_PRESETS[DisplayPreset.EXPORT_FORMAT]).toBeDefined();
+      expect(INTELLIGENT_PRESETS[DisplayPreset.TREE_NAVIGATION]).toBeDefined();
+    });
+
+    it('should have correct category for each preset', () => {
+      expect(INTELLIGENT_PRESETS[DisplayPreset.QUICK_OVERVIEW].category).toBe(ToolCategory.DISPLAY);
+      expect(INTELLIGENT_PRESETS[DisplayPreset.SEARCH_RESULTS].category).toBe(ToolCategory.SEARCH);
+      expect(INTELLIGENT_PRESETS[DisplayPreset.EXPORT_FORMAT].category).toBe(ToolCategory.EXPORT);
+      expect(INTELLIGENT_PRESETS[DisplayPreset.TREE_NAVIGATION].category).toBe(ToolCategory.UTILITY);
+    });
+
+    it('should have processing level defined for each preset', () => {
+      const quickOverview = INTELLIGENT_PRESETS[DisplayPreset.QUICK_OVERVIEW];
+      expect(quickOverview.processingLevel).toBe(ProcessingLevel.IMMEDIATE);
+
+      const detailedAnalysis = INTELLIGENT_PRESETS[DisplayPreset.DETAILED_ANALYSIS];
+      expect(detailedAnalysis.processingLevel).toBe(ProcessingLevel.BACKGROUND);
+
+      const treeNavigation = INTELLIGENT_PRESETS[DisplayPreset.TREE_NAVIGATION];
+      expect(treeNavigation.processingLevel).toBe(ProcessingLevel.MIXED);
+    });
+
+    it('should have tools array for each preset', () => {
+      Object.values(INTELLIGENT_PRESETS).forEach(preset => {
+        expect(preset.tools).toBeInstanceOf(Array);
+        expect(preset.tools.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('should have default options for each preset', () => {
+      Object.values(INTELLIGENT_PRESETS).forEach(preset => {
+        expect(preset.defaultOptions).toBeDefined();
+        expect(typeof preset.defaultOptions).toBe('object');
+      });
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('should return healthy status', async () => {
+      const health = await gateway.healthCheck();
+
+      expect(health.status).toBeDefined();
+      expect(['healthy', 'degraded', 'unhealthy']).toContain(health.status);
+      expect(health.checks).toBeDefined();
+      expect(health.metrics).toBeDefined();
+    });
+
+    it('should include all required checks', async () => {
+      const health = await gateway.healthCheck();
+
+      expect(health.checks.cacheAntiLeak).toBeDefined();
+      expect(health.checks.averageProcessingTime).toBeDefined();
+      expect(health.checks.servicesAvailable).toBeDefined();
+    });
+  });
+
+  describe('getMetrics', () => {
+    it('should return metrics with uptime', async () => {
+      // Add small delay to ensure uptime is measurable
+      await new Promise(resolve => setTimeout(resolve, 1));
+      const metrics = gateway.getMetrics();
+
+      expect(metrics.uptime).toBeGreaterThanOrEqual(0);
+      expect(metrics.totalRequests).toBe(0);
+    });
+
+    it('should update metrics after execution', async () => {
+      await gateway.execute(DisplayPreset.QUICK_OVERVIEW);
+
+      const metrics = gateway.getMetrics();
+      expect(metrics.totalRequests).toBe(1);
+    });
+  });
+
+  describe('createUnifiedApiGateway factory', () => {
+    it('should create gateway instance', () => {
+      const instance = createUnifiedApiGateway();
+
+      expect(instance).toBeInstanceOf(UnifiedApiGateway);
+    });
+
+    it('should pass config to constructor', () => {
+      const instance = createUnifiedApiGateway({
+        debugMode: true,
+        immediateProcessingTimeout: 10000
+      });
+
+      expect(instance).toBeInstanceOf(UnifiedApiGateway);
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should handle execution errors gracefully', async () => {
+      // Test with invalid preset that will throw
+      await expect(gateway.execute('invalid_preset' as any)).rejects.toThrow();
+    });
+
+    it('should update metrics even on error', async () => {
+      const beforeMetrics = gateway.getMetrics();
+
+      try {
+        await gateway.execute('invalid' as any);
+      } catch {
+        // Expected to throw
+      }
+
+      const afterMetrics = gateway.getMetrics();
+      expect(afterMetrics.totalRequests).toBeGreaterThan(beforeMetrics.totalRequests);
+    });
+  });
+
+  describe('Cache Anti-Leak protection', () => {
+    it('should have cache protection config', () => {
+      const customGateway = new UnifiedApiGateway({
+        cacheProtection: {
+          maxTrafficGB: 220,
+          consistencyCheckHours: 24,
+          minReindexIntervalHours: 4,
+          enabled: true,
+          alerts: {
+            memoryThresholdGB: 200,
+            processingTimeoutMs: 30000
+          }
+        }
+      });
+
+      expect(customGateway).toBeDefined();
+    });
+
+    it('should check cache anti-leak during execution', async () => {
+      const customGateway = new UnifiedApiGateway({
+        cacheProtection: {
+          maxTrafficGB: 220,
+          consistencyCheckHours: 24,
+          minReindexIntervalHours: 4,
+          enabled: true,
+          alerts: {
+            memoryThresholdGB: 200,
+            processingTimeoutMs: 30000
+          }
+        }
+      });
+
+      const result = await customGateway.execute(DisplayPreset.QUICK_OVERVIEW);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Background processing', () => {
+    it('should return job ID for background processing', async () => {
+      const result = await gateway.execute(DisplayPreset.DETAILED_ANALYSIS);
+
+      expect(result.data?.jobId).toBeDefined();
+      expect(result.data?.jobId).toMatch(/^bg_\d+_[a-z0-9]+$/);
+    });
+
+    it('should include estimated completion time', async () => {
+      const result = await gateway.execute(DisplayPreset.DETAILED_ANALYSIS);
+
+      expect(result.metadata?.estimatedCompletionTime).toBeDefined();
+      expect(result.metadata?.estimatedCompletionTime).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('Processing levels', () => {
+    it('should use immediate processing for QUICK_OVERVIEW', async () => {
+      const beforeMetrics = gateway.getMetrics();
+      await gateway.execute(DisplayPreset.QUICK_OVERVIEW);
+      const afterMetrics = gateway.getMetrics();
+
+      expect(afterMetrics.immediateProcessingCount).toBeGreaterThan(beforeMetrics.immediateProcessingCount);
+    });
+
+    it('should use background processing for DETAILED_ANALYSIS', async () => {
+      const beforeMetrics = gateway.getMetrics();
+      await gateway.execute(DisplayPreset.DETAILED_ANALYSIS);
+      const afterMetrics = gateway.getMetrics();
+
+      expect(afterMetrics.backgroundProcessingCount).toBeGreaterThan(beforeMetrics.backgroundProcessingCount);
+    });
+  });
+});

--- a/servers/roo-state-manager/src/interfaces/__tests__/unified-tool-interface.test.ts
+++ b/servers/roo-state-manager/src/interfaces/__tests__/unified-tool-interface.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Tests unitaires pour UnifiedToolInterface
+ *
+ * Valide les interfaces, types et constantes unifiées
+ * pour les 32 outils MCP roo-state-manager
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ToolCategory,
+  ProcessingLevel,
+  DisplayPreset,
+  type DisplayPresetType,
+  type CacheStrategy,
+  type DisplayOptions,
+  type ValidationResult,
+  type DisplayResult,
+  type CacheAntiLeakConfig
+} from '../UnifiedToolInterface.js';
+
+describe('ToolCategory', () => {
+  it('should have all 5 categories', () => {
+    expect(ToolCategory.DISPLAY).toBe('display');
+    expect(ToolCategory.SEARCH).toBe('search');
+    expect(ToolCategory.SUMMARY).toBe('summary');
+    expect(ToolCategory.EXPORT).toBe('export');
+    expect(ToolCategory.UTILITY).toBe('utility');
+  });
+
+  it('should have distinct values', () => {
+    const values = Object.values(ToolCategory);
+    const uniqueValues = new Set(values);
+    expect(uniqueValues.size).toBe(values.length);
+  });
+});
+
+describe('ProcessingLevel', () => {
+  it('should have 3 processing levels', () => {
+    expect(ProcessingLevel.IMMEDIATE).toBe('immediate');
+    expect(ProcessingLevel.BACKGROUND).toBe('background');
+    expect(ProcessingLevel.MIXED).toBe('hybrid');
+  });
+
+  it('should have distinct values', () => {
+    const values = Object.values(ProcessingLevel);
+    const uniqueValues = new Set(values);
+    expect(uniqueValues.size).toBe(values.length);
+  });
+});
+
+describe('DisplayPreset', () => {
+  it('should have 5 presets', () => {
+    expect(DisplayPreset.QUICK_OVERVIEW).toBe('quick');
+    expect(DisplayPreset.DETAILED_ANALYSIS).toBe('detailed');
+    expect(DisplayPreset.SEARCH_RESULTS).toBe('search');
+    expect(DisplayPreset.EXPORT_FORMAT).toBe('export');
+    expect(DisplayPreset.TREE_NAVIGATION).toBe('tree');
+  });
+
+  it('should have string values', () => {
+    expect(typeof DisplayPreset.QUICK_OVERVIEW).toBe('string');
+    expect(typeof DisplayPreset.DETAILED_ANALYSIS).toBe('string');
+    expect(typeof DisplayPreset.SEARCH_RESULTS).toBe('string');
+    expect(typeof DisplayPreset.EXPORT_FORMAT).toBe('string');
+    expect(typeof DisplayPreset.TREE_NAVIGATION).toBe('string');
+  });
+});
+
+describe('DisplayPresetType', () => {
+  it('should accept valid preset values', () => {
+    const validPresets: DisplayPresetType[] = [
+      DisplayPreset.QUICK_OVERVIEW,
+      DisplayPreset.DETAILED_ANALYSIS,
+      DisplayPreset.SEARCH_RESULTS,
+      DisplayPreset.EXPORT_FORMAT,
+      DisplayPreset.TREE_NAVIGATION
+    ];
+
+    validPresets.forEach(preset => {
+      expect(typeof preset).toBe('string');
+    });
+  });
+
+  it('should only allow preset const values', () => {
+    const quick: DisplayPresetType = DisplayPreset.QUICK_OVERVIEW;
+    const detailed: DisplayPresetType = DisplayPreset.DETAILED_ANALYSIS;
+    const search: DisplayPresetType = DisplayPreset.SEARCH_RESULTS;
+    const exportFormat: DisplayPresetType = DisplayPreset.EXPORT_FORMAT;
+    const tree: DisplayPresetType = DisplayPreset.TREE_NAVIGATION;
+
+    expect(quick).toBe('quick');
+    expect(detailed).toBe('detailed');
+    expect(search).toBe('search');
+    expect(exportFormat).toBe('export');
+    expect(tree).toBe('tree');
+  });
+});
+
+describe('CacheStrategy type', () => {
+  it('should define valid cache strategies', () => {
+    const strategies: CacheStrategy[] = ['aggressive', 'moderate', 'conservative', 'bypass'];
+
+    expect(strategies).toContain('aggressive');
+    expect(strategies).toContain('moderate');
+    expect(strategies).toContain('conservative');
+    expect(strategies).toContain('bypass');
+  });
+});
+
+describe('DisplayOptions', () => {
+  it('should accept truncate option', () => {
+    const options: DisplayOptions = { truncate: 50 };
+    expect(options.truncate).toBe(50);
+  });
+
+  it('should accept maxResults option', () => {
+    const options: DisplayOptions = { maxResults: 20 };
+    expect(options.maxResults).toBe(20);
+  });
+
+  it('should accept detailLevel option', () => {
+    const options1: DisplayOptions = { detailLevel: 'skeleton' };
+    const options2: DisplayOptions = { detailLevel: 'summary' };
+    const options3: DisplayOptions = { detailLevel: 'full' };
+
+    expect(options1.detailLevel).toBe('skeleton');
+    expect(options2.detailLevel).toBe('summary');
+    expect(options3.detailLevel).toBe('full');
+  });
+
+  it('should accept outputFormat option', () => {
+    const formats: Array<'json' | 'csv' | 'xml' | 'markdown' | 'html'> = ['json', 'csv', 'xml', 'markdown', 'html'];
+
+    formats.forEach(format => {
+      const options: DisplayOptions = { outputFormat: format };
+      expect(options.outputFormat).toBe(format);
+    });
+  });
+
+  it('should accept includeContent option', () => {
+    const options1: DisplayOptions = { includeContent: true };
+    const options2: DisplayOptions = { includeContent: false };
+
+    expect(options1.includeContent).toBe(true);
+    expect(options2.includeContent).toBe(false);
+  });
+
+  it('should accept export options', () => {
+    const options: DisplayOptions = {
+      prettyPrint: true,
+      includeCss: true
+    };
+
+    expect(options.prettyPrint).toBe(true);
+    expect(options.includeCss).toBe(true);
+  });
+
+  it('should accept search options', () => {
+    const options: DisplayOptions = {
+      searchQuery: 'test query',
+      maxResults: 10
+    };
+
+    expect(options.searchQuery).toBe('test query');
+    expect(options.maxResults).toBe(10);
+  });
+
+  it('should accept entity IDs', () => {
+    const options: DisplayOptions = {
+      taskId: 'task-123',
+      conversationId: 'conv-456',
+      rootTaskId: 'root-789'
+    };
+
+    expect(options.taskId).toBe('task-123');
+    expect(options.conversationId).toBe('conv-456');
+    expect(options.rootTaskId).toBe('root-789');
+  });
+
+  it('should accept navigation options', () => {
+    const options: DisplayOptions = {
+      maxDepth: 5,
+      viewMode: 'chain',
+      includeSiblings: true
+    };
+
+    expect(options.maxDepth).toBe(5);
+    expect(options.viewMode).toBe('chain');
+    expect(options.includeSiblings).toBe(true);
+  });
+
+  it('should accept filter and sort options', () => {
+    const options: DisplayOptions = {
+      sortBy: 'lastActivity',
+      sortOrder: 'desc',
+      hasApiHistory: true,
+      hasUiMessages: false
+    };
+
+    expect(options.sortBy).toBe('lastActivity');
+    expect(options.sortOrder).toBe('desc');
+    expect(options.hasApiHistory).toBe(true);
+    expect(options.hasUiMessages).toBe(false);
+  });
+
+  it('should accept dry run options', () => {
+    const options1: DisplayOptions = { dryRun: true };
+    const options2: DisplayOptions = { dry_run: true };
+
+    expect(options1.dryRun).toBe(true);
+    expect(options2.dry_run).toBe(true);
+  });
+});
+
+describe('ValidationResult', () => {
+  it('should create valid result with isValid true', () => {
+    const result: ValidationResult = {
+      isValid: true,
+      errors: []
+    };
+
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('should create valid result with isValid false', () => {
+    const result: ValidationResult = {
+      isValid: false,
+      errors: ['Error 1', 'Error 2']
+    };
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toHaveLength(2);
+  });
+
+  it('should include optional warnings', () => {
+    const result: ValidationResult = {
+      isValid: true,
+      errors: [],
+      warnings: ['Warning 1', 'Warning 2']
+    };
+
+    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings).toContain('Warning 1');
+  });
+});
+
+describe('DisplayResult', () => {
+  it('should create successful result', () => {
+    const result: DisplayResult = {
+      success: true,
+      data: { message: 'Success' }
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.data?.message).toBe('Success');
+  });
+
+  it('should create failed result', () => {
+    const result: DisplayResult = {
+      success: false,
+      errors: ['Error 1', 'Error 2']
+    };
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toHaveLength(2);
+  });
+
+  it('should include metadata', () => {
+    const result: DisplayResult = {
+      success: true,
+      data: {},
+      metadata: {
+        processingLevel: ProcessingLevel.IMMEDIATE,
+        executionTime: new Date(),
+        toolsCount: 5
+      }
+    };
+
+    expect(result.metadata?.processingLevel).toBe(ProcessingLevel.IMMEDIATE);
+    expect(result.metadata?.toolsCount).toBe(5);
+    expect(result.metadata?.executionTime).toBeInstanceOf(Date);
+  });
+});
+
+describe('CacheAntiLeakConfig', () => {
+  it('should create valid config with defaults', () => {
+    const config: CacheAntiLeakConfig = {
+      maxTrafficGB: 220,
+      consistencyCheckHours: 24,
+      minReindexIntervalHours: 4,
+      enabled: true,
+      alerts: {
+        memoryThresholdGB: 200,
+        processingTimeoutMs: 30000
+      }
+    };
+
+    expect(config.maxTrafficGB).toBe(220);
+    expect(config.consistencyCheckHours).toBe(24);
+    expect(config.minReindexIntervalHours).toBe(4);
+    expect(config.enabled).toBe(true);
+    expect(config.alerts.memoryThresholdGB).toBe(200);
+    expect(config.alerts.processingTimeoutMs).toBe(30000);
+  });
+
+  it('should allow custom values', () => {
+    const config: CacheAntiLeakConfig = {
+      maxTrafficGB: 100,
+      consistencyCheckHours: 12,
+      minReindexIntervalHours: 2,
+      enabled: false,
+      alerts: {
+        memoryThresholdGB: 80,
+        processingTimeoutMs: 15000
+      }
+    };
+
+    expect(config.maxTrafficGB).toBe(100);
+    expect(config.enabled).toBe(false);
+  });
+});
+
+describe('Type compatibility', () => {
+  it('should allow DisplayPresetType assignment from DisplayPreset', () => {
+    const presetType: DisplayPresetType = DisplayPreset.QUICK_OVERVIEW;
+    expect(presetType).toBe('quick');
+  });
+
+  it('should preserve type checking for invalid values', () => {
+    // This test validates that the type system works correctly
+    // Invalid values should not compile (TypeScript handles this at compile time)
+    const validPreset: DisplayPresetType = DisplayPreset.SEARCH_RESULTS;
+    expect(validPreset).toBe('search');
+  });
+});
+
+describe('Edge cases', () => {
+  it('should handle empty DisplayOptions', () => {
+    const options: DisplayOptions = {};
+    expect(Object.keys(options)).toHaveLength(0);
+  });
+
+  it('should handle null-like values in DisplayOptions', () => {
+    const options: DisplayOptions = {
+      truncate: 0,
+      maxResults: 0,
+      startIndex: 0,
+      endIndex: 0
+    };
+
+    expect(options.truncate).toBe(0);
+    expect(options.maxResults).toBe(0);
+  });
+
+  it('should handle ValidationResult with no errors', () => {
+    const result: ValidationResult = {
+      isValid: true,
+      errors: []
+    };
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.isValid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add 37 tests for UnifiedApiGateway (src/gateway/UnifiedApiGateway.ts)
- Add 33 tests for UnifiedToolInterface (src/interfaces/UnifiedToolInterface.ts)

## Test Coverage

UnifiedApiGateway tests cover:
- Constructor and initialization
- Execute method for all 5 presets (QUICK_OVERVIEW, DETAILED_ANALYSIS, SEARCH_RESULTS, EXPORT_FORMAT, TREE_NAVIGATION)
- Validation tests for invalid inputs
- INTELLIGENT_PRESETS validation
- Health check and metrics
- Error handling
- Cache Anti-Leak protection
- Background processing
- Processing levels

UnifiedToolInterface tests cover:
- ToolCategory enum (5 categories)
- ProcessingLevel enum (3 levels)
- DisplayPreset const and DisplayPresetType
- DisplayOptions interface (all option types)
- ValidationResult, DisplayResult, CacheAntiLeakConfig
- Type compatibility
- Edge cases

## Test Results

All 70 tests pass (37 + 33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)