### PR TITLE
fix(roo-state-manager): redirect BaselineService logs to stderr

### DIFF
--- a/servers/roo-state-manager/mcp-wrapper.cjs
+++ b/servers/roo-state-manager/mcp-wrapper.cjs
@@ -186,9 +186,23 @@ server.stdout.on('data', (data) => {
         if (!trimmed) return;
 
         if (trimmed.startsWith('{')) {
-            // Message MCP JSON-RPC - cacher tools/list pour éviter doublons
-            const processed = cacheToolsList(trimmed);
-            process.stdout.write(processed + '\n');
+            // Only forward genuine JSON-RPC messages. Some services (e.g. BaselineService)
+            // historically wrote JSON.stringify(logEntry) to stdout — those look like JSON
+            // but aren't JSON-RPC, and they break clients like mcp-proxy/pydantic.
+            let parsed;
+            try {
+                parsed = JSON.parse(trimmed);
+            } catch {
+                process.stderr.write('[MCP-WRAPPER] dropped non-JSON line: ' + trimmed.slice(0, 120) + '\n');
+                return;
+            }
+            if (parsed && parsed.jsonrpc === '2.0') {
+                const processed = cacheToolsList(trimmed);
+                process.stdout.write(processed + '\n');
+            } else {
+                // Valid JSON but not JSON-RPC — route to stderr so it's still visible in logs.
+                process.stderr.write('[MCP-WRAPPER] dropped non-JSONRPC JSON: ' + trimmed.slice(0, 120) + '\n');
+            }
         } else if (trimmed.includes('Roo State Manager Server started')) {
             // FIX: Redirect to stderr, NOT stdout - MCP stdio protocol requires
             // only JSON-RPC messages on stdout. Non-JSON text breaks the handshake.

--- a/servers/roo-state-manager/src/services/BaselineService.ts
+++ b/servers/roo-state-manager/src/services/BaselineService.ts
@@ -815,7 +815,9 @@ ${decision.notes ? `### Notes\n${decision.notes}` : ''}
     };
 
     if (this.config.logLevel === 'DEBUG' || this.config.logLevel === 'INFO') {
-      console.log(JSON.stringify(logEntry));
+      // stderr, not stdout: MCP stdio protocol reserves stdout for JSON-RPC only.
+      // Mixing log JSON with protocol JSON breaks clients (pydantic parse errors in mcp-proxy).
+      console.error(JSON.stringify(logEntry));
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes broken MCP stdio protocol where `BaselineService.logInfo` wrote JSON log lines to stdout, crashing downstream consumers (sparfenyuk mcp-proxy → HTTP 404; pydantic parse errors).

- `src/services/BaselineService.ts:818` — `console.log(JSON.stringify(logEntry))` → `console.error(...)`
- `mcp-wrapper.cjs` — hardened: only forwards lines where `parsed.jsonrpc === "2.0"`; non-JSONRPC JSON goes to stderr (still visible in logs, but no longer breaks the protocol).

## Why

MCP stdio reserves stdout for JSON-RPC only. Mixing log JSON with protocol JSON breaks pydantic-based clients:

```
pydantic_core._pydantic_core.ValidationError: 11 validation errors for JSONRPCMessage
JSONRPCRequest.method Field required [input_value={'timestamp': '2026-04-20...tate\sync-roadmap.md'}]
```

When parsing failed, sparfenyuk returned HTTP 200 content-length:0 → starlette middleware crashed → route served 404. This cut off NanoClaw cluster's access to roo-state-manager via `mcp-tools.myia.io`.

## Verification

After fix + rebuild + restart of scheduled task `MCP-Proxy-RSM` + TBXark restart:

- `curl http://localhost:9091/servers/roo-state-manager/mcp` → HTTP 200 JSONRPC (was: 404)
- `curl http://localhost:9090/roo-state-manager/mcp` (TBXark) → HTTP 200
- `curl https://mcp-tools.myia.io/roo-state-manager/mcp` (from NanoClaw container) → HTTP 200

## Related

Fixes jsboige/roo-extensions#1572

🤖 Generated with [Claude Code](https://claude.com/claude-code)