### PR TITLE
fix(dashboard): split oversize messages + durationBreakdown (#1589)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
@@ -998,17 +998,27 @@ describe('roosync_dashboard', () => {
       expect(mockChatCreate).not.toHaveBeenCalled();
     });
 
-    it('does NOT preemptively condense when messages.length <= CONDENSE_KEEP', async () => {
-      // Even if size hits threshold, with <= 10 messages we must not condense
-      // (nothing to keep minus nothing to archive = edge case).
+    it('splits large incoming messages so condense can archive them (#1589)', async () => {
+      // Regression: prior behaviour was "single large message protected by
+      // CONDENSE_KEEP slice policy → dashboard stays above threshold forever".
+      // With per-append split (#1589), a 47KB message becomes ~12 parts (4KB
+      // cap each). After an initial small message + the big one split into
+      // parts, messages.length > CONDENSE_KEEP and the next append correctly
+      // triggers condensation.
       mockGetChatClient.mockReturnValue({
         chat: { completions: { create: mockChatCreate } }
       });
+      mockChatCreate.mockResolvedValue({
+        choices: [{ message: { content: '## Summary\n\nArchived content' } }]
+      });
 
       await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
-      // Very large message, only 1 entry — size > 92% but count < CONDENSE_KEEP
-      const huge = 'Y'.repeat(47 * 1024); // 47 KB single message (above 46 KB threshold)
-      await roosyncDashboard({ action: 'append', type: 'global', content: huge });
+      const huge = 'Y'.repeat(47 * 1024); // 47 KB single message
+      const firstResult = await roosyncDashboard({ action: 'append', type: 'global', content: huge });
+
+      // The 47KB content is split into ~12 parts of 4KB each.
+      expect(firstResult.splitCount).toBeGreaterThan(1);
+      expect(firstResult.messageCount).toBeGreaterThan(10);
 
       const result = await roosyncDashboard({
         action: 'append',
@@ -1017,9 +1027,9 @@ describe('roosync_dashboard', () => {
       });
 
       expect(result.success).toBe(true);
-      // Preemptive condense skipped because messageCount (1) <= CONDENSE_KEEP (10)
-      expect(result.condensed).toBe(false);
-      expect(mockChatCreate).not.toHaveBeenCalled();
+      // Now that the big message is multiple parts and count > CONDENSE_KEEP,
+      // preemptive condense fires and LLM is called.
+      expect(mockChatCreate).toHaveBeenCalled();
     });
 
     it('accumulates archivedCount when preemptive AND reactive condense both fire', async () => {
@@ -1067,6 +1077,153 @@ describe('roosync_dashboard', () => {
       // mockChatCreate must have been called at least once (condense happened)
       expect(mockChatCreate).toHaveBeenCalled();
     });
+  });
+
+  describe('Message splitting and duration breakdown (#1589)', () => {
+    it('does NOT split messages under the per-message cap', async () => {
+      await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
+      const result = await roosyncDashboard({
+        action: 'append',
+        type: 'global',
+        content: 'A small message under 4KB.'
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.splitCount).toBe(1);
+      // Verify the dashboard has exactly one message added.
+      expect(result.messageCount).toBe(1);
+    });
+
+    it('splits a single oversize content on line boundaries', async () => {
+      await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
+
+      // Build a paragraph-heavy body: 20 lines × ~600 chars = ~12KB.
+      const line = 'This is a readable sentence that contributes toward the total byte budget. '.repeat(8);
+      const body = Array.from({ length: 20 }, (_, i) => `## Section ${i + 1}\n${line}`).join('\n\n');
+
+      const result = await roosyncDashboard({
+        action: 'append',
+        type: 'global',
+        content: body
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.splitCount).toBeGreaterThan(1);
+      expect(result.messageCount).toBe(result.splitCount);
+      // Each part should be tagged with the PART marker for readers.
+      const dashboard = await roosyncDashboard({ action: 'read', type: 'global' });
+      const firstMsg = dashboard.data?.intercom?.messages?.[0];
+      expect(firstMsg?.content).toMatch(/^\*\*\[PART 1\//);
+    });
+
+    it('hard-slices individual lines that exceed the cap', async () => {
+      await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
+
+      // One single-line body of 10KB — must be sliced at char boundaries.
+      const giantLine = 'X'.repeat(10 * 1024);
+      const result = await roosyncDashboard({
+        action: 'append',
+        type: 'global',
+        content: giantLine
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.splitCount).toBeGreaterThan(1);
+    });
+
+    it('populates durationBreakdown on every append', async () => {
+      await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
+      const result = await roosyncDashboard({
+        action: 'append',
+        type: 'global',
+        content: 'quick'
+      });
+
+      expect(result.durationBreakdown).toBeDefined();
+      expect(result.durationBreakdown!.totalMs).toBeGreaterThanOrEqual(0);
+      // No condensation fired, so preemptive & reactive are 0.
+      expect(result.durationBreakdown!.preemptiveCondenseMs).toBe(0);
+      expect(result.durationBreakdown!.reactiveCondenseMs).toBe(0);
+      expect(result.durationBreakdown!.writeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('reports preemptiveCondenseMs > 0 when preemptive condense fires', async () => {
+      mockGetChatClient.mockReturnValue({
+        chat: { completions: { create: mockChatCreate } }
+      });
+      mockChatCreate.mockResolvedValue({
+        choices: [{ message: { content: '## Summary\n\nCondensed' } }]
+      });
+
+      await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
+      // Fill past 92% of 50KB with 16 ≥ CONDENSE_KEEP messages of 3KB each.
+      const filler = 'A'.repeat(3000);
+      for (let i = 0; i < 16; i++) {
+        await roosyncDashboard({
+          action: 'append',
+          type: 'global',
+          content: `${filler} msg${i}`
+        });
+      }
+
+      const result = await roosyncDashboard({
+        action: 'append',
+        type: 'global',
+        content: 'trigger preemptive'
+      });
+
+      expect(result.condensed).toBe(true);
+      expect(result.durationBreakdown!.preemptiveCondenseMs).toBeGreaterThan(0);
+    });
+
+    it('unblocks a saturated dashboard pattern (3 large + filler)', async () => {
+      // Reproduces the CoursIA / po-2025 failure mode: 3 oversized dispatches
+      // in the recent window + 9 small messages = 55+ KB. Without split, the
+      // recent-slice policy of condense protected the 3 big ones and we never
+      // dropped below threshold. With split, the big messages become many
+      // parts, condense archives them normally, dashboard comes back under
+      // MAX_DASHBOARD_SIZE_BYTES.
+      mockGetChatClient.mockReturnValue({
+        chat: { completions: { create: mockChatCreate } }
+      });
+      mockChatCreate.mockResolvedValue({
+        choices: [{ message: { content: '## Summary\n\nArchived dispatches' } }]
+      });
+
+      await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
+
+      // 9 small "INFO" messages (~300 chars each)
+      for (let i = 0; i < 9; i++) {
+        await roosyncDashboard({
+          action: 'append',
+          type: 'global',
+          content: `[INFO] Small message ${i} with minor coordination detail.`
+        });
+      }
+
+      // 3 oversize dispatches mimicking CoursIA: 15KB, 12KB, 5KB
+      const dispatch1 = 'Mission A content. '.repeat(800); // ~15KB
+      const dispatch2 = 'Mission B content. '.repeat(660); // ~12KB
+      const dispatch3 = 'Mission C content. '.repeat(270); // ~5KB
+
+      await roosyncDashboard({ action: 'append', type: 'global', content: dispatch1 });
+      await roosyncDashboard({ action: 'append', type: 'global', content: dispatch2 });
+      const result = await roosyncDashboard({ action: 'append', type: 'global', content: dispatch3 });
+
+      // With split, the 3 big dispatches become many 4KB parts spread across
+      // the message list. The dashboard stays below the 50KB threshold either
+      // because (a) the split itself kept each append small or (b) condense
+      // then naturally archived older parts. Either outcome is success — the
+      // old bug was "saturated forever".
+      const readBack = await roosyncDashboard({ action: 'read', type: 'global' });
+      const intercomSize = (readBack.sizes as any).intercomLength;
+      const statusSize = (readBack.sizes as any).statusLength;
+      const totalSize = intercomSize + statusSize;
+
+      expect(totalSize).toBeLessThan(50 * 1024);
+      // The 3rd dispatch was split into multiple parts.
+      expect(result.splitCount).toBeGreaterThan(1);
+    }, 15000);
   });
 
   describe('Mention parsing and filtering (#1363)', () => {

--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -102,6 +102,14 @@ const CONDENSE_KEEP = 10;
 // the working set smaller and shifts the latency into more predictable slots.
 const PREEMPTIVE_CONDENSE_THRESHOLD_BYTES = Math.floor(MAX_DASHBOARD_SIZE_BYTES * 0.92); // ~46 KB
 
+// #1589: Per-message size cap. Messages larger than this are split into multiple
+// parts at append time, so each part is subject to the CONDENSE_KEEP slice policy
+// independently. Prevents the pathological case where 3 "recent" 15KB dispatches
+// protect themselves from archival (all within the CONDENSE_KEEP=10 window) while
+// the dashboard sits above the 50KB threshold, producing an infinite condensation
+// loop (reported on workspace-CoursIA + po-2025, 2026-04-20, 10+min appends).
+const MAX_INDIVIDUAL_MESSAGE_BYTES = 4 * 1024; // 4 KB per part
+
 // Size limits for LLM outputs (bytes). If exceeded, retry with a stricter prompt.
 const MAX_STATUS_SIZE_BYTES = 15 * 1024;  // 15 KB
 const MAX_SUMMARY_SIZE_BYTES = 5 * 1024;  // 5 KB
@@ -1326,6 +1334,23 @@ export interface DashboardResult {
    * action has 1 (manual). No entry means no condensation was attempted.
    */
   condenseDiagnostic?: CondenseAttemptInfo[];
+  /**
+   * Count of parts the incoming content was split into (#1589). `1` means no
+   * split was performed (content fit under MAX_INDIVIDUAL_MESSAGE_BYTES).
+   * Present only on `append` results.
+   */
+  splitCount?: number;
+  /**
+   * Wall-clock breakdown of the append call (#1589). Populated on every
+   * `append` result so operators can attribute latency to condensation phases
+   * vs disk write vs other work without tailing MCP logs. Times are in ms.
+   */
+  durationBreakdown?: {
+    totalMs: number;
+    preemptiveCondenseMs: number;
+    reactiveCondenseMs: number;
+    writeMs: number;
+  };
 }
 
 /**
@@ -1464,6 +1489,87 @@ function estimateDashboardSize(dashboard: Dashboard): number {
   return size;
 }
 
+/**
+ * Split a message body into smaller parts, each <= MAX_INDIVIDUAL_MESSAGE_BYTES.
+ *
+ * Strategy: prefer line-boundary splits (preserves markdown readability); fall
+ * back to hard char-slice for individual lines that exceed the cap.
+ *
+ * Returns a single-element array when the body already fits. Otherwise each
+ * part is prefixed with `**[PART n/N]**` so readers can reassemble the original
+ * and so dashboard readers see the message structure without surprise.
+ *
+ * Trailing whitespace on each part is trimmed. Parts are guaranteed non-empty.
+ */
+export function splitLargeMessage(
+  content: string,
+  maxBytes: number = MAX_INDIVIDUAL_MESSAGE_BYTES
+): string[] {
+  if (Buffer.byteLength(content, 'utf8') <= maxBytes) {
+    return [content];
+  }
+
+  const rawParts: string[] = [];
+  const lines = content.split('\n');
+  let buffer = '';
+  let bufferBytes = 0;
+
+  const flush = () => {
+    const trimmed = buffer.replace(/\n+$/, '');
+    if (trimmed.length > 0) {
+      rawParts.push(trimmed);
+    }
+    buffer = '';
+    bufferBytes = 0;
+  };
+
+  for (const line of lines) {
+    const lineWithNl = line + '\n';
+    const lineBytes = Buffer.byteLength(lineWithNl, 'utf8');
+
+    if (lineBytes > maxBytes) {
+      // Single line too big — flush current buffer, then hard-slice the line.
+      flush();
+      let remainder = line;
+      while (Buffer.byteLength(remainder, 'utf8') > maxBytes) {
+        // Binary search a char-boundary cut under the byte cap
+        let lo = 1;
+        let hi = remainder.length;
+        while (lo < hi) {
+          const mid = Math.ceil((lo + hi) / 2);
+          if (Buffer.byteLength(remainder.slice(0, mid), 'utf8') <= maxBytes) {
+            lo = mid;
+          } else {
+            hi = mid - 1;
+          }
+        }
+        rawParts.push(remainder.slice(0, lo));
+        remainder = remainder.slice(lo);
+      }
+      if (remainder.length > 0) {
+        buffer = remainder + '\n';
+        bufferBytes = Buffer.byteLength(buffer, 'utf8');
+      }
+      continue;
+    }
+
+    if (bufferBytes + lineBytes > maxBytes) {
+      flush();
+    }
+    buffer += lineWithNl;
+    bufferBytes += lineBytes;
+  }
+  flush();
+
+  if (rawParts.length === 0) {
+    // Should not happen given the input-size guard above, but keep contract
+    return [content];
+  }
+
+  const total = rawParts.length;
+  return rawParts.map((part, idx) => `**[PART ${idx + 1}/${total}]**\n\n${part}`);
+}
+
 async function handleRead(
   key: string,
   args: DashboardArgs,
@@ -1598,6 +1704,10 @@ async function handleAppend(
   if (!args.content) {
     throw new Error('content est requis pour action=append');
   }
+  const appendStart = Date.now();
+  let preemptiveCondenseMs = 0;
+  let reactiveCondenseMs = 0;
+  let writeMs = 0;
   const author: Author = args.author ?? {
     machineId: resolvedMachineId,
     workspace: resolvedWorkspace
@@ -1645,7 +1755,9 @@ async function handleAppend(
     });
     const beforePreemptive = dashboard.intercom.messages.length;
     const preemptiveDiag = newDiagnostic('preemptive');
+    const tPre = Date.now();
     dashboard = await condenseIntercom(key, dashboard, CONDENSE_KEEP, preemptiveDiag);
+    preemptiveCondenseMs = Date.now() - tPre;
     condenseDiagnostics.push(preemptiveDiag);
     preemptivelyArchivedCount = beforePreemptive - dashboard.intercom.messages.length;
     preemptivelyCondensed = preemptivelyArchivedCount > 0;
@@ -1658,31 +1770,61 @@ async function handleAppend(
   // 3. Generate new ID as fallback
   const messageIdValue = pendingMessageIds.get(key) || (args as any).messageId || generateMessageId(author.machineId, author.workspace);
 
-  const message: IntercomMessage = {
-    id: messageIdValue,
-    timestamp: new Date().toISOString(),
-    author,
-    content: args.content
-  };
+  // #1589: Split messages above MAX_INDIVIDUAL_MESSAGE_BYTES into multiple
+  // IntercomMessage entries. Each part is an independent message subject to
+  // the CONDENSE_KEEP slice policy, so oversized dispatches no longer
+  // indefinitely protect themselves from archival by virtue of being recent.
+  const contentParts = splitLargeMessage(args.content);
+  const isMultiPart = contentParts.length > 1;
+  if (isMultiPart) {
+    logger.info('Large message split at append time (#1589)', {
+      key,
+      originalSizeKB: `${(Buffer.byteLength(args.content, 'utf8') / 1024).toFixed(1)}KB`,
+      partCount: contentParts.length,
+      perPartCapKB: `${(MAX_INDIVIDUAL_MESSAGE_BYTES / 1024).toFixed(0)}KB`
+    });
+  }
 
-  // Parse mentions in the message content
+  const nowDate = new Date();
+  const newMessages: IntercomMessage[] = contentParts.map((partContent, idx) => ({
+    // First part inherits the caller-provided messageId (so consumers that
+    // referenced it via `messageId` still resolve). Subsequent parts get fresh
+    // generated IDs keyed to the same author.
+    id: idx === 0
+      ? messageIdValue
+      : generateMessageId(author.machineId, author.workspace),
+    // Stagger per-part timestamps by 1ms so insertion order survives any
+    // later sort that keys on timestamp alone.
+    timestamp: new Date(nowDate.getTime() + idx).toISOString(),
+    author,
+    content: partContent
+  }));
+
+  // Use the FIRST part as the "primary" message for mention/crossPost wiring —
+  // it carries the caller-provided messageId and is the natural anchor in the
+  // intercom stream.
+  const message = newMessages[0];
+
+  // Parse mentions on the FULL original content (not on a single part) so
+  // @-mentions that happen to cross a part boundary still fire exactly once.
   const mentions = parseMentions(args.content);
   if (mentions.length > 0) {
     logger.debug('Mentions detected in dashboard message', {
       messageId: message.id,
       mentionCount: mentions.length,
-      mentions: mentions.map(m => m.pattern)
+      mentions: mentions.map(m => m.pattern),
+      isMultiPart
     });
   }
 
-  const now = new Date().toISOString();
+  const now = nowDate.toISOString();
   const updatedDashboard: Dashboard = {
     ...dashboard,
     lastModified: now,
     lastModifiedBy: author,
     intercom: {
-      messages: [...dashboard.intercom.messages, message],
-      totalMessages: dashboard.intercom.totalMessages + 1,
+      messages: [...dashboard.intercom.messages, ...newMessages],
+      totalMessages: dashboard.intercom.totalMessages + newMessages.length,
       lastCondensedAt: dashboard.intercom.lastCondensedAt
     }
   };
@@ -1705,14 +1847,18 @@ async function handleAppend(
     });
     const beforeCount = updatedDashboard.intercom.messages.length;
     const reactiveDiag = newDiagnostic('reactive');
+    const tReact = Date.now();
     finalDashboard = await condenseIntercom(key, updatedDashboard, CONDENSE_KEEP, reactiveDiag);
+    reactiveCondenseMs = Date.now() - tReact;
     condenseDiagnostics.push(reactiveDiag);
     const newlyArchived = beforeCount - finalDashboard.intercom.messages.length;
     archivedCount += newlyArchived;
     condensed = condensed || newlyArchived > 0;
   }
 
+  const tWrite = Date.now();
   await writeDashboardFile(key, finalDashboard);
+  writeMs = Date.now() - tWrite;
 
   // Fire-and-forget: Send mention notifications if mentions were detected
   if (mentions.length > 0) {
@@ -1849,6 +1995,9 @@ async function handleAppend(
     }
   }
 
+  const totalMs = Date.now() - appendStart;
+  const splitSuffix = isMultiPart ? ` [split en ${newMessages.length} parts]` : '';
+
   return {
     success: true,
     action: 'append',
@@ -1861,7 +2010,14 @@ async function handleAppend(
     archivedCount: reportedArchivedCount,
     crossPost: crossPostResults.length > 0 ? crossPostResults : undefined,
     condenseDiagnostic: condenseDiagnostics.length > 0 ? condenseDiagnostics : undefined,
-    message: `Message ajouté au dashboard '${key}'${condensed ? ` (auto-condensation: ${reportedArchivedCount} messages archivés, taille réduite)` : ''}${diagSuffix}${crossPostSuffix}`
+    splitCount: newMessages.length,
+    durationBreakdown: {
+      totalMs,
+      preemptiveCondenseMs,
+      reactiveCondenseMs,
+      writeMs
+    },
+    message: `Message ajouté au dashboard '${key}'${splitSuffix}${condensed ? ` (auto-condensation: ${reportedArchivedCount} messages archivés, taille réduite)` : ''}${diagSuffix}${crossPostSuffix}`
   };
 }
 


### PR DESCRIPTION
Fixes part of #1589 (condensation ineffective on oversize recent messages).

## What

Split incoming messages > 4KB into multiple IntercomMessage entries at append
time, so the `CONDENSE_KEEP=10` slice policy no longer protects oversized
dispatches from archival by virtue of being recent.

Also adds `splitCount` + `durationBreakdown` to the `append` result for
operator observability.

## Why

Observed 2026-04-20 on workspace-CoursIA and workspace-* (po-2025): 108%
utilization, 10 min 7 s append durations, `archivedCount: 1` per cycle.
Three recent dispatch messages (15KB + 12KB + 5KB = 32KB of 50KB budget) sat
in the CONDENSE_KEEP window and were never eligible for archival. Condense
archived 1-2 small old messages per pass → dashboard stayed above threshold.

The existing test `does NOT preemptively condense when messages.length <=
CONDENSE_KEEP` (line 1001, pre-fix) **documented the bug**: a 47 KB single
message + a small append → `condensed=false`, no condense ever happens. That
assertion is now rewritten as the regression test for this fix.

## Changes

- `dashboard.ts`:
  - `MAX_INDIVIDUAL_MESSAGE_BYTES = 4 * 1024` constant.
  - `splitLargeMessage(content, maxBytes?)` helper. Line-boundary splits, with
    binary-search char-slice for single lines exceeding the cap. Each part
    prefixed with `**[PART n/N]**`.
  - `handleAppend` uses split → N IntercomMessages. First part inherits the
    caller-provided `messageId`; subsequent parts get generated IDs. Timestamps
    staggered by 1ms to preserve order.
  - Mentions parsed on the **full** original content (boundary-safe).
  - `durationBreakdown` tracks preemptive/reactive/write phase latencies.
  - `splitCount` surfaced in result.

- `dashboard.test.ts`:
  - Rewrote ex-bug-documenting test as regression test for the fix.
  - New describe block `Message splitting and duration breakdown (#1589)`:
    - Small messages stay single.
    - Line-boundary splitting for paragraph-heavy bodies.
    - Hard char-slice for single oversize lines.
    - `durationBreakdown` populated on every append.
    - `preemptiveCondenseMs > 0` when preemptive condense fires.
    - Integration scenario: 9 small + 3 oversize dispatches → dashboard back
      under 50 KB (the CoursIA / po-2025 failure mode).

## Test results

- Full CI suite: **7898 passed / 0 failed / 18 skipped / 2 test-file skipped** (84 s).
- Target file `dashboard.test.ts`: **82 passed / 1 skipped** (includes 6 new
  `#1589` tests).

## Out of scope (future work)

- Size-aware condense keep policy (condense by bytes target, not by message
  count). Split makes it unnecessary for the observed failure mode, but the
  underlying slice-by-count logic remains and could trip on other shapes.
- LLM retry backoff tuning (the 10-min duration was both the split gap AND
  the LLM retry loop; reducing the max retries or timeout could help in
  LLM-down scenarios).

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
