### PR TITLE
fix(#1365): filter orphan test machines from roosync_get_status

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
@@ -1,5 +1,6 @@
 /**
  * Tests pour get-status.ts — Option B compact status (#1206)
+ * Updated #1365: Use real machine IDs (myia-*) to match isKnownMachine filter.
  */
 
 import { describe, test, expect, vi, beforeEach } from 'vitest';
@@ -41,18 +42,18 @@ vi.mock('../../../services/MessageManager.js', () => ({
 describe('get-status (Option B)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetConfig.mockReturnValue({ machineId: 'ai-01', sharedPath: '/shared' });
+    mockGetConfig.mockReturnValue({ machineId: 'myia-ai-01', sharedPath: '/shared' });
     mockLoadDashboard.mockResolvedValue({
       overallStatus: 'synced',
       lastUpdate: new Date().toISOString(),
       machines: {
-        'ai-01': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 }
+        'myia-ai-01': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 }
       }
     });
     mockGetHeartbeatService.mockReturnValue({
       checkHeartbeats: vi.fn(),
       getState: vi.fn(() => ({
-        onlineMachines: ['ai-01', 'po-2023'],
+        onlineMachines: ['myia-ai-01', 'myia-po-2023'],
         offlineMachines: [],
         warningMachines: []
       }))
@@ -68,8 +69,8 @@ describe('get-status (Option B)', () => {
     });
 
     test('accepts machineFilter', () => {
-      const result = GetStatusArgsSchema.parse({ machineFilter: 'po-2023' });
-      expect(result.machineFilter).toBe('po-2023');
+      const result = GetStatusArgsSchema.parse({ machineFilter: 'myia-po-2023' });
+      expect(result.machineFilter).toBe('myia-po-2023');
     });
 
     test('accepts resetCache', () => {
@@ -105,7 +106,7 @@ describe('get-status (Option B)', () => {
         inbox: { unread: 15, urgent: 2 },
         decisions: { pending: 3 },
         dashboards: { active: 1 },
-        flags: ['OFFLINE:po-2025', 'INBOX_URGENT:2', 'DECISIONS_PENDING:3'],
+        flags: ['OFFLINE:myia-po-2025', 'INBOX_URGENT:2', 'DECISIONS_PENDING:3'],
         lastUpdated: '2026-04-08T00:00:00Z'
       });
       expect(result.status).toBe('CRITICAL');
@@ -131,7 +132,7 @@ describe('get-status (Option B)', () => {
         overallStatus: 'synced',
         lastUpdate: new Date().toISOString(),
         machines: {
-          'ai-01': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 }
+          'myia-ai-01': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 }
         }
       });
 
@@ -146,8 +147,8 @@ describe('get-status (Option B)', () => {
       mockGetHeartbeatService.mockReturnValue({
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
-          onlineMachines: ['ai-01'],
-          offlineMachines: ['po-2025'],
+          onlineMachines: ['myia-ai-01'],
+          offlineMachines: ['myia-po-2025'],
           warningMachines: []
         }))
       });
@@ -156,7 +157,7 @@ describe('get-status (Option B)', () => {
 
       expect(result.status).toBe('CRITICAL');
       expect(result.machines.offline).toBe(1);
-      expect(result.flags).toContain('OFFLINE:po-2025');
+      expect(result.flags).toContain('OFFLINE:myia-po-2025');
     });
 
     test('returns CRITICAL when urgent messages', async () => {
@@ -197,22 +198,22 @@ describe('get-status (Option B)', () => {
       mockGetHeartbeatService.mockReturnValue({
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
-          onlineMachines: ['ai-01'],
+          onlineMachines: ['myia-ai-01'],
           offlineMachines: [],
-          warningMachines: ['po-2023']
+          warningMachines: ['myia-po-2023']
         }))
       });
 
       const result = await roosyncGetStatus({});
 
-      expect(result.flags).toContain('HEARTBEAT_STALE:po-2023');
+      expect(result.flags).toContain('HEARTBEAT_STALE:myia-po-2023');
     });
 
     test('throws when machine not found', async () => {
       mockLoadDashboard.mockResolvedValue({
         overallStatus: 'synced',
         lastUpdate: '2026-01-01T00:00:00Z',
-        machines: { 'ai-01': { status: 'online', lastSync: '2026-01-01', pendingDecisions: 0, diffsCount: 0 } }
+        machines: { 'myia-ai-01': { status: 'online', lastSync: '2026-01-01', pendingDecisions: 0, diffsCount: 0 } }
       });
 
       await expect(roosyncGetStatus({ machineFilter: 'nonexistent' })).rejects.toThrow('non trouvée');
@@ -222,10 +223,10 @@ describe('get-status (Option B)', () => {
       mockLoadDashboard.mockResolvedValue({
         overallStatus: 'synced',
         lastUpdate: new Date().toISOString(),
-        machines: { 'ai-01': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 } }
+        machines: { 'myia-ai-01': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 } }
       });
 
-      const result = await roosyncGetStatus({ machineFilter: 'ai-01' });
+      const result = await roosyncGetStatus({ machineFilter: 'myia-ai-01' });
       expect(result).toBeDefined();
     });
 
@@ -247,6 +248,81 @@ describe('get-status (Option B)', () => {
       const result = await roosyncGetStatus({});
 
       expect(result).toBeDefined();
+    });
+  });
+
+  describe('#1365 orphan test entry filtering', () => {
+    test('excludes orphan test machines from offline count', async () => {
+      // Simulates real scenario: 6 real machines online + 3 test artifacts offline
+      mockGetHeartbeatService.mockReturnValue({
+        checkHeartbeats: vi.fn(),
+        getState: vi.fn(() => ({
+          onlineMachines: ['myia-ai-01', 'myia-po-2023', 'myia-po-2024'],
+          offlineMachines: ['test-machine', 'persistent-machine', 'machine-2'],
+          warningMachines: []
+        }))
+      });
+
+      const result = await roosyncGetStatus({});
+
+      // Orphan test machines should NOT trigger CRITICAL
+      expect(result.status).toBe('HEALTHY');
+      expect(result.machines.offline).toBe(0);
+      expect(result.flags).not.toContain('OFFLINE:test-machine');
+      expect(result.flags).not.toContain('OFFLINE:persistent-machine');
+    });
+
+    test('excludes orphan test machines from dashboard total', async () => {
+      mockLoadDashboard.mockResolvedValue({
+        overallStatus: 'synced',
+        lastUpdate: new Date().toISOString(),
+        machines: {
+          'myia-ai-01': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 },
+          'myia-po-2023': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 },
+          'test-machine': { status: 'offline', lastSync: '2025-01-01', pendingDecisions: 0, diffsCount: 0 }
+        }
+      });
+
+      const result = await roosyncGetStatus({});
+
+      // Total should be 2 real machines, not 3
+      expect(result.machines.total).toBe(2);
+    });
+
+    test('excludes orphan warning machines from status derivation', async () => {
+      mockGetHeartbeatService.mockReturnValue({
+        checkHeartbeats: vi.fn(),
+        getState: vi.fn(() => ({
+          onlineMachines: ['myia-ai-01'],
+          offlineMachines: [],
+          warningMachines: ['test-machine']  // Orphan, should be filtered
+        }))
+      });
+
+      const result = await roosyncGetStatus({});
+
+      // test-machine warning should NOT trigger WARNING status
+      expect(result.status).toBe('HEALTHY');
+      expect(result.flags).not.toContain('HEARTBEAT_STALE:test-machine');
+    });
+
+    test('still detects real offline machines correctly', async () => {
+      mockGetHeartbeatService.mockReturnValue({
+        checkHeartbeats: vi.fn(),
+        getState: vi.fn(() => ({
+          onlineMachines: ['myia-ai-01'],
+          offlineMachines: ['myia-po-2025', 'test-machine'],  // 1 real + 1 orphan
+          warningMachines: []
+        }))
+      });
+
+      const result = await roosyncGetStatus({});
+
+      // Should be CRITICAL from real offline machine only
+      expect(result.status).toBe('CRITICAL');
+      expect(result.machines.offline).toBe(1);  // Only myia-po-2025
+      expect(result.flags).toContain('OFFLINE:myia-po-2025');
+      expect(result.flags).not.toContain('OFFLINE:test-machine');
     });
   });
 });

