### PR TITLE
fix(#1498): roosync_read inbox workspace/machine override

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/read.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/read.test.ts
@@ -230,6 +230,47 @@ describe.sequential('roosyncRead', () => {
   });
 
   // ============================================================
+  // Tests pour mode: 'inbox' — workspace & to_machine overrides (#1498)
+  // ============================================================
+
+  describe('mode: inbox — workspace override (#1498)', () => {
+    test('filters inbox by explicit workspace param (scheduler multi-workspace)', async () => {
+      // Send one message to each workspace on test-machine
+      await messageManager.sendMessage(
+        'sender-a', 'test-machine:workspace-a', 'For A', 'Body A', 'MEDIUM'
+      );
+      await messageManager.sendMessage(
+        'sender-b', 'test-machine:workspace-b', 'For B', 'Body B', 'MEDIUM'
+      );
+
+      // Read only workspace-a
+      const resA = await roosyncRead({ mode: 'inbox', workspace: 'workspace-a' });
+      const textA = (resA.content[0] as any).text;
+      expect(textA).toContain('workspace-a');
+      expect(textA).toContain('For A');
+      expect(textA).not.toContain('For B');
+
+      // Read only workspace-b
+      const resB = await roosyncRead({ mode: 'inbox', workspace: 'workspace-b' });
+      const textB = (resB.content[0] as any).text;
+      expect(textB).toContain('workspace-b');
+      expect(textB).toContain('For B');
+      expect(textB).not.toContain('For A');
+    });
+
+    test('returns empty for workspace that has no messages', async () => {
+      await messageManager.sendMessage(
+        'sender', 'test-machine:workspace-a', 'Only A', 'Body', 'LOW'
+      );
+
+      const res = await roosyncRead({ mode: 'inbox', workspace: 'workspace-nonexistent' });
+      const text = (res.content[0] as any).text;
+      expect(text).toContain('Aucun message');
+      expect(text).toContain('workspace-nonexistent');
+    });
+  });
+
+  // ============================================================
   // Tests pour mode: 'message'
   // ============================================================
 

--- a/servers/roo-state-manager/src/tools/roosync/read.ts
+++ b/servers/roo-state-manager/src/tools/roosync/read.ts
@@ -56,6 +56,16 @@ interface RooSyncReadArgs {
 
   /** Marquer automatiquement comme lu (défaut: false, mode 'message' uniquement) */
   mark_as_read?: boolean;
+
+  // #1498: multi-workspace inbox polling (dashboard-watcher Phase 2).
+  // A single scheduler running in ai-01/roo-extensions needs to poll inboxes
+  // for ai-01/nanoclaw, ai-01/foo, etc. The default filter (localWorkspaceId
+  // from process cwd) makes that impossible without these overrides.
+  /** Override workspace filter (défaut: workspace du process MCP). Permet à un scheduler tournant dans workspace X de lire l'inbox adressée à workspace Y sur la même machine. */
+  workspace?: string;
+
+  /** Override machine filter (défaut: machine locale). Usage avancé : lire inbox d'une autre machine. Normalement tu veux garder ta propre machine. */
+  to_machine?: string;
 }
 
 /**
@@ -69,26 +79,30 @@ async function readInboxMode(
   args: RooSyncReadArgs,
   messageManager: MessageManager
 ): Promise<string> {
-  const localMachineId = getLocalMachineId();
-  const localWorkspaceId = getLocalWorkspaceId();
+  // #1498: allow explicit override of machine + workspace filters so a single
+  // dashboard-watcher process can poll inboxes for every workspace on a machine.
+  const effectiveMachineId = args.to_machine || getLocalMachineId();
+  const effectiveWorkspaceId = args.workspace || getLocalWorkspaceId();
   const status = args.status || 'all';
   const limit = args.limit;
   const page = args.page;
   const perPage = args.per_page;
 
-  logger.info('📬 Reading inbox', { machineId: localMachineId, workspaceId: localWorkspaceId, status, limit, page, perPage });
+  logger.info('📬 Reading inbox', { machineId: effectiveMachineId, workspaceId: effectiveWorkspaceId, status, limit, page, perPage });
 
   // Get counts from cache (single scan, no double-read — #638 perf fix)
-  const counts = await messageManager.getFilteredCount(localMachineId, 'all', localWorkspaceId);
+  const counts = await messageManager.getFilteredCount(effectiveMachineId, 'all', effectiveWorkspaceId);
 
   // Read messages with pagination
   const messages = await messageManager.readInbox(
-    localMachineId, status, limit, localWorkspaceId, page, perPage
+    effectiveMachineId, status, limit, effectiveWorkspaceId, page, perPage
   );
 
-  // Fire-and-forget heartbeat update
+  // Fire-and-forget heartbeat update. Always use the REAL local machine, not
+  // the overridden filter — heartbeat is proof-of-life for the local process,
+  // not for the machine whose inbox is being read.
   (await getRooSyncService()).getHeartbeatService()
-    .registerHeartbeat(localMachineId, { lastActivity: 'roosync_read_inbox', messageCount: messages.length })
+    .registerHeartbeat(getLocalMachineId(), { lastActivity: 'roosync_read_inbox', messageCount: messages.length })
     .catch(err => logger.debug('Heartbeat update skipped (non-critical)', { error: String(err) }));
 
   // Throttled fire-and-forget cleanup tasks (run at most once every 5 min)
@@ -118,12 +132,13 @@ async function readInboxMode(
 
 Votre inbox est vide pour le moment.
 
-**Machine :** ${localMachineId}
+**Machine :** ${effectiveMachineId}
+**Workspace :** ${effectiveWorkspaceId}
 **Filtre :** ${status}`;
   }
 
   // Formater la liste
-  let result = `📬 **Boîte de Réception** - ${localMachineId}\n\n`;
+  let result = `📬 **Boîte de Réception** - ${effectiveMachineId}:${effectiveWorkspaceId}\n\n`;
   result += `**Total :** ${counts.total} message${counts.total > 1 ? 's' : ''} | `;
   result += `🆕 ${counts.unread} non-lu${counts.unread > 1 ? 's' : ''} | `;
   result += `✅ ${counts.read} lu${counts.read > 1 ? 's' : ''}\n`;
@@ -395,6 +410,14 @@ export const readToolMetadata = {
       mark_as_read: {
         type: 'boolean',
         description: 'Marquer automatiquement comme lu (mode message, défaut: false)'
+      },
+      workspace: {
+        type: 'string',
+        description: '(mode inbox, #1498) Override workspace filter. Défaut: workspace du process MCP. Permet à un scheduler tournant dans workspace X de lire l\'inbox adressée à workspace Y sur la même machine (dashboard-watcher multi-workspace).'
+      },
+      to_machine: {
+        type: 'string',
+        description: '(mode inbox, #1498, avancé) Override machine filter. Défaut: machine locale. Normalement tu veux ta propre machine.'
       }
     },
     required: ['mode']

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -605,7 +605,9 @@ export const roosyncReadDefinition = {
             page: { type: 'number', description: 'Page number (1-based) for pagination. Requires per_page.' },
             per_page: { type: 'number', description: 'Messages per page. Requires page. Recommended: 20.' },
             message_id: { type: 'string', description: "ID du message à récupérer (requis pour mode=message ou mode=attachments)" },
-            mark_as_read: { type: 'boolean', description: 'Marquer automatiquement comme lu (mode message, défaut: false)' }
+            mark_as_read: { type: 'boolean', description: 'Marquer automatiquement comme lu (mode message, défaut: false)' },
+            workspace: { type: 'string', description: "(mode inbox, #1498) Override workspace filter. Défaut: workspace du process MCP. Permet à un scheduler tournant dans workspace X de lire l'inbox adressée à workspace Y sur la même machine (dashboard-watcher multi-workspace)." },
+            to_machine: { type: 'string', description: '(mode inbox, #1498, avancé) Override machine filter. Défaut: machine locale. Normalement tu veux ta propre machine.' }
         },
         required: ['mode']
     }


### PR DESCRIPTION
## Resolves issue #1498 (parent repo)

Adds optional `workspace` and `to_machine` params to `roosync_read(mode: "inbox")` so a single dashboard-watcher process can poll inboxes for every workspace on a machine without spawning one MCP server per workspace.

### Before
Filter was hardcoded to `getLocalMachineId() + getLocalWorkspaceId()`. A scheduler in `ai-01/roo-extensions` could not see mentions addressed to `ai-01/nanoclaw` — blocker for Phase 2 dashboard-watcher (#1430).

### After
Both params defaultable to local, overridable per call:
- `workspace: "nanoclaw"` → scheduler running in `roo-extensions` reads `ai-01:nanoclaw` inbox
- `to_machine: "other"` → advanced (rarely used)
- Heartbeat keeps using real local machine (it's proof-of-life for the process, not the reading identity)

### Schema updates
Both `readToolMetadata.inputSchema` and `roosyncReadDefinition.inputSchema` (tool-definitions.ts) bumped in lockstep.

### Tests
- 2 new cases in read.test.ts: explicit workspace filter + empty-workspace
- All 63 read-related tests green with CI config

### Unblocks
- #1430 dashboard-watcher Phase 2 (refactor poll-dashboard.ps1 to multi-workspace unified scheduler)
- Nanoclaw bidirectional bot <-> Claude Code

Generated with Claude Code