### PR TITLE
fix(test): increase timeout for tool-discoverability ListTools consistency

### DIFF
--- a/servers/roo-state-manager/src/tools/__tests__/tool-discoverability.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-discoverability.test.ts
@@ -112,7 +112,7 @@ async function hasCallToolHandler(handler: (req: any) => Promise<any>, toolName:
 // ============================================================================
 
 describe('Category 1: ListTools → CallTool Consistency', () => {
-    it('every tool in ListTools must have a CallTool handler', async () => {
+    it('every tool in ListTools must have a CallTool handler', { timeout: 60000 }, async () => {
         const toolNames = await getListToolsNames();
         const { handler } = createCallToolHandler();
 


### PR DESCRIPTION
## Summary
- Fix flaky test timeout in `tool-discoverability.test.ts` — the "every tool in ListTools must have a CallTool handler" test was timing out at the default 15s limit
- The test exercises ~35 tools sequentially with 5s timeout per tool, needing ~19s total
- Increased test-level timeout to 60s to match actual execution time

## Test plan
- [x] `npx vitest run src/tools/__tests__/tool-discoverability.test.ts` — 17/17 passed (was 16 passed, 1 failed timeout)
- [x] `npm run build` — passes
- [x] No other tests affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)