### PR TITLE
test(roosync): fix baseline.test.ts enum to include list_versions

### DIFF
--- a/servers/roo-state-manager/tests/unit/tools/roosync/baseline.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/baseline.test.ts
@@ -277,7 +277,7 @@ describe('roosync_baseline - Metadata', () => {
     expect(metadata.inputSchema.type).toBe('object');
     expect(metadata.inputSchema.properties).toBeDefined();
     expect(metadata.inputSchema.properties.action).toBeDefined();
-    expect(metadata.inputSchema.properties.action.enum).toEqual(['update', 'version', 'restore', 'export']);
+    expect(metadata.inputSchema.properties.action.enum).toEqual(['update', 'version', 'restore', 'export', 'list_versions']);
     expect(metadata.inputSchema.required).toEqual(['action']);
   });
 


### PR DESCRIPTION
## Summary
The list_versions action was added to the baseline tool in commit 52fddcca (fix #1410) but the metadata test was not updated. CI test fails with mismatch on action enum.

## Change
Single line: add 'list_versions' to the expected enum array in baseline.test.ts:280.

## Verification
expect(metadata.inputSchema.properties.action.enum).toEqual(['update', 'version', 'restore', 'export', 'list_versions']) — matches actual implementation in baseline.ts:46 and baseline.ts:1225.

## Why now
Found uncommitted on local submod state (myia-ai-01) during 2026-04-19 coordination cycle. No-op for everything except CI test pass rate.