### PR TITLE
test(coverage): 56 unit tests for encoding-helpers, error-format, path-normalizer, parsing-config

### DIFF
--- a/servers/roo-state-manager/tests/unit/utils/encoding-helpers.test.ts
+++ b/servers/roo-state-manager/tests/unit/utils/encoding-helpers.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { stripBOM, parseJSONWithoutBOM } from '../../../src/utils/encoding-helpers';
+
+describe('encoding-helpers', () => {
+	describe('stripBOM', () => {
+		it('should return content unchanged when no BOM present', () => {
+			expect(stripBOM('hello world')).toBe('hello world');
+		});
+
+		it('should strip UTF-8 BOM from content', () => {
+			expect(stripBOM('\uFEFFhello')).toBe('hello');
+		});
+
+		it('should handle BOM-only content', () => {
+			expect(stripBOM('\uFEFF')).toBe('');
+		});
+
+		it('should handle empty string', () => {
+			expect(stripBOM('')).toBe('');
+		});
+
+		it('should not strip BOM that is not at the beginning', () => {
+			const content = 'hello\uFEFFworld';
+			expect(stripBOM(content)).toBe(content);
+		});
+
+		it('should strip only one BOM character', () => {
+			expect(stripBOM('\uFEFF\uFEFFhello')).toBe('\uFEFFhello');
+		});
+
+		it('should handle BOM with JSON content', () => {
+			const bomJson = '\uFEFF{"key": "value", "num": 42}';
+			expect(stripBOM(bomJson)).toBe('{"key": "value", "num": 42}');
+		});
+
+		it('should handle BOM with multiline content', () => {
+			const content = '\uFEFFline1\nline2\nline3';
+			expect(stripBOM(content)).toBe('line1\nline2\nline3');
+		});
+	});
+
+	describe('parseJSONWithoutBOM', () => {
+		it('should parse valid JSON without BOM', () => {
+			expect(parseJSONWithoutBOM('{"name":"test"}')).toEqual({ name: 'test' });
+		});
+
+		it('should parse JSON with BOM', () => {
+			expect(parseJSONWithoutBOM('\uFEFF{"name":"test"}')).toEqual({ name: 'test' });
+		});
+
+		it('should throw SyntaxError for invalid JSON', () => {
+			expect(() => parseJSONWithoutBOM('not json')).toThrow(SyntaxError);
+		});
+
+		it('should parse arrays', () => {
+			expect(parseJSONWithoutBOM('[1,2,3]')).toEqual([1, 2, 3]);
+		});
+
+		it('should parse JSON with BOM and nested objects', () => {
+			const json = '\uFEFF{"a":{"b":[1,2]},"c":null}';
+			expect(parseJSONWithoutBOM(json)).toEqual({ a: { b: [1, 2] }, c: null });
+		});
+
+		it('should respect generic type parameter', () => {
+			interface TestType { id: number; label: string }
+			const result = parseJSONWithoutBOM<TestType>('{"id":1,"label":"x"}');
+			expect(result.id).toBe(1);
+			expect(result.label).toBe('x');
+		});
+
+		it('should parse empty object', () => {
+			expect(parseJSONWithoutBOM('{}')).toEqual({});
+		});
+
+		it('should parse boolean and number values', () => {
+			expect(parseJSONWithoutBOM('{"flag":true,"count":0}')).toEqual({ flag: true, count: 0 });
+		});
+	});
+});

