### PR TITLE
fix(#1364): resolve parent workspace from worktree paths

### DIFF
--- a/servers/roo-state-manager/src/utils/__tests__/message-helpers.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/message-helpers.test.ts
@@ -17,7 +17,8 @@ import {
   normalizeWorkspaceId,
   formatDate,
   getPriorityIcon,
-  getStatusIcon
+  getStatusIcon,
+  resolveWorkspaceFromWorktree
 } from '../message-helpers.js';
 
 describe('message-helpers', () => {
@@ -262,6 +263,89 @@ describe('message-helpers', () => {
       expect(getStatusIcon('unread')).toBeTruthy();
       expect(getStatusIcon('read')).toBeTruthy();
       expect(getStatusIcon('archived')).toBeTruthy();
+    });
+  });
+
+  describe('#1364 resolveWorkspaceFromWorktree', () => {
+    test('resolves parent workspace from worktree path (Windows)', () => {
+      expect(resolveWorkspaceFromWorktree(
+        'c:/dev/roo-extensions/.claude/worktrees/wt-worker-myia-ai-01-20260413-110726'
+      )).toBe('roo-extensions');
+    });
+
+    test('resolves parent workspace from worktree path (backslashes)', () => {
+      expect(resolveWorkspaceFromWorktree(
+        'c:\\dev\\roo-extensions\\.claude\\worktrees\\wt-fix-1365-get-status'
+      )).toBe('roo-extensions');
+    });
+
+    test('resolves parent workspace from deeply nested worktree', () => {
+      expect(resolveWorkspaceFromWorktree(
+        'c:/dev/roo-extensions/.claude/worktrees/wt-1030-declutter'
+      )).toBe('roo-extensions');
+    });
+
+    test('resolves parent workspace with different project name', () => {
+      expect(resolveWorkspaceFromWorktree(
+        'd:/projects/my-app/.claude/worktrees/wt-feature-branch'
+      )).toBe('my-app');
+    });
+
+    test('returns null for non-worktree path', () => {
+      expect(resolveWorkspaceFromWorktree('c:/dev/roo-extensions')).toBeNull();
+    });
+
+    test('returns null for regular project subdirectory', () => {
+      expect(resolveWorkspaceFromWorktree('c:/dev/roo-extensions/src/tools')).toBeNull();
+    });
+
+    test('returns null for .claude but not worktrees', () => {
+      expect(resolveWorkspaceFromWorktree('c:/dev/roo-extensions/.claude/rules')).toBeNull();
+    });
+  });
+
+  describe('#1364 getLocalWorkspaceId worktree detection', () => {
+    const origEnv = process.env.ROOSYNC_WORKSPACE_ID;
+    const origWorkspacePath = process.env.WORKSPACE_PATH;
+    const origCwd = process.cwd;
+
+    afterEach(() => {
+      if (origEnv !== undefined) {
+        process.env.ROOSYNC_WORKSPACE_ID = origEnv;
+      } else {
+        delete process.env.ROOSYNC_WORKSPACE_ID;
+      }
+      if (origWorkspacePath !== undefined) {
+        process.env.WORKSPACE_PATH = origWorkspacePath;
+      } else {
+        delete process.env.WORKSPACE_PATH;
+      }
+      process.cwd = origCwd;
+    });
+
+    test('resolves parent workspace when cwd is worktree (no env overrides)', () => {
+      delete process.env.ROOSYNC_WORKSPACE_ID;
+      delete process.env.WORKSPACE_PATH;
+      // Mock process.cwd to return a worktree path
+      process.cwd = () => 'c:/dev/roo-extensions/.claude/worktrees/wt-1365';
+
+      expect(getLocalWorkspaceId()).toBe('roo-extensions');
+    });
+
+    test('env override takes precedence over worktree detection', () => {
+      process.env.ROOSYNC_WORKSPACE_ID = 'custom-override';
+      delete process.env.WORKSPACE_PATH;
+      process.cwd = () => 'c:/dev/roo-extensions/.claude/worktrees/wt-1365';
+
+      expect(getLocalWorkspaceId()).toBe('custom-override');
+    });
+
+    test('WORKSPACE_PATH takes precedence over worktree cwd', () => {
+      delete process.env.ROOSYNC_WORKSPACE_ID;
+      process.env.WORKSPACE_PATH = 'd:/other-project';
+      process.cwd = () => 'c:/dev/roo-extensions/.claude/worktrees/wt-1365';
+
+      expect(getLocalWorkspaceId()).toBe('other-project');
     });
   });
 });

