### PR TITLE
fix(sk-agent): re-enable OWUI models (path routing validated, drop dead GLM)

### DIFF
--- a/servers/sk-agent/sk_agent_config.template.json
+++ b/servers/sk-agent/sk_agent_config.template.json
@@ -80,7 +80,7 @@
     },
 
     {
-      "_comment": "=== OWUI proxied models (vLLM downstream through Open WebUI) ===",
+      "_comment": "=== OWUI proxied models (validated 2026-04-19 with OpenAI SDK >=1.109 + base_url ending /openai — SDK does NOT append /v1). GLM-4.7-Flash wrappers dead (no more local GLM since pre-March 2026) ===",
       "id": "owui-glm-4.7-flash-fast",
       "enabled": false,
       "base_url": "https://open-webui.myia.io/openai",
@@ -88,7 +88,7 @@
       "model_id": "Local.glm-4.7-flash-fast",
       "vision": false,
       "thinking": false,
-      "description": "GLM-4.7-Flash AWQ via OWUI (no thinking). Fast local responses through OWUI proxy",
+      "description": "GLM-4.7-Flash AWQ via OWUI (no thinking). DISABLED: model deleted upstream (no more local GLM hosting)",
       "context_window": 131072
     },
     {
@@ -99,64 +99,64 @@
       "model_id": "Local.glm-4.7-flash",
       "vision": false,
       "thinking": true,
-      "description": "GLM-4.7-Flash AWQ via OWUI (with thinking mode). Reasoning-capable local model through OWUI proxy",
+      "description": "GLM-4.7-Flash AWQ via OWUI (thinking ON). DISABLED: model deleted upstream. No equivalent thinking local/cloud — use Qwen_think wrappers or direct qwen3.6-35b-a3b",
       "context_window": 131072
     },
     {
       "id": "owui-omnicoder-9b",
-      "enabled": false,
+      "enabled": true,
       "base_url": "https://open-webui.myia.io/openai",
       "api_key": "YOUR_OWUI_API_KEY_HERE",
       "model_id": "Local.omnicoder-9b",
       "vision": true,
       "thinking": true,
-      "description": "OmniCoder-9B via OWUI proxy — vision+thinking, tool calling through OWUI",
+      "description": "OmniCoder-9B via OWUI proxy (bénéficie des filters/pipelines OWUI, notamment detoxify). Fallback direct vLLM via id omnicoder-9b.",
       "context_window": 131072
     },
     {
-      "id": "owui-qwen3.5-35b",
-      "enabled": false,
+      "id": "owui-qwen3.6-35b",
+      "enabled": true,
       "base_url": "https://open-webui.myia.io/openai",
       "api_key": "YOUR_OWUI_API_KEY_HERE",
-      "model_id": "Local.qwen3.5-35b-a3b",
+      "model_id": "Local.qwen3.6-35b-a3b",
       "vision": true,
       "thinking": true,
-      "description": "Qwen3.5 35B MoE via OWUI proxy — vision+thinking, highest quality local model",
+      "description": "Qwen3.6 35B MoE via OWUI proxy (bénéficie des filters/pipelines OWUI). Renommé depuis qwen3.5 (OWUI commit 4b8d8d521). Fallback direct vLLM via id qwen3.6-35b-a3b.",
       "context_window": 262144
     },
 
     {
-      "_comment": "=== OWUI custom models (Direction 2: enriched system prompts) ===",
+      "_comment": "=== OWUI custom models (validated present 2026-04-19 via GET /api/models). Thin wrappers over qwen3.6-35b-a3b / omnicoder-9b with system prompts spécialisés ===",
       "id": "owui-expert-analyste",
-      "enabled": false,
+      "enabled": true,
       "base_url": "https://open-webui.myia.io/openai",
       "api_key": "YOUR_OWUI_API_KEY_HERE",
       "model_id": "expert-analyste",
       "vision": false,
       "thinking": false,
-      "description": "OWUI Expert Analyste — structured French analyst with decomposition methodology",
+      "description": "OWUI Expert Analyste (wrapper qwen3.6-35b-a3b).",
       "context_window": 131072
     },
     {
       "id": "owui-redacteur-technique",
-      "enabled": false,
+      "enabled": true,
       "base_url": "https://open-webui.myia.io/openai",
       "api_key": "YOUR_OWUI_API_KEY_HERE",
       "model_id": "redacteur-technique",
       "vision": false,
       "thinking": false,
-      "description": "OWUI Rédacteur Technique — technical documentation writer",
+      "description": "OWUI Rédacteur Technique (wrapper qwen3.6-35b-a3b).",
       "context_window": 131072
     },
     {
       "id": "owui-vision-expert",
-      "enabled": false,
+      "enabled": true,
       "base_url": "https://open-webui.myia.io/openai",
       "api_key": "YOUR_OWUI_API_KEY_HERE",
       "model_id": "vision-expert",
       "vision": true,
       "thinking": false,
-      "description": "OWUI Expert Vision — image and document analysis specialist",
+      "description": "OWUI Expert Vision (wrapper omnicoder-9b).",
       "context_window": 131072
     }
   ],


