### PR TITLE
feat(#1497): bump preemptive condensation threshold to 92%

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
@@ -760,7 +760,7 @@ describe('roosync_dashboard', () => {
   });
 
   describe('Preemptive condensation (#1497)', () => {
-    it('triggers condensation during fill-up when dashboard crosses 85% utilization', async () => {
+    it('triggers condensation during fill-up when dashboard crosses 92% utilization', async () => {
       // Persistent mock — preemptive may fire multiple times during fill-up loop
       mockGetChatClient.mockReturnValue({
         chat: { completions: { create: mockChatCreate } }
@@ -773,7 +773,7 @@ describe('roosync_dashboard', () => {
 
       // Fill with messages until the preemptive threshold triggers condensation.
       // Each message is ~3 KB; 20 messages would total ~60 KB (120% of 50 KB),
-      // so preemptive condensation at 85% (42.5 KB) must fire before we get there.
+      // so preemptive condensation at 92% (46 KB) must fire before we get there.
       const bigContent = 'X'.repeat(3000);
       let firstCondensedAt = -1;
       for (let i = 0; i < 20; i++) {
@@ -792,13 +792,13 @@ describe('roosync_dashboard', () => {
       expect(mockChatCreate).toHaveBeenCalled();
     });
 
-    it('does NOT trigger preemptive condensation below 85% utilization', async () => {
+    it('does NOT trigger preemptive condensation below 92% utilization', async () => {
       mockGetChatClient.mockReturnValue({
         chat: { completions: { create: mockChatCreate } }
       });
 
       await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
-      // 5 small messages — should stay well below 85%
+      // 5 small messages — should stay well below 92%
       for (let i = 0; i < 5; i++) {
         await roosyncDashboard({ action: 'append', type: 'global', content: `small ${i}` });
       }
@@ -824,8 +824,8 @@ describe('roosync_dashboard', () => {
       });
 
       await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
-      // Very large message, only 1 entry — size > 85% but count < CONDENSE_KEEP
-      const huge = 'Y'.repeat(45 * 1024); // 45 KB single message
+      // Very large message, only 1 entry — size > 92% but count < CONDENSE_KEEP
+      const huge = 'Y'.repeat(47 * 1024); // 47 KB single message (above 46 KB threshold)
       await roosyncDashboard({ action: 'append', type: 'global', content: huge });
 
       const result = await roosyncDashboard({
@@ -855,9 +855,9 @@ describe('roosync_dashboard', () => {
 
       await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
 
-      // Fill to just above 85% threshold: ~15 messages × 3KB = 45KB (≥ 42.5 KB)
+      // Fill to just above 92% threshold: ~16 messages × 3KB = 48KB (≥ 46 KB)
       const filler = 'A'.repeat(3000);
-      for (let i = 0; i < 15; i++) {
+      for (let i = 0; i < 16; i++) {
         await roosyncDashboard({
           action: 'append',
           type: 'global',

--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -56,14 +56,14 @@ const logger: Logger = createLogger('DashboardTool');
 const MAX_DASHBOARD_SIZE_BYTES = 50 * 1024; // 50 KB
 const CONDENSE_KEEP = 10;
 
-// #1497: Preemptive condensation threshold (85% of MAX)
+// #1497: Preemptive condensation threshold (92% of MAX)
 // Triggered BEFORE appending a new message when the dashboard is near-full, so
 // that the condense (which can take ~30s via LLM) completes on smaller data
 // and does not timeout the client call at 96%+ utilization (reported by
 // nanoclaw-cluster, 2026-04-17T22:17Z). Rationale: appending to a 96% dashboard
-// forces condense of ~50 messages at LLM speed; pre-condensing at 85% keeps
+// forces condense of ~50 messages at LLM speed; pre-condensing at 92% keeps
 // the working set smaller and shifts the latency into more predictable slots.
-const PREEMPTIVE_CONDENSE_THRESHOLD_BYTES = Math.floor(MAX_DASHBOARD_SIZE_BYTES * 0.85); // ~42.5 KB
+const PREEMPTIVE_CONDENSE_THRESHOLD_BYTES = Math.floor(MAX_DASHBOARD_SIZE_BYTES * 0.92); // ~46 KB
 
 // Size limits for LLM outputs (bytes). If exceeded, retry with a stricter prompt.
 const MAX_STATUS_SIZE_BYTES = 15 * 1024;  // 15 KB
@@ -1543,13 +1543,13 @@ async function handleAppend(
     dashboard = createEmptyDashboard(args.type!, key, author);
   }
 
-  // #1497: Preemptive condensation at 85% utilization
+  // #1497: Preemptive condensation at 92% utilization
   // Runs BEFORE the new message is appended, so condense operates on the existing
   // messages (current state) rather than waiting for the post-append size check
   // to fire at 100%. Prevents client-side timeout when dashboard is near-saturation.
   //
   // Concurrency contract: this function is NOT serialized per-key. Concurrent
-  // appends to the same dashboard that both cross the 85% threshold will each
+  // appends to the same dashboard that both cross the 92% threshold will each
   // enter condenseIntercom, and the writeDashboardFile at the end uses
   // last-writer-wins semantics (same as the pre-existing reactive path). The
   // #1497 change does not introduce a new race beyond what already exists in
@@ -1564,7 +1564,7 @@ async function handleAppend(
     logger.info('Preemptive condensation triggered (#1497)', {
       key,
       preAppendSize: `${Math.round(preAppendSize / 1024)}KB`,
-      preemptiveThreshold: `${Math.round(PREEMPTIVE_CONDENSE_THRESHOLD_BYTES / 1024)}KB (85% of ${Math.round(MAX_DASHBOARD_SIZE_BYTES / 1024)}KB)`,
+      preemptiveThreshold: `${Math.round(PREEMPTIVE_CONDENSE_THRESHOLD_BYTES / 1024)}KB (92% of ${Math.round(MAX_DASHBOARD_SIZE_BYTES / 1024)}KB)`,
       messageCount: dashboard.intercom.messages.length
     });
     const beforePreemptive = dashboard.intercom.messages.length;


### PR DESCRIPTION
## Summary
- Change preemptive condensation threshold from 85% (~42.5 KB) to 92% (~46 KB)
- Update tests to match new threshold values

## Context
User requested higher threshold to allow more dashboard content before triggering preemptive condensation.

## Test plan
- [x] All 70 dashboard tests pass with new threshold values

🤖 Generated with [Claude Code](https://claude.com/claude-code)