### PR TITLE
test(baseline): update test for list_versions action enum

### DIFF
--- a/servers/roo-state-manager/tests/unit/tools/roosync/baseline.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/baseline.test.ts
@@ -277,11 +277,11 @@ describe('roosync_baseline - Metadata', () => {
     expect(metadata.inputSchema.type).toBe('object');
     expect(metadata.inputSchema.properties).toBeDefined();
     expect(metadata.inputSchema.properties.action).toBeDefined();
-    expect(metadata.inputSchema.properties.action.enum).toEqual(['update', 'version', 'restore', 'export']);
+    expect(metadata.inputSchema.properties.action.enum).toEqual(['update', 'version', 'restore', 'export', 'list_versions']);
     expect(metadata.inputSchema.required).toEqual(['action']);
   });
 
-  it('devrait documenter tous les paramètres des 4 actions', () => {
+  it('devrait documenter tous les paramètres des 5 actions', () => {
     const metadata = module.baselineToolMetadata;
     const props = metadata.inputSchema.properties;
 


### PR DESCRIPTION
## Summary
- Update baseline tool test to reflect the new `list_versions` action
- Enum assertion now expects 5 actions instead of 4

## Test plan
- [x] `npx vitest run tests/unit/tools/roosync/baseline.test.ts` — 25/25 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)