### PR DESCRIPTION
## Context

Audit of `sk_agent_config.json` on myia-ai-01 during STOP & REPAIR sk-agent (2026-04-19) revealed 7 OWUI models stuck in `enabled: false` since ~2026-04-15 due to presumed path routing bug and "4 custom models deleted upstream" — both assumptions turned out to be outdated/incorrect.

## Findings (validated via curl + GET /api/models, OWUI admin)

**Path routing (Bug #1 — not a bug)**:
- OWUI route `/openai/chat/completions` returns 200
- OWUI route `/openai/v1/chat/completions` returns 404
- OpenAI Python SDK `>=1.109` with `base_url="https://open-webui.myia.io/openai"` does NOT append `/v1/` → final URL = `/openai/chat/completions` → works ✅
- Earlier assumption was based on older SDK behavior

**Custom models (Bug #2 — only 1 of 4 actually dead)**:
- `expert-analyste` — PRESENT
- `redacteur-technique` — PRESENT
- `vision-expert` — PRESENT
- `glm-4.7-flash-fast` (custom workflow) — DELETED (dead upstream)

**Local GLM wrappers — confirmed dead**:
- `Local.glm-4.7-flash*` no longer exist — no more local GLM hosting since pre-March 2026
- No equivalent thinking mode local/cloud — alternatives are Qwen_think wrappers or direct `qwen3.6-35b-a3b`

**Qwen wrapper renamed upstream**:
- OWUI commit `4b8d8d521` renamed `Local.qwen3.5-35b-a3b` -> `Local.qwen3.6-35b-a3b`

## Round-trip validation (5/5 PASS)

Tested via sk-agent venv (openai 1.109+):

| sk-agent ID | model_id OWUI | Status |
|-------------|---------------|--------|
| `owui-omnicoder-9b` | `Local.omnicoder-9b` | 200 |
| `owui-qwen3.6-35b` | `Local.qwen3.6-35b-a3b` | 200 |
| `owui-expert-analyste` | `expert-analyste` | 200 |
| `owui-redacteur-technique` | `redacteur-technique` | 200 |
| `owui-vision-expert` | `vision-expert` | 200 |

## Changes (template only, no secrets)

- ENABLED: `owui-omnicoder-9b`, `owui-qwen3.6-35b` (renamed), `owui-expert-analyste`, `owui-redacteur-technique`, `owui-vision-expert`
- KEPT DISABLED: `owui-glm-4.7-flash-fast`, `owui-glm-4.7-flash-thinking` (confirmed dead)
- Updated `_comment` blocks with validation notes

## Coordination

Cross-workspace signalling via RooSync thread msg-20260419T162845-ibzghr (roo-extensions <-> myia-open-webui). Related: Issue #11 OWUI audit (jsboige/open-webui).

## Propagation plan

1. Merge this submod PR
2. Bump parent pointer in roo-extensions
3. RooSync broadcast [UPDATE] to all 6 machines for `git pull --recurse-submodules` + local `sk_agent_config.json` adjustment

Generated with Claude Code