### PR TITLE
fix: update baseline test for list_versions action

### DIFF
--- a/servers/roo-state-manager/tests/unit/tools/roosync/baseline.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/baseline.test.ts
@@ -277,7 +277,7 @@ describe('roosync_baseline - Metadata', () => {
     expect(metadata.inputSchema.type).toBe('object');
     expect(metadata.inputSchema.properties).toBeDefined();
     expect(metadata.inputSchema.properties.action).toBeDefined();
-    expect(metadata.inputSchema.properties.action.enum).toEqual(['update', 'version', 'restore', 'export']);
+    expect(metadata.inputSchema.properties.action.enum).toEqual(['update', 'version', 'restore', 'export', 'list_versions']);
     expect(metadata.inputSchema.required).toEqual(['action']);
   });
 


### PR DESCRIPTION
## Summary
- Update `baseline.test.ts` action enum assertion to include `list_versions`
- The `roosync_baseline` tool added `list_versions` action but the test wasn't updated

## Test plan
- [x] `npx vitest run tests/unit/tools/roosync/baseline.test.ts` — 25/25 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)