### PR TITLE
fix(#1410): treat limit as hard cap, not page size with floor

### DIFF
--- a/servers/roo-state-manager/src/tools/conversation/__tests__/conversation-browser.test.ts
+++ b/servers/roo-state-manager/src/tools/conversation/__tests__/conversation-browser.test.ts
@@ -720,7 +720,7 @@ describe('conversation_browser', () => {
 			expect(parsed[2].taskId).toBe('task-old'); // 5 messages
 		});
 
-		test('list clamps limit below 10 to the floor (#1245: pages of <10 are useless)', async () => {
+		test('list respects limit as hard cap (#1410: limit is total cap, not page size)', async () => {
 			// mockCache has 3 tasks. limit=2 gets clamped to 10 → all 3 returned in sorted order.
 			const result = await handleConversationBrowser(
 				{ action: 'list', limit: 2, sortBy: 'lastActivity', sortOrder: 'desc' },
@@ -731,10 +731,9 @@ describe('conversation_browser', () => {
 			expect(result.isError).toBeFalsy();
 			const _response = JSON.parse(getTextContent(result));
 			const parsed = _response.conversations ?? _response;
-			expect(parsed.length).toBe(3);
+			expect(parsed.length).toBe(2);
 			expect(parsed[0].taskId).toBe('task-new');
 			expect(parsed[1].taskId).toBe('task-middle');
-			expect(parsed[2].taskId).toBe('task-old');
 		});
 
 		test('list filters by workspace when specified', async () => {

--- a/servers/roo-state-manager/src/tools/conversation/__tests__/list-conversations.test.ts
+++ b/servers/roo-state-manager/src/tools/conversation/__tests__/list-conversations.test.ts
@@ -271,8 +271,8 @@ describe('listConversationsTool.handler', () => {
       expect(parsed.length).toBe(12);
     });
 
-    test('limit inférieur au plancher 10 → clamp à 10', async () => {
-      // Create 15 tasks and ask for 3 → should be clamped to 10
+    test('limit < 10 is respected as hard cap (#1410: floor only applies to per_page)', async () => {
+      // Create 15 tasks and ask for 3 → should return 3 (limit is hard cap, not page size)
       const tasks = Array.from({ length: 15 }, (_, i) => makeConversation(`task-${i + 1}`));
       const cache = makeCache(...tasks);
 
@@ -280,7 +280,7 @@ describe('listConversationsTool.handler', () => {
       const _response = JSON.parse((result.content[0] as any).text);
       const parsed = _response.conversations ?? _response;
 
-      expect(parsed.length).toBe(10);
+      expect(parsed.length).toBe(3);
     });
 
     test('sans limit → default 10 (page 1) — retourne au plus 10 tâches', async () => {

--- a/servers/roo-state-manager/src/tools/conversation/__tests__/list-conversations.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/conversation/__tests__/list-conversations.tool.test.ts
@@ -432,8 +432,8 @@ describe('list-conversations', () => {
       expect(parsed).toHaveLength(15);
     });
 
-    it('should clamp limit to floor of 10 (pages of 5 are useless)', async () => {
-      // Create 12 tasks, ask for 5 → clamped up to 10
+    it('should respect limit as hard cap (#1410: floor only applies to per_page)', async () => {
+      // Create 12 tasks, ask for 5 → returns 5 (limit is a hard cap, not page size)
       const mockCache = new Map<string, any>();
       for (let i = 0; i < 12; i++) {
         mockCache.set(`task${i}`, {
@@ -455,7 +455,7 @@ describe('list-conversations', () => {
       const _response = JSON.parse(result.content[0].text as string);
       const parsed = _response.conversations ?? _response;
 
-      expect(parsed).toHaveLength(10);
+      expect(parsed).toHaveLength(5);
     });
 
     it('should return all results when limit is not specified', async () => {

--- a/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
+++ b/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
@@ -889,14 +889,20 @@ export const listConversationsTool = {
         });
 
         // --- Pagination ---
-        // #1245 round 2: clamp to [10, 100].
+        // #1245 round 2: clamp per_page to [10, 100].
         //   - floor 10: user explicit ("pas moins de 10 éléments par page, des pages de 5 ça n'a jamais été utile")
         //   - cap 100: an agent may deliberately want a large page (it will be redirected to a file
         //     above ~50KB — that's fine as an opt-in, just not the default behaviour).
         //   - default 10: keeps the default output comfortably under 50KB so Claude Code displays
         //     content inline; agents can pass per_page=50/100 when they want everything in a file.
-        const rawPerPage = args.per_page || args.limit || 10;
-        const perPage = Math.min(Math.max(rawPerPage, 10), 100);
+        // #1410 fix: `limit` (from conversation_browser) is a hard cap on total results, NOT a page size.
+        //   When only `limit` is provided (no `per_page`), it acts as both page size and total cap.
+        //   The floor of 10 does NOT apply to `limit` — the caller explicitly asked for fewer.
+        const hasExplicitPerPage = args.per_page !== undefined && args.per_page !== null;
+        const rawPerPage = (hasExplicitPerPage ? args.per_page : (args.limit || 10)) as number;
+        const perPage = hasExplicitPerPage
+            ? Math.min(Math.max(rawPerPage, 10), 100)
+            : Math.min(rawPerPage, 100);
         const page = Math.max(args.page || 1, 1);
         const totalCount = forest.length;
         const totalPages = Math.ceil(totalCount / perPage);

--- a/servers/roo-state-manager/tests/unit/tools/conversation/list-conversations.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/conversation/list-conversations.test.ts
@@ -112,13 +112,14 @@ describe('list_conversations tool', () => {
         expect(content[1].taskId).toBe('task-1'); // 10 messages
     });
 
-    it('should clamp limit below floor to 10 (#1245: pages of <10 are useless)', async () => {
-        // mockCache has only 2 tasks. limit=1 gets clamped to 10, so we get all 2 back.
+    it('should respect limit as hard cap (#1410: floor only applies to per_page)', async () => {
+        // #1410 fix: limit is a hard cap on total results, not a page size.
+        // mockCache has 2 tasks, limit=1 → should return 1.
         const result = await listConversationsTool.handler({ limit: 1 }, mockCache);
         const _response = JSON.parse(result.content[0].text as string);
         const content = _response.conversations ?? _response;
 
-        expect(content).toHaveLength(2);
+        expect(content).toHaveLength(1);
     });
 
     // Test for pendingSubtaskOnly filter


### PR DESCRIPTION
## Summary
- `limit` parameter in `list_conversations` was treated as `per_page` fallback with a floor of 10, causing `conversation_browser(list, limit: 3)` to return 10+ results
- Fix: when only `limit` is provided (no `per_page`), treat it as a hard cap on total results with no floor; the [10, 100] clamp only applies to explicit `per_page`

## Test plan
- [x] 4 test files updated to expect `limit` as hard cap
- [x] `npx vitest run --config vitest.config.ci.ts` — 416 passed, 0 failed
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)