### PR TITLE
fix(#1502): dashboard condensation produces incoherent status

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, rm } from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import { roosyncDashboard, MentionSchema } from '../dashboard.js';
+import { roosyncDashboard, MentionSchema, detectStatusContradictions } from '../dashboard.js';
 import { resolveMentionTarget } from '@/utils/dashboard-helpers';
 import { resetChatOpenAIClient } from '@/services/openai';
 
@@ -1140,6 +1140,71 @@ describe('roosync_dashboard', () => {
         expect(target).toBeDefined();
         expect(target!.id).toMatch(/^test-machine:test-workspace:ic-\d{4}-\d{2}-\d{2}/);
       });
+    });
+  });
+
+  // ============================================================
+  // Tests detectStatusContradictions (#1502)
+  // ============================================================
+  describe('detectStatusContradictions (#1502)', () => {
+    it('returns empty for a clean status with no contradictions', () => {
+      const status = `## Status
+### État des systèmes
+- **vllm** : UP (source: 2026-04-18)
+- **myia-ai-01** : online (source: 2026-04-18)`;
+      const contradictions = detectStatusContradictions(status);
+      expect(contradictions).toHaveLength(0);
+    });
+
+    it('detects UP vs DOWN contradiction for same entity', () => {
+      const status = `## Status
+- **vllm** : DOWN (ancien statut)
+- vllm is now UP and running fine`;
+      const contradictions = detectStatusContradictions(status);
+      expect(contradictions.length).toBeGreaterThanOrEqual(1);
+      const vllmContradiction = contradictions.find(c => c.entity === 'vllm');
+      expect(vllmContradiction).toBeDefined();
+      expect(vllmContradiction!.conflictingStates.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('detects actif vs inactif contradiction for a machine', () => {
+      const status = `## Status
+- myia-po-2024 est actif et fonctionne
+- myia-po-2024 inactif ce matin`;
+      const contradictions = detectStatusContradictions(status);
+      const po2024 = contradictions.find(c => c.entity === 'myia-po-2024' || c.entity === 'po-2024');
+      expect(po2024).toBeDefined();
+    });
+
+    it('detects terminé vs en cours contradiction for same entity', () => {
+      const status = `## Status
+- myia-ai-01 : tâche X terminée (PR merged)
+- myia-ai-01 : tâche X en cours de déploiement`;
+      const contradictions = detectStatusContradictions(status);
+      const ai01 = contradictions.find(c => c.entity === 'myia-ai-01' || c.entity === 'ai-01');
+      expect(ai01).toBeDefined();
+    });
+
+    it('does not flag a single state as contradiction', () => {
+      const status = `## Status
+- **vllm** : DOWN since yesterday`;
+      const contradictions = detectStatusContradictions(status);
+      expect(contradictions).toHaveLength(0);
+    });
+
+    it('handles empty status gracefully', () => {
+      const contradictions = detectStatusContradictions('');
+      expect(contradictions).toHaveLength(0);
+    });
+
+    it('detects multiple contradictory entities simultaneously', () => {
+      const status = `## Status
+- vllm : DOWN (ancien statut)
+- vllm : UP et opérationnel (mis à jour)
+- myia-web1 : offline ce matin
+- myia-web1 : active et running maintenant`;
+      const contradictions = detectStatusContradictions(status);
+      expect(contradictions.length).toBeGreaterThanOrEqual(2);
     });
   });
 });

--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -707,38 +707,51 @@ Les messages les plus anciens vont être archivés. Ta mission : RÉÉCRIRE le s
 Le statut doit rester COMPACT (max 15 Ko) tout en préservant l'information critique.
 Viser 50-100 lignes. Au-delà, synthétiser plus agressivement.
 
+RÈGLE ABSOLUE — LAST-KNOWN-STATE WINS (#1502) :
+Pour CHAQUE sujet (machine, service, tâche), SEUL le dernier état connu doit apparaître.
+- Si un message récent dit "vLLM UP" et l'ancien statut dit "vLLM DOWN" → écrire "vLLM UP" UNIQUEMENT.
+- Si un message récent dit "[DONE] tâche X" → la tâche X est TERMINÉE, pas "en cours".
+- SUPPRIMER explicitement tout fait contredit par une source plus récente. Ne PAS garder les deux versions.
+
 EXIGENCES :
 1. ZÉRO perte d'information stratégique (décisions, blocages, livrables, métriques)
 2. DATES à jour : timestamps messages récents > dates ancien statut
-3. CONTRADICTIONS : messages récents ont RAISON (plus frais)
-4. [DONE] dans messages récents → TERMINÉ dans statut (pas "en cours")
+3. CONTRADICTIONS : messages récents ont TOUJOURS RAISON — SUPPRIMER les faits obsolètes de l'ancien statut
+4. [DONE] dans messages récents → TERMINÉ dans statut (JAMAIS "en cours")
 5. Métriques chiffrées EXACTES préservées
 6. INTÉGRER infos des messages [SERA ARCHIVÉ] sinon perdues
 7. Pas d'emojis. Pas de prose. Factuel et structuré.
+8. INTERDICTION D'EXTRAPOLER : ne rien afficher qui ne soit pas EXPLICITEMENT dans les sources
 
 STRUCTURE :
 ## [Workspace] — État au ${lastDate}
 
 ### Résumé
-[2-3 phrases : état global, tendance]
+[2-3 phrases INTERPRÉTATIVES : état global, tendance — clairement séparé des faits ci-dessous]
+
+### État des systèmes
+[FACTUEL uniquement : par entité (machine/service), dernier état connu avec date source]
+Format : "- **entité** : état (source: [date])"
 
 ### Livrables récents
 [Réalisations avec dates — synthétiser par thème, pas par PR/commit individuel]
 
 ### En cours
-[Tâches actives avec responsable]
+[Tâches actives avec responsable — uniquement celles sans [DONE] récent]
 
 ### Blocages / Attention
-[Problèmes non résolus]
+[Problèmes non résolus — retirer ceux résolus par des messages récents]
 
 ### Décisions et métriques
 [Choix actés + chiffres clés]
 
-NE PAS :
+INTERDIT :
 - Copier-coller l'ancien statut (SYNTHÉTISER et METTRE À JOUR)
+- Garder un fait contredit par un message plus récent (ex: "X DOWN" si un message dit "X UP")
 - Garder des tâches terminées depuis longtemps sans valeur de référence
 - Lister chaque commit/PR individuellement
-- Inventer des informations absentes des sources`;
+- Inventer des informations absentes des sources
+- Inférer un état à partir d'informations partielles (extrapolation)`;
 
   const userPrompt = `**Statut précédent :**
 ${previousStatus}
@@ -851,7 +864,10 @@ RÈGLES :
 - Supprimer les formulations verbeuses, garder le factuel
 - Supprimer les sections obsolètes (tâches terminées sans valeur de référence)
 - Pas d'emojis, pas de prose
-- Le résultat DOIT être plus court que l'original`;
+- Le résultat DOIT être plus court que l'original
+- LAST-KNOWN-STATE WINS : pour chaque sujet, ne garder QUE le dernier état connu (#1502)
+- INTERDICTION D'EXTRAPOLER : ne rien afficher qui ne soit pas dans le texte source (#1502)
+- SUPPRIMER les faits contredits par des informations plus récentes dans le texte (#1502)`;
 
   const startTime = Date.now();
   try {
@@ -891,6 +907,57 @@ RÈGLES :
     });
     return text;
   }
+}
+
+/**
+ * Détecte les contradictions dans un statut généré (#1502).
+ * Vérifie que chaque entité connue n'apparaît qu'avec un seul état (le plus récent).
+ * Retourne la liste des contradictions trouvées pour logging et marquage.
+ */
+export function detectStatusContradictions(status: string): Array<{ entity: string; conflictingStates: string[] }> {
+  const contradictions: Array<{ entity: string; conflictingStates: string[] }> = [];
+
+  // Paires d'états contradictoires (positif vs négatif)
+  const statePairs: Array<{ positive: string[]; negative: string[] }> = [
+    { positive: ['UP', 'running', 'actif', 'active', 'online', 'ok', 'opérationnel'], negative: ['DOWN', 'stopped', 'inactif', 'inactive', 'offline', 'ko', 'hs', 'error', 'panne'] },
+    { positive: ['terminé', 'done', 'complété', 'résolu', 'closed', 'merged'], negative: ['en cours', 'in progress', 'open', 'bloqué', 'blocked', 'todo'] },
+  ];
+
+  // Entités connues à surveiller (machines + services)
+  const knownEntities = [
+    'vllm', 'ollama', 'qdrant',
+    'myia-ai-01', 'myia-po-2023', 'myia-po-2024', 'myia-po-2025', 'myia-po-2026', 'myia-web1',
+    'ai-01', 'po-2023', 'po-2024', 'po-2025', 'po-2026', 'web1'
+  ];
+
+  const lines = status.split('\n');
+
+  for (const entity of knownEntities) {
+    const entityLower = entity.toLowerCase();
+    const matchingLines = lines.filter(l => l.toLowerCase().includes(entityLower));
+
+    if (matchingLines.length < 2) continue; // Besoin d'au moins 2 lignes pour une contradiction
+
+    for (const { positive, negative } of statePairs) {
+      const foundPositive = matchingLines.some(line =>
+        positive.some(p => line.toLowerCase().includes(p.toLowerCase()))
+      );
+      const foundNegative = matchingLines.some(line =>
+        negative.some(n => line.toLowerCase().includes(n.toLowerCase()))
+      );
+
+      if (foundPositive && foundNegative) {
+        const posStates = positive.filter(p => matchingLines.some(l => l.toLowerCase().includes(p.toLowerCase())));
+        const negStates = negative.filter(n => matchingLines.some(l => l.toLowerCase().includes(n.toLowerCase())));
+        contradictions.push({
+          entity,
+          conflictingStates: [...posStates, ...negStates]
+        });
+      }
+    }
+  }
+
+  return contradictions;
 }
 
 /**
@@ -984,6 +1051,21 @@ async function condenseIntercom(
   // Both operations succeeded — now auto-condense if outputs exceed size limits
   newStatus = await condenseTextIfTooLarge(newStatus, MAX_STATUS_SIZE_BYTES, 'Status');
   llmSummary = await condenseTextIfTooLarge(llmSummary, MAX_SUMMARY_SIZE_BYTES, 'Summary');
+
+  // #1502: Detect contradictions in generated status before committing
+  const detectedContradictions = detectStatusContradictions(newStatus!);
+  if (detectedContradictions.length > 0) {
+    logger.warn('Status contradictions detected after LLM generation (#1502)', {
+      contradictionCount: detectedContradictions.length,
+      contradictions: detectedContradictions.map(c => `${c.entity}: ${c.conflictingStates.join(' vs ')}`)
+    });
+    // Append HTML comment markers for visibility to next readers
+    const warningLines = detectedContradictions.map(c =>
+      `<!-- #1502 CONTRADICTION: ${c.entity} has conflicting states: ${c.conflictingStates.join(' vs ')} -->`
+    ).join('\n');
+    newStatus = newStatus! + '\n\n' + warningLines;
+  }
+
   const statusUpdated = true;
 
   // Archiver les anciens messages (format Markdown)


### PR DESCRIPTION
## Problem

La fonction `condense` du dashboard RooSync produit un status markdown incohérent avec:
1. Faits obsolètes conservés (vLLM DOWN alors qu il est UP)
2. Contradictions internes (po-2024 actif + inactif simultanément)
3. Extrapolations non sourcées

## Root Cause

Le prompt LLM de `generateStatusUpdate()` manquait de directives explicites pour:
- Supprimer les faits contredits par des messages plus récents
- Interdire l extrapolation
- Séparer les faits sourcés des interprétations

## Changes

### 1. Prompt `generateStatusUpdate()` renforcé
- **LAST-KNOWN-STATE WINS** : règle absolue — seul le dernier état connu par sujet doit apparaître
- **SUPPRIMER les faits contredits** : instruction explicite de ne pas garder les deux versions
- **INTERDICTION D EXTRAPOLER** : ne rien afficher qui ne soit pas dans les sources
- **Section `Etat des systèmes`** : section factuelle séparée du résumé interprétatif, avec format `entité : état (source: [date])`

### 2. Prompt `condenseTextIfTooLarge()` renforcé
- Mêmes règles anti-contradiction et anti-extrapolation ajoutées

### 3. Validation post-génération `detectStatusContradictions()`
- Nouvelle fonction qui détecte les paires d états contradictoires (UP/DOWN, actif/inactif, terminé/en cours) pour les entités connues
- Injecte des commentaires HTML `<!-- #1502 CONTRADICTION -->` quand des contradictions sont détectées
- Logging des contradictions pour diagnostic

### 4. Tests (7 nouveaux)
- Tests unitaires pour `detectStatusContradictions()` couvrant: status clean, UP vs DOWN, actif vs inactif, termine vs en cours, single state, empty, multiple entities

## Test Results

```
66 passed | 1 skipped (67 total)
Build: OK
```

## Files Changed

- `src/tools/roosync/dashboard.ts` — Prompt renforcé + détection contradictions
- `src/tools/roosync/__tests__/dashboard.test.ts` — 7 nouveaux tests