--- a/servers/roo-state-manager/src/utils/message-helpers.ts
+++ b/servers/roo-state-manager/src/utils/message-helpers.ts
@@ -2,7 +2,7 @@
  * Fonctions utilitaires partagées pour les outils RooSync de messagerie
  *
  * @module utils/message-helpers
- * @version 1.1.0 - Auto-détection workspace depuis process.cwd()
+ * @version 1.2.0 - #1364 Worktree detection: resolve parent workspace from .claude/worktrees/*
  */
 
 import os from 'os';
@@ -68,8 +68,17 @@ export function getLocalWorkspaceId(): string {
     }
   }
 
-  // 3. Auto-détection depuis le répertoire courant (fallback)
+  // 3. Auto-détection depuis le répertoire courant
   const cwd = process.cwd();
+
+  // 3a. Worktree detection (#1364): if cwd is inside .claude/worktrees/,
+  //     resolve to the parent workspace name instead of the worktree name.
+  const worktreeWorkspace = resolveWorkspaceFromWorktree(cwd);
+  if (worktreeWorkspace) {
+    return worktreeWorkspace;
+  }
+
+  // 3b. Standard: use basename of current directory
   const workspaceName = path.basename(cwd);
 
   // Validation basique : le nom doit être significatif
@@ -79,6 +88,37 @@ export function getLocalWorkspaceId(): string {
 
   // 4. Fallback ultime (ne devrait jamais arriver en production)
   return 'default';
+}
+
+/**
+ * Detects if a path is inside a git worktree (.claude/worktrees/*) and
+ * resolves the parent workspace name.
+ *
+ * #1364: Agents running in worktrees pollute dashboards with keys like
+ * `workspace-wt-worker-*` instead of posting to the parent workspace dashboard.
+ *
+ * Detection patterns:
+ * - Path contains `.claude/worktrees/wt-*` → extract parent workspace from
+ *   the path before `.claude/` (e.g., `c:/dev/roo-extensions/.claude/worktrees/wt-X`
+ *   → parent is `roo-extensions`)
+ *
+ * @param cwd Current working directory path
+ * @returns Parent workspace name if in worktree, null otherwise
+ */
+export function resolveWorkspaceFromWorktree(cwd: string): string | null {
+  const normalized = cwd.replace(/\\/g, '/');
+
+  // Match pattern: <parent-path>/.claude/worktrees/wt-<name>
+  const worktreeMatch = normalized.match(/(.+)\/\.claude\/worktrees\/wt-[^/]+/);
+  if (worktreeMatch) {
+    const parentPath = worktreeMatch[1];
+    const parentName = path.basename(parentPath);
+    if (parentName && parentName !== '.' && parentName.length >= 2) {
+      return parentName;
+    }
+  }
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `resolveWorkspaceFromWorktree()` to detect `.claude/worktrees/wt-*` paths and extract parent workspace name
- Fixes dashboard key pollution where worktree agents create `workspace-wt-worker-*` keys instead of `workspace-roo-extensions`
- Integrated into `getLocalWorkspaceId()` priority chain (step 3a, before cwd basename fallback)

## Root Cause
`getLocalWorkspaceId()` used `path.basename(process.cwd())` which returns the worktree directory name (e.g., `wt-worker-myia-ai-01-20260413-110726`) when running from a worktree, causing dashboard messages to be posted to isolated worktree-specific dashboards invisible to other machines.

## Changes
- **`src/utils/message-helpers.ts`**: Added `resolveWorkspaceFromWorktree()` function with regex detection of `.claude/worktrees/` pattern
- **`src/utils/__tests__/message-helpers.test.ts`**: 10 new tests (7 unit tests for resolveWorkspaceFromWorktree + 3 integration tests with mocked cwd)
- Version bumped to 1.2.0

## Resolution Priority (unchanged for non-worktree cases)
1. `ROOSYNC_WORKSPACE_ID` env var (override)
2. `WORKSPACE_PATH` env var (from wrapper)
3. **NEW**: Worktree detection → parent workspace name
4. `path.basename(process.cwd())` (fallback)

## Test plan
- [x] 109/109 tests pass (99 existing + 10 new)
- [x] Build passes
- [ ] Verify worktree agents post to parent workspace dashboard
- [ ] Verify non-worktree paths unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)