### PR TITLE
test(coverage): add unit tests for deployment/git/github helpers (62 tests)

### DIFF
--- a/servers/roo-state-manager/tests/unit/utils/deployment-helpers.test.ts
+++ b/servers/roo-state-manager/tests/unit/utils/deployment-helpers.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock PowerShellExecutor — must use vi.hoisted for reference in mock factory
+const mockExecuteScript = vi.hoisted(() => vi.fn());
+vi.mock('../../../src/services/PowerShellExecutor.js', () => ({
+  PowerShellExecutor: vi.fn(() => ({ executeScript: mockExecuteScript })),
+}));
+
+// Mock logger
+vi.mock('../../../src/utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import {
+  DeploymentHelpers,
+  getDeploymentHelpers,
+  resetDeploymentHelpers,
+  type DeploymentResult,
+} from '../../../src/utils/deployment-helpers.js';
+
+function makeSuccessResult(overrides?: Partial<DeploymentResult>): DeploymentResult {
+  return {
+    success: true,
+    scriptName: 'test.ps1',
+    duration: 100,
+    exitCode: 0,
+    stdout: 'OK',
+    stderr: '',
+    ...overrides,
+  };
+}
+
+describe('DeploymentHelpers', () => {
+  let helpers: DeploymentHelpers;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetDeploymentHelpers();
+    helpers = new DeploymentHelpers('/fake/scripts');
+  });
+
+  describe('constructor', () => {
+    it('uses provided scriptsBasePath', () => {
+      const h = new DeploymentHelpers('/custom/path');
+      // Verified indirectly via executeDeploymentScript
+      expect(h).toBeDefined();
+    });
+
+    it('falls back to ROO_HOME env var', () => {
+      const original = process.env.ROO_HOME;
+      process.env.ROO_HOME = '/custom/roo';
+      const h = new DeploymentHelpers();
+      expect(h).toBeDefined();
+      process.env.ROO_HOME = original;
+    });
+
+    it('falls back to d:/roo-extensions when no ROO_HOME', () => {
+      const original = process.env.ROO_HOME;
+      delete process.env.ROO_HOME;
+      const h = new DeploymentHelpers();
+      expect(h).toBeDefined();
+      process.env.ROO_HOME = original;
+    });
+  });
+
+  describe('executeDeploymentScript', () => {
+    it('executes script and returns success result', async () => {
+      mockExecuteScript.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+        stdout: 'deployed',
+        stderr: '',
+      });
+
+      const result = await helpers.executeDeploymentScript('deploy.ps1');
+
+      expect(result.success).toBe(true);
+      expect(result.scriptName).toBe('deploy.ps1');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('deployed');
+      expect(result.duration).toBeGreaterThanOrEqual(0);
+    });
+
+    it('passes args to executor', async () => {
+      mockExecuteScript.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      });
+
+      await helpers.executeDeploymentScript('script.ps1', ['-Flag', 'value']);
+
+      expect(mockExecuteScript).toHaveBeenCalledWith(
+        expect.stringContaining('script.ps1'),
+        ['-Flag', 'value'],
+        expect.objectContaining({ timeout: 300000 }),
+      );
+    });
+
+    it('appends -WhatIf when dryRun is true', async () => {
+      mockExecuteScript.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      });
+
+      await helpers.executeDeploymentScript('script.ps1', ['-Arg1'], { dryRun: true });
+
+      expect(mockExecuteScript).toHaveBeenCalledWith(
+        expect.any(String),
+        ['-Arg1', '-WhatIf'],
+        expect.any(Object),
+      );
+    });
+
+    it('uses custom timeout when provided', async () => {
+      mockExecuteScript.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      });
+
+      await helpers.executeDeploymentScript('script.ps1', [], { timeout: 60000 });
+
+      expect(mockExecuteScript).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.objectContaining({ timeout: 60000 }),
+      );
+    });
+
+    it('passes env variables to executor', async () => {
+      mockExecuteScript.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      });
+
+      await helpers.executeDeploymentScript('script.ps1', [], {
+        env: { MY_VAR: 'value' },
+      });
+
+      expect(mockExecuteScript).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.objectContaining({ env: { MY_VAR: 'value' } }),
+      );
+    });
+
+    it('returns error result when script fails', async () => {
+      mockExecuteScript.mockResolvedValue({
+        success: false,
+        exitCode: 1,
+        stdout: '',
+        stderr: 'error output',
+      });
+
+      const result = await helpers.executeDeploymentScript('fail.ps1');
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
+      expect(result.error).toBe('Script failed with exit code 1');
+      expect(result.stderr).toBe('error output');
+    });
+
+    it('handles exceptions from executor', async () => {
+      mockExecuteScript.mockRejectedValue(new Error('timeout'));
+
+      const result = await helpers.executeDeploymentScript('crash.ps1');
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(-1);
+      expect(result.error).toContain('Exception');
+      expect(result.error).toContain('timeout');
+      expect(result.stderr).toContain('timeout');
+    });
+
+    it('handles non-Error exceptions', async () => {
+      mockExecuteScript.mockRejectedValue('string error');
+
+      const result = await helpers.executeDeploymentScript('crash.ps1');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('string error');
+    });
+
+    it('measures duration accurately', async () => {
+      mockExecuteScript.mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve({
+          success: true, exitCode: 0, stdout: '', stderr: '',
+        }), 50)),
+      );
+
+      const result = await helpers.executeDeploymentScript('slow.ps1');
+
+      expect(result.duration).toBeGreaterThanOrEqual(40);
+    });
+  });
+
+  describe('convenience methods', () => {
+    beforeEach(() => {
+      mockExecuteScript.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      });
+    });
+
+    it('deployModes calls deploy-modes.ps1', async () => {
+      await helpers.deployModes();
+      expect(mockExecuteScript).toHaveBeenCalledWith(
+        expect.stringContaining('deploy-modes.ps1'),
+        [],
+        expect.any(Object),
+      );
+    });
+
+    it('deployMCPs calls install-mcps.ps1', async () => {
+      await helpers.deployMCPs();
+      expect(mockExecuteScript).toHaveBeenCalledWith(
+        expect.stringContaining('install-mcps.ps1'),
+        [],
+        expect.any(Object),
+      );
+    });
+
+    it('createProfile passes profile name to create-profile.ps1', async () => {
+      await helpers.createProfile('test-profile');
+      expect(mockExecuteScript).toHaveBeenCalledWith(
+        expect.stringContaining('create-profile.ps1'),
+        ['-ProfileName', 'test-profile'],
+        expect.any(Object),
+      );
+    });
+
+    it('createCleanModes calls create-clean-modes.ps1', async () => {
+      await helpers.createCleanModes();
+      expect(mockExecuteScript).toHaveBeenCalledWith(
+        expect.stringContaining('create-clean-modes.ps1'),
+        [],
+        expect.any(Object),
+      );
+    });
+
+    it('forceDeployWithEncodingFix calls correct script', async () => {
+      await helpers.forceDeployWithEncodingFix();
+      expect(mockExecuteScript).toHaveBeenCalledWith(
+        expect.stringContaining('force-deploy-with-encoding-fix.ps1'),
+        [],
+        expect.any(Object),
+      );
+    });
+
+    it('convenience methods forward options', async () => {
+      await helpers.deployModes({ dryRun: true, timeout: 60000 });
+      expect(mockExecuteScript).toHaveBeenCalledWith(
+        expect.any(String),
+        ['-WhatIf'],
+        expect.objectContaining({ timeout: 60000 }),
+      );
+    });
+  });
+});
+
+describe('getDeploymentHelpers / resetDeploymentHelpers', () => {
+  afterEach(() => {
+    resetDeploymentHelpers();
+  });
+
+  it('returns singleton instance', () => {
+    const a = getDeploymentHelpers();
+    const b = getDeploymentHelpers();
+    expect(a).toBe(b);
+  });
+
+  it('reset creates new instance', () => {
+    const a = getDeploymentHelpers();
+    resetDeploymentHelpers();
+    const b = getDeploymentHelpers();
+    expect(a).not.toBe(b);
+  });
+
+  it('respects custom path only on first call', () => {
+    const a = getDeploymentHelpers('/first');
+    const b = getDeploymentHelpers('/second');
+    expect(a).toBe(b);
+  });
+});

