### PR TITLE
fix(#1551): add critical warnings + missing vars to .env.example

### DIFF
--- a/servers/roo-state-manager/.env.example
+++ b/servers/roo-state-manager/.env.example
@@ -1,3 +1,16 @@
+# =============================================================================
+# CRITICAL — DO NOT EMPTY OR DELETE VALUES (Issue #1551)
+# =============================================================================
+# The MCP server validates these at startup (see src/index.ts REQUIRED_ENV_VARS).
+# If any REQUIRED variable is empty or missing, the server calls process.exit(1).
+# NEVER set a key to "" to "fix" something — restore the correct value instead.
+#
+# REQUIRED (server won't start without these):
+#   QDRANT_URL, QDRANT_API_KEY, QDRANT_COLLECTION_NAME, ROOSYNC_SHARED_PATH
+# STRONGLY RECOMMENDED (semantic search won't work without these):
+#   EMBEDDING_API_KEY or OPENAI_API_KEY
+# =============================================================================
+
 # Configuration Qdrant (base de données vectorielle)
 QDRANT_URL=https://qdrant.example.com
 QDRANT_API_KEY=your-qdrant-api-key-here
@@ -77,3 +90,19 @@ ROOSYNC_CONFLICT_STRATEGY=manual
 # - error: Erreurs uniquement
 # Valeurs: debug | info | warn | error
 ROOSYNC_LOG_LEVEL=info
+
+# =============================================================================
+# SK-AGENT / VLLM API KEYS (self-hosted models on myia.io)
+# =============================================================================
+# Documentation: mcps/internal/servers/sk-agent/README.md
+
+# LLM Chat/Synthesis — OpenAI-compatible endpoint
+# For self-hosted vLLM, set OPENAI_BASE_URL to the vLLM /v1 endpoint
+# The OpenAI SDK reads OPENAI_BASE_URL automatically
+# OPENAI_BASE_URL=https://api.medium.text-generation-webui.myia.io/v1
+
+# Clés pour les modèles self-hosted accessibles via sk-agent
+# glm-4.7-flash text model (api.medium.text-generation-webui.myia.io)
+VLLM_API_KEY_MEDIUM=your-vllm-medium-api-key-here
+# zwz-8b vision model (api.mini.text-generation-webui.myia.io)
+VLLM_API_KEY_MINI=your-vllm-mini-api-key-here


### PR DESCRIPTION
## Summary
- Add prominent header warning about NEVER emptying required env vars, linking to `REQUIRED_ENV_VARS` validation in `src/index.ts`
- Add missing `VLLM_API_KEY_MEDIUM`, `VLLM_API_KEY_MINI`, and `OPENAI_BASE_URL` entries
- Lists REQUIRED vs STRONGLY RECOMMENDED variables at the top for quick reference

## Context
Issue #1551 documents 2 .env corruption incidents where agents emptied critical keys (QDRANT_URL, QDRANT_API_KEY), causing MCP crash across all sessions on affected machines.

The startup validation code already exists (`src/index.ts` lines 38-76). This PR adds the reference template that was missing, making it easy to restore correct values.

## Test plan
- [x] Build passes (`npm run build`)
- [x] Visual review of .env.example content
- [ ] Deploy to a test machine and verify .env matches template structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)