### PR TITLE
fix(#1409): data quality regressions — heartbeat, dashboard, cleanup

### DIFF
--- a/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
+++ b/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
@@ -156,7 +156,7 @@ export class HeartbeatService {
     // Configuration par défaut (#607 fix: réduit fréquence d'écriture GDrive)
     this.config = {
       heartbeatInterval: 60000,  // 1 minute (réduit de 30s)
-      offlineTimeout: 600000,    // 10 minutes (réduit faux positifs avec dirty-flag)
+      offlineTimeout: 1200000,   // 20 minutes (4x persistence interval, tolerates GDrive sync delay) (#1409)
       missedHeartbeatThreshold: 4,
       autoSyncEnabled: true,
       autoSyncInterval: 60000,   // 1 minute
@@ -757,19 +757,30 @@ export class HeartbeatService {
    */
   public async cleanupOldOfflineMachines(maxAge: number = 86400000): Promise<number> {
     // maxAge par défaut: 24 heures
-    // #1409: Don't delete heartbeat files — just keep machines as offline.
-    // Deleting files causes machineCount to drop below the actual cluster size.
+    // #1409: Don't delete heartbeat files for production machines (myia-*) — just keep as offline.
+    // Deleting production files causes machineCount to drop below the actual cluster size.
+    // Non-production machines (test artifacts, machine-2, workflow-machine) are deleted after maxAge.
     const now = Date.now();
     let cleanedCount = 0;
+    const isProduction = (id: string) => id.toLowerCase().startsWith('myia-');
 
     for (const [machineId, heartbeatData] of this.state.heartbeats.entries()) {
       if (heartbeatData.offlineSince) {
         const offlineAge = now - new Date(heartbeatData.offlineSince).getTime();
 
         if (offlineAge > maxAge) {
-          // Keep in state as offline, don't remove file or delete from map
-          heartbeatData.status = 'offline';
-          cleanedCount++;
+          if (isProduction(machineId)) {
+            // Production machines: keep in state as offline, don't remove file
+            heartbeatData.status = 'offline';
+            cleanedCount++;
+          } else {
+            // Non-production (test artifacts): delete file and remove from state
+            await this.removeMachineFile(machineId);
+            this.state.heartbeats.delete(machineId);
+            cleanedCount++;
+            logger.info(`Test machine supprimée (offline ${Math.round(offlineAge / 3600000)}h): ${machineId}`);
+            continue;
+          }
 
           logger.info(`Machine offline longue durée (conservée): ${machineId}`, {
             offlineAge,

--- a/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
@@ -645,17 +645,17 @@ describe('HeartbeatService', () => {
     test('garde les machines offline anciennes en statut offline (#1409)', async () => {
       const service = new HeartbeatService(TEST_PATH, { offlineTimeout: 10 });
 
-      await service.registerHeartbeat('old-offline');
-      const hb = service.getHeartbeatData('old-offline')!;
+      await service.registerHeartbeat('myia-old-offline');
+      const hb = service.getHeartbeatData('myia-old-offline')!;
       hb.status = 'offline';
       hb.offlineSince = new Date(Date.now() - 100_000).toISOString(); // offline depuis 100s
 
       const removed = await service.cleanupOldOfflineMachines(50_000); // maxAge = 50s
 
       expect(removed).toBe(1);
-      // #1409: Machine kept in state as offline, not deleted
-      expect(service.getHeartbeatData('old-offline')).toBeDefined();
-      expect(service.getHeartbeatData('old-offline')!.status).toBe('offline');
+      // #1409: Production machines (myia-*) kept in state as offline, not deleted
+      expect(service.getHeartbeatData('myia-old-offline')).toBeDefined();
+      expect(service.getHeartbeatData('myia-old-offline')!.status).toBe('offline');
     });
 
     test('garde les machines offline récentes', async () => {
@@ -682,22 +682,37 @@ describe('HeartbeatService', () => {
       expect(removed).toBe(0);
     });
 
-    test('ne supprime plus les fichiers heartbeat des machines nettoyées (#1409)', async () => {
+    test('supprime les machines non-production (test artifacts) offline anciennes (#1409)', async () => {
       const service = new HeartbeatService(TEST_PATH, { offlineTimeout: 10 });
 
-      await service.registerHeartbeat('cleanup-target');
-      const hb = service.getHeartbeatData('cleanup-target')!;
+      await service.registerHeartbeat('test-artifact-machine');
+      const hb = service.getHeartbeatData('test-artifact-machine')!;
       hb.status = 'offline';
       hb.offlineSince = new Date(Date.now() - 100_000).toISOString();
 
-      // The file exists on disk
       mockExistsSync.mockReturnValue(true);
 
       await service.cleanupOldOfflineMachines(50_000);
 
-      // #1409: Files are NOT deleted anymore — machines are kept as offline
+      // #1409: Non-production machines (not myia-*) ARE deleted
+      expect(service.getHeartbeatData('test-artifact-machine')).toBeUndefined();
+    });
+
+    test('garde les machines production offline sans supprimer le fichier (#1409)', async () => {
+      const service = new HeartbeatService(TEST_PATH, { offlineTimeout: 10 });
+
+      await service.registerHeartbeat('myia-cleanup-target');
+      const hb = service.getHeartbeatData('myia-cleanup-target')!;
+      hb.status = 'offline';
+      hb.offlineSince = new Date(Date.now() - 100_000).toISOString();
+
+      mockExistsSync.mockReturnValue(true);
+
+      await service.cleanupOldOfflineMachines(50_000);
+
+      // #1409: Production machines (myia-*) kept as offline, files NOT deleted
       expect(mockUnlink).not.toHaveBeenCalled();
-      expect(service.getHeartbeatData('cleanup-target')).toBeDefined();
+      expect(service.getHeartbeatData('myia-cleanup-target')).toBeDefined();
     });
   });
 

--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -11,6 +11,9 @@
 import { z } from 'zod';
 import { getRooSyncService, RooSyncServiceError } from '../../services/lazy-roosync.js';
 import { getMessageManager } from '../../services/MessageManager.js';
+import { getSharedStatePath } from '../../utils/shared-state-path.js';
+import { join } from 'path';
+import { readdirSync, statSync } from 'fs';
 
 /**
  * Check if a machine ID is a real production machine (not a test artifact).
@@ -182,11 +185,24 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
           }))
         : []);
 
-    // Dashboard activity (<24h)
+    // Dashboard activity (<24h) — count actual intercom dashboard files (#1409 fix)
     const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
-    const activeDashboards = dashboard?.lastUpdate
-      ? (new Date(dashboard.lastUpdate).getTime() > oneDayAgo ? 1 : 0)
-      : 0;
+    let activeDashboards = 0;
+    try {
+      const dashboardsDir = join(getSharedStatePath(), 'dashboards');
+      const files = readdirSync(dashboardsDir);
+      for (const file of files) {
+        if (file.endsWith('.md') && !file.endsWith('.tmp')) {
+          const filePath = join(dashboardsDir, file);
+          const stat = statSync(filePath);
+          if (stat.mtimeMs > oneDayAgo) {
+            activeDashboards++;
+          }
+        }
+      }
+    } catch {
+      // dashboards dir may not exist yet
+    }
 
     // #1365: Filter out orphan test entries (test-machine, persistent-machine, etc.)
     // Only keep machines matching the known pattern: myia-*

--- a/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
@@ -379,40 +379,40 @@ describe('HeartbeatService - Tests Unitaires', () => {
 
     it('devrait nettoyer les machines offline depuis longtemps', async () => {
       // Arrange - Créer des machines offline avec différents âges
-      await heartbeatService.registerHeartbeat('machine-old-1');
-      await heartbeatService.registerHeartbeat('machine-old-2');
-      await heartbeatService.registerHeartbeat('machine-recent');
-      
+      await heartbeatService.registerHeartbeat('myia-old-1');
+      await heartbeatService.registerHeartbeat('myia-old-2');
+      await heartbeatService.registerHeartbeat('myia-recent');
+
       const heartbeatPath = join(sharedPath, 'heartbeat.json');
       const state = heartbeatService.getState();
-      
+
       // Modifier les timestamps
       const now = Date.now();
-      
-      const old1Data = state.heartbeats.get('machine-old-1');
+
+      const old1Data = state.heartbeats.get('myia-old-1');
       if (old1Data) {
         old1Data.lastHeartbeat = new Date(now - 90000000).toISOString(); // Plus de 24h
         old1Data.status = 'offline';
         old1Data.offlineSince = new Date(now - 90000000).toISOString();
-        state.heartbeats.set('machine-old-1', old1Data);
+        state.heartbeats.set('myia-old-1', old1Data);
       }
-      
-      const old2Data = state.heartbeats.get('machine-old-2');
+
+      const old2Data = state.heartbeats.get('myia-old-2');
       if (old2Data) {
         old2Data.lastHeartbeat = new Date(now - 90000000).toISOString(); // Plus de 24h
         old2Data.status = 'offline';
         old2Data.offlineSince = new Date(now - 90000000).toISOString();
-        state.heartbeats.set('machine-old-2', old2Data);
+        state.heartbeats.set('myia-old-2', old2Data);
       }
-      
-      const recentData = state.heartbeats.get('machine-recent');
+
+      const recentData = state.heartbeats.get('myia-recent');
       if (recentData) {
         recentData.lastHeartbeat = new Date(now - 3600000).toISOString(); // 1 heure
         recentData.status = 'offline';
         recentData.offlineSince = new Date(now - 3600000).toISOString();
-        state.heartbeats.set('machine-recent', recentData);
+        state.heartbeats.set('myia-recent', recentData);
       }
-      
+
       await fs.writeFile(heartbeatPath, JSON.stringify({
         heartbeats: Object.fromEntries(state.heartbeats),
         onlineMachines: state.onlineMachines,
@@ -420,7 +420,7 @@ describe('HeartbeatService - Tests Unitaires', () => {
         warningMachines: state.warningMachines,
         statistics: state.statistics
       }, null, 2));
-      
+
       // Recréer le service
       await heartbeatService.stopHeartbeatService();
       heartbeatService = new HeartbeatService(sharedPath, {
@@ -430,18 +430,18 @@ describe('HeartbeatService - Tests Unitaires', () => {
         autoSyncEnabled: false,
         autoSyncInterval: 60000
       });
-      
+
       // Act - Nettoyer les machines offline depuis plus de 24h
       const removedCount = await heartbeatService.cleanupOldOfflineMachines(86400000); // 24h
-      
+
       // Assert
       expect(removedCount).toBe(2);
-      // #1409: Machines kept in state as offline, not deleted
-      expect(heartbeatService.getHeartbeatData('machine-old-1')).toBeDefined();
-      expect(heartbeatService.getHeartbeatData('machine-old-1')!.status).toBe('offline');
-      expect(heartbeatService.getHeartbeatData('machine-old-2')).toBeDefined();
-      expect(heartbeatService.getHeartbeatData('machine-old-2')!.status).toBe('offline');
-      expect(heartbeatService.getHeartbeatData('machine-recent')).toBeDefined(); // Pas supprimée
+      // #1409: Production machines (myia-*) kept in state as offline, not deleted
+      expect(heartbeatService.getHeartbeatData('myia-old-1')).toBeDefined();
+      expect(heartbeatService.getHeartbeatData('myia-old-1')!.status).toBe('offline');
+      expect(heartbeatService.getHeartbeatData('myia-old-2')).toBeDefined();
+      expect(heartbeatService.getHeartbeatData('myia-old-2')!.status).toBe('offline');
+      expect(heartbeatService.getHeartbeatData('myia-recent')).toBeDefined(); // Pas supprimée
     });
   });
 


### PR DESCRIPTION
## Summary
- Increase heartbeat offlineTimeout from 10min to 20min (4x persistence interval) to tolerate GDrive sync latency — fixes false offline detection
- Fix active dashboard counting to scan filesystem instead of stale sync-dashboard.json timestamp
- Fix cleanupOldOfflineMachines to DELETE non-production machines (non-myia-* prefix) while preserving production machines as offline
- Update test machine names to myia-* prefix and split cleanup test into production vs non-production cases

## Root Causes Addressed
1. **online:0 false positive**: GDrive persistence interval (5min) + propagation delay exceeded 10min offlineTimeout → machines appear offline when alive
2. **dashboards.active:0**: Code counted sync-dashboard.json freshness (always stale) instead of actual dashboard files
3. **Stale test machine entries**: Non-production machines (test-machine, persistent-machine) were kept offline indefinitely instead of deleted

## Test plan
- [x] `npm run build` passes
- [x] `npx vitest run --config vitest.config.ci.ts` — 7660 tests pass, 0 failures
- [x] HeartbeatService cleanup tests updated for production vs non-production split
- [ ] Live verification via `roosync_get_status()` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)