--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -5,12 +5,24 @@
  * Un seul appel suffit pour décider des prochaines actions.
  *
  * @module tools/roosync/get-status
- * @version 3.0.0 — #1206 Option B (compact status with flags)
+ * @version 3.1.0 — #1365 Fix false positives (orphan test entries + stale sync)
  */
 
 import { z } from 'zod';
 import { getRooSyncService, RooSyncServiceError } from '../../services/lazy-roosync.js';
 import { getMessageManager } from '../../services/MessageManager.js';
+
+/**
+ * Check if a machine ID is a real production machine (not a test artifact).
+ *
+ * Production machines match the pattern: myia-*
+ * Test artifacts (test-machine, persistent-machine, machine-2, etc.) are excluded.
+ *
+ * #1365: Orphan test entries in heartbeat files pollute offline counts.
+ */
+function isKnownMachine(machineId: string): boolean {
+	return machineId.toLowerCase().startsWith('myia-');
+}
 
 /**
  * Schema de validation pour roosync_get_status
@@ -176,37 +188,44 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
       ? (new Date(dashboard.lastUpdate).getTime() > oneDayAgo ? 1 : 0)
       : 0;
 
-    // Compute machine counts
-    const onlineMachines = heartbeatState?.onlineMachines ?? [];
-    const offlineMachines = heartbeatState?.offlineMachines ?? [];
-    const totalMachines = Math.max(machines.length, onlineMachines.length + offlineMachines.length);
+    // #1365: Filter out orphan test entries (test-machine, persistent-machine, etc.)
+    // Only keep machines matching the known pattern: myia-*
+    const filteredOnlineMachines = (heartbeatState?.onlineMachines ?? []).filter(isKnownMachine);
+    const filteredOfflineMachines = (heartbeatState?.offlineMachines ?? []).filter(isKnownMachine);
+    const filteredWarningMachines = (heartbeatState?.warningMachines ?? []).filter(isKnownMachine);
+    const filteredDashboardMachines = machines.filter(m => isKnownMachine(m.id));
+
+    const totalMachines = Math.max(
+      filteredDashboardMachines.length,
+      filteredOnlineMachines.length + filteredOfflineMachines.length
+    );
 
     // Build flags
     const flags = buildFlags(
       {
-        onlineMachines: onlineMachines as string[],
-        offlineMachines: offlineMachines as string[],
-        warningMachines: (heartbeatState?.warningMachines ?? []) as string[]
+        onlineMachines: filteredOnlineMachines,
+        offlineMachines: filteredOfflineMachines,
+        warningMachines: filteredWarningMachines
       },
       inboxStats,
       pendingDecisions,
-      machines
+      filteredDashboardMachines
     );
 
-    // Derive overall status
+    // Derive overall status (based on KNOWN machines only)
     let status: 'HEALTHY' | 'WARNING' | 'CRITICAL' = 'HEALTHY';
-    if (offlineMachines.length > 0 || inboxStats.urgent > 0) {
+    if (filteredOfflineMachines.length > 0 || inboxStats.urgent > 0) {
       status = 'CRITICAL';
-    } else if (inboxStats.unread > 5 || (heartbeatState?.warningMachines?.length ?? 0) > 0) {
+    } else if (inboxStats.unread > 5 || filteredWarningMachines.length > 0) {
       // WARNING if: high unread count OR heartbeat warning machines (but no offline)
       status = 'WARNING';
     }
 
     // Apply machine filter if specified
     if (args.machineFilter) {
-      const machineExists = machines.some(m => m.id === args.machineFilter) ||
-        onlineMachines.includes(args.machineFilter) ||
-        offlineMachines.includes(args.machineFilter);
+      const machineExists = filteredDashboardMachines.some(m => m.id === args.machineFilter) ||
+        filteredOnlineMachines.includes(args.machineFilter) ||
+        filteredOfflineMachines.includes(args.machineFilter);
 
       if (!machineExists) {
         throw new RooSyncServiceError(
@@ -219,8 +238,8 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
     return {
       status,
       machines: {
-        online: onlineMachines.length,
-        offline: offlineMachines.length,
+        online: filteredOnlineMachines.length,
+        offline: filteredOfflineMachines.length,
         total: totalMachines
       },
       inbox: inboxStats,


### PR DESCRIPTION
## Summary
- Add `isKnownMachine()` filter (myia-* pattern) to exclude test artifacts from machine counts
- Filter heartbeat lists (online/offline/warning) and dashboard machines before computing status
- Update test mocks to use real machine IDs (myia-*) and add 4 anti-orphan filtering tests

## Problem
`roosync_get_status` returned false CRITICAL status because orphan test entries (`test-machine`, `persistent-machine`, `machine-2`) in heartbeat files were counted as offline machines.

## Fix
- `isKnownMachine()` only accepts machine IDs matching `myia-*` pattern
- All heartbeat and dashboard machine lists are filtered before computing counts/flags/status
- Test IDs updated to real format (myia-ai-01, myia-po-2023, etc.)

## Test plan
- [x] 18/18 unit tests passing (including 4 new anti-orphan tests)
- [x] 2/2 smoke tests passing
- [x] Build passes
- [ ] Deploy and verify `roosync_get_status` no longer returns false CRITICAL on any machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)