### PR TITLE
fix(#1496): Remove silent fallback semantic→text in roosync_search

### DIFF
--- a/servers/roo-state-manager/src/tools/search/__tests__/roosync-search.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/roosync-search.test.ts
@@ -160,13 +160,28 @@ describe('roosync_search', () => {
 					conversation_id: 'conv-123',
 					max_results: 5,
 					workspace: 'test-ws',
-					diagnose_index: false
+					diagnose_index: false,
+					// #1496: strict_mode must be passed through so semantic errors
+					// propagate to the caller instead of silently falling back to text.
+					strict_mode: true
 				}),
 				mockCache,
 				mockEnsureCache,
 				mockFallbackHandler,
 				mockDiagnoseHandler
 			);
+		});
+
+		test('#1496: passes strict_mode=true to semantic handler', async () => {
+			await handleRooSyncSearch(
+				{ action: 'semantic', search_query: 'test', workspace: 'd:\\test-workspace' },
+				mockCache,
+				mockEnsureCache,
+				mockFallbackHandler
+			);
+
+			const callArgs = mockSemanticHandler.mock.calls[0][0];
+			expect(callArgs.strict_mode).toBe(true);
 		});
 
 		test('returns semantic handler result', async () => {

--- a/servers/roo-state-manager/src/tools/search/roosync-search.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/roosync-search.tool.ts
@@ -185,7 +185,10 @@ export async function handleRooSyncSearch(
                 effectiveWorkspace = undefined;
             }
 
-            // Déléguer au handler sémantique existant (inclut fallback automatique sur erreur)
+            // Déléguer au handler sémantique existant.
+            // #1496: strict_mode=true so semantic errors are propagated to the caller
+            // instead of silently falling back to text search (which masked the
+            // #1407 and #1451 embedding backend regressions for days).
             const semanticArgs: SearchTasksByContentArgs = {
                 search_query: args.search_query,
                 conversation_id: args.conversation_id,
@@ -193,6 +196,7 @@ export async function handleRooSyncSearch(
                 workspace: effectiveWorkspace,
                 source: args.source,
                 diagnose_index: false,
+                strict_mode: true,
                 // #636: Advanced filters
                 chunk_type: args.chunk_type,
                 role: args.role,

--- a/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
@@ -54,6 +54,12 @@ export interface SearchTasksByContentArgs {
     // #636 Phase 3: Convenience filter
     /** Exclude tool_interaction chunks, returning only message_exchange chunks */
     exclude_tool_results?: boolean;
+    // #1496: When true, propagate semantic errors instead of silently falling
+    // back to text search. Used by `roosync_search(action: "semantic")` so the
+    // caller gets a clear signal when the embedding backend is down, rather
+    // than returning `searchType: "text"` without warning. Default: false
+    // (legacy behavior preserved for direct `searchTasks` callers).
+    strict_mode?: boolean;
 }
 
 /**
@@ -666,9 +672,30 @@ export const searchTasksByContentTool = {
                 lastEmbeddingFailureTime = Date.now();
                 console.warn(`[WARN] #1232: Embedding circuit breaker activated for ${EMBEDDING_CIRCUIT_BREAKER_TTL_MS / 1000}s (HTTP 5xx detected)`);
             }
-            console.warn(`[WARN] Semantic search failed, falling back to text search: ${semanticError instanceof Error ? semanticError.message : String(semanticError)}`);
 
-            // Fallback vers la recherche textuelle simple
+            const semanticErrorMsg = semanticError instanceof Error ? semanticError.message : String(semanticError);
+
+            // #1496: Strict mode — propagate the semantic error instead of silently
+            // falling back to text. Callers that explicitly requested semantic
+            // (like `roosync_search(action: "semantic")`) need to know when the
+            // embedding backend is down, otherwise they treat text results as
+            // semantic and real regressions go unnoticed for days (cf #1407, #1451).
+            if (args.strict_mode) {
+                console.warn(`[WARN] Semantic search failed in strict_mode (no fallback): ${semanticErrorMsg}`);
+                return {
+                    isError: true,
+                    content: [{
+                        type: 'text',
+                        text: `Semantic search failed: ${semanticErrorMsg}\n\n` +
+                              `Diagnostic: run roosync_search(action: "diagnose") to check backend state.\n` +
+                              `Hint: if you want text fallback, use roosync_search(action: "text") explicitly.`
+                    }]
+                };
+            }
+
+            console.warn(`[WARN] Semantic search failed, falling back to text search: ${semanticErrorMsg}`);
+
+            // Fallback vers la recherche textuelle simple (legacy — default path)
             try {
                 // Fix: mapper search_query → query pour le fallback
                 const fallbackResult = await fallbackHandler(

--- a/servers/roo-state-manager/tests/unit/tools/search/roosync-search.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/search/roosync-search.test.ts
@@ -202,7 +202,11 @@ describe('roosync_search - CONS-11', () => {
             expect(result.isError).toBeFalsy();
         });
 
-        it('should fallback to text on semantic error', async () => {
+        it('#1496: propagates semantic error instead of silent fallback (strict_mode)', async () => {
+            // Before #1496: semantic errors caused a silent fallback to text search,
+            // which masked embedding backend regressions for days (cf #1407, #1451).
+            // After #1496: `roosync_search(action: "semantic")` must return isError:true
+            // with a diagnostic hint so the caller knows the semantic path failed.
             mockOpenAIClient.embeddings.create.mockRejectedValue(new Error('OpenAI Error'));
 
             const result = await handleRooSyncSearch(
@@ -212,8 +216,13 @@ describe('roosync_search - CONS-11', () => {
                 fallbackHandler
             );
 
-            expect(fallbackHandler).toHaveBeenCalled();
-            expect((result.content[0] as any).text).toBe('Fallback result');
+            expect(fallbackHandler).not.toHaveBeenCalled();
+            expect(result.isError).toBe(true);
+            const errorText = (result.content[0] as any).text;
+            expect(errorText).toContain('Semantic search failed');
+            expect(errorText).toContain('OpenAI Error');
+            expect(errorText).toContain('roosync_search(action: "diagnose")');
+            expect(errorText).toContain('roosync_search(action: "text")');
         });
     });
 


### PR DESCRIPTION
Closes jsboige/roo-extensions#1496 (partial — parent pointer bump follows)

## Problem

Before this change, `roosync_search(action: "semantic")` would catch any error from the semantic pipeline (OpenAI embedding, Qdrant search, etc.) and **silently fall back to text search** with `searchType: "text"` in the response — no warning, no error flag, no hint.

This masked real regressions for days. Incidents **#1407** and **#1451** (both closed 2026-04-18 with postmortem) turned out to be caused by the vLLM embedding backend (`qwen3-4b-awq-embedding`) hung at the application layer for an unknown duration. Agents calling `roosync_search(semantic)` got 0 results or poor text matches — no alert, no signal to investigate.

## Fix

Add `strict_mode?: boolean` to `SearchTasksByContentArgs`. When `true`:

- `search-semantic.tool.ts` catch block returns `isError: true` with a structured message containing:
  - the semantic error message
  - a hint to run `roosync_search(action: "diagnose")`
  - a hint to use `roosync_search(action: "text")` if text fallback was the intent

When `false` (default), the existing silent fallback is preserved — backward-compat for direct `searchTasks` callers via `registry.ts`.

`roosync_search(action: "semantic")` now passes `strict_mode: true` unconditionally. Callers wanting text fallback must explicitly use `action: "text"`.

## Tests

- `src/tools/search/__tests__/roosync-search.test.ts`:
  - asserts `strict_mode: true` is passed through
  - dedicated test case `#1496: passes strict_mode=true to semantic handler`
- `tests/unit/tools/search/roosync-search.test.ts`:
  - replaced the legacy `should fallback to text on semantic error` case with new assertion `#1496: propagates semantic error instead of silent fallback`

Full CI: **7610 tests passed / 2 skipped** (baseline preserved).

## Non-breaking

- Direct `searchTasks` MCP callers: unchanged (legacy path, silent fallback preserved)
- Only `roosync_search(action: "semantic")` callers see the new strict behavior
- For users wanting text fallback: explicit `action: "text"` still works

Refs: jsboige/roo-extensions#1496, #1407, #1451