### PR TITLE
chore(#603): mark remaining legacy roosync routes as backward-compat only

### DIFF
--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -417,6 +417,8 @@ export function registerCallToolHandler(
               }
               break;
           }
+          // [BACKWARD-COMPAT ONLY] roosync_get_decision_details -> use roosync_decision_info
+          // Kept for compatibility. Consolidation: CONS-5
           case 'roosync_get_decision_details': {
               try {
                   const m = await import('./roosync/get-decision-details.js');
@@ -427,6 +429,8 @@ export function registerCallToolHandler(
               }
               break;
           }
+          // [BACKWARD-COMPAT ONLY] roosync_approve_decision -> use roosync_decision(action: 'approve')
+          // Kept for compatibility. Consolidation: CONS-5
           case 'roosync_approve_decision': {
               try {
                   const m = await import('./roosync/approve-decision.js');
@@ -437,6 +441,8 @@ export function registerCallToolHandler(
               }
               break;
           }
+          // [BACKWARD-COMPAT ONLY] roosync_reject_decision -> use roosync_decision(action: 'reject')
+          // Kept for compatibility. Consolidation: CONS-5
           case 'roosync_reject_decision': {
               try {
                   const m = await import('./roosync/reject-decision.js');
@@ -447,6 +453,8 @@ export function registerCallToolHandler(
               }
               break;
           }
+          // [BACKWARD-COMPAT ONLY] roosync_apply_decision -> use roosync_decision(action: 'apply')
+          // Kept for compatibility. Consolidation: CONS-5
           case 'roosync_apply_decision': {
               try {
                   const m = await import('./roosync/apply-decision.js');
@@ -457,6 +465,8 @@ export function registerCallToolHandler(
               }
               break;
           }
+          // [BACKWARD-COMPAT ONLY] roosync_rollback_decision -> use roosync_decision(action: 'rollback')
+          // Kept for compatibility. Consolidation: CONS-5
           case 'roosync_rollback_decision': {
               try {
                   const m = await import('./roosync/rollback-decision.js');
@@ -477,6 +487,8 @@ export function registerCallToolHandler(
               }
               break;
           }
+          // [BACKWARD-COMPAT ONLY] roosync_update_baseline -> use roosync_baseline(action: 'update')
+          // Kept for compatibility. Consolidation: CONS-2
           case 'roosync_update_baseline': {
               try {
                   const m = await import('./roosync/update-baseline.js');
@@ -487,6 +499,8 @@ export function registerCallToolHandler(
               }
               break;
           }
+          // [BACKWARD-COMPAT ONLY] roosync_manage_baseline -> use roosync_baseline(action: 'manage')
+          // Kept for compatibility. Consolidation: CONS-2
           case 'roosync_manage_baseline': {
               try {
                   const m = await import('./roosync/manage-baseline.js');
@@ -507,6 +521,8 @@ export function registerCallToolHandler(
               }
               break;
           }
+          // [BACKWARD-COMPAT ONLY] roosync_export_baseline -> use roosync_baseline(action: 'export')
+          // Kept for compatibility. Consolidation: CONS-2
           case 'roosync_export_baseline': {
               try {
                   const m = await import('./roosync/export-baseline.js');
@@ -517,6 +533,8 @@ export function registerCallToolHandler(
               }
               break;
           }
+          // [BACKWARD-COMPAT ONLY] roosync_collect_config -> use roosync_config(action: 'collect')
+          // Kept for compatibility. Consolidation: CONS-3
           case 'roosync_collect_config': {
               try {
                   const m = await import('./roosync/collect-config.js');
@@ -527,6 +545,8 @@ export function registerCallToolHandler(
               }
               break;
           }
+          // [BACKWARD-COMPAT ONLY] roosync_publish_config -> use roosync_config(action: 'publish')
+          // Kept for compatibility. Consolidation: CONS-3
           case 'roosync_publish_config': {
               try {
                   const m = await import('./roosync/publish-config.js');
@@ -537,6 +557,8 @@ export function registerCallToolHandler(
               }
               break;
           }
+          // [BACKWARD-COMPAT ONLY] roosync_apply_config -> use roosync_config(action: 'apply')
+          // Kept for compatibility. Consolidation: CONS-3
           case 'roosync_apply_config': {
               try {
                   const m = await import('./roosync/apply-config.js');
@@ -708,7 +730,8 @@ export function registerCallToolHandler(
                }
                break;
            }
-           // NOUVEAU: Outil d'inventaire
+           // [BACKWARD-COMPAT ONLY] roosync_get_machine_inventory -> use roosync_inventory
+           // Kept for compatibility.
            case 'roosync_get_machine_inventory': {
                try {
                    const m = await import('./roosync/get-machine-inventory.js');


### PR DESCRIPTION
## Summary
Mark remaining legacy RooSync routes in tool registry as explicit backward-compat only aliases.

## Changes
- Add markers for decision routes (approve/reject/apply/rollback/details)
- Add markers for baseline routes (update/manage/export)
- Add markers for config routes (collect/publish/apply)
- Add marker for machine inventory legacy route

No behavior changes; discoverability tests remain green.