### PR TITLE
fix(#1461): use getSharedStatePath() in CommitLogService

### DIFF
--- a/servers/roo-state-manager/src/services/roosync/CommitLogService.ts
+++ b/servers/roo-state-manager/src/services/roosync/CommitLogService.ts
@@ -12,6 +12,7 @@ import { promises as fs, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { createHash } from 'crypto';
 import { createLogger } from '../../utils/logger.js';
+import { getSharedStatePath } from '../../utils/shared-state-path.js';
 import {
   CommitEntryType,
   CommitStatus,
@@ -53,7 +54,7 @@ export class CommitLogService {
   constructor(config: Partial<CommitLogConfig> = {}) {
     // Configuration par défaut
     this.config = {
-      commitLogPath: config.commitLogPath || join(process.cwd(), '.shared-state', 'commit-log'),
+      commitLogPath: config.commitLogPath || join(getSharedStatePath(), 'commit-log'),
       syncInterval: config.syncInterval || 30000, // 30 secondes
       maxEntries: config.maxEntries || 10000,
       maxRetryAttempts: config.maxRetryAttempts || 3,


### PR DESCRIPTION
## Summary
- Replace `join(process.cwd(), '.shared-state', 'commit-log')` with `join(getSharedStatePath(), 'commit-log')` in CommitLogService

## Problem
`CommitLogService` was using `process.cwd()` as fallback for the commit log path, which creates `.shared-state/commit-log/` directories in the repo root when `ROOSYNC_SHARED_PATH` is not set.

## Fix
Use the centralized `getSharedStatePath()` utility which properly throws when the env var is missing, preventing silent directory creation in wrong locations.

## Test plan
- [x] `npm run build` passes
- [ ] Verify no `.shared-state/` created in repo root after restart

Related: jsboige/roo-extensions#1461

🤖 Generated with [Claude Code](https://claude.com/claude-code)