--- a/servers/roo-state-manager/tests/unit/utils/error-format.test.ts
+++ b/servers/roo-state-manager/tests/unit/utils/error-format.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { formatErrorForResponse, formatErrorForLog } from '../../../src/utils/error-format';
+
+describe('error-format', () => {
+	const originalEnv = process.env.MCP_INCLUDE_STACKS;
+
+	afterEach(() => {
+		if (originalEnv === undefined) {
+			delete process.env.MCP_INCLUDE_STACKS;
+		} else {
+			process.env.MCP_INCLUDE_STACKS = originalEnv;
+		}
+	});
+
+	describe('formatErrorForResponse', () => {
+		it('should format Error instance as message only by default', () => {
+			const err = new Error('test error');
+			const result = formatErrorForResponse(err);
+			expect(result).toBe('test error');
+			expect(result).not.toContain('Stack:');
+		});
+
+		it('should format non-Error value as string', () => {
+			expect(formatErrorForResponse('string error')).toBe('string error');
+			expect(formatErrorForResponse(42)).toBe('42');
+			expect(formatErrorForResponse(null)).toBe('null');
+			expect(formatErrorForResponse(undefined)).toBe('undefined');
+		});
+
+		it('should include stack trace when MCP_INCLUDE_STACKS=1', () => {
+			process.env.MCP_INCLUDE_STACKS = '1';
+			const err = new Error('debug error');
+			const result = formatErrorForResponse(err);
+			expect(result).toContain('debug error');
+			expect(result).toContain('Stack:');
+			expect(result).toContain('Error: debug error');
+		});
+
+		it('should not include stack for non-Error even with MCP_INCLUDE_STACKS=1', () => {
+			process.env.MCP_INCLUDE_STACKS = '1';
+			const result = formatErrorForResponse('plain string');
+			expect(result).toBe('plain string');
+			expect(result).not.toContain('Stack:');
+		});
+
+		it('should handle Error without stack', () => {
+			const err = new Error('no stack');
+			delete err.stack;
+			process.env.MCP_INCLUDE_STACKS = '1';
+			const result = formatErrorForResponse(err);
+			expect(result).toBe('no stack');
+		});
+
+		it('should not include stack when MCP_INCLUDE_STACKS is not "1"', () => {
+			process.env.MCP_INCLUDE_STACKS = '0';
+			const err = new Error('test');
+			const result = formatErrorForResponse(err);
+			expect(result).toBe('test');
+			expect(result).not.toContain('Stack:');
+		});
+	});
+
+	describe('formatErrorForLog', () => {
+		it('should always include message and stack for Error', () => {
+			const err = new Error('log error');
+			const result = formatErrorForLog(err);
+			expect(result.message).toBe('log error');
+			expect(result.stack).toBeDefined();
+			expect(result.stack).toContain('Error: log error');
+		});
+
+		it('should truncate stack to 3 lines', () => {
+			const err = new Error('long stack');
+			const result = formatErrorForLog(err);
+			const stackLines = result.stack!.split(' | ');
+			expect(stackLines.length).toBeLessThanOrEqual(3);
+		});
+
+		it('should handle non-Error values', () => {
+			expect(formatErrorForLog('string').message).toBe('string');
+			expect(formatErrorForLog('string').stack).toBeUndefined();
+			expect(formatErrorForLog(42).message).toBe('42');
+			expect(formatErrorForLog(null).message).toBe('null');
+		});
+
+		it('should handle Error without stack', () => {
+			const err = new Error('no stack');
+			delete err.stack;
+			const result = formatErrorForLog(err);
+			expect(result.message).toBe('no stack');
+			expect(result.stack).toBeUndefined();
+		});
+	});
+});

--- a/servers/roo-state-manager/tests/unit/utils/parsing-config.test.ts
+++ b/servers/roo-state-manager/tests/unit/utils/parsing-config.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+	validateComparisonResults,
+	getParsingConfig,
+	shouldUseNewParsing,
+	isComparisonMode,
+	getDefaultConfig,
+} from '../../../src/utils/parsing-config';
+
+describe('parsing-config', () => {
+	const envVars = [
+		'USE_NEW_PARSING',
+		'PARSING_COMPARISON_MODE',
+		'LOG_PARSING_DIFFERENCES',
+		'PARSING_SIMILARITY_THRESHOLD',
+		'VALIDATE_IMPROVEMENTS',
+		'MIN_CHILD_TASKS_IMPROVEMENT',
+	];
+
+	afterEach(() => {
+		envVars.forEach(v => delete process.env[v]);
+	});
+
+	describe('getDefaultConfig', () => {
+		it('should return default config values', () => {
+			const config = getDefaultConfig();
+			expect(config.useNewParsing).toBe(false);
+			expect(config.comparisonMode).toBe(false);
+			expect(config.logDifferences).toBe(false);
+			expect(config.similarityThreshold).toBe(44);
+			expect(config.validateImprovements).toBe(true);
+			expect(config.minChildTasksImprovement).toBe(10);
+		});
+
+		it('should return a copy (not reference)', () => {
+			const c1 = getDefaultConfig();
+			const c2 = getDefaultConfig();
+			c1.similarityThreshold = 999;
+			expect(c2.similarityThreshold).toBe(44);
+		});
+	});
+
+	describe('getParsingConfig', () => {
+		it('should return defaults when no env vars set', () => {
+			const config = getParsingConfig();
+			expect(config.useNewParsing).toBe(false);
+			expect(config.similarityThreshold).toBe(44);
+		});
+
+		it('should read USE_NEW_PARSING from env', () => {
+			process.env.USE_NEW_PARSING = 'true';
+			expect(getParsingConfig().useNewParsing).toBe(true);
+		});
+
+		it('should read PARSING_COMPARISON_MODE from env', () => {
+			process.env.PARSING_COMPARISON_MODE = 'true';
+			expect(getParsingConfig().comparisonMode).toBe(true);
+		});
+
+		it('should read PARSING_SIMILARITY_THRESHOLD from env', () => {
+			process.env.PARSING_SIMILARITY_THRESHOLD = '80';
+			expect(getParsingConfig().similarityThreshold).toBe(80);
+		});
+
+		it('should read MIN_CHILD_TASKS_IMPROVEMENT from env', () => {
+			process.env.MIN_CHILD_TASKS_IMPROVEMENT = '20';
+			expect(getParsingConfig().minChildTasksImprovement).toBe(20);
+		});
+
+		it('should fall back validateImprovements to default true', () => {
+			expect(getParsingConfig().validateImprovements).toBe(true);
+		});
+	});
+
+	describe('validateComparisonResults', () => {
+		it('should reject when similarity below threshold', () => {
+			const result = validateComparisonResults(30, 100, 200, ['improved']);
+			expect(result.isValid).toBe(false);
+			expect(result.reason).toContain('30%');
+			expect(result.reason).toContain('44%');
+		});
+
+		it('should reject when child tasks improvement below minimum', () => {
+			const result = validateComparisonResults(50, 100, 105, ['improved']);
+			expect(result.isValid).toBe(false);
+			expect(result.reason).toContain('5');
+			expect(result.reason).toContain('10');
+		});
+
+		it('should reject when no improvements documented', () => {
+			const result = validateComparisonResults(50, 100, 200, []);
+			expect(result.isValid).toBe(false);
+			expect(result.reason).toContain('am\u00e9lioration document\u00e9e');
+		});
+
+		it('should accept valid results', () => {
+			const result = validateComparisonResults(60, 100, 200, ['faster', 'more accurate']);
+			expect(result.isValid).toBe(true);
+			expect(result.reason).toContain('60%');
+			expect(result.reason).toContain('+100');
+		});
+
+		it('should accept at boundary similarity', () => {
+			const result = validateComparisonResults(44, 100, 200, ['improved']);
+			expect(result.isValid).toBe(true);
+		});
+
+		it('should accept at boundary child tasks improvement', () => {
+			const result = validateComparisonResults(50, 100, 110, ['improved']);
+			expect(result.isValid).toBe(true);
+		});
+
+		it('should reject exactly below similarity boundary', () => {
+			const result = validateComparisonResults(43, 100, 200, ['improved']);
+			expect(result.isValid).toBe(false);
+		});
+	});
+
+	describe('shouldUseNewParsing', () => {
+		it('should return false by default', () => {
+			expect(shouldUseNewParsing()).toBe(false);
+		});
+
+		it('should return true when USE_NEW_PARSING=true', () => {
+			process.env.USE_NEW_PARSING = 'true';
+			expect(shouldUseNewParsing()).toBe(true);
+		});
+
+		it('should return true when PARSING_COMPARISON_MODE=true', () => {
+			process.env.PARSING_COMPARISON_MODE = 'true';
+			expect(shouldUseNewParsing()).toBe(true);
+		});
+	});
+
+	describe('isComparisonMode', () => {
+		it('should return false by default', () => {
+			expect(isComparisonMode()).toBe(false);
+		});
+
+		it('should return true when PARSING_COMPARISON_MODE=true', () => {
+			process.env.PARSING_COMPARISON_MODE = 'true';
+			expect(isComparisonMode()).toBe(true);
+		});
+	});
+});

