### PR TITLE
fix(#1363): expose mentions[]/crossPost[] in MCP inputSchema

### DIFF
--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -680,7 +680,59 @@ export const roosyncDashboardDefinition = {
             createIfNotExists: { type: 'boolean', description: "(write/append) Créer le dashboard s'il n'existe pas (défaut: true)" },
             tags: { type: 'array', items: { type: 'string' }, description: '(append) Tags pour le message intercom (ex: ["INFO", "WARN", "ERROR"])' },
             keepMessages: { type: 'number', description: '(condense) Nombre de messages à conserver (défaut: 100)' },
-            archiveFile: { type: 'string', description: '(read_archive) Nom du fichier archive à lire. Si absent, liste les archives disponibles.' }
+            archiveFile: { type: 'string', description: '(read_archive) Nom du fichier archive à lire. Si absent, liste les archives disponibles.' },
+            mentions: {
+                type: 'array',
+                description: '(append) Mentions structurées v3 (#1363). Chaque entrée = userId XOR messageId (exactement un des deux). Notifie les destinataires via RooSync (fire-and-forget, dedup par machineId).',
+                items: {
+                    type: 'object',
+                    properties: {
+                        userId: {
+                            type: 'object',
+                            description: 'userId explicite à mentionner (exclusif avec messageId).',
+                            properties: {
+                                machineId: { type: 'string', description: 'ID de la machine' },
+                                workspace: { type: 'string', description: 'Workspace ID' }
+                            },
+                            required: ['machineId', 'workspace'],
+                            additionalProperties: false
+                        },
+                        messageId: {
+                            type: 'string',
+                            description: 'ID de message à référencer (format: machineId:workspace:ic-...). Résout en userId = auteur du message référencé.'
+                        },
+                        note: {
+                            type: 'string',
+                            description: 'Note optionnelle expliquant la raison de la mention.'
+                        }
+                    },
+                    additionalProperties: false
+                }
+            },
+            crossPost: {
+                type: 'array',
+                description: '(append) Cross-post le même message vers d\'autres dashboards v3 (#1363), SANS notification RooSync. Self-skip : une cible pointant vers le dashboard source ne duplique pas. Target manquant + createIfNotExists=false = entrée { key, ok: false, error } dans result.crossPost.',
+                items: {
+                    type: 'object',
+                    properties: {
+                        type: {
+                            type: 'string',
+                            enum: ['global', 'machine', 'workspace'],
+                            description: 'Type de dashboard cible.'
+                        },
+                        machineId: {
+                            type: 'string',
+                            description: 'machineId cible (pour type=machine).'
+                        },
+                        workspace: {
+                            type: 'string',
+                            description: 'workspace cible (pour type=workspace).'
+                        }
+                    },
+                    required: ['type'],
+                    additionalProperties: false
+                }
+            }
         },
         required: ['action'],
         additionalProperties: false


### PR DESCRIPTION
## Context

PR #123 (merged yesterday) fixed the Zod runtime validation to accept `mentions[]` and `crossPost[]` on `roosync_dashboard(action: "append")`, by patching `dashboardToolMetadata.inputSchema` in `src/tools/roosync/dashboard.ts`.

**But that wasn't enough.** nanoClaw tested E2E and reported fields were still dropped by MCP clients with `additionalProperties: false` rejection.

## Root cause

`dashboardToolMetadata` in `dashboard.ts` is **orphan** — never imported by `registry.ts`. The actual source advertised to MCP clients via `ListTools` is `roosyncDashboardDefinition` in [`src/tools/tool-definitions.ts:666-688`](src/tools/tool-definitions.ts#L666-L688), which was **not updated** by #123.

Chain:
- `registry.ts:15` imports `allToolDefinitions` from `tool-definitions.ts`
- `registry.ts:35` serves it to `ListToolsRequestSchema` handler
- Clients see the JSON Schema from `tool-definitions.ts`, reject unknown props

## Fix

Add `mentions` + `crossPost` to `roosyncDashboardDefinition.inputSchema.properties`, mirroring the Zod-derived schema from [`dashboard.ts:2046-2097`](src/tools/roosync/dashboard.ts#L2046-L2097).

## Scope

Intentionally narrow. Deferred to separate PRs:
- `messageId` (append, also missing)
- `mentionsOnly` (read filter, also missing)
- Consolidation of dual schema definitions (see followup issue)

## Test plan

- [x] `npm run build` passes
- [x] `mentions` and `crossPost` appear in `build/tools/tool-definitions.js` (3 occurrences)
- [ ] VS Code restart on ai-01 to load new MCP schema (manual)
- [ ] nanoClaw re-tests E2E mentions flow via `git pull --recurse-submodules` + build + restart

## Followup

Root cause is dual schema maintenance. `zod-to-json-schema` is already a dep and used in 13 roosync tool files — but `tool-definitions.ts` intentionally avoids handler imports (#1145 perf fix for ESM circular deps). Followup issue will extract Zod schemas into schema-only modules that `tool-definitions.ts` can safely import.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>