--- a/servers/roo-state-manager/tests/unit/utils/github-helpers.test.ts
+++ b/servers/roo-state-manager/tests/unit/utils/github-helpers.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock child_process
+const mockExecAsync = vi.hoisted(() => vi.fn());
+vi.mock('util', () => ({
+  promisify: () => mockExecAsync,
+}));
+
+import {
+  getGitHubProjectMetrics,
+  getGitHubIssuesMetrics,
+  getGitHubMetrics,
+  formatGitHubMetricsForDashboard,
+  type GitHubMetrics,
+} from '../../../src/utils/github-helpers.js';
+
+function makeProjectGraphQLResponse(statusCounts: { done: number; inProgress: number; todo: number }) {
+  const nodes: any[] = [];
+  for (let i = 0; i < statusCounts.done; i++) {
+    nodes.push({ fieldValues: { nodes: [{ field: { name: 'Status' }, name: 'Done' }] } });
+  }
+  for (let i = 0; i < statusCounts.inProgress; i++) {
+    nodes.push({ fieldValues: { nodes: [{ field: { name: 'Status' }, name: 'In Progress' }] } });
+  }
+  for (let i = 0; i < statusCounts.todo; i++) {
+    nodes.push({ fieldValues: { nodes: [{ field: { name: 'Status' }, name: 'Todo' }] } });
+  }
+  // Add some items without Status field
+  nodes.push({ fieldValues: { nodes: [{ field: { name: 'Other' }, name: 'X' }] } });
+
+  return {
+    data: {
+      user: {
+        projectV2: {
+          items: {
+            totalCount: nodes.length,
+            nodes,
+          },
+        },
+      },
+    },
+  };
+}
+
+describe('getGitHubProjectMetrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('counts items by status correctly', async () => {
+    const response = makeProjectGraphQLResponse({ done: 3, inProgress: 2, todo: 5 });
+    const jsonStr = JSON.stringify(response);
+    mockExecAsync.mockResolvedValue({ stdout: jsonStr });
+
+    const result = await getGitHubProjectMetrics();
+
+    expect(result.totalItems).toBe(11); // 3+2+5+1(no status)
+    expect(result.doneCount).toBe(3);
+    expect(result.inProgressCount).toBe(2);
+    expect(result.todoCount).toBe(5);
+    expect(result.donePercentage).toBe(27); // 3/11 = 27%
+  });
+
+  it('handles all done', async () => {
+    const response = makeProjectGraphQLResponse({ done: 10, inProgress: 0, todo: 0 });
+    mockExecAsync.mockResolvedValue({ stdout: JSON.stringify(response) });
+
+    const result = await getGitHubProjectMetrics();
+
+    expect(result.donePercentage).toBe(91); // 10/11
+  });
+
+  it('handles empty project', async () => {
+    const response = {
+      data: { user: { projectV2: { items: { totalCount: 0, nodes: [] } } } },
+    };
+    mockExecAsync.mockResolvedValue({ stdout: JSON.stringify(response) });
+
+    const result = await getGitHubProjectMetrics();
+
+    expect(result.totalItems).toBe(0);
+    expect(result.doneCount).toBe(0);
+    expect(result.donePercentage).toBe(0);
+  });
+
+  it('handles case-insensitive status names', async () => {
+    const response = {
+      data: {
+        user: {
+          projectV2: {
+            items: {
+              totalCount: 2,
+              nodes: [
+                { fieldValues: { nodes: [{ field: { name: 'Status' }, name: 'DONE' }] } },
+                { fieldValues: { nodes: [{ field: { name: 'Status' }, name: 'todo' }] } },
+              ],
+            },
+          },
+        },
+      },
+    };
+    mockExecAsync.mockResolvedValue({ stdout: JSON.stringify(response) });
+
+    const result = await getGitHubProjectMetrics();
+
+    expect(result.doneCount).toBe(1);
+    expect(result.todoCount).toBe(1);
+  });
+
+  it('returns defaults on error', async () => {
+    mockExecAsync.mockRejectedValue(new Error('network error'));
+
+    const result = await getGitHubProjectMetrics();
+
+    expect(result.totalItems).toBe(0);
+    expect(result.doneCount).toBe(0);
+    expect(result.donePercentage).toBe(0);
+  });
+
+  it('handles items with null status name', async () => {
+    const response = {
+      data: {
+        user: {
+          projectV2: {
+            items: {
+              totalCount: 1,
+              nodes: [
+                { fieldValues: { nodes: [{ field: { name: 'Status' }, name: null }] } },
+              ],
+            },
+          },
+        },
+      },
+    };
+    mockExecAsync.mockResolvedValue({ stdout: JSON.stringify(response) });
+
+    const result = await getGitHubProjectMetrics();
+
+    expect(result.totalItems).toBe(1);
+    expect(result.doneCount).toBe(0);
+  });
+
+  it('escapes quotes in GraphQL query', async () => {
+    mockExecAsync.mockResolvedValue({
+      stdout: JSON.stringify(makeProjectGraphQLResponse({ done: 1, inProgress: 0, todo: 0 })),
+    });
+
+    await getGitHubProjectMetrics();
+
+    expect(mockExecAsync).toHaveBeenCalledWith(
+      expect.stringContaining('gh api graphql'),
+      expect.objectContaining({ timeout: 60_000 }),
+    );
+  });
+});
+
+describe('getGitHubIssuesMetrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns correct counts', async () => {
+    mockExecAsync
+      .mockResolvedValueOnce({ stdout: '15' })    // openCount
+      .mockResolvedValueOnce({ stdout: '1' })     // closed result (gh issue list)
+      .mockResolvedValueOnce({ stdout: '42' })    // closedCount (gh search)
+      .mockResolvedValueOnce({ stdout: '7' });    // recentActivity
+
+    const result = await getGitHubIssuesMetrics();
+
+    expect(result.openCount).toBe(15);
+    expect(result.closedCount).toBe(42);
+    expect(result.recentActivity).toBe(7);
+  });
+
+  it('handles NaN values', async () => {
+    mockExecAsync
+      .mockResolvedValueOnce({ stdout: 'not-a-number' })
+      .mockResolvedValueOnce({ stdout: '' })
+      .mockResolvedValueOnce({ stdout: '' })
+      .mockResolvedValueOnce({ stdout: '' });
+
+    const result = await getGitHubIssuesMetrics();
+
+    expect(result.openCount).toBe(0);
+    expect(result.closedCount).toBe(0);
+    expect(result.recentActivity).toBe(0);
+  });
+
+  it('returns defaults on error', async () => {
+    mockExecAsync.mockRejectedValue(new Error('gh not installed'));
+
+    const result = await getGitHubIssuesMetrics();
+
+    expect(result.openCount).toBe(0);
+    expect(result.closedCount).toBe(0);
+    expect(result.recentActivity).toBe(0);
+  });
+
+  it('computes recent date for activity query', async () => {
+    mockExecAsync
+      .mockResolvedValueOnce({ stdout: '5' })
+      .mockResolvedValueOnce({ stdout: '1' })
+      .mockResolvedValueOnce({ stdout: '10' })
+      .mockResolvedValueOnce({ stdout: '3' });
+
+    await getGitHubIssuesMetrics();
+
+    // The 4th call should contain the recent date filter
+    const lastCall = mockExecAsync.mock.calls[3][0] as string;
+    expect(lastCall).toContain('updated:>=');
+    // Should be within the last 7 days
+    expect(lastCall).toMatch(/\d{4}-\d{2}-\d{2}/);
+  });
+});
+
+describe('getGitHubMetrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('combines project and issues metrics', async () => {
+    const projectResponse = makeProjectGraphQLResponse({ done: 5, inProgress: 3, todo: 2 });
+    mockExecAsync
+      .mockResolvedValueOnce({ stdout: JSON.stringify(projectResponse) }) // project
+      .mockResolvedValueOnce({ stdout: '5' })    // openCount
+      .mockResolvedValueOnce({ stdout: '1' })    // closed
+      .mockResolvedValueOnce({ stdout: '20' })   // closedCount
+      .mockResolvedValueOnce({ stdout: '3' });   // recentActivity
+
+    const result = await getGitHubMetrics();
+
+    expect(result.project).toBeDefined();
+    expect(result.issues).toBeDefined();
+    expect(result.project.doneCount).toBe(5);
+    expect(result.issues.openCount).toBe(5);
+    expect(result.lastUpdated).toBeDefined();
+    // Verify ISO date format
+    expect(new Date(result.lastUpdated).toISOString()).toBe(result.lastUpdated);
+  });
+
+  it('handles partial failures gracefully', async () => {
+    // Project fails, issues succeed
+    mockExecAsync
+      .mockRejectedValueOnce(new Error('project fail'))
+      .mockResolvedValueOnce({ stdout: '10' })
+      .mockResolvedValueOnce({ stdout: '1' })
+      .mockResolvedValueOnce({ stdout: '50' })
+      .mockResolvedValueOnce({ stdout: '5' });
+
+    const result = await getGitHubMetrics();
+
+    expect(result.project.totalItems).toBe(0); // defaults from error
+    expect(result.issues.openCount).toBe(10);
+  });
+});
+
+describe('formatGitHubMetricsForDashboard', () => {
+  it('formats metrics as markdown', () => {
+    const metrics: GitHubMetrics = {
+      project: {
+        totalItems: 30,
+        doneCount: 15,
+        inProgressCount: 5,
+        todoCount: 10,
+        donePercentage: 50,
+      },
+      issues: {
+        openCount: 12,
+        closedCount: 88,
+        recentActivity: 7,
+      },
+      lastUpdated: '2026-04-21T10:00:00.000Z',
+    };
+
+    const md = formatGitHubMetricsForDashboard(metrics);
+
+    expect(md).toContain('30 items');
+    expect(md).toContain('Done :** 15 (50%)');
+    expect(md).toContain('In Progress :** 5');
+    expect(md).toContain('Todo :** 10');
+    expect(md).toContain('Ouvertes :** 12');
+    expect(md).toContain('Fermées :** 88');
+    expect(md).toContain('7 issues');
+    expect(md).toContain('Métriques GitHub');
+  });
+
+  it('handles zero values', () => {
+    const metrics: GitHubMetrics = {
+      project: { totalItems: 0, doneCount: 0, inProgressCount: 0, todoCount: 0, donePercentage: 0 },
+      issues: { openCount: 0, closedCount: 0, recentActivity: 0 },
+      lastUpdated: new Date().toISOString(),
+    };
+
+    const md = formatGitHubMetricsForDashboard(metrics);
+
+    expect(md).toContain('0 items');
+    expect(md).toContain('0%');
+  });
+
+  it('includes ISO timestamp', () => {
+    const metrics: GitHubMetrics = {
+      project: { totalItems: 1, doneCount: 1, inProgressCount: 0, todoCount: 0, donePercentage: 100 },
+      issues: { openCount: 0, closedCount: 0, recentActivity: 0 },
+      lastUpdated: '2026-04-21T12:34:56.000Z',
+    };
+
+    const md = formatGitHubMetricsForDashboard(metrics);
+
+    expect(md).toMatch(/\d{4}-\d{2}-\d{2}/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 62 unit tests covering 3 previously untested utility modules
- **deployment-helpers.test.ts** (21 tests): constructor, executeDeploymentScript, convenience methods, singleton
- **git-helpers.test.ts** (25 tests): verifyGitAvailable caching, execGitCommand with SHA logging, safePull/safeCheckout with rollback, HEAD validation
- **github-helpers.test.ts** (16 tests): GraphQL project metrics parsing, issues metrics, dashboard markdown formatting, error handling

## Technical notes
- Uses `vi.hoisted()` pattern for mock function references inside `vi.mock()` factories (Vitest hoisting fix)
- All mocks properly cleaned between tests via `beforeEach(() => vi.clearAllMocks())`

## Test plan
- [x] `npx vitest run` — 62/62 tests pass
- [x] `npm run build` — TypeScript compiles clean
- [x] CI suite — no regressions (3 flaky smoke tests are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)