### PR TITLE
fix(#1493): prefix-match Claude project dirs for worktree sessions

### DIFF
--- a/servers/roo-state-manager/src/tools/view-conversation-tree.ts
+++ b/servers/roo-state-manager/src/tools/view-conversation-tree.ts
@@ -301,13 +301,16 @@ async function handleViewConversationTreeExecutionAsync(
             let claudeProjectPath: string | null = null;
             const locationsChecked: string[] = [];
 
-            for (const loc of claudeLocations) {
-                locationsChecked.push(loc.projectPath);
-                if (path.basename(loc.projectPath) === projectBasename) {
-                    claudeProjectPath = loc.projectPath;
-                    break;
-                }
-            }
+            // #1493: Use prefix match instead of exact match.
+            // Task ID format: claude-{projectDir}--{sessionUUID}
+            // The project directory basename does NOT include the session UUID suffix,
+            // so an exact === match fails for worktree sessions. Instead, find the
+            // longest project directory that is a prefix of the task-derived basename.
+            const candidates = claudeLocations
+                .filter(loc => projectBasename.startsWith(path.basename(loc.projectPath)))
+                .sort((a, b) => path.basename(b.projectPath).length - path.basename(a.projectPath).length);
+            claudeProjectPath = candidates.length > 0 ? candidates[0].projectPath : null;
+            locationsChecked.push(...claudeLocations.map(loc => loc.projectPath));
 
             if (!claudeProjectPath) {
                 throw new GenericError(


### PR DESCRIPTION
## Summary
- Fix `conversation_browser(view)` returning empty for Claude Code sessions in worktrees
- Root cause: task IDs include a session UUID suffix but project directory basenames do not
- Change exact match (`===`) to longest-prefix match so worktree sessions resolve correctly

## Test plan
- [x] `npm run build` passes
- [x] 7669 tests pass (0 failures)
- [ ] Manual: `conversation_browser(view)` on a worktree session returns content

## Issue
Closes #1493

🤖 Generated with [Claude Code](https://claude.com/claude-code)