### PR TITLE
fix(#1654): persist skeleton index after handleBuildSkeletonCache

### DIFF
--- a/servers/roo-state-manager/src/tools/cache/build-skeleton-cache.tool.ts
+++ b/servers/roo-state-manager/src/tools/cache/build-skeleton-cache.tool.ts
@@ -7,10 +7,11 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Tool } from '../../types/tool-definitions.js';
 import { RooStorageDetector } from '../../utils/roo-storage-detector.js';
-import { ConversationSkeleton } from '../../types/conversation.js';
+import { ConversationSkeleton, SkeletonHeader } from '../../types/conversation.js';
 import { promises as fs, existsSync } from 'fs';
 import path from 'path';
 import { ServerState } from '../../services/state-manager.service.js';
+import { saveSkeletonIndex, toHeader } from '../../services/background-services.js';
 
 const SKELETON_CACHE_DIR_NAME = '.skeletons';
 
@@ -91,6 +92,25 @@ async function saveSkeletonWithRetry(
     }
     
     return { success: false, attempts: maxRetries, error: 'Max retries reached' };
+}
+
+/**
+ * #1654: Persist the skeleton index (_skeleton_index.json) from the current cache.
+ * Called on all return paths of handleBuildSkeletonCache so that cold-start
+ * loadSkeletonsFromDisk() sees a non-empty index even when the build times out partway.
+ */
+async function persistSkeletonIndex(
+    conversationCache: Map<string, ConversationSkeleton>
+): Promise<void> {
+    try {
+        const headerMap = new Map<string, SkeletonHeader>();
+        for (const [taskId, skeleton] of conversationCache) {
+            headerMap.set(taskId, toHeader(skeleton));
+        }
+        await saveSkeletonIndex(headerMap);
+    } catch (indexError) {
+        console.warn('[#1654] Non-blocking: failed to persist skeleton index:', indexError);
+    }
 }
 
 /**
@@ -588,6 +608,8 @@ export async function handleBuildSkeletonCache(
             const partialResult = buildTimeoutResponse(skeletonsBuilt, skeletonsSkipped, 0, debugLogs,
                 "TIMEOUT: Phase hiérarchique non exécutée. Relancez le build pour compléter l'analyse des parentID.",
                 conversationCache.size);
+            // #1654: Persist whatever we managed to load — partial index is better than empty.
+            await persistSkeletonIndex(conversationCache);
             console.log = originalConsoleLog; // Restaurer
             return partialResult;
         }
@@ -799,6 +821,8 @@ export async function handleBuildSkeletonCache(
                 const partialResult = buildTimeoutResponse(skeletonsBuilt, skeletonsSkipped, hierarchyRelationsFound, debugLogs,
                     "TIMEOUT: Build partiel terminé. Phase hiérarchique incomplète - relancez pour finaliser l'analyse parentID.",
                     conversationCache.size);
+                // #1654: Persist partial index even on engine timeout.
+                await persistSkeletonIndex(conversationCache);
                 console.log = originalConsoleLog; // Restaurer
                 return partialResult;
             }
@@ -810,6 +834,8 @@ export async function handleBuildSkeletonCache(
             const partialResult = buildTimeoutResponse(skeletonsBuilt, skeletonsSkipped, hierarchyRelationsFound, debugLogs,
                 "TIMEOUT: Relations trouvées mais sauvegarde incomplète. Relancez pour persister les changements.",
                 conversationCache.size);
+            // #1654: Persist partial index so cold-start has at least the loaded skeletons.
+            await persistSkeletonIndex(conversationCache);
             console.log = originalConsoleLog; // Restaurer
             return partialResult;
         }
@@ -917,6 +943,9 @@ export async function handleBuildSkeletonCache(
         }
 
         console.log(`✅ Skeleton cache build complete. Mode: ${mode}, Cache size: ${conversationCache.size}, New relations: ${hierarchyRelationsFound}`);
+
+        // #1654: Persist _skeleton_index.json so cold-start sees the rebuilt cache.
+        await persistSkeletonIndex(conversationCache);
 
         // 🔍 Restaurer console.log original
         console.log = originalConsoleLog;


### PR DESCRIPTION
Fixes [jsboige/roo-extensions#1654](https://github.com/jsboige/roo-extensions/issues/1654).

## Root cause

Investigation by web1 pinpointed that `handleBuildSkeletonCache()`:

1. Clears the in-memory `conversationCache` (line 173)
2. Rebuilds per-task skeleton files (`tasks/.skeletons/<id>.json`)
3. Re-populates the in-memory cache
4. **Never writes the aggregate `_skeleton_index.json`**

The aggregate index is only written by `saveSkeletonIndex()` inside `background-services.ts`, on two conditional code paths gated by `updatedCount > 0` in the periodic refresh worker. When:

- a user triggers `build_skeleton_cache` directly (MCP call), **or**
- the 5-minute global timeout fires before the background worker runs

the on-disk index stays empty/stale. Next cold start, `loadSkeletonsFromDisk()` reads the empty index → returns an empty in-memory cache → MCP appears to have lost all history.

This is the 3rd recurrence of this symptom on **po-2026**, tracked as #1654.

## Fix

Small helper `persistSkeletonIndex()` that maps `ConversationSkeleton → SkeletonHeader` via the existing `toHeader()` and calls the existing `saveSkeletonIndex()`. Called on **all return paths** of `handleBuildSkeletonCache`:

- Happy path (end of function)
- Timeout before hierarchy phase
- Engine error + timeout
- Timeout before save phase

Persisting a **partial** index on timeout is strictly better than keeping a stale empty one — cold-start will then see what was loaded, not nothing.

## Changes

- `src/tools/cache/build-skeleton-cache.tool.ts`: +30/-1 lines
  - Import `SkeletonHeader`, `saveSkeletonIndex`, `toHeader`
  - Add `persistSkeletonIndex()` helper
  - Call it on 4 return paths

No new behavior — only plumbing a call that was missing.

## Validation

- `npm run build`: success (tsc, no TS errors)
- `npx vitest run --config vitest.config.ci.ts`: **2274 passed / 13 skipped / 0 failed**
- No existing tests relied on `saveSkeletonIndex` NOT being called

## Rule 16 integration tracing

- **Entry point**: `handleBuildSkeletonCache(args, conversationCache, state?)` in build-skeleton-cache.tool.ts
- **Consumers of `_skeleton_index.json`**: `loadSkeletonsFromDisk()` in background-services.ts (cold-start path, line 59)
- **Side effects**: Additional disk write per `build_skeleton_cache` invocation (~1-2MB for 7000+ tasks) — negligible
- **Cache state preservation**: No mutation of in-memory cache; only adds a read-then-transform-then-write
- **Error handling**: Wrapped in try/catch in the helper, non-blocking (index failure does not break the build result)
- **E2E**: `handleBuildSkeletonCache` → `persistSkeletonIndex` → `toHeader` (existing) → `saveSkeletonIndex` (existing) → `fs.writeFile(_skeleton_index.json)` → cold-start reads populated index

Refs: #1654 (root cause investigation by web1 on ai-01 dashboard workspace)