### PR TITLE
fix(dashboard): condense diagnostic, archivedCount clamp, dedup 20min, max_tokens 30k

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
@@ -760,6 +760,187 @@ describe('roosync_dashboard', () => {
     });
   });
 
+  // === Diagnostic + archivedCount clamp (2026-04-20) ===
+  //
+  // Regression coverage for the CoursIA condense incident on 2026-04-20:
+  //   - archivedCount came back as -2 (two injected error msgs × 2 passes)
+  //   - result.condensed was false but no explanation was visible to callers
+  //   - dedup window (5min) was shorter than the LLM retry cycle (~6min) on
+  //     40KB prompts, so both passes injected an error msg
+  // These tests lock in: diagnostic exposed, archivedCount ≥ 0, dedup works.
+  describe('Condense diagnostic + error semantics (2026-04-20)', () => {
+    it('populates condenseDiagnostic with LLM stats on manual condense success', async () => {
+      mockGetChatClient.mockReturnValue({
+        chat: { completions: { create: mockChatCreate } }
+      });
+      mockChatCreate
+        .mockResolvedValueOnce({ choices: [{ message: { content: '## Status' } }] })
+        .mockResolvedValueOnce({ choices: [{ message: { content: '## Summary' } }] });
+
+      await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
+      for (let i = 0; i < 10; i++) {
+        await roosyncDashboard({ action: 'append', type: 'global', content: `Msg ${i}` });
+      }
+
+      const result = await roosyncDashboard({ action: 'condense', type: 'global', keepMessages: 3 });
+
+      expect(result.condensed).toBe(true);
+      expect(result.condenseDiagnostic).toBeDefined();
+      expect(result.condenseDiagnostic).toHaveLength(1);
+      const diag = result.condenseDiagnostic![0];
+      expect(diag.phase).toBe('manual');
+      expect(diag.outcome).toBe('condensed');
+      expect(diag.archivedMessageCount).toBe(7);
+      expect(diag.elapsedMs).toBeGreaterThan(0);
+      expect(diag.llm?.summary.finalOutcome).toBe('ok');
+      expect(diag.llm?.status.finalOutcome).toBe('ok');
+      expect(diag.llm?.summary.attempts).toBe(1);
+      expect(diag.llm?.status.attempts).toBe(1);
+    });
+
+    it('reports llm-failed-injected with nullCount when LLM returns empty content', async () => {
+      mockGetChatClient.mockReturnValue({
+        chat: { completions: { create: mockChatCreate } }
+      });
+      mockChatCreate.mockResolvedValue({
+        choices: [{ message: { content: null }, finish_reason: 'length' }]
+      });
+
+      await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
+      for (let i = 0; i < 10; i++) {
+        await roosyncDashboard({ action: 'append', type: 'global', content: `Msg ${i}` });
+      }
+
+      const result = await roosyncDashboard({ action: 'condense', type: 'global', keepMessages: 3 });
+
+      expect(result.condensed).toBe(false);
+      expect(result.archivedCount).toBe(0);
+      const diag = result.condenseDiagnostic![0];
+      expect(diag.outcome).toBe('llm-failed-injected');
+      expect(diag.llm?.summary.finalOutcome).toBe('null');
+      expect(diag.llm?.summary.nullCount).toBe(3); // 3 retries
+      expect(diag.llm?.summary.lastError).toContain('null content');
+      expect(diag.llm?.status.finalOutcome).toBe('null');
+      expect(diag.llm?.status.nullCount).toBe(3);
+      // Human-readable message must surface the failure mode
+      expect(result.message).toContain('summary=null');
+      expect(result.message).toContain('status=null');
+    });
+
+    it('reports error + lastError when LLM throws', async () => {
+      mockGetChatClient.mockReturnValue({
+        chat: { completions: { create: mockChatCreate } }
+      });
+      mockChatCreate.mockRejectedValue(new Error('ECONNREFUSED 127.0.0.1:5002'));
+
+      await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
+      for (let i = 0; i < 10; i++) {
+        await roosyncDashboard({ action: 'append', type: 'global', content: `Msg ${i}` });
+      }
+
+      const result = await roosyncDashboard({ action: 'condense', type: 'global', keepMessages: 3 });
+
+      expect(result.condensed).toBe(false);
+      const diag = result.condenseDiagnostic![0];
+      expect(diag.llm?.summary.finalOutcome).toBe('error');
+      expect(diag.llm?.summary.errorCount).toBe(3);
+      expect(diag.llm?.summary.lastError).toContain('ECONNREFUSED');
+      expect(result.message).toContain('summary=error');
+    });
+
+    it('reports client-init-failed when LLM client throws on init', async () => {
+      // mockGetChatClient throws (default beforeEach behavior sets this)
+      // Leave mockGetChatClient at its default "No chat API key configured" throw.
+      await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
+      for (let i = 0; i < 10; i++) {
+        await roosyncDashboard({ action: 'append', type: 'global', content: `Msg ${i}` });
+      }
+
+      const result = await roosyncDashboard({ action: 'condense', type: 'global', keepMessages: 3 });
+
+      expect(result.condensed).toBe(false);
+      const diag = result.condenseDiagnostic![0];
+      expect(diag.llm?.summary.finalOutcome).toBe('client-init-failed');
+      expect(diag.llm?.summary.attempts).toBe(0); // Never entered the retry loop
+      expect(diag.llm?.summary.lastError).toContain('No chat API key');
+    });
+
+    it('archivedCount clamped to 0 on failed append (regression: CoursIA -2)', async () => {
+      // When an append triggers preemptive+reactive condense that both fail
+      // with LLM null content, the old accounting computed
+      //   archivedCount = preempArchived + reactiveArchived
+      //                 = (before - (before + 1)) + (before+1 - (before+2))
+      //                 = -1 + -1 = -2
+      // The reported archivedCount must be >= 0. The truth lives in
+      // condenseDiagnostic[].outcome which must mark both passes as failed.
+      mockGetChatClient.mockReturnValue({
+        chat: { completions: { create: mockChatCreate } }
+      });
+      mockChatCreate.mockResolvedValue({
+        choices: [{ message: { content: null }, finish_reason: 'length' }]
+      });
+
+      await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
+      // Fill past 92% with enough 3KB messages to trigger preemptive
+      const filler = 'X'.repeat(3000);
+      for (let i = 0; i < 16; i++) {
+        await roosyncDashboard({ action: 'append', type: 'global', content: `${filler} m${i}` });
+      }
+
+      // Now append something else — triggers preemptive (at >= 92%) + possibly reactive
+      const result = await roosyncDashboard({
+        action: 'append',
+        type: 'global',
+        content: `${filler} trigger`
+      });
+
+      expect(result.success).toBe(true);
+      // CRITICAL: archivedCount must be >= 0 even when LLM injected error msgs
+      expect(result.archivedCount).toBeGreaterThanOrEqual(0);
+      expect(result.condensed).toBe(false);
+      // Diagnostic must show the failure mode
+      expect(result.condenseDiagnostic).toBeDefined();
+      expect(result.condenseDiagnostic!.length).toBeGreaterThanOrEqual(1);
+      const failedPasses = result.condenseDiagnostic!.filter(d =>
+        d.outcome === 'llm-failed-dedup' || d.outcome === 'llm-failed-injected'
+      );
+      expect(failedPasses.length).toBeGreaterThanOrEqual(1);
+      // Human-readable message must carry the failure detail
+      expect(result.message).toContain('LLM échoué');
+    });
+
+    it('dedup within 20min window does NOT re-inject a second error message', async () => {
+      // Regression for the 5min window that was too short. A second condense
+      // within 20min after a failure must return outcome=llm-failed-dedup and
+      // leave the dashboard untouched (same message count).
+      mockGetChatClient.mockReturnValue({
+        chat: { completions: { create: mockChatCreate } }
+      });
+      mockChatCreate.mockResolvedValue({
+        choices: [{ message: { content: null }, finish_reason: 'length' }]
+      });
+
+      await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
+      for (let i = 0; i < 10; i++) {
+        await roosyncDashboard({ action: 'append', type: 'global', content: `Msg ${i}` });
+      }
+
+      // First condense — injects [ERROR] CONDENSATION CANCELLED
+      const r1 = await roosyncDashboard({ action: 'condense', type: 'global', keepMessages: 3 });
+      expect(r1.condenseDiagnostic![0].outcome).toBe('llm-failed-injected');
+      const afterFirst = await roosyncDashboard({ action: 'read', type: 'global', section: 'intercom' });
+      const countAfterFirst = afterFirst.data?.intercom?.messages.length ?? 0;
+      expect(countAfterFirst).toBe(11); // 10 user + 1 error
+
+      // Immediate second condense — dedup must kick in (still within 20min)
+      const r2 = await roosyncDashboard({ action: 'condense', type: 'global', keepMessages: 3 });
+      expect(r2.condenseDiagnostic![0].outcome).toBe('llm-failed-dedup');
+      const afterSecond = await roosyncDashboard({ action: 'read', type: 'global', section: 'intercom' });
+      expect(afterSecond.data?.intercom?.messages.length).toBe(11); // unchanged
+      expect(r2.archivedCount).toBe(0);
+    });
+  });
+
   describe('Preemptive condensation (#1497)', () => {
     it('triggers condensation during fill-up when dashboard crosses 92% utilization', async () => {
       // Persistent mock — preemptive may fire multiple times during fill-up loop

--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -110,7 +110,14 @@ const LLM_INITIAL_BACKOFF_MS = 2000; // 2s, doubles each retry
 
 // Dedup window for [ERROR] CONDENSATION CANCELLED system messages (prevent loop
 // when LLM is down and every append re-triggers a failed condensation).
-const CONDENSATION_ERROR_DEDUP_MS = 5 * 60 * 1000; // 5 minutes
+// 2026-04-20: bumped 5min → 20min. A single append triggers up to 2 condense
+// passes (preemptive + reactive). Each pass can burn several minutes in LLM
+// retries when Qwen thinking mode eats max_tokens on a 40KB prompt. With a
+// 5min window, the 2nd pass fell outside and injected a 2nd error message →
+// archivedCount went to -2 (math correct, semantics broken). 20min covers both
+// passes even under worst-case LLM latency while still allowing legitimate
+// retries after a user-driven restart of the MCP / LLM endpoint.
+const CONDENSATION_ERROR_DEDUP_MS = 20 * 60 * 1000; // 20 minutes
 
 // === Per-key mutex ===
 //
@@ -481,12 +488,81 @@ function isMentioned(mentions: ParsedMention[], localMachineId: string, localWor
 }
 
 /**
+ * Per-condense-pass telemetry bubbled up to the tool result. Populated by
+ * `condenseIntercom` via an optional accumulator argument (non-breaking change
+ * to preserve the Dashboard return type consumed by legacy paths).
+ *
+ * Outcomes:
+ *   - `condensed`         : LLM succeeded, archive written, status updated
+ *   - `no-op`             : messages ≤ keepCount, nothing to do
+ *   - `llm-failed-dedup`  : LLM failed but a recent CONDENSATION CANCELLED
+ *                           already exists within CONDENSATION_ERROR_DEDUP_MS
+ *                           → dashboard returned unchanged, no extra error msg
+ *   - `llm-failed-injected`: LLM failed, no recent error → new CONDENSATION
+ *                            CANCELLED system message appended
+ */
+export interface CondenseAttemptInfo {
+  phase: 'preemptive' | 'reactive' | 'manual';
+  outcome: 'condensed' | 'no-op' | 'llm-failed-dedup' | 'llm-failed-injected';
+  elapsedMs: number;
+  archivedMessageCount: number;
+  llm?: {
+    summary: LLMCallStats;
+    status: LLMCallStats;
+  };
+}
+
+function newDiagnostic(phase: CondenseAttemptInfo['phase']): CondenseAttemptInfo {
+  return { phase, outcome: 'no-op', elapsedMs: 0, archivedMessageCount: 0 };
+}
+
+/**
+ * Per-phase LLM call telemetry. Populated by `generateLLMSummary` /
+ * `generateStatusUpdate` and bubbled up through `condenseIntercom` → the
+ * dashboard tool result so operators can distinguish "LLM down" from "LLM
+ * returned null content because thinking ate max_tokens" from "prompt too
+ * large" without tailing server logs.
+ */
+export interface LLMCallStats {
+  /** Number of attempts made (1..LLM_MAX_RETRIES). */
+  attempts: number;
+  /** Total wall-clock elapsed including backoffs (ms). */
+  elapsedMs: number;
+  /** How many attempts returned a null/empty content (thinking overran max_tokens, etc.). */
+  nullCount: number;
+  /** How many attempts threw (connection, 4xx/5xx, JSON parse). */
+  errorCount: number;
+  /** Subset of errorCount: attempts that aborted on timeout. */
+  timeoutCount: number;
+  /** Truncated last error message (first 240 chars). Only set when final outcome is error/timeout. */
+  lastError?: string;
+  /** Final outcome. */
+  finalOutcome: 'ok' | 'null' | 'error' | 'timeout' | 'client-init-failed';
+}
+
+/**
+ * Result wrapper for an LLM generation call.
+ */
+interface LLMCallResult {
+  content: string | null;
+  stats: LLMCallStats;
+}
+
+function emptyLLMStats(outcome: LLMCallStats['finalOutcome']): LLMCallStats {
+  return { attempts: 0, elapsedMs: 0, nullCount: 0, errorCount: 0, timeoutCount: 0, finalOutcome: outcome };
+}
+
+function truncateError(msg: string): string {
+  return msg.length > 240 ? `${msg.slice(0, 237)}...` : msg;
+}
+
+/**
  * Génère un résumé LLM des messages intercom (#858)
  *
  * @param messages - Messages à résumer
- * @returns Résumé markdown ou null si échec (fallback)
+ * @returns Résumé markdown + stats. content = null si échec (3 retries failed).
  */
-async function generateLLMSummary(messages: IntercomMessage[]): Promise<string | null> {
+async function generateLLMSummary(messages: IntercomMessage[]): Promise<LLMCallResult> {
   // #1497: bumped 600s → 1800s (30 min). Qwen3.6 thinking mode can take 60-90s
   // per call on 40KB prompts; with 3 retries + backoff 2s/4s/8s, total
   // wall-clock per call can exceed 5 min. Since the 2 LLM calls now run in
@@ -529,17 +605,25 @@ FORMAT :
 
   logger.info('Calling LLM for intercom summary', { messageCount: messages.length });
 
+  const callStart = Date.now();
+  const stats: LLMCallStats = emptyLLMStats('null');
+
   let openai: OpenAI;
   try {
     openai = getChatOpenAIClient();
   } catch (error) {
-    logger.error('LLM client init failed for summary', { error: error instanceof Error ? error.message : String(error) });
-    return null;
+    const errStr = error instanceof Error ? error.message : String(error);
+    logger.error('LLM client init failed for summary', { error: errStr });
+    return {
+      content: null,
+      stats: { ...emptyLLMStats('client-init-failed'), lastError: truncateError(errStr), elapsedMs: Date.now() - callStart }
+    };
   }
   const modelId = getLLMModelId();
 
   // Retry with exponential backoff (error/empty only — size handled post-hoc)
   for (let attempt = 1; attempt <= LLM_MAX_RETRIES; attempt++) {
+    stats.attempts = attempt;
     const startTime = Date.now();
     try {
       const response = await openai.chat.completions.create({
@@ -548,7 +632,11 @@ FORMAT :
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userPrompt }
         ],
-        max_tokens: 10000,
+        // 2026-04-20: bumped 10000 → 30000. Qwen3.6 thinking mode can easily
+        // spend 10k+ tokens on reasoning for a 40KB prompt, leaving the model
+        // no room for the actual markdown output — `content` comes back null
+        // with finish_reason=length. Room for ~20k thinking + 10k summary.
+        max_tokens: 30000,
         temperature: 0.3
       }, {
         timeout: timeoutMs
@@ -556,27 +644,37 @@ FORMAT :
 
       const summary = response.choices[0]?.message?.content;
       if (!summary) {
-        logger.warn('LLM returned empty summary', { attempt });
+        stats.nullCount += 1;
+        logger.warn('LLM returned empty summary', { attempt, finishReason: response.choices[0]?.finish_reason });
         if (attempt < LLM_MAX_RETRIES) {
           const backoff = LLM_INITIAL_BACKOFF_MS * Math.pow(2, attempt - 1);
           logger.info(`Retrying summary in ${backoff}ms...`, { attempt, backoff });
           await new Promise(resolve => setTimeout(resolve, backoff));
           continue;
         }
-        return null;
+        stats.finalOutcome = 'null';
+        stats.elapsedMs = Date.now() - callStart;
+        stats.lastError = `LLM returned null content ${stats.nullCount}× (finish_reason likely "length" — thinking consumed max_tokens=30000)`;
+        return { content: null, stats };
       }
 
       const sizeBytes = Buffer.byteLength(summary, 'utf8');
       const elapsed = Date.now() - startTime;
       logger.info('LLM summary generated', { attempt, elapsed: `${elapsed}ms`, summaryLength: summary.length, sizeKB: `${(sizeBytes / 1024).toFixed(1)}KB` });
-      return summary;
+      stats.finalOutcome = 'ok';
+      stats.elapsedMs = Date.now() - callStart;
+      return { content: summary, stats };
 
     } catch (error: unknown) {
       const elapsed = Date.now() - startTime;
-      if (error instanceof Error && error.name === 'AbortError') {
+      const errStr = error instanceof Error ? error.message : String(error);
+      stats.errorCount += 1;
+      const isTimeout = error instanceof Error && error.name === 'AbortError';
+      if (isTimeout) {
+        stats.timeoutCount += 1;
         logger.warn('LLM summary timeout', { attempt, timeout: timeoutMs, elapsed: `${elapsed}ms` });
       } else {
-        logger.error('LLM summary error', { attempt, elapsed: `${elapsed}ms`, error: error instanceof Error ? error.message : String(error) });
+        logger.error('LLM summary error', { attempt, elapsed: `${elapsed}ms`, error: errStr });
       }
       if (attempt < LLM_MAX_RETRIES) {
         const backoff = LLM_INITIAL_BACKOFF_MS * Math.pow(2, attempt - 1);
@@ -584,11 +682,16 @@ FORMAT :
         await new Promise(resolve => setTimeout(resolve, backoff));
         continue;
       }
-      return null;
+      stats.finalOutcome = isTimeout ? 'timeout' : 'error';
+      stats.elapsedMs = Date.now() - callStart;
+      stats.lastError = truncateError(errStr);
+      return { content: null, stats };
     }
   }
 
-  return null;
+  stats.finalOutcome = 'null';
+  stats.elapsedMs = Date.now() - callStart;
+  return { content: null, stats };
 }
 
 /**
@@ -603,7 +706,7 @@ async function generateStatusUpdate(
   previousStatus: string,
   allMessages: IntercomMessage[],
   archivedCount: number
-): Promise<string | null> {
+): Promise<LLMCallResult> {
   // #1497: bumped 600s → 1800s (30 min) — see generateLLMSummary for rationale.
   const timeoutMs = 1800000;
 
@@ -684,17 +787,25 @@ Mets à jour le statut en intégrant les informations des messages [SERA ARCHIV�
     archivedCount
   });
 
+  const callStart = Date.now();
+  const stats: LLMCallStats = emptyLLMStats('null');
+
   let openai: OpenAI;
   try {
     openai = getChatOpenAIClient();
   } catch (error) {
-    logger.error('LLM client init failed for status update', { error: error instanceof Error ? error.message : String(error) });
-    return null;
+    const errStr = error instanceof Error ? error.message : String(error);
+    logger.error('LLM client init failed for status update', { error: errStr });
+    return {
+      content: null,
+      stats: { ...emptyLLMStats('client-init-failed'), lastError: truncateError(errStr), elapsedMs: Date.now() - callStart }
+    };
   }
   const modelId = getLLMModelId();
 
   // Retry with exponential backoff
   for (let attempt = 1; attempt <= LLM_MAX_RETRIES; attempt++) {
+    stats.attempts = attempt;
     const startTime = Date.now();
     try {
       const response = await openai.chat.completions.create({
@@ -703,7 +814,8 @@ Mets à jour le statut en intégrant les informations des messages [SERA ARCHIV�
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userPrompt }
         ],
-        max_tokens: 10000,
+        // 2026-04-20: bumped 10000 → 30000 (see generateLLMSummary for rationale).
+        max_tokens: 30000,
         temperature: 0.3
       }, {
         timeout: timeoutMs
@@ -711,27 +823,37 @@ Mets à jour le statut en intégrant les informations des messages [SERA ARCHIV�
 
       const newStatus = response.choices[0]?.message?.content;
       if (!newStatus) {
-        logger.warn('LLM returned empty status update', { attempt });
+        stats.nullCount += 1;
+        logger.warn('LLM returned empty status update', { attempt, finishReason: response.choices[0]?.finish_reason });
         if (attempt < LLM_MAX_RETRIES) {
           const backoff = LLM_INITIAL_BACKOFF_MS * Math.pow(2, attempt - 1);
           logger.info(`Retrying status update in ${backoff}ms...`, { attempt, backoff });
           await new Promise(resolve => setTimeout(resolve, backoff));
           continue;
         }
-        return null;
+        stats.finalOutcome = 'null';
+        stats.elapsedMs = Date.now() - callStart;
+        stats.lastError = `LLM returned null content ${stats.nullCount}× (finish_reason likely "length" — thinking consumed max_tokens=30000)`;
+        return { content: null, stats };
       }
 
       const sizeBytes = Buffer.byteLength(newStatus, 'utf8');
       const elapsed = Date.now() - startTime;
       logger.info('LLM status update generated', { attempt, elapsed: `${elapsed}ms`, newStatusLength: newStatus.length, sizeKB: `${(sizeBytes / 1024).toFixed(1)}KB` });
-      return newStatus;
+      stats.finalOutcome = 'ok';
+      stats.elapsedMs = Date.now() - callStart;
+      return { content: newStatus, stats };
 
     } catch (error: unknown) {
       const elapsed = Date.now() - startTime;
-      if (error instanceof Error && error.name === 'AbortError') {
+      const errStr = error instanceof Error ? error.message : String(error);
+      stats.errorCount += 1;
+      const isTimeout = error instanceof Error && error.name === 'AbortError';
+      if (isTimeout) {
+        stats.timeoutCount += 1;
         logger.warn('LLM status update timeout', { attempt, timeout: timeoutMs, elapsed: `${elapsed}ms` });
       } else {
-        logger.error('LLM status update error', { attempt, elapsed: `${elapsed}ms`, error: error instanceof Error ? error.message : String(error) });
+        logger.error('LLM status update error', { attempt, elapsed: `${elapsed}ms`, error: errStr });
       }
       if (attempt < LLM_MAX_RETRIES) {
         const backoff = LLM_INITIAL_BACKOFF_MS * Math.pow(2, attempt - 1);
@@ -739,11 +861,16 @@ Mets à jour le statut en intégrant les informations des messages [SERA ARCHIV�
         await new Promise(resolve => setTimeout(resolve, backoff));
         continue;
       }
-      return null;
+      stats.finalOutcome = isTimeout ? 'timeout' : 'error';
+      stats.elapsedMs = Date.now() - callStart;
+      stats.lastError = truncateError(errStr);
+      return { content: null, stats };
     }
   }
 
-  return null;
+  stats.finalOutcome = 'null';
+  stats.elapsedMs = Date.now() - callStart;
+  return { content: null, stats };
 }
 
 /**
@@ -794,7 +921,8 @@ RÈGLES :
         { role: 'system', content: systemPrompt },
         { role: 'user', content: text }
       ],
-      max_tokens: 10000,
+      // 2026-04-20: bumped 10000 → 30000 (see generateLLMSummary for rationale).
+      max_tokens: 30000,
       temperature: 0.3
     }, {
       timeout: 900000  // #1497: 5 min → 15 min, accommodate thinking-mode latency
@@ -886,11 +1014,17 @@ export function detectStatusContradictions(status: string): Array<{ entity: stri
 async function condenseIntercom(
   key: string,
   dashboard: Dashboard,
-  keepCount: number
+  keepCount: number,
+  diagnostic?: CondenseAttemptInfo
 ): Promise<Dashboard> {
   const condensationStart = Date.now();
   const messages = dashboard.intercom.messages;
   if (messages.length <= keepCount) {
+    if (diagnostic) {
+      diagnostic.outcome = 'no-op';
+      diagnostic.elapsedMs = Date.now() - condensationStart;
+      diagnostic.archivedMessageCount = 0;
+    }
     return dashboard; // Rien à condenser
   }
 
@@ -907,17 +1041,22 @@ async function condenseIntercom(
   // races the client timeout. A single failing call still cancels condensation
   // via the existing null-check below.
   const tParallel = Date.now();
-  const [newStatusResult, llmSummaryResult] = await Promise.all([
+  const [statusCall, summaryCall] = await Promise.all([
     generateStatusUpdate(previousStatus, messages, toArchive.length),
     generateLLMSummary(toArchive)
   ]);
-  let newStatus = newStatusResult;
-  let llmSummary = llmSummaryResult;
+  if (diagnostic) {
+    diagnostic.llm = { summary: summaryCall.stats, status: statusCall.stats };
+  }
+  let newStatus = statusCall.content;
+  let llmSummary = summaryCall.content;
   const tParallelElapsed = Date.now() - tParallel;
   logger.info('LLM calls completed (parallel)', {
     elapsed: `${tParallelElapsed}ms`,
     statusOk: newStatus !== null,
-    summaryOk: llmSummary !== null
+    summaryOk: llmSummary !== null,
+    statusOutcome: statusCall.stats.finalOutcome,
+    summaryOutcome: summaryCall.stats.finalOutcome
   });
 
   // Both LLM calls are MANDATORY — if either fails, cancel condensation
@@ -926,7 +1065,9 @@ async function condenseIntercom(
       key,
       messageCount: toArchive.length,
       summaryOk: !!llmSummary,
-      statusOk: !!newStatus
+      statusOk: !!newStatus,
+      summaryOutcome: summaryCall.stats.finalOutcome,
+      statusOutcome: statusCall.stats.finalOutcome
     });
 
     // Inject a visible [ERROR] system message so next readers see the failure.
@@ -943,25 +1084,40 @@ async function condenseIntercom(
          ).getTime()) < CONDENSATION_ERROR_DEDUP_MS;
 
     if (recentErrorExists) {
+      if (diagnostic) {
+        diagnostic.outcome = 'llm-failed-dedup';
+        diagnostic.elapsedMs = Date.now() - condensationStart;
+        diagnostic.archivedMessageCount = 0;
+      }
       return dashboard; // Déjà signalé récemment, pas de spam
     }
 
     const errorTimestamp = new Date().toISOString();
-    const statusOkLabel = newStatus ? 'OK' : 'FAILED';
-    const summaryOkLabel = llmSummary ? 'OK' : 'FAILED';
+    const statusOkLabel = newStatus ? 'OK' : `FAILED (${statusCall.stats.finalOutcome})`;
+    const summaryOkLabel = llmSummary ? 'OK' : `FAILED (${summaryCall.stats.finalOutcome})`;
     const errorMessage: IntercomMessage = {
       id: generateMessageId('system', 'system'),
       timestamp: errorTimestamp,
       author: { machineId: 'system', workspace: 'system' },
       content: `**[ERROR] CONDENSATION CANCELLED** - ${errorTimestamp}\n\n`
         + `LLM calls failed after ${LLM_MAX_RETRIES} retries (backoff 2s/4s/8s):\n`
-        + `- Status update: ${statusOkLabel}\n`
-        + `- Summary generation: ${summaryOkLabel}\n\n`
-        + `Dashboard left unchanged (${dashboard.intercom.messages.length} messages). `
+        + `- Status update: ${statusOkLabel} (${Math.round(statusCall.stats.elapsedMs / 1000)}s, `
+        + `null×${statusCall.stats.nullCount}, err×${statusCall.stats.errorCount})\n`
+        + `- Summary generation: ${summaryOkLabel} (${Math.round(summaryCall.stats.elapsedMs / 1000)}s, `
+        + `null×${summaryCall.stats.nullCount}, err×${summaryCall.stats.errorCount})\n`
+        + (statusCall.stats.lastError ? `- Status last error: ${statusCall.stats.lastError}\n` : '')
+        + (summaryCall.stats.lastError ? `- Summary last error: ${summaryCall.stats.lastError}\n` : '')
+        + `\nDashboard left unchanged (${dashboard.intercom.messages.length} messages). `
         + `Verify LLM endpoint (OPENAI_CHAT_API_BASE / OPENAI_CHAT_MODEL_ID) and retry. `
         + `Next condensation attempt will occur on the next append exceeding the `
         + `${Math.round(MAX_DASHBOARD_SIZE_BYTES / 1024)}KB threshold.`
     };
+
+    if (diagnostic) {
+      diagnostic.outcome = 'llm-failed-injected';
+      diagnostic.elapsedMs = Date.now() - condensationStart;
+      diagnostic.archivedMessageCount = 0;
+    }
 
     return {
       ...dashboard,
@@ -1076,6 +1232,12 @@ ${archiveMessages}
 
   logger.info('Condensation completed', { totalElapsed: `${totalElapsed}ms` });
 
+  if (diagnostic) {
+    diagnostic.outcome = 'condensed';
+    diagnostic.elapsedMs = totalElapsed;
+    diagnostic.archivedMessageCount = toArchive.length;
+  }
+
   return {
     ...dashboard,
     lastModified: now,
@@ -1154,6 +1316,16 @@ export interface DashboardResult {
   } | null>;
   /** Per-target cross-post outcomes (v3 #1363). Present only when args.crossPost was used. */
   crossPost?: Array<{ key: string; ok: boolean; error?: string }>;
+  /**
+   * Per-pass condensation telemetry (2026-04-20). Present whenever condensation
+   * was attempted (append with size over threshold, or explicit condense
+   * action). Each entry reports phase + outcome + LLM call stats so operators
+   * can tell "LLM down" from "LLM returned null content" without tailing logs.
+   *
+   * An append can have up to 2 entries (preemptive + reactive). A condense
+   * action has 1 (manual). No entry means no condensation was attempted.
+   */
+  condenseDiagnostic?: CondenseAttemptInfo[];
 }
 
 /**
@@ -1462,6 +1634,7 @@ async function handleAppend(
   // post-condense binding.
   let preemptivelyCondensed = false;
   let preemptivelyArchivedCount = 0;
+  const condenseDiagnostics: CondenseAttemptInfo[] = [];
   const preAppendSize = estimateDashboardSize(dashboard);
   if (preAppendSize >= PREEMPTIVE_CONDENSE_THRESHOLD_BYTES && dashboard.intercom.messages.length > CONDENSE_KEEP) {
     logger.info('Preemptive condensation triggered (#1497)', {
@@ -1471,7 +1644,9 @@ async function handleAppend(
       messageCount: dashboard.intercom.messages.length
     });
     const beforePreemptive = dashboard.intercom.messages.length;
-    dashboard = await condenseIntercom(key, dashboard, CONDENSE_KEEP);
+    const preemptiveDiag = newDiagnostic('preemptive');
+    dashboard = await condenseIntercom(key, dashboard, CONDENSE_KEEP, preemptiveDiag);
+    condenseDiagnostics.push(preemptiveDiag);
     preemptivelyArchivedCount = beforePreemptive - dashboard.intercom.messages.length;
     preemptivelyCondensed = preemptivelyArchivedCount > 0;
   }
@@ -1529,7 +1704,9 @@ async function handleAppend(
       messageCount: updatedDashboard.intercom.messages.length
     });
     const beforeCount = updatedDashboard.intercom.messages.length;
-    finalDashboard = await condenseIntercom(key, updatedDashboard, CONDENSE_KEEP);
+    const reactiveDiag = newDiagnostic('reactive');
+    finalDashboard = await condenseIntercom(key, updatedDashboard, CONDENSE_KEEP, reactiveDiag);
+    condenseDiagnostics.push(reactiveDiag);
     const newlyArchived = beforeCount - finalDashboard.intercom.messages.length;
     archivedCount += newlyArchived;
     condensed = condensed || newlyArchived > 0;
@@ -1640,6 +1817,38 @@ async function handleAppend(
     ? ` (cross-post: ${crossPostOk}/${crossPostResults.length} OK${crossPostFail > 0 ? `, ${crossPostFail} échecs` : ''})`
     : '';
 
+  // 2026-04-20: Clamp archivedCount to non-negative. When LLM failure injects
+  // an [ERROR] CONDENSATION CANCELLED message, `newlyArchived = beforeCount -
+  // finalDashboard.intercom.messages.length` goes negative (the +1 system
+  // message). That's mathematically consistent but misleads clients that read
+  // `archivedCount` as "messages archived". The truth lives in
+  // `condenseDiagnostic[].outcome`. Clients needing the signed delta can
+  // compute it from sizes.
+  const reportedArchivedCount = Math.max(0, archivedCount);
+
+  // Build a diagnostic suffix for the human message whenever condensation was
+  // attempted — so the failure mode is visible in the primary tool result
+  // (not just in condenseDiagnostic which some consumers won't inspect).
+  let diagSuffix = '';
+  if (condenseDiagnostics.length > 0 && !condensed) {
+    const failed = condenseDiagnostics.filter(d =>
+      d.outcome === 'llm-failed-dedup' || d.outcome === 'llm-failed-injected'
+    );
+    if (failed.length > 0) {
+      const first = failed[0];
+      const totalS = Math.round(failed.reduce((sum, d) => sum + d.elapsedMs, 0) / 1000);
+      const summary = first.llm?.summary;
+      const status = first.llm?.status;
+      const llmBits: string[] = [];
+      if (summary) llmBits.push(`summary=${summary.finalOutcome}×${summary.attempts}`);
+      if (status) llmBits.push(`status=${status.finalOutcome}×${status.attempts}`);
+      const dedupNote = failed.some(d => d.outcome === 'llm-failed-dedup')
+        ? ' [recent error msg within dedup window → not re-injected]'
+        : '';
+      diagSuffix = ` — LLM échoué (${totalS}s total, ${llmBits.join(', ')})${dedupNote}`;
+    }
+  }
+
   return {
     success: true,
     action: 'append',
@@ -1649,9 +1858,10 @@ async function handleAppend(
     sizes: buildSizes(finalDashboard),
     messageCount: finalDashboard.intercom.messages.length,
     condensed,
-    archivedCount,
+    archivedCount: reportedArchivedCount,
     crossPost: crossPostResults.length > 0 ? crossPostResults : undefined,
-    message: `Message ajouté au dashboard '${key}'${condensed ? ` (auto-condensation: ${archivedCount} messages archivés, taille réduite)` : ''}${crossPostSuffix}`
+    condenseDiagnostic: condenseDiagnostics.length > 0 ? condenseDiagnostics : undefined,
+    message: `Message ajouté au dashboard '${key}'${condensed ? ` (auto-condensation: ${reportedArchivedCount} messages archivés, taille réduite)` : ''}${diagSuffix}${crossPostSuffix}`
   };
 }
 
@@ -1691,7 +1901,8 @@ async function handleCondense(
   }
 
   const condenseStart = Date.now();
-  const condensedDashboard = await condenseIntercom(key, dashboard, keepCount);
+  const manualDiag = newDiagnostic('manual');
+  const condensedDashboard = await condenseIntercom(key, dashboard, keepCount, manualDiag);
   const condenseElapsed = Date.now() - condenseStart;
   const actuallyCondensed = condensedDashboard.intercom.messages.length < beforeCount;
   // Persist whenever the dashboard changed — either condensation succeeded
@@ -1704,6 +1915,23 @@ async function handleCondense(
   }
 
   const archivedCount = actuallyCondensed ? beforeCount - condensedDashboard.intercom.messages.length : 0;
+
+  // Build a rich diag suffix when the LLM failed, so the tool's `message` field
+  // carries the "why" without requiring the caller to parse condenseDiagnostic.
+  let failureDetail = '';
+  if (!actuallyCondensed && manualDiag.llm) {
+    const summary = manualDiag.llm.summary;
+    const status = manualDiag.llm.status;
+    const llmBits = [
+      `summary=${summary.finalOutcome}×${summary.attempts} (${Math.round(summary.elapsedMs / 1000)}s)`,
+      `status=${status.finalOutcome}×${status.attempts} (${Math.round(status.elapsedMs / 1000)}s)`
+    ];
+    failureDetail = ` [${llmBits.join(', ')}]`;
+    if (manualDiag.outcome === 'llm-failed-dedup') {
+      failureDetail += ' (dedup: recent error msg within window, not re-injected)';
+    }
+  }
+
   return {
     success: true,
     action: 'condense',
@@ -1714,9 +1942,10 @@ async function handleCondense(
     messageCount: condensedDashboard.intercom.messages.length,
     condensed: actuallyCondensed,
     archivedCount,
+    condenseDiagnostic: [manualDiag],
     message: actuallyCondensed
       ? `Condensation terminée en ${Math.round(condenseElapsed / 1000)}s : ${archivedCount} messages archivés, ${condensedDashboard.intercom.messages.length} conservés`
-      : `Condensation annulée (LLM indisponible) — ${beforeCount} messages inchangés (${Math.round(condenseElapsed / 1000)}s)`
+      : `Condensation annulée (LLM indisponible) — ${beforeCount} messages inchangés (${Math.round(condenseElapsed / 1000)}s)${failureDetail}`
   };
 }
 


### PR DESCRIPTION
## Contexte

CoursIA dashboard condensation failed 2026-04-20 19:23-19:35Z with baffling result: `archivedCount: -2, condensed: false, utilizationPct: 119.6, 12m31s elapsed`. No diagnostic beyond "condensed: false".

User feedback: "Ca serait bien d'avoir plus d'instrumentation quand l'outil essaie pendant 12 minutes et échoue, on devrait avoir un diagnostic plutôt que 'condensed: false'". Then: "IL va falloir que tu muscle l'instrumentation et les tests, car là tu ne maîtrise pas bien ce qui se passe".

## Root causes (3 distinct bugs)

1. **`archivedCount: -2`** — both preemptive AND reactive passes each injected an `[ERROR] CONDENSATION CANCELLED` message. `archivedCount -= 1` twice → -2. The two timestamps were 6m16s apart (19:23:15 / 19:29:31), outside the 5min dedup window → 2nd error got injected.
2. **12m31s wall-clock** — 2 passes × 3 LLM retries × ~2min/retry. Qwen3.6-35B-A3B in thinking mode on a 40KB prompt consumed the entire `max_tokens: 10000` budget on reasoning trace, returning `content: null` + `finish_reason: 'length'`. All 6 LLM attempts (3 summary + 3 status) failed identically.
3. **Silent failure** — result said just `condensed: false`, no indication of WHY. User had zero observability into the 12-minute failure.

## Fix

- **Instrumentation**: New `CondenseAttemptInfo[]` result field tracking per-phase (preemptive/reactive/manual): outcome, elapsedMs, archivedMessageCount, and per-LLM-call stats (attempts, nullCount, errorCount, timeoutCount, lastError). Error message in dashboard now embeds diagnostic suffix: `LLM échoué (12s total, summary=null×3, status=null×3)`.
- **archivedCount clamp**: `Math.max(0, archivedCount)` in handleAppend result — prevents nonsense negative counts from leaking to clients.
- **Dedup window 5min → 20min**: preemptive+reactive passes can each burn >5min, so 5min was ineffective. 20min ensures within-a-single-user-cycle error deduplication. (User chose 20min over my initial 60min proposal.)
- **`max_tokens: 10000 → 30000`**: more headroom for Qwen thinking mode on large prompts. **Thinking mode stays ON per user instruction** — "ON ne veut pas disable thinking, on veut des timeout généreux".

## Tests (6 new)

New describe block `'Condense diagnostic + error semantics (2026-04-20)'` in `dashboard.test.ts`:

1. Diagnostic populated with LLM stats on manual condense success
2. Reports `llm-failed-injected` with `nullCount: 3` when LLM returns empty content (thinking-mode simulation)
3. Reports `lastError: 'ECONNREFUSED 127.0.0.1:5002'` when LLM throws
4. Reports `client-init-failed` with `attempts: 0` when `getChatOpenAIClient` throws
5. **archivedCount clamped to 0** on failed append (regression test for CoursIA -2 incident)
6. Dedup within 20min window does NOT re-inject a second error message (outcome `'llm-failed-dedup'`, message count unchanged)

## Build & tests

- TypeScript: clean compile
- Vitest: 7693/7693 passed (18 intentionally skipped)

## Non-goals

- Does not disable thinking mode (per user instruction)
- Does not rotate Qdrant key / rewrite git history (separate concern, already handled)
- Does not fix the parasite `D` file (already removed in previous cycle)

## Diff size

2 files changed, 452 insertions(+), 42 deletions(-). Above 50 LOC → sk-agent code review per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)