--- a/servers/roo-state-manager/tests/unit/utils/path-normalizer.test.ts
+++ b/servers/roo-state-manager/tests/unit/utils/path-normalizer.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { normalizePath } from '../../../src/utils/path-normalizer';
+
+describe('path-normalizer', () => {
+	describe('normalizePath', () => {
+		it('should normalize Windows backslashes to forward slashes', () => {
+			expect(normalizePath('C:\\Users\\test\\file.txt')).toBe('c:/users/test/file.txt');
+		});
+
+		it('should remove trailing slashes', () => {
+			expect(normalizePath('/path/to/dir/')).toBe('/path/to/dir');
+		});
+
+		it('should remove multiple trailing slashes', () => {
+			expect(normalizePath('/path/to/dir///')).toBe('/path/to/dir');
+		});
+
+		it('should convert to lowercase', () => {
+			expect(normalizePath('/PATH/TO/FILE')).toBe('/path/to/file');
+		});
+
+		it('should handle empty string', () => {
+			expect(normalizePath('')).toBe('');
+		});
+
+		it('should handle already normalized path', () => {
+			expect(normalizePath('/already/normalized')).toBe('/already/normalized');
+		});
+
+		it('should handle mixed slashes', () => {
+			expect(normalizePath('C:/Users\\test/path\\file')).toBe('c:/users/test/path/file');
+		});
+
+		it('should handle root path', () => {
+			expect(normalizePath('/')).toBe('');
+		});
+
+		it('should handle single segment', () => {
+			expect(normalizePath('folder')).toBe('folder');
+		});
+
+		it('should handle UNC path', () => {
+			expect(normalizePath('\\\\server\\share\\path')).toBe('//server/share/path');
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Add unit test coverage for 4 utils files with 0% test coverage
- 56 new tests total, all passing (7749/7749 CI tests green)

## Files covered
| File | Tests | Coverage |
|------|-------|----------|
| `encoding-helpers.ts` | 16 | stripBOM, parseJSONWithoutBOM |
| `error-format.ts` | 10 | formatErrorForResponse, formatErrorForLog |
| `path-normalizer.ts` | 10 | normalizePath |
| `parsing-config.ts` | 20 | validateComparisonResults, getParsingConfig, shouldUseNewParsing, isComparisonMode, getDefaultConfig |

## Test plan
- [x] Build passes (`npm run build`)
- [x] All CI tests pass (`npx vitest run --config vitest.config.ci.ts`)
- [x] No source code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)