### PR TITLE
feat(#1657): Add backup rotation and fallback chain to FileLockManager

### DIFF
--- a/servers/roo-state-manager/src/services/roosync/FileLockManager.simple.ts
+++ b/servers/roo-state-manager/src/services/roosync/FileLockManager.simple.ts
@@ -12,6 +12,9 @@ import { promises as fs } from 'fs';
 import { join } from 'path';
 import { StateManagerError } from '../../types/errors.js';
 
+/** Maximum number of backup files to keep (.bak-1, .bak-2, .bak-3) */
+const MAX_BACKUPS = 3;
+
 /**
  * Options de verrouillage
  */
@@ -231,20 +234,9 @@ export class FileLockManager {
     options?: LockOptions
   ): Promise<LockOperationResult<T>> {
     return this.withLock(filePath, async () => {
-      let data: T | undefined;
-      try {
-        const content = await fs.readFile(filePath, 'utf-8');
-        data = JSON.parse(content) as T;
-      } catch (error: any) {
-        if (error.code === 'ENOENT') {
-          // Fichier n'existe pas - data reste undefined
-        } else {
-          // Corrupt/empty file — treat as missing, updater will recreate (#1623)
-          console.warn(`[FileLockManager] Corrupt JSON in ${filePath}, treating as empty: ${error.message}`);
-          data = undefined;
-        }
-      }
+      const data = await this.readJsonWithFallback<T>(filePath);
       const updated = updater(data);
+      await this.rotateBackups(filePath);
       await fs.writeFile(filePath, JSON.stringify(updated, null, 2), 'utf-8');
       return updated;
     }, options);
@@ -258,6 +250,81 @@ export class FileLockManager {
    */
   private getLockFilePath(filePath: string): string {
     return `${filePath}.lock`;
+  }
+
+  /**
+   * Rotate backup files before a write (.bak-3 <- .bak-2 <- .bak-1 <- current)
+   *
+   * @param filePath - Chemin du fichier original
+   */
+  private async rotateBackups(filePath: string): Promise<void> {
+    // Delete oldest backup if it exists
+    const oldestBackup = `${filePath}.bak-${MAX_BACKUPS}`;
+    try {
+      await fs.unlink(oldestBackup);
+    } catch (error: any) {
+      if (error.code !== 'ENOENT') {
+        console.warn(`[FileLockManager] Failed to remove old backup ${oldestBackup}: ${error.message}`);
+      }
+    }
+
+    // Shift backups: .bak-(N-1) -> .bak-N, ..., .bak-1 -> .bak-2
+    for (let i = MAX_BACKUPS - 1; i >= 1; i--) {
+      const src = `${filePath}.bak-${i}`;
+      const dest = `${filePath}.bak-${i + 1}`;
+      try {
+        await fs.rename(src, dest);
+      } catch (error: any) {
+        if (error.code !== 'ENOENT') {
+          console.warn(`[FileLockManager] Failed to rotate backup ${src} -> ${dest}: ${error.message}`);
+        }
+      }
+    }
+
+    // Copy current file to .bak-1
+    try {
+      await fs.copyFile(filePath, `${filePath}.bak-1`);
+    } catch (error: any) {
+      if (error.code !== 'ENOENT') {
+        console.warn(`[FileLockManager] Failed to create backup of ${filePath}: ${error.message}`);
+      }
+    }
+  }
+
+  /**
+   * Try to read and parse a JSON file, falling back to backup files on failure
+   *
+   * @param filePath - Chemin du fichier original
+   * @returns Parsed data, or undefined if no valid file found
+   */
+  private async readJsonWithFallback<T>(filePath: string): Promise<T | undefined> {
+    // Try the main file first
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      return JSON.parse(content) as T;
+    } catch (error: any) {
+      if (error.code === 'ENOENT') {
+        return undefined;
+      }
+      // Corrupt/empty — log and try backups
+      console.warn(`[FileLockManager] Corrupt JSON in ${filePath}: ${error.message}, trying backups`);
+    }
+
+    // Try backups in order: .bak-1, .bak-2, .bak-3
+    for (let i = 1; i <= MAX_BACKUPS; i++) {
+      const backupPath = `${filePath}.bak-${i}`;
+      try {
+        const content = await fs.readFile(backupPath, 'utf-8');
+        const data = JSON.parse(content) as T;
+        console.warn(`[FileLockManager] Recovered data from backup ${backupPath}`);
+        return data;
+      } catch {
+        // Continue to next backup
+      }
+    }
+
+    console.warn(`[FileLockManager] No valid data found in ${filePath} or any backup`);
+    return undefined;
   }
 }
 

--- a/servers/roo-state-manager/src/services/roosync/FileLockManager.ts
+++ b/servers/roo-state-manager/src/services/roosync/FileLockManager.ts
@@ -13,6 +13,9 @@ import { promises as fs } from 'fs';
 import * as fsSync from 'fs';
 import { join, dirname } from 'path';
 
+/** Maximum number of backup files to keep (.bak-1, .bak-2, .bak-3) */
+const MAX_BACKUPS = 3;
+
 /**
  * Options de verrouillage
  */
@@ -207,25 +210,96 @@ export class FileLockManager {
    */
   async updateJsonWithLock<T>(
     filePath: string,
-    updateFn: (data: T) => T,
+    updateFn: (data: T | undefined) => T,
     options: LockOptions = {}
   ): Promise<LockOperationResult<T>> {
     return this.withLock<T>(filePath, async () => {
-      // Lire le fichier existant
-      const content = await fs.readFile(filePath, 'utf-8');
-      const data = JSON.parse(content) as T;
-      
+      const data = await this.readJsonWithFallback<T>(filePath);
+
       // Appliquer la mise à jour
       const updatedData = updateFn(data);
-      
+
+      // Rotation des backups avant écriture
+      await this.rotateBackups(filePath);
+
       // Écrire le fichier mis à jour
       await fs.writeFile(filePath, JSON.stringify(updatedData, null, 2), 'utf-8');
-      
+
       console.log(`[FileLockManager] Fichier JSON mis à jour avec succès: ${filePath}`);
       return updatedData;
     }, options);
   }
   
+  /**
+   * Rotate backup files before a write (.bak-3 <- .bak-2 <- .bak-1 <- current)
+   */
+  private async rotateBackups(filePath: string): Promise<void> {
+    // Delete oldest backup if it exists
+    const oldestBackup = `${filePath}.bak-${MAX_BACKUPS}`;
+    try {
+      await fs.unlink(oldestBackup);
+    } catch (error: any) {
+      if (error.code !== 'ENOENT') {
+        console.warn(`[FileLockManager] Failed to remove old backup ${oldestBackup}: ${error.message}`);
+      }
+    }
+
+    // Shift backups: .bak-(N-1) -> .bak-N, ..., .bak-1 -> .bak-2
+    for (let i = MAX_BACKUPS - 1; i >= 1; i--) {
+      const src = `${filePath}.bak-${i}`;
+      const dest = `${filePath}.bak-${i + 1}`;
+      try {
+        await fs.rename(src, dest);
+      } catch (error: any) {
+        if (error.code !== 'ENOENT') {
+          console.warn(`[FileLockManager] Failed to rotate backup ${src} -> ${dest}: ${error.message}`);
+        }
+      }
+    }
+
+    // Copy current file to .bak-1
+    try {
+      await fs.copyFile(filePath, `${filePath}.bak-1`);
+    } catch (error: any) {
+      if (error.code !== 'ENOENT') {
+        console.warn(`[FileLockManager] Failed to create backup of ${filePath}: ${error.message}`);
+      }
+    }
+  }
+
+  /**
+   * Try to read and parse a JSON file, falling back to backup files on failure
+   */
+  private async readJsonWithFallback<T>(filePath: string): Promise<T | undefined> {
+    // Try the main file first
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      return JSON.parse(content) as T;
+    } catch (error: any) {
+      if (error.code === 'ENOENT') {
+        return undefined;
+      }
+      // Corrupt/empty — log and try backups
+      console.warn(`[FileLockManager] Corrupt JSON in ${filePath}: ${error.message}, trying backups`);
+    }
+
+    // Try backups in order: .bak-1, .bak-2, .bak-3
+    for (let i = 1; i <= MAX_BACKUPS; i++) {
+      const backupPath = `${filePath}.bak-${i}`;
+      try {
+        const content = await fs.readFile(backupPath, 'utf-8');
+        const data = JSON.parse(content) as T;
+        console.warn(`[FileLockManager] Recovered data from backup ${backupPath}`);
+        return data;
+      } catch {
+        // Continue to next backup
+      }
+    }
+
+    console.warn(`[FileLockManager] No valid data found in ${filePath} or any backup`);
+    return undefined;
+  }
+
   /**
    * Nettoyer tous les verrous (en cas d'arrêt d'urgence)
    */

--- a/servers/roo-state-manager/src/services/roosync/__tests__/FileLockManager.simple.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/FileLockManager.simple.test.ts
@@ -7,11 +7,13 @@
 
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 
-const { mockWriteFile, mockReadFile, mockUnlink, mockAccess } = vi.hoisted(() => ({
+const { mockWriteFile, mockReadFile, mockUnlink, mockAccess, mockCopyFile, mockRename } = vi.hoisted(() => ({
 	mockWriteFile: vi.fn(),
 	mockReadFile: vi.fn(),
 	mockUnlink: vi.fn(),
-	mockAccess: vi.fn()
+	mockAccess: vi.fn(),
+	mockCopyFile: vi.fn(),
+	mockRename: vi.fn()
 }));
 
 vi.mock('fs', () => ({
@@ -19,14 +21,18 @@ vi.mock('fs', () => ({
 		writeFile: mockWriteFile,
 		readFile: mockReadFile,
 		unlink: mockUnlink,
-		access: mockAccess
+		access: mockAccess,
+		copyFile: mockCopyFile,
+		rename: mockRename
 	},
 	default: {
 		promises: {
 			writeFile: mockWriteFile,
 			readFile: mockReadFile,
 			unlink: mockUnlink,
-			access: mockAccess
+			access: mockAccess,
+			copyFile: mockCopyFile,
+			rename: mockRename
 		}
 	}
 }));
@@ -256,6 +262,8 @@ describe('FileLockManager', () => {
 		test('updates existing JSON file', async () => {
 			mockWriteFile.mockResolvedValue(undefined);
 			mockUnlink.mockResolvedValue(undefined);
+			mockCopyFile.mockResolvedValue(undefined);
+			mockRename.mockResolvedValue(undefined);
 			mockReadFile.mockResolvedValue(JSON.stringify({ count: 1 }));
 
 			const manager = FileLockManager.getInstance();
@@ -266,11 +274,17 @@ describe('FileLockManager', () => {
 
 			expect(result.success).toBe(true);
 			expect(result.data).toEqual({ count: 2 });
+			expect(mockCopyFile).toHaveBeenCalledWith(
+				'/test/data.json',
+				'/test/data.json.bak-1'
+			);
 		});
 
 		test('creates new JSON when file does not exist', async () => {
 			mockWriteFile.mockResolvedValue(undefined);
 			mockUnlink.mockResolvedValue(undefined);
+			mockCopyFile.mockResolvedValue(undefined);
+			mockRename.mockResolvedValue(undefined);
 			const enoentError = Object.assign(new Error('Not found'), { code: 'ENOENT' });
 			mockReadFile.mockRejectedValue(enoentError);
 
@@ -287,6 +301,8 @@ describe('FileLockManager', () => {
 		test('auto-repairs corrupt/empty JSON file (#1623)', async () => {
 			mockWriteFile.mockResolvedValue(undefined);
 			mockUnlink.mockResolvedValue(undefined);
+			mockCopyFile.mockResolvedValue(undefined);
+			mockRename.mockResolvedValue(undefined);
 			mockReadFile.mockResolvedValue('');
 
 			const manager = FileLockManager.getInstance();
@@ -307,6 +323,8 @@ describe('FileLockManager', () => {
 		test('auto-repairs truncated JSON file (#1623)', async () => {
 			mockWriteFile.mockResolvedValue(undefined);
 			mockUnlink.mockResolvedValue(undefined);
+			mockCopyFile.mockResolvedValue(undefined);
+			mockRename.mockResolvedValue(undefined);
 			mockReadFile.mockResolvedValue('{"count":');
 
 			const manager = FileLockManager.getInstance();
@@ -317,6 +335,109 @@ describe('FileLockManager', () => {
 
 			expect(result.success).toBe(true);
 			expect(result.data).toEqual({ count: 0 });
+		});
+	});
+
+	// ============================================================
+	// Backup rotation (#1657)
+	// ============================================================
+
+	describe('backup rotation (#1657)', () => {
+		test('creates .bak-1 on first write', async () => {
+			mockWriteFile.mockResolvedValue(undefined);
+			mockUnlink.mockResolvedValue(undefined);
+			mockCopyFile.mockResolvedValue(undefined);
+			mockRename.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(JSON.stringify({ v: 1 }));
+
+			const manager = FileLockManager.getInstance();
+			await manager.updateJsonWithLock('/test/f.json', (d) => ({ v: (d?.v ?? 0) + 1 }));
+
+			expect(mockCopyFile).toHaveBeenCalledWith('/test/f.json', '/test/f.json.bak-1');
+		});
+
+		test('rotates .bak-1 -> .bak-2 on second write', async () => {
+			mockWriteFile.mockResolvedValue(undefined);
+			mockUnlink.mockResolvedValue(undefined);
+			mockCopyFile.mockResolvedValue(undefined);
+			mockRename.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(JSON.stringify({ v: 2 }));
+
+			const manager = FileLockManager.getInstance();
+			await manager.updateJsonWithLock('/test/f.json', (d) => ({ v: (d?.v ?? 0) + 1 }));
+
+			expect(mockRename).toHaveBeenCalledWith('/test/f.json.bak-1', '/test/f.json.bak-2');
+		});
+
+		test('deletes oldest .bak-3 when max backups reached', async () => {
+			mockWriteFile.mockResolvedValue(undefined);
+			mockUnlink.mockResolvedValue(undefined);
+			mockCopyFile.mockResolvedValue(undefined);
+			mockRename.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(JSON.stringify({ v: 3 }));
+
+			const manager = FileLockManager.getInstance();
+			await manager.updateJsonWithLock('/test/f.json', (d) => ({ v: (d?.v ?? 0) + 1 }));
+
+			expect(mockUnlink).toHaveBeenCalledWith('/test/f.json.bak-3');
+			expect(mockRename).toHaveBeenCalledWith('/test/f.json.bak-2', '/test/f.json.bak-3');
+		});
+
+		test('falls back to .bak-1 when main file is corrupt', async () => {
+			mockWriteFile.mockResolvedValue(undefined);
+			mockUnlink.mockResolvedValue(undefined);
+			mockCopyFile.mockResolvedValue(undefined);
+			mockRename.mockResolvedValue(undefined);
+			mockReadFile
+				.mockResolvedValueOnce('not-json')
+				.mockResolvedValueOnce(JSON.stringify({ recovered: true }));
+
+			const manager = FileLockManager.getInstance();
+			const result = await manager.updateJsonWithLock<{ recovered: boolean }>(
+				'/test/f.json',
+				(d) => ({ recovered: d?.recovered ?? false })
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({ recovered: true });
+		});
+
+		test('cascades fallback through .bak-1 -> .bak-2 -> .bak-3', async () => {
+			mockWriteFile.mockResolvedValue(undefined);
+			mockUnlink.mockResolvedValue(undefined);
+			mockCopyFile.mockResolvedValue(undefined);
+			mockRename.mockResolvedValue(undefined);
+			mockReadFile
+				.mockResolvedValueOnce('bad')
+				.mockResolvedValueOnce('also-bad')
+				.mockResolvedValueOnce('still-bad')
+				.mockResolvedValueOnce(JSON.stringify({ last: true }));
+
+			const manager = FileLockManager.getInstance();
+			const result = await manager.updateJsonWithLock<{ last: boolean }>(
+				'/test/f.json',
+				(d) => ({ last: d?.last ?? false })
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({ last: true });
+		});
+
+		test('returns undefined when all files are corrupt', async () => {
+			mockWriteFile.mockResolvedValue(undefined);
+			mockUnlink.mockResolvedValue(undefined);
+			mockCopyFile.mockResolvedValue(undefined);
+			mockRename.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue('bad-json');
+
+			const manager = FileLockManager.getInstance();
+			const result = await manager.updateJsonWithLock<{ x: number }>(
+				'/test/f.json',
+				(d) => ({ x: d?.x ?? 42 })
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({ x: 42 });
 		});
 	});
 });

--- a/servers/roo-state-manager/src/services/roosync/__tests__/FileLockManager.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/FileLockManager.test.ts
@@ -332,10 +332,11 @@ describe('FileLockManager', () => {
       );
     });
 
-    test('retourne success=false si JSON invalide', async () => {
+    test('fallback to undefined si JSON invalide (backup rotation)', async () => {
       mockReadFile.mockResolvedValue('invalid-json{{{');
       const result = await manager.updateJsonWithLock('/tmp/bad.json', (d) => d);
-      expect(result.success).toBe(false);
+      // With backup rotation, corrupt JSON falls back to undefined (no crash)
+      expect(result.success).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- Implements `.bak-1/.bak-2/.bak-3` rotation before writes in both `FileLockManager.simple.ts` and `FileLockManager.ts`
- Adds `readJsonWithFallback()` that tries main file → .bak-1 → .bak-2 → .bak-3 on JSON parse failure
- `updateJsonWithLock()` now accepts `(data: T | undefined) => T` to handle undefined from fallback
- 6 new unit tests covering rotation, fallback chain, and all-corrupt scenario

## Test plan
- [x] 26/26 FileLockManager.simple tests pass (20 existing + 6 new)
- [x] Full CI suite: 8609/8634 pass (4 pre-existing smoke test timeouts unrelated)
- [x] `npm run build` succeeds
- [ ] Manual: corrupt a JSON file used by PresenceManager, verify auto-recovery from .bak-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)