### PR TITLE
fix(#1510): explicit workspace passing in readInbox callers

### DIFF
--- a/servers/roo-state-manager/src/notifications/ToolUsageInterceptor.ts
+++ b/servers/roo-state-manager/src/notifications/ToolUsageInterceptor.ts
@@ -16,6 +16,7 @@ import { NotificationService, NotificationEvent } from './NotificationService.js
 import { MessageManager, Message } from '../services/MessageManager.js';
 import { scanDiskForNewTasks } from '../tools/task/disk-scanner.js';
 import { SkeletonHeader } from '../types/conversation.js';
+import { getLocalWorkspaceId } from '../utils/message-helpers.js';
 
 /**
  * Configuration de l'intercepteur
@@ -172,7 +173,9 @@ export class ToolUsageInterceptor {
       // Utiliser readInbox avec filtre 'unread'
       const unreadItems = await this.messageManager.readInbox(
         this.config.machineId,
-        'unread'
+        'unread',
+        undefined,
+        getLocalWorkspaceId()
       );
       
       // Récupérer les messages complets

--- a/servers/roo-state-manager/src/services/MessageManager.ts
+++ b/servers/roo-state-manager/src/services/MessageManager.ts
@@ -454,9 +454,8 @@ export class MessageManager {
     page?: number,
     perPage?: number
   ): Promise<MessageListItem[]> {
-    // Auto-détection du workspace si non fourni
-    const effectiveWorkspaceId = workspaceId || getLocalWorkspaceId();
-    logger.info(`Reading inbox for: ${machineId}:${effectiveWorkspaceId}`);
+    const effectiveWorkspaceId = workspaceId;
+    logger.info(`Reading inbox for: ${machineId}${effectiveWorkspaceId ? ':' + effectiveWorkspaceId : ''}`);
 
     try {
       // Use cached data (#638 perf optimization)
@@ -522,7 +521,7 @@ export class MessageManager {
     status?: 'unread' | 'read' | 'all',
     workspaceId?: string
   ): Promise<{ total: number; unread: number; read: number }> {
-    const effectiveWorkspaceId = workspaceId || getLocalWorkspaceId();
+    const effectiveWorkspaceId = workspaceId;
     const { items, full } = await this.ensureInboxCache();
 
     let total = 0;

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/read_inbox.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/read_inbox.test.ts
@@ -68,7 +68,7 @@ describe('read_inbox', () => {
 
 		const result = await readInbox({ status: 'unread' });
 
-		expect(mockReadInbox).toHaveBeenCalledWith('myia-ai-01', 'unread', undefined);
+		expect(mockReadInbox).toHaveBeenCalledWith('myia-ai-01', 'unread', undefined, expect.any(String));
 		expect(result.content[0].text).toContain('unread');
 	});
 
@@ -77,7 +77,7 @@ describe('read_inbox', () => {
 
 		await readInbox({ limit: 5 });
 
-		expect(mockReadInbox).toHaveBeenCalledWith('myia-ai-01', 'all', 5);
+		expect(mockReadInbox).toHaveBeenCalledWith('myia-ai-01', 'all', 5, expect.any(String));
 	});
 
 	test('formats messages as table', async () => {
@@ -150,7 +150,7 @@ describe('read_inbox', () => {
 
 		await readInbox({});
 
-		expect(mockReadInbox).toHaveBeenCalledWith('myia-web1', 'all', undefined);
+		expect(mockReadInbox).toHaveBeenCalledWith('myia-web1', 'all', undefined, expect.any(String));
 	});
 
 	test('returns error on failure', async () => {

--- a/servers/roo-state-manager/src/tools/roosync/read_inbox.ts
+++ b/servers/roo-state-manager/src/tools/roosync/read_inbox.ts
@@ -12,6 +12,7 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import os from 'os';
 import { createLogger, Logger } from '../../utils/logger.js';
+import { getLocalWorkspaceId } from '../../utils/message-helpers.js';
 
 // Logger instance for read_inbox tool
 const logger: Logger = createLogger('ReadInboxTool');
@@ -107,7 +108,8 @@ export async function readInbox(
     const messages = await messageManager.readInbox(
       machineId,
       args.status || 'all',
-      args.limit
+      args.limit,
+      getLocalWorkspaceId()
     );
 
     // Cas : aucun message

--- a/servers/roo-state-manager/src/utils/message-helpers.ts
+++ b/servers/roo-state-manager/src/utils/message-helpers.ts
@@ -206,7 +206,7 @@ export function normalizeWorkspaceId(workspaceId: string): string {
 export function matchesRecipient(
   messageTo: string,
   localMachineId: string,
-  localWorkspaceId: string
+  localWorkspaceId: string | undefined
 ): boolean {
   // Broadcast
   if (messageTo === 'all' || messageTo === 'All') {
@@ -223,6 +223,7 @@ export function matchesRecipient(
   // If message targets a specific workspace, only that workspace should see it
   // Normalize both sides: basename + lowercase (handles "D:\vllm" vs "vllm")
   if (parsed.workspaceId) {
+    if (!localWorkspaceId) return false;
     return normalizeWorkspaceId(localWorkspaceId) === normalizeWorkspaceId(parsed.workspaceId);
   }
 


### PR DESCRIPTION
## Summary
- Removes auto-detection of workspace in `readInbox()` and `getFilteredCount()` — callers now pass workspace explicitly
- Updates `read_inbox.ts` and `ToolUsageInterceptor.ts` to import `getLocalWorkspaceId` and pass as argument
- `matchesRecipient()` accepts `string | undefined` for `localWorkspaceId` param

## Problem
`readInbox()` was auto-detecting workspace via `getLocalWorkspaceId()` fallback, which meant callers that intentionally omitted workspace (e.g., workspace-unaware inbox checks) would still get workspace filtering applied. This caused messages targeted at specific workspaces to appear in unrelated workspace inboxes.

## Test plan
- [x] `MessageManager.test.ts` — 74/74 passed (including "readInbox without workspace should NOT see workspace-targeted messages")
- [x] `read_inbox.test.ts` — 10/10 passed (updated call expectations for 4th arg)
- [x] `npm run build` — clean
- [ ] Pre-existing failures in unrelated tests (skepticism-protocol, tool-discoverability, baseline) — not caused by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)