### PR TITLE
fix(#1628): add .env fallback for ROOSYNC_SHARED_PATH resolution

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/InventoryCollectorWrapper.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/InventoryCollectorWrapper.test.ts
@@ -20,7 +20,9 @@ vi.mock('fs', () => ({
 }));
 
 vi.mock('path', () => ({
-  join: vi.fn((...args) => args.join('/'))
+  join: vi.fn((...args) => args.join('/')),
+  dirname: vi.fn((p: string) => p.split('/').slice(0, -1).join('/')),
+  resolve: vi.fn((...args) => args.join('/'))
 }));
 
 vi.mock('../../utils/server-helpers.js', () => ({

--- a/servers/roo-state-manager/src/utils/__tests__/server-helpers.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/server-helpers.test.ts
@@ -95,14 +95,20 @@ describe('server-helpers', () => {
             expect(result).toBe('/custom/shared-state');
         });
 
-        test('should throw error when env var is not set', () => {
+        test('should fall back to .env when env var is not set (#1628)', () => {
             delete process.env.ROOSYNC_SHARED_PATH;
-            expect(() => getSharedStatePath()).toThrow('ROOSYNC_SHARED_PATH environment variable is not set');
+            // With the .env fallback, it should return a path from .env (not throw)
+            const result = getSharedStatePath();
+            expect(result).toBeTruthy();
+            // Should also cache in process.env
+            expect(process.env.ROOSYNC_SHARED_PATH).toBe(result);
         });
 
-        test('should throw error when env var is empty string', () => {
+        test('should fall back to .env when env var is empty string (#1628)', () => {
             process.env.ROOSYNC_SHARED_PATH = '';
-            expect(() => getSharedStatePath()).toThrow('ROOSYNC_SHARED_PATH environment variable is not set');
+            // Empty string is falsy, so fallback to .env kicks in
+            const result = getSharedStatePath();
+            expect(result).toBeTruthy();
         });
     });
 

--- a/servers/roo-state-manager/src/utils/__tests__/server-helpers.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/server-helpers.test.ts
@@ -22,6 +22,8 @@ vi.mock('fs', async () => {
     return {
         ...actual,
         default: actual,
+        existsSync: vi.fn(() => true),
+        readFileSync: vi.fn(() => 'ROOSYNC_SHARED_PATH=/mock/env/path\n'),
         promises: {
             access: vi.fn(),
             utimes: vi.fn(),
@@ -97,9 +99,9 @@ describe('server-helpers', () => {
 
         test('should fall back to .env when env var is not set (#1628)', () => {
             delete process.env.ROOSYNC_SHARED_PATH;
-            // With the .env fallback, it should return a path from .env (not throw)
+            // With mocked fs (existsSync=true, readFileSync returns .env content)
             const result = getSharedStatePath();
-            expect(result).toBeTruthy();
+            expect(result).toBe('/mock/env/path');
             // Should also cache in process.env
             expect(process.env.ROOSYNC_SHARED_PATH).toBe(result);
         });
@@ -108,7 +110,7 @@ describe('server-helpers', () => {
             process.env.ROOSYNC_SHARED_PATH = '';
             // Empty string is falsy, so fallback to .env kicks in
             const result = getSharedStatePath();
-            expect(result).toBeTruthy();
+            expect(result).toBe('/mock/env/path');
         });
     });
 

--- a/servers/roo-state-manager/src/utils/__tests__/shared-state-path.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/shared-state-path.test.ts
@@ -1,49 +1,86 @@
 /**
  * Tests for shared-state-path.ts
- * Coverage improvement - #1110 ESM cycle fix helper
+ * Coverage: env var resolution + .env fallback (#1628)
  *
  * @module utils/__tests__/shared-state-path
  */
 
-import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 
 describe('getSharedStatePath', () => {
-	const originalEnv = process.env.ROOSYNC_SHARED_PATH;
+    const originalEnv = process.env.ROOSYNC_SHARED_PATH;
 
-	beforeEach(() => {
-		delete process.env.ROOSYNC_SHARED_PATH;
-	});
+    beforeEach(() => {
+        delete process.env.ROOSYNC_SHARED_PATH;
+        vi.resetModules();
+    });
 
-	afterEach(() => {
-		if (originalEnv !== undefined) {
-			process.env.ROOSYNC_SHARED_PATH = originalEnv;
-		} else {
-			delete process.env.ROOSYNC_SHARED_PATH;
-		}
-	});
+    afterEach(() => {
+        if (originalEnv !== undefined) {
+            process.env.ROOSYNC_SHARED_PATH = originalEnv;
+        } else {
+            delete process.env.ROOSYNC_SHARED_PATH;
+        }
+        vi.restoreAllMocks();
+    });
 
-	test('returns ROOSYNC_SHARED_PATH when set', async () => {
-		process.env.ROOSYNC_SHARED_PATH = '/some/shared/path';
-		const { getSharedStatePath } = await import('../shared-state-path.js');
-		expect(getSharedStatePath()).toBe('/some/shared/path');
-	});
+    test('returns ROOSYNC_SHARED_PATH when set via env var', async () => {
+        process.env.ROOSYNC_SHARED_PATH = '/some/shared/path';
+        const { getSharedStatePath } = await import('../shared-state-path.js');
+        expect(getSharedStatePath()).toBe('/some/shared/path');
+    });
 
-	test('throws descriptive error when ROOSYNC_SHARED_PATH is not set', async () => {
-		const { getSharedStatePath } = await import('../shared-state-path.js');
-		expect(() => getSharedStatePath()).toThrow('ROOSYNC_SHARED_PATH environment variable is not set');
-	});
+    test('falls back to .env file when env var is not set', async () => {
+        // The real .env file exists in the project with ROOSYNC_SHARED_PATH set.
+        // When env var is deleted, the fallback should read from it.
+        const { getSharedStatePath } = await import('../shared-state-path.js');
+        const result = getSharedStatePath();
+        // Should return a non-empty path from .env (not throw)
+        expect(result).toBeTruthy();
+        expect(result).not.toBe('');
+        // Should also cache it in process.env
+        expect(process.env.ROOSYNC_SHARED_PATH).toBe(result);
+    });
 
-	test('throws error mentioning Google Drive for user guidance', async () => {
-		const { getSharedStatePath } = await import('../shared-state-path.js');
-		expect(() => getSharedStatePath()).toThrow(/Google Drive/);
-	});
+    test('env var takes precedence over .env file', async () => {
+        process.env.ROOSYNC_SHARED_PATH = '/env-var-path';
+        const { getSharedStatePath } = await import('../shared-state-path.js');
+        expect(getSharedStatePath()).toBe('/env-var-path');
+    });
 
-	test('returns different paths when env changes between imports', async () => {
-		process.env.ROOSYNC_SHARED_PATH = '/path/one';
-		const { getSharedStatePath } = await import('../shared-state-path.js');
-		expect(getSharedStatePath()).toBe('/path/one');
+    test('returns different paths when env changes between calls', async () => {
+        process.env.ROOSYNC_SHARED_PATH = '/path/one';
+        const { getSharedStatePath } = await import('../shared-state-path.js');
+        expect(getSharedStatePath()).toBe('/path/one');
 
-		process.env.ROOSYNC_SHARED_PATH = '/path/two';
-		expect(getSharedStatePath()).toBe('/path/two');
-	});
+        process.env.ROOSYNC_SHARED_PATH = '/path/two';
+        expect(getSharedStatePath()).toBe('/path/two');
+    });
+
+    test('throws descriptive error when .env file is missing', async () => {
+        // Mock existsSync to simulate missing .env file
+        vi.doMock('fs', async () => {
+            const actual = await vi.importActual('fs');
+            return {
+                ...actual,
+                existsSync: () => false,
+            };
+        });
+
+        const { getSharedStatePath } = await import('../shared-state-path.js');
+        expect(() => getSharedStatePath()).toThrow('ROOSYNC_SHARED_PATH environment variable is not set');
+    });
+
+    test('error mentions Google Drive for user guidance', async () => {
+        vi.doMock('fs', async () => {
+            const actual = await vi.importActual('fs');
+            return {
+                ...actual,
+                existsSync: () => false,
+            };
+        });
+
+        const { getSharedStatePath } = await import('../shared-state-path.js');
+        expect(() => getSharedStatePath()).toThrow(/Google Drive/);
+    });
 });

--- a/servers/roo-state-manager/src/utils/__tests__/shared-state-path.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/shared-state-path.test.ts
@@ -31,13 +31,19 @@ describe('getSharedStatePath', () => {
     });
 
     test('falls back to .env file when env var is not set', async () => {
-        // The real .env file exists in the project with ROOSYNC_SHARED_PATH set.
-        // When env var is deleted, the fallback should read from it.
+        // Mock fs to simulate .env file (CI doesn't have a real one)
+        vi.doMock('fs', async () => {
+            const actual = await vi.importActual('fs');
+            return {
+                ...actual,
+                existsSync: () => true,
+                readFileSync: () => 'ROOSYNC_SHARED_PATH=/mock/env/path\n',
+            };
+        });
+
         const { getSharedStatePath } = await import('../shared-state-path.js');
         const result = getSharedStatePath();
-        // Should return a non-empty path from .env (not throw)
-        expect(result).toBeTruthy();
-        expect(result).not.toBe('');
+        expect(result).toBe('/mock/env/path');
         // Should also cache it in process.env
         expect(process.env.ROOSYNC_SHARED_PATH).toBe(result);
     });

--- a/servers/roo-state-manager/src/utils/server-helpers.ts
+++ b/servers/roo-state-manager/src/utils/server-helpers.ts
@@ -16,23 +16,9 @@ import { OUTPUT_CONFIG } from '../config/server-config.js';
 // Only 2 functions use toolExports, so lazy-loading is safe.
 import { GenericError, GenericErrorCode } from '../types/errors.js';
 
-/**
- * Obtenir le chemin du répertoire shared-state RooSync
- *
- * @throws {Error} Si ROOSYNC_SHARED_PATH n'est pas défini
- * @returns {string} Le chemin vers le répertoire shared-state
- */
-export function getSharedStatePath(): string {
-    // ROOSYNC_SHARED_PATH est OBLIGATOIRE - pas de fallback pour éviter la pollution du dépôt
-    if (!process.env.ROOSYNC_SHARED_PATH) {
-        throw new Error(
-            'ROOSYNC_SHARED_PATH environment variable is not set. ' +
-            'This variable is required to prevent file pollution in the repository. ' +
-            'Please set ROOSYNC_SHARED_PATH to your Google Drive shared state path.'
-        );
-    }
-    return process.env.ROOSYNC_SHARED_PATH;
-}
+// #1628: Re-export from shared-state-path.ts instead of duplicating.
+// The isolated module has no project imports, so this does not create cycles.
+export { getSharedStatePath } from './shared-state-path.js';
 /**
  * Tronque les résultats trop longs
  */

--- a/servers/roo-state-manager/src/utils/shared-state-path.ts
+++ b/servers/roo-state-manager/src/utils/shared-state-path.ts
@@ -4,23 +4,71 @@
  * Previously in server-helpers.ts, which caused 19+ cycles:
  *   server-helpers → tools/index barrel → roosync/* → server-helpers
  *
- * #1110 FIX: Isolated to its own module with ZERO imports.
+ * #1110 FIX: Isolated to its own module with ZERO project imports.
  * This breaks ALL cycles through the roosync/* → server-helpers edge.
+ * #1628 FIX: Added .env file fallback for resilience when env var is missing
+ * (e.g., Roo MCP config doesn't pass ROOSYNC_SHARED_PATH in its env section).
  */
+
+import { readFileSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Try to read ROOSYNC_SHARED_PATH from .env file as fallback (#1628) */
+function readFromDotenv(): string | null {
+    const envPath = join(__dirname, '..', '..', '.env');
+    try {
+        if (!existsSync(envPath)) return null;
+        const content = readFileSync(envPath, 'utf-8');
+        for (const line of content.split('\n')) {
+            const trimmed = line.trim();
+            if (trimmed.startsWith('#') || !trimmed) continue;
+            const eqIndex = trimmed.indexOf('=');
+            if (eqIndex === -1) continue;
+            const key = trimmed.slice(0, eqIndex).trim();
+            if (key !== 'ROOSYNC_SHARED_PATH') continue;
+            let value = trimmed.slice(eqIndex + 1).trim();
+            // Strip surrounding quotes
+            if ((value.startsWith('"') && value.endsWith('"')) ||
+                (value.startsWith("'") && value.endsWith("'"))) {
+                value = value.slice(1, -1);
+            }
+            return value || null;
+        }
+    } catch {
+        // Silently ignore — will throw the standard error below
+    }
+    return null;
+}
 
 /**
  * Get the RooSync shared state directory path from environment.
  *
- * @throws {Error} If ROOSYNC_SHARED_PATH is not set
+ * Resolution order:
+ * 1. process.env.ROOSYNC_SHARED_PATH (set by config or dotenv)
+ * 2. .env file fallback (#1628)
+ *
+ * @throws {Error} If ROOSYNC_SHARED_PATH cannot be resolved
  * @returns {string} The path to the shared-state directory
  */
 export function getSharedStatePath(): string {
-    if (!process.env.ROOSYNC_SHARED_PATH) {
-        throw new Error(
-            'ROOSYNC_SHARED_PATH environment variable is not set. ' +
-            'This variable is required to prevent file pollution in the repository. ' +
-            'Please set ROOSYNC_SHARED_PATH to your Google Drive shared state path.'
-        );
+    if (process.env.ROOSYNC_SHARED_PATH) {
+        return process.env.ROOSYNC_SHARED_PATH;
     }
-    return process.env.ROOSYNC_SHARED_PATH;
+
+    // #1628: Fallback to .env file when env var is not set
+    const fromDotenv = readFromDotenv();
+    if (fromDotenv) {
+        process.env.ROOSYNC_SHARED_PATH = fromDotenv;
+        return fromDotenv;
+    }
+
+    throw new Error(
+        'ROOSYNC_SHARED_PATH environment variable is not set. ' +
+        'This variable is required to prevent file pollution in the repository. ' +
+        'Please set ROOSYNC_SHARED_PATH to your Google Drive shared state path.'
+    );
 }


### PR DESCRIPTION
## Summary
- Add `.env` file fallback in `getSharedStatePath()` when `ROOSYNC_SHARED_PATH` env var is missing
- Replace duplicate implementation in `server-helpers.ts` with re-export from `shared-state-path.ts`
- Update tests for both modules

## Problem
Roo MCP config (`mcp_settings.json`) launches the server via `cmd /c node build/index.js` (without the wrapper), and `ROOSYNC_SHARED_PATH` is not in the `env` section. When the `.env` loading fails or the file is missing, the server crashes with `process.exit(1)`, causing Roo sessions to stall.

## Fix
- `getSharedStatePath()` now tries to read `.env` directly if the env var is not in `process.env`
- The `.env` file has the correct path on all machines (gitignored, machine-specific)
- Falls back gracefully: env var > .env file > throw error

## Test plan
- [x] `shared-state-path.test.ts` — 6 tests pass (env var, fallback, precedence, error)
- [x] `server-helpers.test.ts` — 21 tests pass (updated for new behavior)
- [x] Build passes
- [x] CI test suite: 8243 pass, 3 fail (pre-existing: tool-discoverability timeout)

Ref: jsboige/roo-extensions#1628

🤖 Generated with [Claude Code](https://claude.com/claude-code)