### PR TITLE
fix(#1401): classify 'not found' as permanent indexing error

### DIFF
--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -857,6 +857,7 @@ export function classifyIndexingError(error: any): boolean {
 
     const permanentErrors = [
         'file not found',
+        'not found',              // #1401: "Claude Code session XXX not found" (archived/deleted)
         'access denied',
         'permission denied',
         'invalid format',


### PR DESCRIPTION
## Summary
- Add `'not found'` to `classifyIndexingError()` permanent errors list
- Stops infinite retry loop for archived Claude Code sessions (3 sessions retrying every 30s on po-2023)

## Problem
After archiving Claude Code sessions (via `roosync_indexing(action: "archive")`), the background indexer kept retrying them with error:
```
Claude Code session claude-d--Dev-CoursIA--004d7740... not found
```

This error didn't match the existing `'file not found'` permanent pattern, so it was classified as temporary → exponential backoff → eventual permanent failure only after MAX_RETRY_ATTEMPTS.

## Fix
Add generic `'not found'` to permanent errors list. If something is "not found", retrying won't help.

## Test plan
- [x] `npm run build` passes
- [x] `npx vitest run --config vitest.config.ci.ts`: 7659 passed, 0 failures
- [ ] Verify indexing retries stop after deploy (check VS Code logs for absence of RETRY_FAIL messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)