### PR TITLE
fix(#1275): Replace Promise.race with native Qdrant timeout + connectivity cache

### DIFF
--- a/servers/roo-state-manager/src/services/task-searcher.ts
+++ b/servers/roo-state-manager/src/services/task-searcher.ts
@@ -210,28 +210,16 @@ export async function searchTasks(
   const searchFilter = filterConditions.length > 0 ? { must: filterConditions } : options.filter;
 
   // 2. Étape 1: Recherche des Chunks Initiaux dans Qdrant
-  // #1275: Add timeout to prevent hanging on large collections
-  const searchTimeoutMs = parseInt(process.env.QDRANT_SEARCH_TIMEOUT_MS || '30000', 10);
-  let searchTimeoutId;
-  const searchPromise = qdrant.search(collectionName, {
+  // #1275: Use native Qdrant timeout parameter (seconds) instead of Promise.race leak
+  const searchTimeoutSec = Math.ceil(parseInt(process.env.QDRANT_SEARCH_TIMEOUT_MS || '30000', 10) / 1000);
+  const searchResult = await qdrant.search(collectionName, {
     vector,
     limit,
     filter: searchFilter,
     score_threshold: options.scoreThreshold,
     with_payload: true,
+    timeout: searchTimeoutSec,
   });
-  const timeoutPromise = new Promise((_, reject) => {
-    searchTimeoutId = setTimeout(() => reject(new Error('Qdrant search timeout after ' + searchTimeoutMs + 'ms')), searchTimeoutMs);
-  });
-
-  let searchResult: any;
-  try {
-    searchResult = await Promise.race([searchPromise, timeoutPromise]);
-  } finally {
-    if (searchTimeoutId !== undefined) {
-      clearTimeout(searchTimeoutId);
-    }
-  }
 
   const foundChunks = searchResult.map((result: any) => ({
     chunk: result.payload as unknown as Chunk,

--- a/servers/roo-state-manager/src/tools/indexing/__tests__/diagnose-index.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/indexing/__tests__/diagnose-index.tool.test.ts
@@ -47,7 +47,7 @@ vi.mock('../../services/openai.js', () => ({
   getEmbeddingModel: vi.fn(() => 'text-embedding-3-small')
 }));
 
-import { handleDiagnoseSemanticIndex } from '../diagnose-index.tool.js';
+import { handleDiagnoseSemanticIndex, _resetConnectivityCache } from '../diagnose-index.tool.js';
 import * as qdrantService from '../../services/qdrant.js';
 import * as openaiService from '../../services/openai.js';
 
@@ -60,6 +60,7 @@ describe('diagnose-index', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetConnectivityCache();
 
     // Set up default environment variables
     process.env.QDRANT_URL = 'http://localhost:6333';

--- a/servers/roo-state-manager/src/tools/indexing/__tests__/diagnose-index.unit.test.ts
+++ b/servers/roo-state-manager/src/tools/indexing/__tests__/diagnose-index.unit.test.ts
@@ -40,7 +40,7 @@ vi.mock('../../../services/openai.js', () => ({
 }));
 
 // Import the module under test (static import, mocks are hoisted)
-import { handleDiagnoseSemanticIndex } from '../diagnose-index.tool.js';
+import { handleDiagnoseSemanticIndex, _resetConnectivityCache } from '../diagnose-index.tool.js';
 import type { ConversationSkeleton } from '../../types/conversation.js';
 
 describe('diagnose-index.tool (unit tests)', () => {
@@ -78,6 +78,7 @@ describe('diagnose-index.tool (unit tests)', () => {
 	beforeEach(() => {
 		// Clear all mocks (not resetModules - we want to keep the module cached)
 		vi.clearAllMocks();
+		_resetConnectivityCache();
 
 		// Reset env vars
 		process.env = { ...origEnv };

--- a/servers/roo-state-manager/src/tools/indexing/diagnose-index.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/diagnose-index.tool.ts
@@ -17,6 +17,19 @@ import { ConversationSkeleton } from '../../types/conversation.js';
 import { getQdrantClient } from '../../services/qdrant.js';
 import getOpenAIClient, { getEmbeddingModel } from '../../services/openai.js';
 
+// #1275: Cache embedding connectivity check to avoid consuming API credits on every diagnose call.
+// TTL: 5 minutes (same as circuit breaker pattern).
+let lastConnectivityCheck = { time: 0, dimension: undefined as number | undefined, status: '' as string };
+const CONNECTIVITY_CACHE_TTL_MS = parseInt(process.env.DIAGNOSE_CONNECTIVITY_TTL_MS || '300000');
+
+/**
+ * Reset the connectivity cache state (for testing).
+ * @internal
+ */
+export function _resetConnectivityCache(): void {
+    lastConnectivityCheck = { time: 0, dimension: undefined, status: '' };
+}
+
 /**
  * Options for the diagnose tool. All optional — preserves backward compatibility.
  */
@@ -135,19 +148,32 @@ export async function handleDiagnoseSemanticIndex(
     // Test de connectivité à OpenAI/vLLM (always run, even if Qdrant fails)
     // #1244: capture the actual returned dimension to compare with collection dimension
     let embeddingLiveDimension: number | undefined;
-    try {
-        const openai = getOpenAIClient();
-        const testEmbedding = await openai.embeddings.create({
-            model: getEmbeddingModel(),
-            input: 'test connectivity',
-        });
-        const embeddingLength = testEmbedding.data[0].embedding.length;
-        embeddingLiveDimension = embeddingLength;
-        diagnostics.details.openai_connection = embeddingLength > 0 ? 'success' : 'failed';
-        diagnostics.details.embedding_live_dimension = embeddingLength;
-    } catch (openaiError: any) {
-        diagnostics.errors.push(`Erreur OpenAI: ${openaiError.message}`);
-        diagnostics.details.openai_connection = 'failed';
+    const now = Date.now();
+    if (lastConnectivityCheck.time && (now - lastConnectivityCheck.time) < CONNECTIVITY_CACHE_TTL_MS) {
+        // Use cached result
+        embeddingLiveDimension = lastConnectivityCheck.dimension;
+        diagnostics.details.openai_connection = lastConnectivityCheck.status;
+        diagnostics.details.embedding_live_dimension = embeddingLiveDimension;
+        diagnostics.details.openai_connectivity_cached = true;
+    } else {
+        try {
+            const openai = getOpenAIClient();
+            const testEmbedding = await openai.embeddings.create({
+                model: getEmbeddingModel(),
+                input: 'test connectivity',
+            });
+            const embeddingLength = testEmbedding.data[0].embedding.length;
+            embeddingLiveDimension = embeddingLength;
+            const status = embeddingLength > 0 ? 'success' : 'failed';
+            diagnostics.details.openai_connection = status;
+            diagnostics.details.embedding_live_dimension = embeddingLength;
+            // Cache the result
+            lastConnectivityCheck = { time: now, dimension: embeddingLength, status };
+        } catch (openaiError: any) {
+            diagnostics.errors.push(`Erreur OpenAI: ${openaiError.message}`);
+            diagnostics.details.openai_connection = 'failed';
+            lastConnectivityCheck = { time: now, dimension: undefined, status: 'failed' };
+        }
     }
 
     // #1244: Dimension mismatch detection (Hypothesis A from plan)

--- a/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
@@ -113,6 +113,14 @@ function getCodebaseEmbeddingClient(): OpenAI {
 	}
 	return codebaseEmbeddingClient;
 }
+/**
+ * Reset the embedding client singleton (for testing).
+ * @internal
+ */
+export function resetCodebaseEmbeddingClient(): void {
+	codebaseEmbeddingClient = null;
+	lastEmbeddingApiKey = undefined;
+}
 
 function getCodebaseEmbeddingModel(): string {
 	return process.env.EMBEDDING_MODEL || 'text-embedding-3-small';
@@ -276,7 +284,8 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 		// #1085: Hash mismatches between Roo (Windows fsPath backslashes) and
 		// Claude Code (Git Bash forward slashes) produce different hashes.
 		if (!collectionName) {
-			const allWsCollections = await listWorkspaceCollections();
+			// #1275: Limit to max 5 collections to prevent cascade timeouts
+			const allWsCollections = (await listWorkspaceCollections()).slice(0, 5);
 			for (const wsCol of allWsCollections) {
 				try {
 					const info = await qdrant.getCollection(wsCol);

--- a/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
@@ -519,15 +519,13 @@ export const searchTasksByContentTool = {
             }
 
             // #831: Add configurable timeout for large vector indexes (9.93M vectors)
-            // #1275: Fix Promise leak — clear timeout if search completes first
-            const searchTimeoutMs = parseInt(process.env.QDRANT_SEARCH_TIMEOUT_MS || '30000', 10); // Default 30s
+            // #1275: Use native Qdrant timeout parameter (seconds) instead of Promise.race leak
+            const searchTimeoutSec = Math.ceil(parseInt(process.env.QDRANT_SEARCH_TIMEOUT_MS || '30000', 10) / 1000);
 
             // #883: Global search is now allowed (workspace auto-defaults in roosync_search)
 
             // #851: Optimized search params for 10M+ vector collection
-            // #831/#1275: Timeout wrapper with proper cleanup to avoid Promise leak
-            let timeoutId: ReturnType<typeof setTimeout> | undefined;
-            const searchPromise = qdrant.search(collectionName, {
+            const searchResults = await qdrant.search(collectionName, {
                 vector: queryVector,
                 limit: max_results || 10,
                 filter: filter,
@@ -538,22 +536,9 @@ export const searchTasksByContentTool = {
                 },
                 with_payload: {
                     include: ['task_id', 'timestamp', 'chunk_type', 'content', 'content_summary', 'workspace', 'workspace_name', 'source', 'chunk_id', 'task_title', 'role', 'model', 'tool_name', 'has_error']
-                }
+                },
+                timeout: searchTimeoutSec,
             });
-
-            const timeoutPromise = new Promise<never>((_, reject) => {
-                timeoutId = setTimeout(() => reject(new Error(`Qdrant search timeout after ${searchTimeoutMs}ms (9.93M vectors). Tip: Provide workspace parameter to narrow search.`)), searchTimeoutMs);
-            });
-
-            let searchResults;
-            try {
-                searchResults = await Promise.race([searchPromise, timeoutPromise]);
-            } finally {
-                // #1275: Always clear timeout to prevent leaked timer
-                if (timeoutId !== undefined) {
-                    clearTimeout(timeoutId);
-                }
-            }
 
 
             // Obtenir l'identifiant de la machine actuelle pour l'en-tête

--- a/servers/roo-state-manager/tests/unit/tools/indexing/diagnose-index.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/indexing/diagnose-index.test.ts
@@ -32,7 +32,7 @@ vi.mock('../../../../src/services/openai.js', () => ({
     getEmbeddingModel: mockGetEmbeddingModel
 }));
 
-import { handleDiagnoseSemanticIndex } from '../../../../src/tools/indexing/diagnose-index.tool.js';
+import { handleDiagnoseSemanticIndex, _resetConnectivityCache } from '../../../../src/tools/indexing/diagnose-index.tool.js';
 import { ConversationSkeleton } from '../../../../src/types/conversation.js';
 
 // ============================================================
@@ -99,6 +99,7 @@ describe('handleDiagnoseSemanticIndex', () => {
     beforeEach(() => {
         conversationCache = new Map();
         vi.clearAllMocks();
+        _resetConnectivityCache();
 
         // Save env and set all expected variables
         savedEnv = { ...process.env };


### PR DESCRIPTION
## Summary

Fixes #1275 — Follow-up to PR #100 which used `Promise.race` with `setTimeout` to wrap Qdrant searches. While the previous fix cleared the timeout timer in `finally`, the underlying `fetch` connection continued running in background after timeout, leaking resources.

### Changes

1. **search-semantic.tool.ts**: Replace `Promise.race` + `setTimeout` with native Qdrant `timeout` parameter (in seconds). The Qdrant client uses `AbortController` internally, so timeout properly cancels the HTTP request.

2. **task-searcher.ts**: Same fix — use native `timeout` parameter instead of `Promise.race` wrapper.

3. **search-codebase.tool.ts**: Limit fallback collection scan to max 5 `ws-*` collections (prevents cascade timeouts when many workspace collections exist). Add `resetCodebaseEmbeddingClient()` export for test isolation.

4. **diagnose-index.tool.ts**: Add 5-minute TTL connectivity cache (`DIAGNOSE_CONNECTIVITY_TTL_MS` env). Avoids consuming embedding API credits on every `diagnose` call. Export `_resetConnectivityCache()` for test isolation.

5. **Tests**: Add `_resetConnectivityCache()` calls in `beforeEach` for both diagnose-index test files to prevent module-level cache leakage between tests.

### Test results

- 97 diagnose-index tests pass (32 + 65)
- Build passes (`tsc` clean)
- Full suite: 448 passed / 4 failed (pre-existing, unrelated to this PR)

## Test plan

- [x] Build passes (`npm run build`)
- [x] Diagnose-index unit tests pass (both test files)
- [ ] Manual: `roosync_indexing action=diagnose` — verify `openai_connectivity_cached: true` on second call
- [ ] Manual: semantic search with low `QDRANT_SEARCH_TIMEOUT_MS` — verify proper timeout error from Qdrant

🤖 Generated with [Claude Code](https://claude.com/claude-code)