### PR TITLE
fix(test): ConfigService saveConfig test uses cross-platform invalid path

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/ConfigService.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/ConfigService.test.ts
@@ -175,7 +175,10 @@ describe('ConfigService', () => {
     });
 
     it('devrait lancer une erreur en cas d\'erreur de sauvegarde', async () => {
-      const service = new ConfigService('/invalid/path/config.json');
+      // Use a path under a guaranteed non-existent temp directory (cross-platform)
+      // /invalid/path/ can resolve to a writable path on Windows (C:\invalid\path\)
+      const invalidDir = join(process.cwd(), 'test-temp-config', 'nonexistent-deep-' + Date.now(), 'nested');
+      const service = new ConfigService(join(invalidDir, 'config.json'));
 
       await expect(service.saveConfig({ test: 'data' })).rejects.toThrow();
     });


### PR DESCRIPTION
## Summary
- Fix flaky `ConfigService.test.ts` where `saveConfig` error test assumed `/invalid/path/` doesn't exist
- On Windows Git Bash, `/invalid/path/config.json` resolves to `C:\invalid\path\config.json` which CAN exist and be writable
- Fix: use a guaranteed non-existent nested temp directory (`test-temp-config/nonexistent-deep-{timestamp}/nested/config.json`)

## Test plan
- [x] `npx vitest run src/services/__tests__/ConfigService.test.ts` — 29/29 pass
- [x] Full suite — 470/470 pass, 8980 tests
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)