### PR TITLE
fix: redirect hierarchy-inference debug output from stdout to stderr

### DIFF
--- a/servers/roo-state-manager/src/utils/hierarchy-inference.ts
+++ b/servers/roo-state-manager/src/utils/hierarchy-inference.ts
@@ -11,7 +11,7 @@ export function extractTaskIdFromText(text: string): string | undefined {
     const uuids = text.match(uuidRegex);
     
     if (uuids && uuids.length > 0) {
-        console.log(`[extractTaskIdFromText] UUID trouvé: ${uuids[0]}`);
+        console.error(`[extractTaskIdFromText] UUID trouvé: ${uuids[0]}`);
         return uuids[0];
     }
 
@@ -25,7 +25,7 @@ export function extractTaskIdFromText(text: string): string | undefined {
     for (const pattern of contextPatterns) {
         const match = text.match(pattern);
         if (match && match[1]) {
-            console.log(`[extractTaskIdFromText] Parent trouvé via pattern: ${match[1]}`);
+            console.error(`[extractTaskIdFromText] Parent trouvé via pattern: ${match[1]}`);
             return match[1];
         }
     }
@@ -38,16 +38,16 @@ export function extractTaskIdFromText(text: string): string | undefined {
  */
 export async function extractParentFromApiHistory(apiHistoryPath: string): Promise<string | undefined> {
     try {
-        process.stdout.write(`[extractParentFromApiHistory] Lecture du fichier: ${apiHistoryPath}\n`);
+        process.stderr.write(`[extractParentFromApiHistory] Lecture du fichier: ${apiHistoryPath}\n`);
         const content = await fs.readFile(apiHistoryPath, 'utf-8');
         const data = JSON.parse(content);
         const messages = Array.isArray(data) ? data : (data?.messages || []);
-        process.stdout.write(`[extractParentFromApiHistory] Messages trouvés: ${messages.length}\n`);
+        process.stderr.write(`[extractParentFromApiHistory] Messages trouvés: ${messages.length}\n`);
         
         const firstUserMessage = messages.find((msg: any) => msg.role === 'user');
-        process.stdout.write(`[extractParentFromApiHistory] Premier message user: ${firstUserMessage ? 'trouvé' : 'non trouvé'}\n`);
+        process.stderr.write(`[extractParentFromApiHistory] Premier message user: ${firstUserMessage ? 'trouvé' : 'non trouvé'}\n`);
         if (!firstUserMessage?.content) {
-            process.stdout.write(`[extractParentFromApiHistory] Pas de content dans le premier message user\n`);
+            process.stderr.write(`[extractParentFromApiHistory] Pas de content dans le premier message user\n`);
             return undefined;
         }
 
@@ -55,13 +55,13 @@ export async function extractParentFromApiHistory(apiHistoryPath: string): Promi
             ? firstUserMessage.content.find((c: any) => c.type === 'text')?.text || ''
             : firstUserMessage.content;
         
-        process.stdout.write(`[extractParentFromApiHistory] Texte à analyser: ${messageText.substring(0, 100)}...\n`);
+        process.stderr.write(`[extractParentFromApiHistory] Texte à analyser: ${messageText.substring(0, 100)}...\n`);
 
         const result = extractTaskIdFromText(messageText);
-        process.stdout.write(`[extractParentFromApiHistory] Résultat: ${result}\n`);
+        process.stderr.write(`[extractParentFromApiHistory] Résultat: ${result}\n`);
         return result;
     } catch (error) {
-        process.stdout.write(`[extractParentFromApiHistory] Erreur: ${error}\n`);
+        process.stderr.write(`[extractParentFromApiHistory] Erreur: ${error}\n`);
         return undefined;
     }
 }
@@ -71,26 +71,26 @@ export async function extractParentFromApiHistory(apiHistoryPath: string): Promi
  */
 export async function extractParentFromUiMessages(uiMessagesPath: string): Promise<string | undefined> {
     try {
-        process.stdout.write(`[extractParentFromUiMessages] Lecture du fichier: ${uiMessagesPath}\n`);
+        process.stderr.write(`[extractParentFromUiMessages] Lecture du fichier: ${uiMessagesPath}\n`);
         const content = await fs.readFile(uiMessagesPath, 'utf-8');
         const data = JSON.parse(content);
         const messages = Array.isArray(data) ? data : (data?.messages || []);
-        process.stdout.write(`[extractParentFromUiMessages] Messages trouvés: ${messages.length}\n`);
+        process.stderr.write(`[extractParentFromUiMessages] Messages trouvés: ${messages.length}\n`);
         
         // Chercher le premier message utilisateur (type 'user' dans ui_messages)
         const firstUserMessage = messages.find((msg: any) => msg.type === 'user' || msg.role === 'user');
-        process.stdout.write(`[extractParentFromUiMessages] Premier message user: ${firstUserMessage ? 'trouvé' : 'non trouvé'}\n`);
+        process.stderr.write(`[extractParentFromUiMessages] Premier message user: ${firstUserMessage ? 'trouvé' : 'non trouvé'}\n`);
         if (!firstUserMessage?.content) {
-            process.stdout.write(`[extractParentFromUiMessages] Pas de content dans le premier message user\n`);
+            process.stderr.write(`[extractParentFromUiMessages] Pas de content dans le premier message user\n`);
             return undefined;
         }
 
-        process.stdout.write(`[extractParentFromUiMessages] Texte à analyser: ${firstUserMessage.content.substring(0, 100)}...\n`);
+        process.stderr.write(`[extractParentFromUiMessages] Texte à analyser: ${firstUserMessage.content.substring(0, 100)}...\n`);
         const result = extractTaskIdFromText(firstUserMessage.content);
-        process.stdout.write(`[extractParentFromUiMessages] Résultat: ${result}\n`);
+        process.stderr.write(`[extractParentFromUiMessages] Résultat: ${result}\n`);
         return result;
     } catch (error) {
-        process.stdout.write(`[extractParentFromUiMessages] Erreur: ${error}\n`);
+        process.stderr.write(`[extractParentFromUiMessages] Erreur: ${error}\n`);
         return undefined;
     }
 }


### PR DESCRIPTION
## Summary

Cleanup follow-up to #1572. The `hierarchy-inference.ts` utility uses 15 `process.stdout.write()` and 2 `console.log()` calls for debug output. While the wrapper already filters non-JSON lines, writing diagnostics to stdout is incorrect practice for an MCP server (stdout is reserved for JSON-RPC).

### Changes
- `process.stdout.write` → `process.stderr.write` (15 occurrences)
- `console.log` → `console.error` (2 occurrences)

### Test plan
- [x] Build passes (tsc clean)
- [x] 7663/7663 tests passing (CI config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)