### PR TITLE
fix(#1495): preload RooSyncService to eliminate MCP cold start

### DIFF
--- a/servers/roo-state-manager/src/index.ts
+++ b/servers/roo-state-manager/src/index.ts
@@ -160,6 +160,12 @@ class RooStateManagerServer {
         const { initializeBackgroundServices } = await getBackgroundServices();
         const state = this.stateManager.getState();
         await initializeBackgroundServices(state);
+
+        // #1495: Preload RooSyncService so dashboard/heartbeat are ready on first call.
+        // Without this, getRooSyncService() only loads on first tool call → "Not connected".
+        const { getRooSyncService: preloadRooSync } = await import('./services/lazy-roosync.js');
+        await preloadRooSync();
+        logger.info('✅ [ColdStart] RooSyncService preloaded — dashboard/heartbeat ready');
     }
 
     /**


### PR DESCRIPTION
## Summary
- Dashboard and heartbeat tools returned "Not connected" on first MCP call after server start
- Root cause: `getRooSyncService()` in `lazy-roosync.ts` used lazy loading, only triggered on first tool call
- `roosync_read` worked immediately because it uses `getMessageManager()` which is initialized during background startup
- Fix: preload `getRooSyncService()` during `initializeAsync()` so dashboard/heartbeat are ready on first call

## Changes
- `servers/roo-state-manager/src/index.ts`: Added RooSyncService preload at end of `initializeAsync()`

## Test plan
- [x] Build passes (`npm run build`)
- [x] CI tests pass (419/420 — 1 pre-existing failure unrelated to this change)
- [ ] Manual test: restart MCP server, immediately call `roosync_dashboard(action: "read")` — should succeed on first call
- [ ] Verify no regression in startup time (preload happens AFTER transport connection)

## Root cause analysis
| Tool | Works on first call? | Why |
|------|---------------------|-----|
| `roosync_read` | YES | Uses `getMessageManager()` initialized in `initializeNotificationSystem()` |
| `roosync_dashboard` | **NO** (before fix) | Uses `getRooSyncService()` — lazy loaded on first call |
| `roosync_heartbeat` | **NO** (before fix) | Uses `getHeartbeatService()` → `getRooSyncService()` — same lazy path |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>