### PR TITLE
fix(#1409): Data quality regressions — 6 items fixed

### DIFF
--- a/servers/roo-state-manager/src/services/RooSyncService.ts
+++ b/servers/roo-state-manager/src/services/RooSyncService.ts
@@ -938,6 +938,14 @@ export class RooSyncService {
   }
 
   /**
+   * Obtient les IDs des machines connues du registre
+   * #1409: Source de vérité pour le nombre total de machines
+   */
+  public getKnownMachineIds(): string[] {
+    return this.baselineManager.getKnownMachineIds();
+  }
+
+  /**
    * Obtient le service de commit log
    */
   public getCommitLogService(): CommitLogService {

--- a/servers/roo-state-manager/src/services/roosync/BaselineManager.ts
+++ b/servers/roo-state-manager/src/services/roosync/BaselineManager.ts
@@ -211,6 +211,14 @@ export class BaselineManager {
   }
 
   /**
+   * Obtenir la liste des IDs machines connues du registre
+   * #1409: Source de vérité pour le nombre total de machines du cluster
+   */
+  public getKnownMachineIds(): string[] {
+    return Array.from(this.machineRegistry.machines.keys());
+  }
+
+  /**
    * Vérifier si une machine existe dans le registre
    */
   private machineExistsInRegistry(machineId: string): boolean {

--- a/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
+++ b/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
@@ -757,18 +757,21 @@ export class HeartbeatService {
    */
   public async cleanupOldOfflineMachines(maxAge: number = 86400000): Promise<number> {
     // maxAge par défaut: 24 heures
+    // #1409: Don't delete heartbeat files — just keep machines as offline.
+    // Deleting files causes machineCount to drop below the actual cluster size.
     const now = Date.now();
-    const removedMachines: string[] = [];
+    let cleanedCount = 0;
 
     for (const [machineId, heartbeatData] of this.state.heartbeats.entries()) {
       if (heartbeatData.offlineSince) {
         const offlineAge = now - new Date(heartbeatData.offlineSince).getTime();
 
         if (offlineAge > maxAge) {
-          this.state.heartbeats.delete(machineId);
-          removedMachines.push(machineId);
+          // Keep in state as offline, don't remove file or delete from map
+          heartbeatData.status = 'offline';
+          cleanedCount++;
 
-          logger.info(`Machine offline supprimée: ${machineId}`, {
+          logger.info(`Machine offline longue durée (conservée): ${machineId}`, {
             offlineAge,
             maxAge
           });
@@ -776,13 +779,10 @@ export class HeartbeatService {
       }
     }
 
-    if (removedMachines.length > 0) {
+    if (cleanedCount > 0) {
       this.updateMachineStatus();
-      for (const machineId of removedMachines) {
-        await this.removeMachineFile(machineId);
-      }
     }
 
-    return removedMachines.length;
+    return cleanedCount;
   }
 }

--- a/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
@@ -642,7 +642,7 @@ describe('HeartbeatService', () => {
       expect(removed).toBe(0);
     });
 
-    test('supprime les machines offline depuis trop longtemps', async () => {
+    test('garde les machines offline anciennes en statut offline (#1409)', async () => {
       const service = new HeartbeatService(TEST_PATH, { offlineTimeout: 10 });
 
       await service.registerHeartbeat('old-offline');
@@ -653,7 +653,9 @@ describe('HeartbeatService', () => {
       const removed = await service.cleanupOldOfflineMachines(50_000); // maxAge = 50s
 
       expect(removed).toBe(1);
-      expect(service.getHeartbeatData('old-offline')).toBeUndefined();
+      // #1409: Machine kept in state as offline, not deleted
+      expect(service.getHeartbeatData('old-offline')).toBeDefined();
+      expect(service.getHeartbeatData('old-offline')!.status).toBe('offline');
     });
 
     test('garde les machines offline récentes', async () => {
@@ -680,7 +682,7 @@ describe('HeartbeatService', () => {
       expect(removed).toBe(0);
     });
 
-    test('deletes per-machine files for cleaned up machines', async () => {
+    test('ne supprime plus les fichiers heartbeat des machines nettoyées (#1409)', async () => {
       const service = new HeartbeatService(TEST_PATH, { offlineTimeout: 10 });
 
       await service.registerHeartbeat('cleanup-target');
@@ -693,7 +695,9 @@ describe('HeartbeatService', () => {
 
       await service.cleanupOldOfflineMachines(50_000);
 
-      expect(mockUnlink).toHaveBeenCalledWith(join(HEARTBEATS_DIR, 'cleanup-target.json'));
+      // #1409: Files are NOT deleted anymore — machines are kept as offline
+      expect(mockUnlink).not.toHaveBeenCalled();
+      expect(service.getHeartbeatData('cleanup-target')).toBeDefined();
     });
   });
 

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
@@ -6,11 +6,12 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { GetStatusArgsSchema, GetStatusResultSchema, roosyncGetStatus } from '../get-status.js';
 
-const { mockGetConfig, mockLoadDashboard, mockGetHeartbeatService, mockLoadPendingDecisions } = vi.hoisted(() => ({
+const { mockGetConfig, mockLoadDashboard, mockGetHeartbeatService, mockLoadPendingDecisions, mockGetKnownMachineIds } = vi.hoisted(() => ({
   mockGetConfig: vi.fn(),
   mockLoadDashboard: vi.fn(),
   mockGetHeartbeatService: vi.fn(),
-  mockLoadPendingDecisions: vi.fn()
+  mockLoadPendingDecisions: vi.fn(),
+  mockGetKnownMachineIds: vi.fn()
 }));
 
 const { mockGetInboxStats } = vi.hoisted(() => ({
@@ -22,7 +23,8 @@ vi.mock('../../../services/RooSyncService.js', () => ({
     getConfig: mockGetConfig,
     loadDashboard: mockLoadDashboard,
     loadPendingDecisions: mockLoadPendingDecisions,
-    getHeartbeatService: mockGetHeartbeatService
+    getHeartbeatService: mockGetHeartbeatService,
+    getKnownMachineIds: mockGetKnownMachineIds
   })),
   RooSyncServiceError: class extends Error {
     code: string;
@@ -60,6 +62,7 @@ describe('get-status (Option B)', () => {
     });
     mockGetInboxStats.mockResolvedValue({ unread: 0, urgent: 0, by_priority: {} });
     mockLoadPendingDecisions.mockResolvedValue([]);
+    mockGetKnownMachineIds.mockReturnValue(['ai-01', 'po-2023']);
   });
 
   describe('GetStatusArgsSchema', () => {

--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -195,9 +195,13 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
     const filteredWarningMachines = (heartbeatState?.warningMachines ?? []).filter(isKnownMachine);
     const filteredDashboardMachines = machines.filter(m => isKnownMachine(m.id));
 
+    // #1409: Use machine registry as authoritative source for total count
+    const registryMachineIds = service.getKnownMachineIds();
+    const heartbeatTotal = filteredOnlineMachines.length + filteredOfflineMachines.length;
     const totalMachines = Math.max(
+      registryMachineIds.length,
       filteredDashboardMachines.length,
-      filteredOnlineMachines.length + filteredOfflineMachines.length
+      heartbeatTotal
     );
 
     // Build flags

--- a/servers/roo-state-manager/src/utils/__tests__/roo-storage-detector.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/roo-storage-detector.test.ts
@@ -137,17 +137,28 @@ describe('RooStorageDetector', () => {
         });
 
         test('calcule la taille totale', async () => {
-            mockReaddir.mockResolvedValue([
+            // #1409: getStatsForPath now reads files inside each task dir
+            const outerEntries = [
                 { name: 'task1', isDirectory: () => true },
                 { name: 'task2', isDirectory: () => true },
-            ]);
+            ];
+
+            // First call: outer readdir (task dirs)
+            // Subsequent calls: inner readdir (files inside each task dir)
+            mockReaddir
+                .mockResolvedValueOnce(outerEntries)      // /mock/tasks → [task1, task2]
+                .mockResolvedValueOnce(['file1.json'])      // task1 files
+                .mockResolvedValueOnce(['file2.json', 'file3.json']); // task2 files
+
+            // stat calls: file1 (1000) + file2 (2000) + file3 (500)
             mockStat
-                .mockResolvedValueOnce({ isDirectory: () => true, size: 1000 })
-                .mockResolvedValueOnce({ isDirectory: () => true, size: 2000 });
+                .mockResolvedValueOnce({ isFile: () => true, size: 1000, mtime: new Date() })
+                .mockResolvedValueOnce({ isFile: () => true, size: 2000, mtime: new Date() })
+                .mockResolvedValueOnce({ isFile: () => true, size: 500, mtime: new Date() });
 
             const stats = await RooStorageDetector.getStatsForPath('/mock/tasks');
 
-            expect(stats.totalSize).toBe(3000);
+            expect(stats.totalSize).toBe(3500);
         });
 
         test('gère readdir retournant undefined (bug Vitest)', async () => {

--- a/servers/roo-state-manager/src/utils/roo-storage-detector.ts
+++ b/servers/roo-state-manager/src/utils/roo-storage-detector.ts
@@ -115,11 +115,23 @@ export class RooStorageDetector {
         if (entry.isDirectory()) {
             const taskPath = path.join(storagePath, entry.name);
             try {
-                const stats = await fs.stat(taskPath); // stat sur le répertoire
+                // #1409: Sum individual file sizes (fs.stat on directory returns 0 on Windows/NTFS)
+                let dirSize = 0;
+                let dirMtime: Date | null = null;
+                try {
+                  const files = await fs.readdir(taskPath);
+                  for (const file of files) {
+                    try {
+                      const fileStat = await fs.stat(path.join(taskPath, file));
+                      if (fileStat.isFile()) dirSize += fileStat.size;
+                      if (!dirMtime || fileStat.mtime > dirMtime) dirMtime = fileStat.mtime;
+                    } catch { /* skip unreadable files */ }
+                  }
+                } catch { /* skip unreadable dirs */ }
                 count++;
-                totalSize += stats.size; // Taille approximative
-                if (!lastActivity || stats.mtime > lastActivity) {
-                    lastActivity = stats.mtime;
+                totalSize += dirSize;
+                if (dirMtime && (!lastActivity || dirMtime > lastActivity)) {
+                    lastActivity = dirMtime;
                 }
             } catch (e) {
                 // ignorer
@@ -1800,27 +1812,54 @@ export class RooStorageDetector {
   /**
    * 🔧 FIX CRITIQUE: Calcule breakdown par workspace en scannant directement le disque
    * pour être cohérent avec getStorageStats() qui compte aussi sur le disque
+   * #1409: Reuses a single WorkspaceDetector instance for cache efficiency
    */
   public static async getWorkspaceBreakdown(): Promise<Record<string, {count: number, totalSize: number, lastActivity: string}>> {
     const locations = await this.detectStorageLocations();
     const workspaceBreakdown: Record<string, {count: number, totalSize: number, lastActivity: string}> = {};
 
+    // #1409: Single WorkspaceDetector instance — cache works across tasks
+    const workspaceDetector = new WorkspaceDetector({
+      enableCache: true,
+      validateExistence: false,
+      normalizePaths: true,
+    });
+
     for (const loc of locations) {
         const tasksPath = path.join(loc, 'tasks');
+        // #1409: Derive fallback workspace from location path
+        const locationWorkspace = path.basename(loc);
 
         try {
             const entries = await fs.readdir(tasksPath, { withFileTypes: true });
 
-            for (const entry of entries) {
-                if (entry.isDirectory()) {
+            // #1409: Batch file size computation with parallelism (limit concurrency)
+            const batchSize = 50;
+            for (let i = 0; i < entries.length; i += batchSize) {
+                const batch = entries.slice(i, i + batchSize).filter(e => e.isDirectory());
+                await Promise.all(batch.map(async (entry) => {
                     const taskPath = path.join(tasksPath, entry.name);
 
                     try {
                         // Détecter le workspace pour cette tâche
-                        const workspace = await this.detectWorkspaceForTask(taskPath);
+                        const workspace = await this.detectWorkspaceForTaskWithDetector(taskPath, workspaceDetector, locationWorkspace);
 
-                        const stats = await fs.stat(taskPath);
-                        const lastActivity = stats.mtime.toISOString();
+                        // #1409: Sum individual file sizes (directory stat returns 0 on Windows/NTFS)
+                        let dirSize = 0;
+                        let lastActivity = '';
+                        try {
+                          const files = await fs.readdir(taskPath);
+                          for (const file of files) {
+                            try {
+                              const fileStat = await fs.stat(path.join(taskPath, file));
+                              if (fileStat.isFile()) dirSize += fileStat.size;
+                              if (!lastActivity || fileStat.mtime.toISOString() > lastActivity) {
+                                lastActivity = fileStat.mtime.toISOString();
+                              }
+                            } catch { /* skip */ }
+                          }
+                        } catch { /* skip unreadable dir */ }
+                        if (!lastActivity) lastActivity = new Date().toISOString();
 
                         // Initialiser ou mettre à jour les stats du workspace
                         if (!workspaceBreakdown[workspace]) {
@@ -1832,7 +1871,7 @@ export class RooStorageDetector {
                         }
 
                         workspaceBreakdown[workspace].count++;
-                        workspaceBreakdown[workspace].totalSize += stats.size;
+                        workspaceBreakdown[workspace].totalSize += dirSize;
 
                         // Mettre à jour la dernière activité si plus récente
                         if (new Date(lastActivity) > new Date(workspaceBreakdown[workspace].lastActivity)) {
@@ -1843,7 +1882,7 @@ export class RooStorageDetector {
                         // Ignorer les tâches non accessibles
                         console.warn(`Impossible d'analyser tâche ${entry.name}:`, (taskError as Error).message);
                     }
-                }
+                }));
             }
         } catch (dirError) {
             console.warn(`Impossible de lire répertoire ${tasksPath}:`, (dirError as Error).message);
@@ -1854,21 +1893,18 @@ export class RooStorageDetector {
   }
 
   /**
-   * Détecte le workspace pour une tâche donnée
-   * @version 2.0 - Utilise WorkspaceDetector moderne (stratégie dual)
-   * @see WorkspaceDetector pour détails stratégie metadata → environment_details fallback
+   * Détecte le workspace pour une tâche, en réutilisant un détecteur existant
+   * et en fallback sur le nom du répertoire parent de la location.
+   * #1409: Avoids 'UNKNOWN' by using location directory name as last resort.
    */
-  public static async detectWorkspaceForTask(taskPath: string): Promise<string> {
+  private static async detectWorkspaceForTaskWithDetector(
+    taskPath: string,
+    detector: WorkspaceDetector,
+    fallbackWorkspace: string
+  ): Promise<string> {
     try {
-      const workspaceDetector = new WorkspaceDetector({
-        enableCache: true,
-        validateExistence: false, // Performance
-        normalizePaths: true,
-      });
+      const result = await detector.detect(taskPath);
 
-      const result = await workspaceDetector.detect(taskPath);
-
-      // Log détaillé si mode debug
       if (process.env.DEBUG_WORKSPACE === 'true') {
         console.log(`[detectWorkspaceForTask] ${taskPath}:`, {
           workspace: result.workspace,
@@ -1877,10 +1913,38 @@ export class RooStorageDetector {
         });
       }
 
+      // #1409: Use fallback from location path instead of 'UNKNOWN'
+      return result.workspace || fallbackWorkspace || 'UNKNOWN';
+    } catch (error) {
+      return fallbackWorkspace || 'UNKNOWN';
+    }
+  }
+
+  /**
+   * Détecte le workspace pour une tâche donnée (standalone, creates new detector)
+   * @version 2.1 - Fallback to location directory name instead of 'UNKNOWN'
+   */
+  public static async detectWorkspaceForTask(taskPath: string): Promise<string> {
+    try {
+      const workspaceDetector = new WorkspaceDetector({
+        enableCache: true,
+        validateExistence: false,
+        normalizePaths: true,
+      });
+
+      const result = await workspaceDetector.detect(taskPath);
+
+      // #1409: Fallback — derive workspace from task path hierarchy
+      if (!result.workspace) {
+        const parentDir = path.basename(path.dirname(path.dirname(taskPath)));
+        if (parentDir && parentDir.length >= 2) return parentDir;
+      }
+
       return result.workspace || 'UNKNOWN';
     } catch (error) {
-      console.warn(`[detectWorkspaceForTask] Error for ${taskPath}:`, error);
-      return 'UNKNOWN';
+      // #1409: Same fallback
+      const parentDir = path.basename(path.dirname(path.dirname(taskPath)));
+      return (parentDir && parentDir.length >= 2) ? parentDir : 'UNKNOWN';
     }
   }
 

--- a/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
@@ -436,8 +436,11 @@ describe('HeartbeatService - Tests Unitaires', () => {
       
       // Assert
       expect(removedCount).toBe(2);
-      expect(heartbeatService.getHeartbeatData('machine-old-1')).toBeUndefined();
-      expect(heartbeatService.getHeartbeatData('machine-old-2')).toBeUndefined();
+      // #1409: Machines kept in state as offline, not deleted
+      expect(heartbeatService.getHeartbeatData('machine-old-1')).toBeDefined();
+      expect(heartbeatService.getHeartbeatData('machine-old-1')!.status).toBe('offline');
+      expect(heartbeatService.getHeartbeatData('machine-old-2')).toBeDefined();
+      expect(heartbeatService.getHeartbeatData('machine-old-2')!.status).toBe('offline');
       expect(heartbeatService.getHeartbeatData('machine-recent')).toBeDefined(); // Pas supprimée
     });
   });

--- a/servers/roo-state-manager/tests/unit/utils/timestamp-parsing.test.ts
+++ b/servers/roo-state-manager/tests/unit/utils/timestamp-parsing.test.ts
@@ -197,12 +197,18 @@ it('should handle malformed JSON gracefully', async () => {
 
   describe('getStatsForPath', () => {
     it('should return storage statistics for valid path', async () => {
-      mockFsPromises.readdir.mockResolvedValue([
+      // #1409: getStatsForPath reads files inside task dirs for actual sizes
+      const outerEntries = [
         { name: 'task1', isDirectory: () => true, isFile: () => false },
         { name: 'task2', isDirectory: () => true, isFile: () => false }
-      ]);
+      ];
+      // Outer readdir → task dirs, then inner readdirs → files in each
+      mockFsPromises.readdir
+        .mockResolvedValueOnce(outerEntries)
+        .mockResolvedValueOnce(['api_conversation_history.json'])
+        .mockResolvedValueOnce(['ui_messages.json', 'task_metadata.json']);
       mockFsPromises.stat.mockResolvedValue({
-        isDirectory: () => true,
+        isFile: () => true,
         size: 2048,
         mtime: new Date('2025-11-30T12:00:00.000Z')
       });


### PR DESCRIPTION
## Summary
- Fix `machineCount=3` (should be 6): stop deleting heartbeat files in cleanup + use machine registry as authoritative source
- Fix `totalSize=0`: sum individual file sizes instead of directory stat (returns 0 on Windows/NTFS)
- Fix `UNKNOWN` workspace bucket: fallback to location directory name instead of 'UNKNOWN'
- Fix storage stats perf (22.7s → batched parallelism + single WorkspaceDetector reuse)

## Changes

### HeartbeatService
- `cleanupOldOfflineMachines()`: keeps machines in state as `offline` instead of deleting heartbeat files (root cause of disappearing machines)

### get-status
- Uses `BaselineManager.getKnownMachineIds()` as authoritative source for total count
- `totalMachines = max(registry, dashboard, heartbeat)` — never drops below known cluster size

### Storage Stats
- `getStatsForPath()`: reads files inside task dirs for actual sizes (Windows/NTFS fix)
- `getWorkspaceBreakdown()`: same fix + batch parallelism (50 concurrent) + reused single WorkspaceDetector
- `detectWorkspaceForTask()`: falls back to location directory name instead of 'UNKNOWN'

## Items from #1409 addressed
- [x] 1. machineCount says 3, should be 6
- [x] 3. Stale machine-2 entry (preserved, not deleted)
- [x] 4. Missing machines in heartbeat
- [x] 5. totalSize: 0 (Windows/NTFS directory stat)
- [x] 6. UNKNOWN workspace bucket
- [x] 8. Storage stats 22.7s → batched with parallelism

## Test plan
- [x] `npm run build` passes
- [x] `npx vitest run --config vitest.config.ci.ts` — 416 passed, 0 failed
- [ ] Manual: `roosync_get_status()` returns correct machineCount on production machines
- [ ] Manual: `getStorageStats()` returns non-zero totalSize

🤖 Generated with [Claude Code](https://claude.com/claude-code)