### PR TITLE
test(coverage): EnrichContentClassifier (90) + GitHelpers (54) = 144 tests

### DIFF
--- a/servers/roo-state-manager/tests/unit/services/EnrichContentClassifier.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/EnrichContentClassifier.test.ts
@@ -1,0 +1,852 @@
+/**
+ * EnrichContentClassifier - Comprehensive test suite
+ *
+ * Tests classification of conversation messages into typed content
+ * with confidence scoring, tool parsing, and relevance evaluation.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { EnrichContentClassifier } from '../../../src/services/EnrichContentClassifier.js';
+import { ConversationSkeleton } from '../../../src/types/conversation.js';
+import { ClassifiedContent } from '../../../src/types/enhanced-conversation.js';
+
+describe('EnrichContentClassifier', () => {
+	let classifier: EnrichContentClassifier;
+
+	beforeEach(() => {
+		classifier = new EnrichContentClassifier();
+	});
+
+	// ─── Helper ────────────────────────────────────────────────────────
+
+	function makeConversation(...messages: { role: 'user' | 'assistant'; content: string }[]): ConversationSkeleton {
+		return {
+			taskId: 'test-task',
+			metadata: {} as any,
+			sequence: messages.map(m => ({
+				role: m.role,
+				content: m.content,
+				timestamp: Date.now().toString(),
+				isTruncated: false,
+			})),
+		};
+	}
+
+	// ═══════════════════════════════════════════════════════════════════
+	// 1. User Messages - UserMessage subType
+	// ═══════════════════════════════════════════════════════════════════
+
+	describe('User messages', () => {
+		it('classifies a plain user message as UserMessage', async () => {
+			const result = await classifier.classifyMessage('Hello, can you help me?', 'user', 0);
+
+			expect(result.type).toBe('User');
+			expect(result.subType).toBe('UserMessage');
+			expect(result.content).toBe('Hello, can you help me?');
+			expect(result.index).toBe(0);
+			expect(result.contentSize).toBe(23);
+			expect(result.toolCallDetails).toBeUndefined();
+			expect(result.toolResultDetails).toBeUndefined();
+		});
+
+		it('assigns confidence 0.9 to plain user messages', async () => {
+			const result = await classifier.classifyMessage('A longer user message that is definitely over twenty chars', 'user', 1);
+
+			// base 0.9, content > 20 chars so no small penalty, no markdown prefix so no boost
+			expect(result.confidenceScore).toBe(0.9);
+		});
+
+		it('preserves original content exactly', async () => {
+			const content = 'Line 1\nLine 2\nLine 3';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.content).toBe(content);
+		});
+	});
+
+	// ═══════════════════════════════════════════════════════════════════
+	// 2. Tool Results - ToolResult subType
+	// ═══════════════════════════════════════════════════════════════════
+
+	describe('Tool results', () => {
+		it('detects [...] Result: pattern as ToolResult', async () => {
+			const content = '[read_file] Result:\nFile content here';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.type).toBe('User');
+			expect(result.subType).toBe('ToolResult');
+		});
+
+		it('detects Command executed pattern as ToolResult', async () => {
+			const content = 'Command executed successfully.\nOutput: done';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.subType).toBe('ToolResult');
+		});
+
+		it('detects <file_write_result> pattern as ToolResult', async () => {
+			const content = '<file_write_result>\n<path>test.ts</path>\n</file_write_result>';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.subType).toBe('ToolResult');
+		});
+
+		it('assigns confidence 0.95 base to tool results', async () => {
+			const content = '[execute_command] Result:\nBuild successful';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			// base 0.95, content > 20 chars, no markdown prefix
+			expect(result.confidenceScore).toBe(0.95);
+		});
+
+		it('populates toolResultDetails for tool results', async () => {
+			const content = '[read_file] Result:\nconst x = 42;';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails).toBeDefined();
+			expect(result.toolResultDetails!.success).toBe(true);
+			expect(result.toolResultDetails!.outputSize).toBe(content.length);
+		});
+
+		it('detects failed tool results via error keyword', async () => {
+			const content = '[execute_command] Result:\nerror: command not found';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails).toBeDefined();
+			expect(result.toolResultDetails!.success).toBe(false);
+			expect(result.toolResultDetails!.resultType).toBe('error');
+			expect(result.toolResultDetails!.errorMessage).toBeDefined();
+		});
+
+		it('detects failed tool results via failed keyword', async () => {
+			const content = '[write_to_file] Result:\nOperation failed to complete';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.success).toBe(false);
+			expect(result.toolResultDetails!.resultType).toBe('error');
+		});
+
+		it('detects file result type from <file_write_result>', async () => {
+			const content = '<file_write_result>\n<path>src/index.ts</path>\n<content>export {}</content>\n</file_write_result>';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.resultType).toBe('file');
+		});
+
+		it('detects file result type from <files> tag', async () => {
+			const content = '[search_files] Result:\n<files>\n<file>test.ts</file>\n</files>';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.resultType).toBe('file');
+		});
+
+		it('detects JSON result type from curly brace content', async () => {
+			const content = '[execute_command] Result:\n{"status": "ok", "count": 5}';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.resultType).toBe('json');
+		});
+
+		it('detects HTML result type', async () => {
+			const content = '[browser_action] Result:\n<html><body>Hello</body></html>';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.resultType).toBe('html');
+		});
+
+		it('defaults to text result type for plain results', async () => {
+			const content = '[read_file] Result:\nJust some plain text output';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.resultType).toBe('text');
+		});
+
+		it('detects truncation via ellipsis', async () => {
+			const content = '[read_file] Result:\nContent truncated...';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.truncated).toBe(true);
+		});
+
+		it('detects truncation via unicode ellipsis', async () => {
+			const content = '[read_file] Result:\nContent truncated\u2026';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.truncated).toBe(true);
+		});
+
+		it('detects truncation via "truncated" keyword', async () => {
+			const content = '[read_file] Result:\nOutput was truncated to fit';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.truncated).toBe(true);
+		});
+
+		it('extracts originalLength from truncation metadata', async () => {
+			const content = '[read_file] Result:\nContent truncated... 15000 characters';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.truncated).toBe(true);
+			expect(result.toolResultDetails!.originalLength).toBe(15000);
+		});
+
+		it('extracts originalLength with "chars" unit', async () => {
+			const content = '[read_file] Result:\nOutput truncated... 8500 chars';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.originalLength).toBe(8500);
+		});
+
+		it('extracts originalLength with "bytes" unit', async () => {
+			const content = '[read_file] Result:\nContent truncated... 32000 bytes';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.originalLength).toBe(32000);
+		});
+
+		it('extracts error message from error line', async () => {
+			const content = '[execute_command] Result:\nError: Permission denied';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.errorMessage).toBe('Permission denied');
+		});
+
+		it('falls back to "Unknown error" when no specific error message found', async () => {
+			const content = '[execute_command] Result:\nUnable to complete the operation fully';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.success).toBe(false);
+			expect(result.toolResultDetails!.errorMessage).toBe('Unknown error');
+		});
+	});
+
+	// ═══════════════════════════════════════════════════════════════════
+	// 3. Assistant Messages - Completion, Thinking, ToolCall subTypes
+	// ═══════════════════════════════════════════════════════════════════
+
+	describe('Assistant messages', () => {
+		it('classifies <attempt_completion> as Completion', async () => {
+			const content = '<attempt_completion>\n<result>Task completed successfully</result>\n</attempt_completion>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.type).toBe('Assistant');
+			expect(result.subType).toBe('Completion');
+			expect(result.confidenceScore).toBe(0.98);
+		});
+
+		it('classifies <thinking> as Thinking', async () => {
+			const content = '<thinking>\nLet me analyze this step by step...\nThe user wants to refactor the code.\n</thinking>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.type).toBe('Assistant');
+			expect(result.subType).toBe('Thinking');
+			expect(result.confidenceScore).toBe(0.85);
+		});
+
+		it('classifies <read_file> as ToolCall', async () => {
+			const content = '<read_file>\n<path>src/index.ts</path>\n</read_file>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.type).toBe('Assistant');
+			expect(result.subType).toBe('ToolCall');
+		});
+
+		it('classifies <write_to_file> as ToolCall', async () => {
+			const content = '<write_to_file>\n<path>src/new.ts</path>\n<content>export const x = 1;</content>\n</write_to_file>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.subType).toBe('ToolCall');
+		});
+
+		it('classifies <execute_command> as ToolCall', async () => {
+			const content = '<execute_command>\n<command>npm run build</command>\n</execute_command>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.subType).toBe('ToolCall');
+		});
+
+		it('classifies underscore patterns like <ask_followup_question> as ToolCall', async () => {
+			const content = '<ask_followup_question>\n<question>Do you want to proceed?</question>\n</ask_followup_question>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.subType).toBe('ToolCall');
+		});
+
+		it('defaults to Completion for unrecognized assistant content', async () => {
+			const content = 'Here is a summary of what was done in this task overall.';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.subType).toBe('Completion');
+			expect(result.confidenceScore).toBe(0.8);
+		});
+
+		it('prioritizes Completion over Thinking', async () => {
+			// <attempt_completion> is checked first in the code
+			const content = '<attempt_completion>\n<result>Done</result>\n</attempt_completion>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.subType).toBe('Completion');
+		});
+
+		it('prioritizes Thinking over ToolCall', async () => {
+			// <thinking> is checked before hasToolCalls
+			const content = '<thinking>\nI should use read_file here\n</thinking>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.subType).toBe('Thinking');
+		});
+	});
+
+	// ═══════════════════════════════════════════════════════════════════
+	// 4. Tool Call Details Extraction
+	// ═══════════════════════════════════════════════════════════════════
+
+	describe('Tool call details extraction', () => {
+		it('extracts tool name from XML tag', async () => {
+			const content = '<read_file>\n<path>src/index.ts</path>\n</read_file>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.toolCallDetails).toBeDefined();
+			expect(result.toolCallDetails!.toolName).toBe('read_file');
+			expect(result.toolCallDetails!.parseSuccess).toBe(true);
+		});
+
+		it('extracts nested arguments', async () => {
+			const content = '<execute_command>\n<command>npm test</command>\n<requires_approval>true</requires_approval>\n</execute_command>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.toolCallDetails!.arguments).toEqual({
+				command: 'npm test',
+				requires_approval: 'true',
+			});
+		});
+
+		it('captures rawXml', async () => {
+			const content = '<write_to_file>\n<path>out.ts</path>\n</write_to_file>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.toolCallDetails!.rawXml).toContain('<write_to_file>');
+			expect(result.toolCallDetails!.rawXml).toContain('</write_to_file>');
+		});
+
+		it('reports parseSuccess true on valid XML', async () => {
+			const content = '<read_file>\n<path>test.ts</path>\n</read_file>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.toolCallDetails!.parseSuccess).toBe(true);
+			expect(result.toolCallDetails!.parseError).toBeUndefined();
+		});
+
+		it('assigns higher confidence on successful parse (0.92)', async () => {
+			const content = '<read_file>\n<path>test.ts</path>\n</read_file>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			// base 0.92, content > 20, no markdown, no low diversity
+			expect(result.confidenceScore).toBe(0.92);
+		});
+
+		it('assigns lower confidence on failed parse (0.7)', async () => {
+			// Content triggers hasToolCalls (has read_file pattern)
+			// but extractToolCallDetails regex can't match properly
+			const content = 'I will use <read_file> to check this file now please';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			// hasToolCalls matches <read_file>, but extractToolCallDetails
+			// tries to match <(\w+)>(...)<\/\1> which requires a closing tag
+			// No closing tag => toolCallDetails.parseSuccess = false
+			expect(result.confidenceScore).toBeLessThanOrEqual(0.7);
+		});
+
+		it('returns unknown tool name when no pattern matches', async () => {
+			// The extractToolCallDetails only runs when hasToolCalls returns true
+			// but the inner regex might not match the same way
+			// Edge case: content with <read_file> but no closing tag
+			const content = 'Please <read_file> the source';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			if (result.toolCallDetails) {
+				expect(result.toolCallDetails!.toolName).toBe('unknown');
+				expect(result.toolCallDetails!.parseSuccess).toBe(false);
+			}
+		});
+
+		it('extracts arguments with multiline values', async () => {
+			const content = '<write_to_file>\n<path>src/output.ts</path>\n<content>import { x } from "y";\n\nexport default x;\n</content>\n</write_to_file>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.toolCallDetails!.arguments.path).toBe('src/output.ts');
+			expect(result.toolCallDetails!.arguments.content).toContain('import { x }');
+			expect(result.toolCallDetails!.arguments.content).toContain('export default x');
+		});
+	});
+
+	// ═══════════════════════════════════════════════════════════════════
+	// 5. Tool Result Details Extraction
+	// ═══════════════════════════════════════════════════════════════════
+
+	describe('Tool result details extraction', () => {
+		it('sets success true for results without error keywords', async () => {
+			const content = '[read_file] Result:\nexport const foo = "bar";';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.success).toBe(true);
+		});
+
+		it('sets outputSize to content length', async () => {
+			const content = '[read_file] Result:\n12345';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.outputSize).toBe(content.length);
+		});
+
+		it('defaults truncated to false', async () => {
+			const content = '[execute_command] Result:\nAll tests passed';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.truncated).toBe(false);
+		});
+
+		it('defaults originalLength to undefined when not truncated', async () => {
+			const content = '[read_file] Result:\nFull content here';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.originalLength).toBeUndefined();
+		});
+
+		it('defaults errorMessage to undefined for successful results', async () => {
+			const content = '[execute_command] Result:\nSuccess: build completed';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.errorMessage).toBeUndefined();
+		});
+
+		it('error detection overrides resultType to error', async () => {
+			// JSON content but with "error" keyword
+			const content = '[execute_command] Result:\n{"error": "file not found"}';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			// Error detection should override JSON detection
+			expect(result.toolResultDetails!.success).toBe(false);
+			expect(result.toolResultDetails!.resultType).toBe('error');
+		});
+
+		it('detects "unable" keyword as failure', async () => {
+			const content = '[write_to_file] Result:\nUnable to write file: permission denied';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.toolResultDetails!.success).toBe(false);
+			expect(result.toolResultDetails!.resultType).toBe('error');
+		});
+	});
+
+	// ═══════════════════════════════════════════════════════════════════
+	// 6. Relevance Evaluation
+	// ═══════════════════════════════════════════════════════════════════
+
+	describe('Relevance evaluation', () => {
+		it('marks content under 10 chars as not relevant', async () => {
+			const result = await classifier.classifyMessage('short', 'user', 0);
+
+			expect(result.isRelevant).toBe(false);
+		});
+
+		it('marks exactly 10 chars as not relevant (<10 check)', async () => {
+			// contentSize < 10, so 9 chars should be irrelevant
+			const result = await classifier.classifyMessage('123456789', 'user', 0);
+
+			expect(result.isRelevant).toBe(false);
+		});
+
+		it('marks 10+ char content as relevant', async () => {
+			const result = await classifier.classifyMessage('This is a valid message with enough content', 'user', 0);
+
+			expect(result.isRelevant).toBe(true);
+		});
+
+		it('marks debug-prefixed content as not relevant', async () => {
+			const content = 'debug: checking variable state in the program';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.isRelevant).toBe(false);
+		});
+
+		it('marks log-prefixed content as not relevant', async () => {
+			const content = 'log: Operation completed with exit code 0';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.isRelevant).toBe(false);
+		});
+
+		it('marks console. prefixed content as not relevant', async () => {
+			const content = 'console.log("This is a debug statement")';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.isRelevant).toBe(false);
+		});
+
+		it('marks <environment_details> content as not relevant', async () => {
+			const content = '<environment_details>\n<cwd>/home/user</cwd>\n</environment_details>';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.isRelevant).toBe(false);
+		});
+
+		it('always marks Completion subType as relevant', async () => {
+			// Even short completion messages are relevant
+			const content = '<attempt_completion>\n<result>ok</result>\n</attempt_completion>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.subType).toBe('Completion');
+			expect(result.isRelevant).toBe(true);
+		});
+
+		it('does not false-positive on content containing "debug" mid-sentence', async () => {
+			const content = 'Please debug the issue in the authentication module';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			// The regex is /^debug/ so "Please debug" should NOT match
+			expect(result.isRelevant).toBe(true);
+		});
+	});
+
+	// ═══════════════════════════════════════════════════════════════════
+	// 7. Confidence Score Adjustment
+	// ═══════════════════════════════════════════════════════════════════
+
+	describe('Confidence score adjustment', () => {
+		it('penalizes content under 20 chars (x0.8)', async () => {
+			// UserMessage base = 0.9, content < 20 => 0.9 * 0.8 = 0.72
+			const result = await classifier.classifyMessage('A short msg', 'user', 0);
+
+			expect(result.confidenceScore).toBeCloseTo(0.72, 2);
+		});
+
+		it('penalizes content over 10000 chars (x0.9)', async () => {
+			const longContent = 'x'.repeat(10001);
+			const result = await classifier.classifyMessage(longContent, 'user', 0);
+
+			// base 0.9 * 0.9 = 0.81 (no markdown prefix, content likely diverse enough)
+			expect(result.confidenceScore).toBeLessThan(0.9);
+		});
+
+		it('boosts content starting with markdown heading (#)', async () => {
+			const content = '# Summary of Changes\n\nThis PR adds new features to the system.';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			// base 0.9 * 1.1 = 0.99
+			expect(result.confidenceScore).toBeCloseTo(0.99, 2);
+		});
+
+		it('boosts content starting with bold (**)', async () => {
+			const content = '**Important**: Please review these changes before merging';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			// base 0.9 * 1.1 = 0.99
+			expect(result.confidenceScore).toBeCloseTo(0.99, 2);
+		});
+
+		it('boosts content starting with list dash (-)', async () => {
+			const content = '- First item in the list of changes\n- Second item here';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			// base 0.9 * 1.1 = 0.99
+			expect(result.confidenceScore).toBeCloseTo(0.99, 2);
+		});
+
+		it('penalizes low word diversity (x0.7)', async () => {
+			// Create content with repetitive words but > 10 words
+			const content = 'test test test test test test test test test test test test';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			// Only 2 unique words out of 12 total => ratio 2/12 < 0.3
+			// base 0.9 * 0.7 = 0.63
+			expect(result.confidenceScore).toBeCloseTo(0.63, 2);
+		});
+
+		it('does not penalize high word diversity', async () => {
+			const content = 'The quick brown fox jumps over the lazy dog in the park today';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			// base 0.9, content > 20, diverse words, no markdown
+			expect(result.confidenceScore).toBe(0.9);
+		});
+
+		it('clamps score to maximum 1.0', async () => {
+			// Completion base = 0.98, with markdown boost: 0.98 * 1.1 = 1.078 => clamped to 1.0
+			const content = '# Title\n\nCompletion with heading and substantial text content here';
+			// Force a Completion by using assistant role with <attempt_completion>
+			const completionContent = '<attempt_completion>\n# Title\n\nResult is here with enough text\n</attempt_completion>';
+			const result = await classifier.classifyMessage(completionContent, 'assistant', 0);
+
+			expect(result.confidenceScore).toBeLessThanOrEqual(1.0);
+		});
+
+		it('clamps score to minimum 0.0', async () => {
+			// Edge case: force negative score through stacking penalties
+			// This is hard to trigger naturally but the Math.max(0, ...) exists
+			// Verify that scores are always >= 0
+			const result = await classifier.classifyMessage('x', 'user', 0);
+
+			expect(result.confidenceScore).toBeGreaterThanOrEqual(0);
+		});
+
+		it('does not apply small-content penalty at exactly 20 chars', async () => {
+			// contentSize < 20, so 20 chars should NOT get penalty
+			const content = '12345678901234567890'; // exactly 20 chars
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.confidenceScore).toBe(0.9);
+		});
+
+		it('does not apply large-content penalty at exactly 10000 chars', async () => {
+			// contentSize > 10000, so 10000 chars should NOT get penalty
+			const content = 'a'.repeat(10000); // exactly 10000 chars
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			// No large penalty (not > 10000), check no markdown prefix
+			// But diversity might kick in since it's all 'a's
+			// Actually: 'a'.repeat(10000) splits to 1 word of 10000 chars
+			// words.length = 1, which is NOT > 10, so no diversity penalty
+			expect(result.confidenceScore).toBe(0.9);
+		});
+
+		it('does not apply low-diversity penalty with <= 10 words', async () => {
+			const content = 'hello world'; // 2 words, ratio irrelevant (words.length <= 10)
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			// words.length = 2 which is NOT > 10, so diversity check is skipped
+			// But content < 20, so penalty 0.9 * 0.8 = 0.72
+			expect(result.confidenceScore).toBeCloseTo(0.72, 2);
+		});
+	});
+
+	// ═══════════════════════════════════════════════════════════════════
+	// 8. Full Conversation Classification
+	// ═══════════════════════════════════════════════════════════════════
+
+	describe('classifyConversationContent', () => {
+		it('classifies a full conversation with mixed message types', async () => {
+			const conversation = makeConversation(
+				{ role: 'user', content: 'Please read the file src/index.ts' },
+				{ role: 'assistant', content: '<read_file>\n<path>src/index.ts</path>\n</read_file>' },
+				{ role: 'user', content: '[read_file] Result:\nexport const x = 42;' },
+				{ role: 'assistant', content: '<attempt_completion>\n<result>Done</result>\n</attempt_completion>' },
+			);
+
+			const results = await classifier.classifyConversationContent(conversation);
+
+			expect(results).toHaveLength(4);
+			expect(results[0].subType).toBe('UserMessage');
+			expect(results[1].subType).toBe('ToolCall');
+			expect(results[2].subType).toBe('ToolResult');
+			expect(results[3].subType).toBe('Completion');
+		});
+
+		it('assigns sequential indices to messages', async () => {
+			const conversation = makeConversation(
+				{ role: 'user', content: 'First message here' },
+				{ role: 'assistant', content: '<thinking>\nProcessing...\n</thinking>' },
+				{ role: 'user', content: 'Second user message here' },
+			);
+
+			const results = await classifier.classifyConversationContent(conversation);
+
+			expect(results[0].index).toBe(0);
+			expect(results[1].index).toBe(1);
+			expect(results[2].index).toBe(2);
+		});
+
+		it('filters out non-message items (ActionMetadata)', async () => {
+			const conversation: ConversationSkeleton = {
+				taskId: 'test-task',
+				metadata: {} as any,
+				sequence: [
+					{ role: 'user', content: 'Hello there user message', timestamp: '1', isTruncated: false },
+					{ type: 'tool', name: 'read_file', parameters: {}, status: 'success', timestamp: '2' },
+					{ role: 'assistant', content: 'I read the file for you now', timestamp: '3', isTruncated: false },
+				],
+			};
+
+			const results = await classifier.classifyConversationContent(conversation);
+
+			expect(results).toHaveLength(2);
+			expect(results[0].content).toBe('Hello there user message');
+			expect(results[1].content).toBe('I read the file for you now');
+		});
+
+		it('handles empty sequence gracefully', async () => {
+			const conversation = makeConversation();
+
+			const results = await classifier.classifyConversationContent(conversation);
+
+			expect(results).toHaveLength(0);
+		});
+
+		it('handles null sequence gracefully', async () => {
+			const conversation: ConversationSkeleton = {
+				taskId: 'test-task',
+				metadata: {} as any,
+				sequence: null as any,
+			};
+
+			const results = await classifier.classifyConversationContent(conversation);
+
+			expect(results).toHaveLength(0);
+		});
+
+		it('handles undefined sequence gracefully', async () => {
+			const conversation: ConversationSkeleton = {
+				taskId: 'test-task',
+				metadata: {} as any,
+				sequence: undefined as any,
+			};
+
+			const results = await classifier.classifyConversationContent(conversation);
+
+			expect(results).toHaveLength(0);
+		});
+
+		it('classifies a conversation with only thinking messages', async () => {
+			const conversation = makeConversation(
+				{ role: 'assistant', content: '<thinking>\nAnalyzing the code structure...\n</thinking>' },
+				{ role: 'assistant', content: '<thinking>\nPlanning the refactoring approach.\n</thinking>' },
+			);
+
+			const results = await classifier.classifyConversationContent(conversation);
+
+			expect(results).toHaveLength(2);
+			expect(results[0].subType).toBe('Thinking');
+			expect(results[1].subType).toBe('Thinking');
+		});
+	});
+
+	// ═══════════════════════════════════════════════════════════════════
+	// 9. Edge Cases
+	// ═══════════════════════════════════════════════════════════════════
+
+	describe('Edge cases', () => {
+		it('handles empty string content', async () => {
+			const result = await classifier.classifyMessage('', 'user', 0);
+
+			expect(result.content).toBe('');
+			expect(result.contentSize).toBe(0);
+			expect(result.isRelevant).toBe(false); // < 10 chars
+			expect(result.subType).toBe('UserMessage');
+		});
+
+		it('handles content with only whitespace', async () => {
+			const content = '     ';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.contentSize).toBe(5);
+			expect(result.isRelevant).toBe(false); // < 10 chars
+		});
+
+		it('handles very long content', async () => {
+			const content = 'A'.repeat(50000);
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.contentSize).toBe(50000);
+			// Large content penalty applies (> 10000): 0.9 * 0.9 = 0.81
+			// Content is single word 'a' repeated, words.length = 1 (not > 10)
+			expect(result.confidenceScore).toBeCloseTo(0.81, 2);
+		});
+
+		it('handles content with special XML characters', async () => {
+			const content = 'Handle <>&"\' characters properly in the message';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.content).toBe(content);
+			expect(result.subType).toBe('UserMessage');
+		});
+
+		it('handles content with unicode characters', async () => {
+			const content = 'Unicode test: \u00e9\u00e8\u00ea\u00eb \u4e2d\u6587 \u0627\u0644\u0639\u0631\u0628\u064a\u0629';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.content).toBe(content);
+			expect(result.contentSize).toBe(content.length);
+		});
+
+		it('handles content that looks like multiple tool calls', async () => {
+			const content = '<read_file>\n<path>a.ts</path>\n</read_file>\n<write_to_file>\n<path>b.ts</path>\n</write_to_file>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			// Should classify as ToolCall and extract the FIRST tool call
+			expect(result.subType).toBe('ToolCall');
+			expect(result.toolCallDetails).toBeDefined();
+			expect(result.toolCallDetails!.toolName).toBe('read_file');
+		});
+
+		it('handles content with mixed patterns (tool result + thinking)', async () => {
+			// User role => checked for tool result first
+			const content = '[read_file] Result:\n<thinking>something</thinking>';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.subType).toBe('ToolResult');
+			// Thinking is only checked for assistant role
+		});
+
+		it('case-insensitive matching for <attempt_completion>', async () => {
+			const content = '<ATTEMPT_COMPLETION>\n<result>Done</result>\n</ATTEMPT_COMPLETION>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			// The regex uses /i flag
+			expect(result.subType).toBe('Completion');
+		});
+
+		it('case-insensitive matching for <thinking>', async () => {
+			const content = '<THINKING>\nDeep analysis\n</THINKING>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.subType).toBe('Thinking');
+		});
+
+		it('case-insensitive matching for Command executed', async () => {
+			const content = 'COMMAND EXECUTED with output: done';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.subType).toBe('ToolResult');
+		});
+
+		it('contentSize matches actual content length', async () => {
+			const content = 'Hello World!';
+			const result = await classifier.classifyMessage(content, 'user', 0);
+
+			expect(result.contentSize).toBe(content.length);
+		});
+
+		it('does not set toolCallDetails for non-ToolCall messages', async () => {
+			const result = await classifier.classifyMessage('Simple user message here', 'user', 0);
+
+			expect(result.toolCallDetails).toBeUndefined();
+		});
+
+		it('does not set toolResultDetails for non-ToolResult messages', async () => {
+			const result = await classifier.classifyMessage('Simple user message here', 'user', 0);
+
+			expect(result.toolResultDetails).toBeUndefined();
+		});
+
+		it('handles deeply nested XML arguments', async () => {
+			const content = '<attempt_completion>\n<result>Done with <nested>tag</nested></result>\n</attempt_completion>';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			expect(result.subType).toBe('Completion');
+			// Completion does not extract tool call details
+			expect(result.toolCallDetails).toBeUndefined();
+		});
+
+		it('classifies assistant content with <read_file> tag (no closing) correctly', async () => {
+			const content = 'Let me read <read_file> this file now';
+			const result = await classifier.classifyMessage(content, 'assistant', 0);
+
+			// hasToolCalls matches <read_file> => ToolCall
+			expect(result.subType).toBe('ToolCall');
+			// But extractToolCallDetails won't find closing tag => parse error
+			if (result.toolCallDetails) {
+				expect(result.toolCallDetails.parseSuccess).toBe(false);
+			}
+		});
+	});
+});

--- a/servers/roo-state-manager/tests/unit/utils/git-helpers.test.ts
+++ b/servers/roo-state-manager/tests/unit/utils/git-helpers.test.ts
@@ -1,0 +1,854 @@
+/**
+ * Tests for GitHelpers - Production Git safety utilities
+ *
+ * @module tests/unit/utils/git-helpers.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — vi.hoisted() ensures references exist before vi.mock factories run
+// ---------------------------------------------------------------------------
+
+const { mockExec, mockInfo, mockError, mockWarn, mockDebug } = vi.hoisted(() => ({
+  mockExec: vi.fn(),
+  mockInfo: vi.fn(),
+  mockError: vi.fn(),
+  mockWarn: vi.fn(),
+  mockDebug: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  exec: mockExec,
+}));
+
+vi.mock('util', () => ({
+  promisify: () => mockExec,
+}));
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  createLogger: () => ({
+    info: mockInfo,
+    error: mockError,
+    warn: mockWarn,
+    debug: mockDebug,
+  }),
+}));
+
+// Import after mocks are set up
+import { GitHelpers, getGitHelpers, resetGitHelpers } from '../../../src/utils/git-helpers.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Standard 40-char hex SHA for tests */
+const FAKE_SHA = '0123456789abcdef0123456789abcdef01234567';
+const FAKE_SHA_ALT = 'fedcba9876543210fedcba9876543210fedcba98';
+const FAKE_GIT_VERSION = 'git version 2.43.0';
+
+/** Make mockExec resolve with given stdout/stderr */
+function mockExecSuccess(stdout: string, stderr = '') {
+  mockExec.mockResolvedValueOnce({ stdout, stderr });
+}
+
+/** Make mockExec reject with given error properties */
+function mockExecFailure(message: string, extra: Record<string, any> = {}) {
+  const err: any = new Error(message);
+  Object.assign(err, extra);
+  mockExec.mockRejectedValueOnce(err);
+}
+
+/**
+ * Sequence the availability check so subsequent execGitCommand / getHeadSHA
+ * calls can proceed without re-mocking git --version every time.
+ * Returns the number of mock slots consumed (always 1).
+ */
+function mockGitAvailable(): number {
+  mockExecSuccess(FAKE_GIT_VERSION);
+  return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GitHelpers', () => {
+  let git: GitHelpers;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExec.mockReset();
+    resetGitHelpers();
+    git = new GitHelpers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // =========================================================================
+  // verifyGitAvailable
+  // =========================================================================
+  describe('verifyGitAvailable', () => {
+    it('should return available=true with version when git is installed', async () => {
+      mockExecSuccess(FAKE_GIT_VERSION);
+
+      const result = await git.verifyGitAvailable();
+
+      expect(result.available).toBe(true);
+      expect(result.version).toBe(FAKE_GIT_VERSION);
+      expect(mockExec).toHaveBeenCalledWith('git --version', { timeout: 5000 });
+      expect(mockInfo).toHaveBeenCalledWith(expect.stringContaining('Git trouvé'));
+    });
+
+    it('should return available=false with error when git is not installed', async () => {
+      mockExecFailure('git not found', { code: 'ENOENT' });
+
+      const result = await git.verifyGitAvailable();
+
+      expect(result.available).toBe(false);
+      expect(result.error).toContain('git not found');
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining('Git NON TROUVÉ'),
+        expect.any(Error),
+      );
+      expect(mockInfo).toHaveBeenCalledWith(expect.stringContaining('git-scm.com'));
+    });
+
+    it('should cache the result and not call exec again on second call', async () => {
+      mockExecSuccess(FAKE_GIT_VERSION);
+
+      await git.verifyGitAvailable();
+      const result = await git.verifyGitAvailable();
+
+      expect(mockExec).toHaveBeenCalledTimes(1);
+      expect(result.available).toBe(true);
+      expect(result.version).toBe(FAKE_GIT_VERSION);
+    });
+
+    it('should cache a failed result as well', async () => {
+      mockExecFailure('not found');
+
+      await git.verifyGitAvailable();
+      const result = await git.verifyGitAvailable();
+
+      expect(mockExec).toHaveBeenCalledTimes(1);
+      expect(result.available).toBe(false);
+    });
+
+    it('should handle non-Error thrown values', async () => {
+      mockExec.mockRejectedValueOnce('string-error');
+
+      const result = await git.verifyGitAvailable();
+
+      expect(result.available).toBe(false);
+      expect(result.error).toBe('string-error');
+    });
+
+    it('should return version from cache even if undefined initially', async () => {
+      mockExecSuccess(FAKE_GIT_VERSION);
+
+      const first = await git.verifyGitAvailable();
+      expect(first.version).toBe(FAKE_GIT_VERSION);
+
+      // Second call should come from cache
+      const second = await git.verifyGitAvailable();
+      expect(second.version).toBe(FAKE_GIT_VERSION);
+    });
+  });
+
+  // =========================================================================
+  // execGitCommand
+  // =========================================================================
+  describe('execGitCommand', () => {
+    it('should execute a command and return success result', async () => {
+      mockGitAvailable(); // availability check
+      mockExecSuccess('On branch main\nnothing to commit');
+
+      const result = await git.execGitCommand('git status', 'Check status');
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('On branch main\nnothing to commit');
+      expect(result.exitCode).toBe(0);
+      expect(mockInfo).toHaveBeenCalledWith(expect.stringContaining('Succès'));
+    });
+
+    it('should return failure when command fails', async () => {
+      mockGitAvailable();
+      mockExecFailure('fatal: not a git repository', { code: 128, stderr: 'not a git repo' });
+
+      const result = await git.execGitCommand('git status', 'Check status');
+
+      expect(result.success).toBe(false);
+      expect(result.output).toBe('');
+      expect(result.exitCode).toBe(128);
+      expect(result.error).toContain('fatal: not a git repository');
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining('Échec'), expect.anything());
+    });
+
+    it('should return error when git is not available', async () => {
+      mockExecFailure('git not found');
+
+      const result = await git.execGitCommand('git status', 'Check status');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Git not available on system');
+      expect(result.exitCode).toBe(-1);
+    });
+
+    it('should pass cwd option to exec', async () => {
+      mockGitAvailable();
+      mockExecSuccess('ok');
+
+      await git.execGitCommand('git status', 'Check status', { cwd: '/repo/path' });
+
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.stringContaining('git status'),
+        expect.objectContaining({ cwd: '/repo/path' }),
+      );
+    });
+
+    it('should pass timeout option to exec (default 30000)', async () => {
+      mockGitAvailable();
+      mockExecSuccess('ok');
+
+      await git.execGitCommand('git status', 'Check status');
+
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ timeout: 30000 }),
+      );
+    });
+
+    it('should use custom timeout when provided', async () => {
+      mockGitAvailable();
+      mockExecSuccess('ok');
+
+      await git.execGitCommand('git status', 'Check status', { timeout: 5000 });
+
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ timeout: 5000 }),
+      );
+    });
+
+    it('should log SHA before and after when logSHA is true and cwd is set', async () => {
+      mockGitAvailable();            // availability
+      mockExecSuccess(FAKE_SHA);     // SHA before (git rev-parse HEAD)
+      mockExecSuccess('done');       // actual command
+      mockExecSuccess(FAKE_SHA_ALT); // SHA after (different)
+
+      const result = await git.execGitCommand(
+        'git pull',
+        'Pull changes',
+        { cwd: '/repo', logSHA: true },
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockDebug).toHaveBeenCalledWith(
+        expect.stringContaining('SHA avant'),
+      );
+      expect(mockInfo).toHaveBeenCalledWith(
+        expect.stringContaining('changé'),
+      );
+    });
+
+    it('should log "inchangé" when SHA is the same after operation', async () => {
+      mockGitAvailable();
+      mockExecSuccess(FAKE_SHA);  // SHA before
+      mockExecSuccess('done');     // actual command
+      mockExecSuccess(FAKE_SHA);  // SHA after (same)
+
+      const result = await git.execGitCommand(
+        'git pull',
+        'Pull changes',
+        { cwd: '/repo', logSHA: true },
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockDebug).toHaveBeenCalledWith(
+        expect.stringContaining('inchangé'),
+      );
+    });
+
+    it('should warn when SHA retrieval fails before operation', async () => {
+      mockGitAvailable();
+      mockExecFailure('no sha'); // SHA before fails
+      mockExecSuccess('done');    // actual command
+
+      const result = await git.execGitCommand(
+        'git pull',
+        'Pull changes',
+        { cwd: '/repo', logSHA: true },
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockWarn).toHaveBeenCalledWith(
+        expect.stringContaining('SHA avant'),
+      );
+    });
+
+    it('should warn when SHA retrieval fails after operation', async () => {
+      mockGitAvailable();
+      mockExecSuccess(FAKE_SHA); // SHA before
+      mockExecSuccess('done');    // actual command
+      mockExecFailure('no sha'); // SHA after fails
+
+      const result = await git.execGitCommand(
+        'git pull',
+        'Pull changes',
+        { cwd: '/repo', logSHA: true },
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockWarn).toHaveBeenCalledWith(
+        expect.stringContaining('SHA après'),
+      );
+    });
+
+    it('should skip SHA logging when cwd is not provided', async () => {
+      mockGitAvailable();
+      mockExecSuccess('done');
+
+      await git.execGitCommand('git status', 'Status check', { logSHA: true });
+
+      // Only 2 calls: availability + actual command (no SHA rev-parse)
+      expect(mockExec).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle stderr output as non-fatal warning', async () => {
+      mockGitAvailable();
+      mockExecSuccess('output', 'some warning message');
+
+      const result = await git.execGitCommand('git status', 'Check status');
+
+      expect(result.success).toBe(true);
+      expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining('stderr'));
+    });
+
+    it('should log stderr in failure case', async () => {
+      mockGitAvailable();
+      mockExecFailure('command failed', { code: 1, stderr: 'error details' });
+
+      await git.execGitCommand('git push', 'Push changes');
+
+      // The source code calls mockError with a string (not an Error) for the
+      // "Git stderr: ..." log line.
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining('Git stderr'),
+      );
+    });
+
+    it('should handle error without stderr', async () => {
+      mockGitAvailable();
+      mockExecFailure('unknown error');
+
+      const result = await git.execGitCommand('git push', 'Push');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('unknown error');
+      expect(result.exitCode).toBe(-1);
+    });
+
+    it('should use cached git availability on repeated calls', async () => {
+      mockGitAvailable(); // availability (cached after first)
+      mockExecSuccess('output1');
+      mockExecSuccess('output2');
+
+      await git.execGitCommand('git status', 'Status 1');
+      await git.execGitCommand('git status', 'Status 2');
+
+      // availability check only once, then 2 actual commands = 3 total
+      expect(mockExec).toHaveBeenCalledTimes(3);
+    });
+
+    it('should pass encoding utf-8 to exec', async () => {
+      mockGitAvailable();
+      mockExecSuccess('ok');
+
+      await git.execGitCommand('git status', 'Check');
+
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ encoding: 'utf-8' }),
+      );
+    });
+
+    it('should handle error with non-Error thrown value', async () => {
+      mockGitAvailable();
+      mockExec.mockRejectedValueOnce('string-error');
+
+      const result = await git.execGitCommand('git status', 'Check');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('string-error');
+    });
+  });
+
+  // =========================================================================
+  // getHeadSHA
+  // =========================================================================
+  describe('getHeadSHA', () => {
+    it('should return the SHA string on success', async () => {
+      mockGitAvailable();       // availability
+      mockExecSuccess(FAKE_SHA); // rev-parse HEAD
+
+      const sha = await git.getHeadSHA('/repo');
+
+      expect(sha).toBe(FAKE_SHA);
+    });
+
+    it('should return null when command fails', async () => {
+      mockGitAvailable();
+      mockExecFailure('not a git repo', { code: 128 });
+
+      const sha = await git.getHeadSHA('/repo');
+
+      expect(sha).toBeNull();
+    });
+
+    it('should pass correct timeout of 5000 and cwd', async () => {
+      mockGitAvailable();
+      mockExecSuccess(FAKE_SHA);
+
+      await git.getHeadSHA('/repo');
+
+      // Second call is the actual command (rev-parse HEAD)
+      expect(mockExec).toHaveBeenNthCalledWith(
+        2,
+        'git rev-parse HEAD',
+        expect.objectContaining({ timeout: 5000, cwd: '/repo' }),
+      );
+    });
+  });
+
+  // =========================================================================
+  // verifyHeadValid
+  // =========================================================================
+  describe('verifyHeadValid', () => {
+    it('should return true for a valid 40-char hex SHA', async () => {
+      mockGitAvailable();
+      mockExecSuccess(FAKE_SHA);
+
+      const valid = await git.verifyHeadValid('/repo');
+
+      expect(valid).toBe(true);
+    });
+
+    it('should return false for an invalid SHA format', async () => {
+      mockGitAvailable();
+      mockExecSuccess('not-a-valid-sha');
+
+      const valid = await git.verifyHeadValid('/repo');
+
+      expect(valid).toBe(false);
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining('SHA HEAD invalide'),
+      );
+    });
+
+    it('should return false when getHeadSHA returns null', async () => {
+      mockGitAvailable();
+      mockExecFailure('error');
+
+      const valid = await git.verifyHeadValid('/repo');
+
+      expect(valid).toBe(false);
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining('Impossible de récupérer HEAD SHA'),
+      );
+    });
+
+    it('should return false for a short SHA', async () => {
+      mockGitAvailable();
+      mockExecSuccess('0123456'); // only 7 chars
+
+      const valid = await git.verifyHeadValid('/repo');
+
+      expect(valid).toBe(false);
+    });
+
+    it('should return false for a SHA with uppercase letters', async () => {
+      mockGitAvailable();
+      mockExecSuccess('ABCDEF0123456789ABCDEF0123456789ABCDEF01');
+
+      const valid = await git.verifyHeadValid('/repo');
+
+      expect(valid).toBe(false);
+    });
+
+    it('should return false for a 39-char hex string', async () => {
+      mockGitAvailable();
+      mockExecSuccess('0123456789abcdef0123456789abcdef0123456'); // 39 chars
+
+      const valid = await git.verifyHeadValid('/repo');
+
+      expect(valid).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // safePull
+  //
+  // Call flow for a successful safePull:
+  //   1. verifyHeadValid -> getHeadSHA -> execGitCommand ->
+  //      verifyGitAvailable (git --version) + git rev-parse HEAD
+  //   2. execGitCommand(pull) with logSHA: true ->
+  //      verifyGitAvailable (cached) + git rev-parse HEAD (SHA before) +
+  //      git pull + git rev-parse HEAD (SHA after)
+  //   3. verifyHeadValid -> getHeadSHA -> execGitCommand ->
+  //      verifyGitAvailable (cached) + git rev-parse HEAD
+  //
+  // Total mockExec calls: 1 + 1 + 1 + 1 + 1 + 1 = 6
+  // =========================================================================
+  describe('safePull', () => {
+    it('should perform a successful pull with HEAD verification', async () => {
+      // Step 1: verifyHeadValid before (getHeadSHA -> execGitCommand)
+      mockExecSuccess(FAKE_GIT_VERSION); // 1. verifyGitAvailable
+      mockExecSuccess(FAKE_SHA);          // 2. git rev-parse HEAD (for getHeadSHA)
+
+      // Step 2: execGitCommand(pull) with logSHA: true
+      mockExecSuccess(FAKE_SHA);          // 3. git rev-parse HEAD (SHA before in logSHA)
+      mockExecSuccess('Already up to date.'); // 4. git pull origin
+      mockExecSuccess(FAKE_SHA);          // 5. git rev-parse HEAD (SHA after in logSHA)
+
+      // Step 3: verifyHeadValid after (getHeadSHA -> execGitCommand)
+      mockExecSuccess(FAKE_SHA);          // 6. git rev-parse HEAD (for getHeadSHA)
+
+      const result = await git.safePull('/repo');
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('Already up to date.');
+      expect(mockExec).toHaveBeenCalledTimes(6);
+    });
+
+    it('should fail if HEAD is invalid before pull', async () => {
+      mockExecSuccess(FAKE_GIT_VERSION); // verifyGitAvailable
+      mockExecFailure('corrupt');         // git rev-parse HEAD fails -> getHeadSHA returns null
+
+      const result = await git.safePull('/repo');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('HEAD SHA invalid before pull');
+      expect(result.exitCode).toBe(-1);
+      expect(mockExec).toHaveBeenCalledTimes(2);
+    });
+
+    it('should fail if HEAD is corrupted after pull (exec throws)', async () => {
+      // verifyHeadValid before
+      mockExecSuccess(FAKE_GIT_VERSION); // 1. verifyGitAvailable
+      mockExecSuccess(FAKE_SHA);          // 2. git rev-parse HEAD (before, valid)
+
+      // execGitCommand(pull) with logSHA
+      mockExecSuccess(FAKE_SHA);          // 3. SHA before (logSHA)
+      mockExecSuccess('pulled');           // 4. git pull origin (succeeds)
+      mockExecSuccess(FAKE_SHA);          // 5. SHA after (logSHA)
+
+      // verifyHeadValid after: getHeadSHA fails
+      mockExecFailure('corrupt');          // 6. git rev-parse HEAD fails
+
+      const result = await git.safePull('/repo');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('HEAD SHA corrupted after pull');
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining('corrompu après pull'),
+      );
+    });
+
+    it('should fail if HEAD SHA is invalid format after pull', async () => {
+      // verifyHeadValid before
+      mockExecSuccess(FAKE_GIT_VERSION); // 1
+      mockExecSuccess(FAKE_SHA);          // 2 valid before
+
+      // execGitCommand(pull) with logSHA
+      mockExecSuccess(FAKE_SHA);          // 3 SHA before
+      mockExecSuccess('pulled');           // 4 git pull
+      mockExecSuccess(FAKE_SHA);          // 5 SHA after
+
+      // verifyHeadValid after: returns bad format SHA
+      mockExecSuccess('bad-format-sha');  // 6
+
+      const result = await git.safePull('/repo');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('HEAD SHA corrupted after pull');
+    });
+
+    it('should use default remote "origin" when not specified', async () => {
+      mockExecSuccess(FAKE_GIT_VERSION); // 1 verifyGitAvailable
+      mockExecSuccess(FAKE_SHA);          // 2 verifyHeadValid before
+      mockExecSuccess(FAKE_SHA);          // 3 SHA before (logSHA)
+      mockExecSuccess('ok');              // 4 git pull origin
+      mockExecSuccess(FAKE_SHA);          // 5 SHA after (logSHA)
+      mockExecSuccess(FAKE_SHA);          // 6 verifyHeadValid after
+
+      await git.safePull('/repo');
+
+      // 4th call is the actual pull command
+      expect(mockExec).toHaveBeenNthCalledWith(
+        4,
+        'git pull origin',
+        expect.objectContaining({ cwd: '/repo' }),
+      );
+    });
+
+    it('should include branch in pull command when specified', async () => {
+      mockExecSuccess(FAKE_GIT_VERSION); // 1
+      mockExecSuccess(FAKE_SHA);          // 2
+      mockExecSuccess(FAKE_SHA);          // 3
+      mockExecSuccess('ok');              // 4 git pull upstream develop
+      mockExecSuccess(FAKE_SHA);          // 5
+      mockExecSuccess(FAKE_SHA);          // 6
+
+      await git.safePull('/repo', 'upstream', 'develop');
+
+      expect(mockExec).toHaveBeenNthCalledWith(
+        4,
+        'git pull upstream develop',
+        expect.objectContaining({ cwd: '/repo' }),
+      );
+    });
+
+    it('should track SHA before and after the pull (logSHA behavior)', async () => {
+      mockExecSuccess(FAKE_GIT_VERSION); // 1 verifyGitAvailable
+      mockExecSuccess(FAKE_SHA);          // 2 verifyHeadValid before
+      mockExecSuccess(FAKE_SHA);          // 3 SHA before (logSHA)
+      mockExecSuccess('ok');              // 4 pull
+      mockExecSuccess(FAKE_SHA);          // 5 SHA after (logSHA)
+      mockExecSuccess(FAKE_SHA);          // 6 verifyHeadValid after
+
+      await git.safePull('/repo');
+
+      // logSHA: true causes 2 extra git rev-parse HEAD calls (SHA before + after)
+      // Total 6 calls: availability + verify-before + SHA-before + pull + SHA-after + verify-after
+      expect(mockExec).toHaveBeenCalledTimes(6);
+      // The pull command itself (4th call)
+      expect(mockExec).toHaveBeenNthCalledWith(4, 'git pull origin', expect.anything());
+    });
+
+    it('should return pull result directly when pull command fails', async () => {
+      mockExecSuccess(FAKE_GIT_VERSION); // 1 verifyGitAvailable
+      mockExecSuccess(FAKE_SHA);          // 2 verifyHeadValid before (valid)
+      mockExecSuccess(FAKE_SHA);          // 3 SHA before (logSHA)
+      mockExecFailure('conflict', { code: 1 }); // 4 git pull fails
+
+      const result = await git.safePull('/repo');
+
+      expect(result.success).toBe(false);
+      // No post-pull HEAD verification when pull itself fails
+      // 4 calls: availability + HEAD before verify + SHA before + pull
+      expect(mockExec).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  // =========================================================================
+  // safeCheckout
+  //
+  // Call flow for a successful safeCheckout:
+  //   1. getHeadSHA -> execGitCommand ->
+  //      verifyGitAvailable (git --version) + git rev-parse HEAD
+  //   2. execGitCommand(checkout) with logSHA: true ->
+  //      verifyGitAvailable (cached) + git rev-parse HEAD (SHA before) +
+  //      git checkout + git rev-parse HEAD (SHA after)
+  //   3. getHeadSHA -> execGitCommand ->
+  //      verifyGitAvailable (cached) + git rev-parse HEAD
+  //
+  // Total mockExec calls: 1 + 1 + 1 + 1 + 1 + 1 + 1 = 7
+  // =========================================================================
+  describe('safeCheckout', () => {
+    it('should perform a successful checkout', async () => {
+      // Step 1: getHeadSHA before
+      mockExecSuccess(FAKE_GIT_VERSION); // 1 verifyGitAvailable
+      mockExecSuccess(FAKE_SHA);          // 2 git rev-parse HEAD
+
+      // Step 2: execGitCommand(checkout) with logSHA: true
+      mockExecSuccess(FAKE_SHA);          // 3 SHA before (logSHA)
+      mockExecSuccess('Switched to branch'); // 4 git checkout feature-branch
+      mockExecSuccess(FAKE_SHA_ALT);      // 5 SHA after (logSHA, changed)
+
+      // Step 3: getHeadSHA after
+      mockExecSuccess(FAKE_SHA_ALT);      // 6 git rev-parse HEAD (valid)
+
+      const result = await git.safeCheckout('/repo', 'feature-branch');
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('Switched to branch');
+    });
+
+    it('should fail when HEAD cannot be retrieved before checkout', async () => {
+      mockExecSuccess(FAKE_GIT_VERSION); // 1 verifyGitAvailable
+      mockExecFailure('no HEAD');         // 2 git rev-parse HEAD fails
+
+      const result = await git.safeCheckout('/repo', 'feature-branch');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Cannot get HEAD SHA before checkout');
+    });
+
+    it('should rollback when HEAD is invalid after checkout', async () => {
+      // Step 1: getHeadSHA before
+      mockExecSuccess(FAKE_GIT_VERSION); // 1 verifyGitAvailable
+      mockExecSuccess(FAKE_SHA);          // 2 git rev-parse HEAD (before)
+
+      // Step 2: execGitCommand(checkout) with logSHA: true
+      mockExecSuccess(FAKE_SHA);          // 3 SHA before (logSHA)
+      mockExecSuccess('Switched to branch'); // 4 git checkout
+      mockExecSuccess(FAKE_SHA_ALT);      // 5 SHA after (logSHA)
+
+      // Step 3: getHeadSHA after fails
+      mockExecFailure('corrupt');          // 6 git rev-parse HEAD fails
+
+      // Step 4: rollback checkout
+      mockExecSuccess('ok');               // 7 git checkout <sha-prefix>
+
+      const result = await git.safeCheckout('/repo', 'feature-branch');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('HEAD SHA invalid after checkout, rolled back');
+      // The 7th call is the rollback: git checkout <full-SHA>
+      // execGitCommand passes only (command, execOptions) to the raw exec
+      expect(mockExec).toHaveBeenNthCalledWith(
+        7,
+        `git checkout ${FAKE_SHA}`,
+        expect.objectContaining({ cwd: '/repo' }),
+      );
+    });
+
+    it('should return success when HEAD is valid after checkout even if SHA changed', async () => {
+      mockExecSuccess(FAKE_GIT_VERSION); // 1
+      mockExecSuccess(FAKE_SHA);          // 2 getHeadSHA before
+      mockExecSuccess(FAKE_SHA);          // 3 SHA before (logSHA)
+      mockExecSuccess('Switched to branch'); // 4 checkout
+      mockExecSuccess(FAKE_SHA_ALT);      // 5 SHA after (logSHA, changed)
+      mockExecSuccess(FAKE_SHA_ALT);      // 6 getHeadSHA after (valid)
+
+      const result = await git.safeCheckout('/repo', 'feature-branch');
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('Switched to branch');
+    });
+
+    it('should return success when HEAD is unchanged (already on branch)', async () => {
+      mockExecSuccess(FAKE_GIT_VERSION); // 1
+      mockExecSuccess(FAKE_SHA);          // 2 getHeadSHA before
+      mockExecSuccess(FAKE_SHA);          // 3 SHA before (logSHA)
+      mockExecSuccess('Already on main'); // 4 checkout
+      mockExecSuccess(FAKE_SHA);          // 5 SHA after (logSHA, unchanged)
+      mockExecSuccess(FAKE_SHA);          // 6 getHeadSHA after (valid)
+
+      const result = await git.safeCheckout('/repo', 'main');
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should return checkout failure result directly when checkout fails', async () => {
+      mockExecSuccess(FAKE_GIT_VERSION); // 1 verifyGitAvailable
+      mockExecSuccess(FAKE_SHA);          // 2 getHeadSHA before
+      mockExecSuccess(FAKE_SHA);          // 3 SHA before (logSHA)
+      mockExecFailure('already on branch', { code: 1 }); // 4 checkout fails
+
+      const result = await git.safeCheckout('/repo', 'nonexistent');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('already on branch');
+      // No post-checkout HEAD retrieval, no rollback
+      expect(mockExec).toHaveBeenCalledTimes(4);
+    });
+
+    it('should track SHA before and after the checkout (logSHA behavior)', async () => {
+      mockExecSuccess(FAKE_GIT_VERSION); // 1
+      mockExecSuccess(FAKE_SHA);          // 2 getHeadSHA before
+      mockExecSuccess(FAKE_SHA);          // 3 SHA before (logSHA)
+      mockExecSuccess('Switched');        // 4 checkout
+      mockExecSuccess(FAKE_SHA_ALT);      // 5 SHA after (logSHA)
+      mockExecSuccess(FAKE_SHA_ALT);      // 6 getHeadSHA after
+
+      await git.safeCheckout('/repo', 'develop');
+
+      // logSHA: true causes 2 extra git rev-parse HEAD calls (SHA before + after)
+      // Total 6 calls: availability + getHeadSHA-before + SHA-before + checkout + SHA-after + getHeadSHA-after
+      expect(mockExec).toHaveBeenCalledTimes(6);
+      // The checkout command itself (4th call)
+      // execGitCommand passes only (command, execOptions) to the raw exec
+      expect(mockExec).toHaveBeenNthCalledWith(
+        4,
+        'git checkout develop',
+        expect.objectContaining({ cwd: '/repo' }),
+      );
+    });
+  });
+
+  // =========================================================================
+  // resetCache
+  // =========================================================================
+  describe('resetCache', () => {
+    it('should clear git availability cache allowing re-check', async () => {
+      mockExecSuccess(FAKE_GIT_VERSION);
+
+      // First check caches
+      await git.verifyGitAvailable();
+      expect(mockExec).toHaveBeenCalledTimes(1);
+
+      // Same instance, cached
+      await git.verifyGitAvailable();
+      expect(mockExec).toHaveBeenCalledTimes(1);
+
+      // Reset and re-check
+      git.resetCache();
+      mockExecSuccess(FAKE_GIT_VERSION);
+
+      await git.verifyGitAvailable();
+      expect(mockExec).toHaveBeenCalledTimes(2);
+    });
+
+    it('should allow switching from cached failure to success', async () => {
+      mockExecFailure('not found');
+      const failResult = await git.verifyGitAvailable();
+      expect(failResult.available).toBe(false);
+
+      git.resetCache();
+      mockExecSuccess(FAKE_GIT_VERSION);
+      const successResult = await git.verifyGitAvailable();
+      expect(successResult.available).toBe(true);
+    });
+
+    it('should log cache reset', () => {
+      git.resetCache();
+      expect(mockDebug).toHaveBeenCalledWith(expect.stringContaining('réinitialisé'));
+    });
+  });
+
+  // =========================================================================
+  // Singleton: getGitHelpers / resetGitHelpers
+  // =========================================================================
+  describe('getGitHelpers / resetGitHelpers', () => {
+    it('should return a GitHelpers instance', () => {
+      const instance = getGitHelpers();
+      expect(instance).toBeInstanceOf(GitHelpers);
+    });
+
+    it('should return the same instance on repeated calls', () => {
+      const a = getGitHelpers();
+      const b = getGitHelpers();
+      expect(a).toBe(b);
+    });
+
+    it('should return a new instance after resetGitHelpers', () => {
+      const first = getGitHelpers();
+      resetGitHelpers();
+      const second = getGitHelpers();
+      expect(first).not.toBe(second);
+    });
+
+    it('should produce independent instances after reset', () => {
+      const first = getGitHelpers();
+      resetGitHelpers();
+      const second = getGitHelpers();
+
+      // Fresh instance should have its own independent cache
+      expect(second).not.toBe(first);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 90 tests for `EnrichContentClassifier` (message classification, tool call/result parsing, relevance evaluation, confidence scoring)
- Add 54 tests for `GitHelpers` (git availability caching, command execution with SHA tracking, safe pull/checkout with rollback)

## Test plan
- [x] `npm run build` passes
- [x] `npx vitest run --config vitest.config.ci.ts` passes: 8074/8074 tests (433 files)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)