### PR TITLE
fix(#1364): apply worktree detection to WORKSPACE_PATH (regression)

### DIFF
--- a/servers/roo-state-manager/src/utils/__tests__/message-helpers.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/message-helpers.test.ts
@@ -340,12 +340,28 @@ describe('message-helpers', () => {
       expect(getLocalWorkspaceId()).toBe('custom-override');
     });
 
-    test('WORKSPACE_PATH takes precedence over worktree cwd', () => {
+    test('WORKSPACE_PATH outside worktree takes precedence over worktree cwd', () => {
       delete process.env.ROOSYNC_WORKSPACE_ID;
       process.env.WORKSPACE_PATH = 'd:/other-project';
       process.cwd = () => 'c:/dev/roo-extensions/.claude/worktrees/wt-1365';
 
       expect(getLocalWorkspaceId()).toBe('other-project');
+    });
+
+    test('WORKSPACE_PATH pointing inside worktree resolves to parent workspace (#1364 regression)', () => {
+      delete process.env.ROOSYNC_WORKSPACE_ID;
+      process.env.WORKSPACE_PATH = 'd:/roo-extensions/.claude/worktrees/wt-worker-myia-ai-01-20260417';
+      process.cwd = () => 'd:/some/unrelated/cwd';
+
+      expect(getLocalWorkspaceId()).toBe('roo-extensions');
+    });
+
+    test('WORKSPACE_PATH with backslashes inside worktree resolves to parent', () => {
+      delete process.env.ROOSYNC_WORKSPACE_ID;
+      process.env.WORKSPACE_PATH = 'd:\\roo-extensions\\.claude\\worktrees\\wt-1364-fix';
+      process.cwd = () => 'd:/some/unrelated/cwd';
+
+      expect(getLocalWorkspaceId()).toBe('roo-extensions');
     });
   });
 });

--- a/servers/roo-state-manager/src/utils/message-helpers.ts
+++ b/servers/roo-state-manager/src/utils/message-helpers.ts
@@ -62,7 +62,15 @@ export function getLocalWorkspaceId(): string {
   // 2. WORKSPACE_PATH from launcher (mcp-wrapper captures original cwd,
   //    or Roo injects ${workspaceFolder} via config)
   if (process.env.WORKSPACE_PATH) {
-    const wsName = path.basename(process.env.WORKSPACE_PATH.replace(/\\/g, '/'));
+    const normalized = process.env.WORKSPACE_PATH.replace(/\\/g, '/');
+    // Worktree detection (#1364 regression fix): WORKSPACE_PATH may itself
+    // point inside .claude/worktrees/* (when the wrapper captured cwd from
+    // a worktree). Resolve to parent workspace before using basename.
+    const worktreeWorkspace = resolveWorkspaceFromWorktree(normalized);
+    if (worktreeWorkspace) {
+      return worktreeWorkspace;
+    }
+    const wsName = path.basename(normalized);
     if (wsName && wsName !== '.' && wsName.length >= 2) {
       return wsName;
     }


### PR DESCRIPTION
## Résumé

PR #1424 a mergé la détection worktree pour `cwd` dans `getLocalWorkspaceId()`, mais la **priorité 2** (`WORKSPACE_PATH`) court-circuite complètement cette détection. Résultat : quand `mcp-wrapper.cjs` capture `originalCwd` depuis un worktree et le passe comme `WORKSPACE_PATH`, le serveur renvoie le nom du worktree au lieu du workspace parent.

## Preuve de régression

**108 dashboards `workspace-wt-*` créés entre 2026-04-06 et 2026-04-17** dans `.shared-state/dashboards/`, bien après le merge de PR #1424. Tous archivés dans `archive/parasites-cleanup-20260417/` lors du nettoyage.

Chaîne de pollution :
1. Claude Code lance un worker dans `.claude/worktrees/wt-worker-*`
2. `mcp-wrapper.cjs:79` : `WORKSPACE_PATH = originalCwd` = chemin worktree
3. `getLocalWorkspaceId()` priorité 2 : `path.basename('.../wt-worker-*')` → nom worktree
4. Priorité 3a (worktree detection) jamais atteinte
5. Dashboard créé comme `workspace-wt-worker-*`

## Correctif

`src/utils/message-helpers.ts` : appliquer `resolveWorkspaceFromWorktree()` à `WORKSPACE_PATH` **avant** de prendre le basename, en miroir de la logique priorité 3 pour `cwd`. Gère les séparateurs `/` et `\`.

## Tests

- `WORKSPACE_PATH takes precedence over worktree cwd` renommé `...outside worktree...` (comportement préservé hors worktree)
- **Nouveau** : `WORKSPACE_PATH pointing inside worktree resolves to parent workspace (#1364 regression)` (slashes)
- **Nouveau** : `WORKSPACE_PATH with backslashes inside worktree resolves to parent` (Windows)
- Build TS : OK
- `npx vitest run src/utils/__tests__/message-helpers.test.ts` : **45 / 45 passent**

## Test plan

- [x] Build TS clean
- [x] 45 tests unitaires passent
- [ ] Post-merge : vérifier qu'aucun nouveau `workspace-wt-*` n'apparaît dans `.shared-state/dashboards/` sous 24 h

🤖 Generated with [Claude Code](https://claude.com/claude-code)