### PR TITLE
fix(#1363): expose mentions[]/crossPost[] in MCP inputSchema (oubli PR #120)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -2042,6 +2042,58 @@ export const dashboardToolMetadata = {
       messageId: {
         type: 'string',
         description: '(append) ID optionnel pour le message (ex: hash GitHub issue). Si absent, généré automatiquement au format ic-{timestamp}.'
+      },
+      mentions: {
+        type: 'array',
+        description: '(append) Mentions structurées v3 (#1363). Chaque entrée = userId XOR messageId (exactement un des deux). Notifie les destinataires via RooSync (fire-and-forget, dedup par machineId).',
+        items: {
+          type: 'object',
+          properties: {
+            userId: {
+              type: 'object',
+              description: 'userId explicite à mentionner (exclusif avec messageId).',
+              properties: {
+                machineId: { type: 'string', description: 'ID de la machine' },
+                workspace: { type: 'string', description: 'Workspace ID' }
+              },
+              required: ['machineId', 'workspace'],
+              additionalProperties: false
+            },
+            messageId: {
+              type: 'string',
+              description: 'ID de message à référencer (format: machineId:workspace:ic-...). Résout en userId = auteur du message référencé.'
+            },
+            note: {
+              type: 'string',
+              description: 'Note optionnelle expliquant la raison de la mention.'
+            }
+          },
+          additionalProperties: false
+        }
+      },
+      crossPost: {
+        type: 'array',
+        description: '(append) Cross-post le même message vers d\'autres dashboards v3 (#1363), SANS notification RooSync. Self-skip : une cible pointant vers le dashboard source ne duplique pas. Target manquant + createIfNotExists=false = entrée { key, ok: false, error } dans result.crossPost.',
+        items: {
+          type: 'object',
+          properties: {
+            type: {
+              type: 'string',
+              enum: ['global', 'machine', 'workspace'],
+              description: 'Type de dashboard cible.'
+            },
+            machineId: {
+              type: 'string',
+              description: 'machineId cible (pour type=machine).'
+            },
+            workspace: {
+              type: 'string',
+              description: 'workspace cible (pour type=workspace).'
+            }
+          },
+          required: ['type'],
+          additionalProperties: false
+        }
       }
     },
     required: ['action'],


### PR DESCRIPTION
## Summary

PR #120 (feat mentions v3, merged 15:00:52Z sans aucune review) a ajouté `mentions` et `crossPost` au Zod `DashboardArgsSchema` mais a **oublié** de les déclarer dans le `inputSchema` JSON exposé aux clients MCP (`dashboardToolMetadata.inputSchema`, lignes 1982-2049). Le flag `additionalProperties: false` droppait silencieusement ces paramètres avant qu'ils atteignent le server.

## Impact

- Feature mentions v3 **non-appelable côté client** depuis 3 jours malgré merge
- E2E test self-mention sur nanoclaw à 16:04Z : `append` succès mais **zéro notification `[MENTION]`** générée
- Dashboard-watcher Phase 2 bloqué sur nanoclaw

## Fix

Ajout de `mentions` et `crossPost` au JSON inputSchema avec descriptions alignées sur `.claude/rules/intercom-protocol.md` v3.2.0 :

- `mentions`: array of `{userId: {machineId, workspace} | messageId, note?}` — XOR userId/messageId noté en description (JSON Schema n'exprime pas nativement XOR, refinement côté Zod)
- `crossPost`: array of `{type: global|machine|workspace, machineId?, workspace?}`

## Review gap (historique)

PR #120 : 615 additions / 24 deletions, mergée **24 secondes** après submod PR #119, **0 reviews / 0 comments**. Un reviewer visual aurait repéré l'asymétrie Zod-added vs inputSchema-unchanged. sk-agent code-review aurait flag automatiquement. Cet oubli justifie la posture sceptique de PR #1464 roo-extensions (needs-approval).

## Test plan

- [x] Build TypeScript OK
- [x] Dashboard tests 59 passed / 1 skipped (pre-existing LLM cancel test)
- [ ] Post-merge : restart MCP server + refaire E2E self-mention sur nanoclaw → notification `[MENTION]` générée
- [ ] Bump submodule pointer dans parent repo roo-extensions (actuellement `48366b48`, doit passer à `02e7a4b9 + this PR`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)