### PR TITLE
test(coverage): Add 24 tests for search-fallback and export-tree-md tools

### DIFF
--- a/servers/roo-state-manager/src/tools/__tests__/export-tree-md.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/export-tree-md.tool.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import {
+    exportTaskTreeMarkdownTool,
+    handleExportTaskTreeMarkdown,
+    type ExportTaskTreeMarkdownArgs,
+} from '../task/export-tree-md.tool.js';
+
+function makeMockTreeResult(text: string) {
+    return {
+        content: [{ type: 'text' as const, text }],
+    };
+}
+
+describe('export-tree-md.tool', () => {
+    describe('tool definition', () => {
+        it('should have correct name', () => {
+            expect(exportTaskTreeMarkdownTool.name).toBe('export_task_tree_markdown');
+        });
+
+        it('should require conversation_id', () => {
+            const schema = exportTaskTreeMarkdownTool.inputSchema;
+            expect(schema.required).toContain('conversation_id');
+        });
+
+        it('should define output_format enum', () => {
+            const props = exportTaskTreeMarkdownTool.inputSchema.properties;
+            expect(props.output_format.enum).toEqual(['ascii-tree', 'markdown', 'hierarchical', 'json']);
+        });
+
+        it('should have default values for optional fields', () => {
+            const props = exportTaskTreeMarkdownTool.inputSchema.properties;
+            expect(props.include_siblings.default).toBe(true);
+            expect(props.output_format.default).toBe('ascii-tree');
+            expect(props.truncate_instruction.default).toBe(80);
+            expect(props.show_metadata.default).toBe(false);
+        });
+    });
+
+    describe('handleExportTaskTreeMarkdown', () => {
+        const mockEnsureFresh = vi.fn();
+        const conversation_id = 'test-conv-1';
+
+        const successTree = vi.fn().mockResolvedValue(makeMockTreeResult(
+            'Task root\n  ├── Task child 1\n  └── Task child 2',
+        ));
+
+        it('should return tree content when no filePath specified', async () => {
+            const result = await handleExportTaskTreeMarkdown(
+                { conversation_id } as ExportTaskTreeMarkdownArgs,
+                successTree,
+                mockEnsureFresh,
+            );
+
+            expect(result.content[0].type).toBe('text');
+            expect((result.content[0] as any).text).toContain('Task root');
+            expect(result.isError).toBeUndefined();
+        });
+
+        it('should throw error when conversation_id is missing', async () => {
+            const result = await handleExportTaskTreeMarkdown(
+                {} as ExportTaskTreeMarkdownArgs,
+                successTree,
+                mockEnsureFresh,
+            );
+
+            expect(result.isError).toBe(true);
+            expect((result.content[0] as any).text).toContain('conversation_id');
+        });
+
+        it('should handle empty tree result gracefully', async () => {
+            const emptyTree = vi.fn().mockResolvedValue({
+                content: [],
+            });
+
+            const result = await handleExportTaskTreeMarkdown(
+                { conversation_id } as ExportTaskTreeMarkdownArgs,
+                emptyTree,
+                mockEnsureFresh,
+            );
+
+            expect(result.isError).toBe(true);
+            expect((result.content[0] as any).text).toContain('Erreur');
+        });
+
+        it('should handle non-text content type', async () => {
+            const imageTree = vi.fn().mockResolvedValue({
+                content: [{ type: 'image', data: 'base64...' }],
+            });
+
+            const result = await handleExportTaskTreeMarkdown(
+                { conversation_id } as ExportTaskTreeMarkdownArgs,
+                imageTree,
+                mockEnsureFresh,
+            );
+
+            expect(result.isError).toBe(true);
+            expect((result.content[0] as any).text).toContain('texte');
+        });
+
+        it('should save to file when filePath is specified', async () => {
+            const tmpDir = path.join(os.tmpdir(), `export-tree-test-${Date.now()}`);
+            const filePath = path.join(tmpDir, 'tree.md');
+
+            try {
+                const result = await handleExportTaskTreeMarkdown(
+                    { conversation_id, filePath } as ExportTaskTreeMarkdownArgs,
+                    successTree,
+                    mockEnsureFresh,
+                );
+
+                expect(result.content[0].type).toBe('text');
+                expect((result.content[0] as any).text).toContain('exporté avec succès');
+                expect((result.content[0] as any).text).toContain(filePath);
+
+                const written = await fs.readFile(filePath, 'utf8');
+                expect(written).toContain('Task root');
+            } finally {
+                await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+            }
+        });
+
+        it('should create parent directories when saving to file', async () => {
+            const tmpDir = path.join(os.tmpdir(), `export-tree-nested-${Date.now()}`);
+            const filePath = path.join(tmpDir, 'nested', 'deep', 'tree.md');
+
+            try {
+                const result = await handleExportTaskTreeMarkdown(
+                    { conversation_id, filePath } as ExportTaskTreeMarkdownArgs,
+                    successTree,
+                    mockEnsureFresh,
+                );
+
+                expect((result.content[0] as any).text).toContain('exporté avec succès');
+                const written = await fs.readFile(filePath, 'utf8');
+                expect(written).toContain('Task root');
+            } finally {
+                await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+            }
+        });
+
+        it('should resolve relative filePath using workspace from cache', async () => {
+            const tmpDir = path.join(os.tmpdir(), `export-tree-rel-${Date.now()}`);
+            await fs.mkdir(tmpDir, { recursive: true });
+
+            const cache = new Map([
+                ['test-conv-1', {
+                    taskId: 'test-conv-1',
+                    metadata: { workspace: tmpDir },
+                    sequence: [],
+                } as any],
+            ]);
+
+            try {
+                const result = await handleExportTaskTreeMarkdown(
+                    { conversation_id, filePath: 'output/tree.md' } as ExportTaskTreeMarkdownArgs,
+                    successTree,
+                    mockEnsureFresh,
+                    cache,
+                );
+
+                expect((result.content[0] as any).text).toContain('exporté avec succès');
+
+                const written = await fs.readFile(path.join(tmpDir, 'output', 'tree.md'), 'utf8');
+                expect(written).toContain('Task root');
+            } finally {
+                await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+            }
+        });
+
+        it('should pass output_format to getTaskTree handler', async () => {
+            const trackingTree = vi.fn().mockResolvedValue(makeMockTreeResult('json output'));
+
+            await handleExportTaskTreeMarkdown(
+                { conversation_id, output_format: 'json' } as ExportTaskTreeMarkdownArgs,
+                trackingTree,
+                mockEnsureFresh,
+            );
+
+            expect(trackingTree).toHaveBeenCalledWith(
+                expect.objectContaining({ output_format: 'json' }),
+            );
+        });
+
+        it('should handle handler throwing an exception', async () => {
+            const failingTree = vi.fn().mockRejectedValue(new Error('Cache corrupted'));
+
+            const result = await handleExportTaskTreeMarkdown(
+                { conversation_id } as ExportTaskTreeMarkdownArgs,
+                failingTree,
+                mockEnsureFresh,
+            );
+
+            expect(result.isError).toBe(true);
+            expect((result.content[0] as any).text).toContain('Cache corrupted');
+        });
+    });
+});

