### PR TITLE
fix(#1623): auto-repair corrupt JSON in updateJsonWithLock (rebased for submod main)

### DIFF
--- a/servers/roo-state-manager/src/services/roosync/FileLockManager.simple.ts
+++ b/servers/roo-state-manager/src/services/roosync/FileLockManager.simple.ts
@@ -236,10 +236,13 @@ export class FileLockManager {
         const content = await fs.readFile(filePath, 'utf-8');
         data = JSON.parse(content) as T;
       } catch (error: any) {
-        if (error.code !== 'ENOENT') {
-          throw error;
+        if (error.code === 'ENOENT') {
+          // Fichier n'existe pas - data reste undefined
+        } else {
+          // Corrupt/empty file — treat as missing, updater will recreate (#1623)
+          console.warn(`[FileLockManager] Corrupt JSON in ${filePath}, treating as empty: ${error.message}`);
+          data = undefined;
         }
-        // Fichier n'existe pas - data reste undefined
       }
       const updated = updater(data);
       await fs.writeFile(filePath, JSON.stringify(updated, null, 2), 'utf-8');

--- a/servers/roo-state-manager/src/services/roosync/__tests__/FileLockManager.simple.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/FileLockManager.simple.test.ts
@@ -283,5 +283,40 @@ describe('FileLockManager', () => {
 			expect(result.success).toBe(true);
 			expect(result.data).toEqual({ items: ['first'] });
 		});
+
+		test('auto-repairs corrupt/empty JSON file (#1623)', async () => {
+			mockWriteFile.mockResolvedValue(undefined);
+			mockUnlink.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue('');
+
+			const manager = FileLockManager.getInstance();
+			const result = await manager.updateJsonWithLock<{ count: number }>(
+				'/test/corrupt.json',
+				(data) => data ?? { count: 1 }
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({ count: 1 });
+			expect(mockWriteFile).toHaveBeenCalledWith(
+				'/test/corrupt.json',
+				JSON.stringify({ count: 1 }, null, 2),
+				'utf-8'
+			);
+		});
+
+		test('auto-repairs truncated JSON file (#1623)', async () => {
+			mockWriteFile.mockResolvedValue(undefined);
+			mockUnlink.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue('{"count":');
+
+			const manager = FileLockManager.getInstance();
+			const result = await manager.updateJsonWithLock<{ count: number }>(
+				'/test/truncated.json',
+				(data) => data ?? { count: 0 }
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({ count: 0 });
+		});
 	});
 });


### PR DESCRIPTION
## Context

This PR rebases the PresenceManager JSON auto-repair fix from po-2024's branch `wt/1623-presence-fix` onto current submod `main`. The original parent PR #1626 (merged as `0df573b6`) bumped the submod pointer to `abcd9ef6`, but `abcd9ef6` was NOT an ancestor of submod origin/main (it branched from `6a067ea8`, before #162/#173/#174 landed).

**Per rule 18 / PR #1598 ancestry check** : we need this fix properly on submod main to prevent the next pointer bump from accidentally reverting it.

## What changed

Cherry-pick of `abcd9ef6` onto current submod main (`1deef96d`). Applied cleanly, no conflicts.

Fix detail: `FileLockManager.simple.ts:236-241` — changed error handling in `updateJsonWithLock` to treat ALL JSON parse failures (not just ENOENT) as "missing data" (`undefined`), allowing the updater callback to create fresh valid data.

## Tests

- 65/65 FileLockManager tests pass (2 new auto-repair tests from original #1626).
- `npx vitest run FileLockManager` — 297ms, all green.

## After merge

Next step: parent pointer bump from `abcd9ef6` (orphan) to the proper merge commit of this PR. Will be bundled with #162/#173/#174 test coverage PRs in a fresh parent PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)