--- a/servers/roo-state-manager/src/tools/__tests__/export-tree-md.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/export-tree-md.tool.test.ts
@@ -40,12 +40,16 @@ describe('export-tree-md.tool', () => {
     });
 
     describe('handleExportTaskTreeMarkdown', () => {
-        const mockEnsureFresh = vi.fn();
+        let mockEnsureFresh: ReturnType<typeof vi.fn>;
+        let successTree: ReturnType<typeof vi.fn>;
         const conversation_id = 'test-conv-1';
 
-        const successTree = vi.fn().mockResolvedValue(makeMockTreeResult(
-            'Task root\n  ├── Task child 1\n  └── Task child 2',
-        ));
+        beforeEach(() => {
+            mockEnsureFresh = vi.fn();
+            successTree = vi.fn().mockResolvedValue(makeMockTreeResult(
+                'Task root\n  ├── Task child 1\n  └── Task child 2',
+            ));
+        });
 
         it('should return tree content when no filePath specified', async () => {
             const result = await handleExportTaskTreeMarkdown(

--- a/servers/roo-state-manager/src/tools/__tests__/search-fallback.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/search-fallback.tool.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest';
+import { handleSearchTasksSemanticFallback, type SearchFallbackArgs } from '../search-fallback.tool.js';
+
+function makeSkeleton(taskId: string, sequence: Array<{ role: string; content: string }>) {
+    return {
+        taskId,
+        parentTaskId: undefined,
+        metadata: {
+            title: `Task ${taskId}`,
+            lastActivity: '2026-04-24T00:00:00Z',
+            messageCount: sequence.length,
+            totalSize: 100,
+            actionCount: 0,
+            createdAt: '2026-04-24T00:00:00Z',
+        },
+        sequence,
+    };
+}
+
+describe('search-fallback.tool', () => {
+    describe('global search (no conversation_id)', () => {
+        it('should find matching conversations by exact content match', async () => {
+            const cache = new Map([
+                ['task-1', makeSkeleton('task-1', [
+                    { role: 'user', content: 'Fix the bug in login.ts' },
+                    { role: 'assistant', content: 'Looking at the login module.' },
+                ])],
+                ['task-2', makeSkeleton('task-2', [
+                    { role: 'user', content: 'Update the README documentation' },
+                    { role: 'assistant', content: 'Updating docs now.' },
+                ])],
+            ]);
+
+            const result = await handleSearchTasksSemanticFallback(
+                { search_query: 'login.ts' } as SearchFallbackArgs,
+                cache,
+            );
+
+            expect(result.isError).toBe(false);
+            expect(result.content).toHaveLength(1);
+            expect((result.content[0] as any).taskId).toBe('task-1');
+        });
+
+        it('should return empty results when no match', async () => {
+            const cache = new Map([
+                ['task-1', makeSkeleton('task-1', [
+                    { role: 'user', content: 'Fix the bug' },
+                ])],
+            ]);
+
+            const result = await handleSearchTasksSemanticFallback(
+                { search_query: 'quantum computing' } as SearchFallbackArgs,
+                cache,
+            );
+
+            expect(result.isError).toBe(false);
+            expect(result.content).toHaveLength(0);
+        });
+
+        it('should return empty results for empty cache', async () => {
+            const cache = new Map();
+
+            const result = await handleSearchTasksSemanticFallback(
+                { search_query: 'anything' } as SearchFallbackArgs,
+                cache,
+            );
+
+            expect(result.isError).toBe(false);
+            expect(result.content).toHaveLength(0);
+        });
+
+        it('should respect max_results limit', async () => {
+            const cache = new Map();
+            for (let i = 0; i < 5; i++) {
+                cache.set(`task-${i}`, makeSkeleton(`task-${i}`, [
+                    { role: 'user', content: `Test query matching item ${i}` },
+                ]));
+            }
+
+            const result = await handleSearchTasksSemanticFallback(
+                { search_query: 'query', max_results: 2 } as SearchFallbackArgs,
+                cache,
+            );
+
+            expect(result.isError).toBe(false);
+            expect(result.content).toHaveLength(2);
+        });
+
+        it('should treat "undefined" string as no conversation_id', async () => {
+            const cache = new Map([
+                ['task-1', makeSkeleton('task-1', [
+                    { role: 'user', content: 'Find this content' },
+                ])],
+            ]);
+
+            const result = await handleSearchTasksSemanticFallback(
+                { conversation_id: 'undefined', search_query: 'Find' } as SearchFallbackArgs,
+                cache,
+            );
+
+            expect(result.isError).toBe(false);
+            expect(result.content).toHaveLength(1);
+        });
+
+        it('should do word-level matching for queries >= 3 chars', async () => {
+            const cache = new Map([
+                ['task-1', makeSkeleton('task-1', [
+                    { role: 'user', content: 'User message 1 with extra words' },
+                ])],
+            ]);
+
+            const result = await handleSearchTasksSemanticFallback(
+                { search_query: 'User message' } as SearchFallbackArgs,
+                cache,
+            );
+
+            expect(result.isError).toBe(false);
+            expect(result.content).toHaveLength(1);
+        });
+    });
+
+    describe('specific conversation search', () => {
+        it('should search within a specific conversation', async () => {
+            const cache = new Map([
+                ['conv-1', makeSkeleton('conv-1', [
+                    { role: 'user', content: 'Fix login authentication' },
+                    { role: 'assistant', content: 'Looking at auth module' },
+                    { role: 'user', content: 'Also check the registration page' },
+                ])],
+            ]);
+
+            const result = await handleSearchTasksSemanticFallback(
+                { conversation_id: 'conv-1', search_query: 'login' } as SearchFallbackArgs,
+                cache,
+            );
+
+            expect(result.isError).toBe(false);
+            expect(result.content).toHaveLength(1);
+            expect((result.content[0] as any).taskId).toBe('conv-1');
+        });
+
+        it('should throw when conversation not found in cache', async () => {
+            const cache = new Map();
+
+            await expect(
+                handleSearchTasksSemanticFallback(
+                    { conversation_id: 'nonexistent', search_query: 'test' } as SearchFallbackArgs,
+                    cache,
+                ),
+            ).rejects.toThrow("not found in cache");
+        });
+
+        it('should return empty when query does not match any content', async () => {
+            const cache = new Map([
+                ['conv-1', makeSkeleton('conv-1', [
+                    { role: 'user', content: 'Fix the bug in parser' },
+                ])],
+            ]);
+
+            const result = await handleSearchTasksSemanticFallback(
+                { conversation_id: 'conv-1', search_query: 'unrelated' } as SearchFallbackArgs,
+                cache,
+            );
+
+            expect(result.isError).toBe(false);
+            expect(result.content).toHaveLength(0);
+        });
+
+        it('should respect max_results in specific conversation search', async () => {
+            const cache = new Map([
+                ['conv-1', makeSkeleton('conv-1', [
+                    { role: 'user', content: 'test query alpha' },
+                    { role: 'assistant', content: 'test query beta' },
+                    { role: 'user', content: 'test query gamma' },
+                ])],
+            ]);
+
+            const result = await handleSearchTasksSemanticFallback(
+                { conversation_id: 'conv-1', search_query: 'test query', max_results: 2 } as SearchFallbackArgs,
+                cache,
+            );
+
+            expect(result.isError).toBe(false);
+            expect(result.content).toHaveLength(2);
+        });
+    });
+
+    describe('result metadata', () => {
+        it('should include task metadata in global search results', async () => {
+            const cache = new Map([
+                ['task-1', makeSkeleton('task-1', [
+                    { role: 'user', content: 'Deploy to production' },
+                ])],
+            ]);
+
+            const result = await handleSearchTasksSemanticFallback(
+                { search_query: 'Deploy' } as SearchFallbackArgs,
+                cache,
+            );
+
+            const item = result.content[0] as any;
+            expect(item.score).toBe(1.0);
+            expect(item.metadata.task_title).toBe('Task task-1');
+            expect(item.metadata.message_count).toBe(1);
+            expect(item.match).toContain('user');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add 11 tests for `search-fallback.tool.ts` (global search, specific conversation, edge cases)
- Add 13 tests for `export-tree-md.tool.ts` (tool definition, file save, error handling, relative path resolution)
- Both files previously had 0 test coverage

## Test plan
- [x] `npx vitest run src/tools/__tests__/search-fallback.tool.test.ts` — 11/11 passed
- [x] `npx vitest run src/tools/__tests__/export-tree-md.tool.test.ts` — 13/13 passed
- [x] `npm run build` — TypeScript compilation OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)