### PR TITLE
fix(roo-state-manager): exclude test files from tsconfig build

### DIFF
--- a/servers/roo-state-manager/tsconfig.json
+++ b/servers/roo-state-manager/tsconfig.json
@@ -30,6 +30,8 @@
   "exclude": [
     "node_modules",
     "build",
-    "src/**/__tests__/**"
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- Exclude `*.test.ts` and `*.spec.ts` files from TypeScript build in tsconfig.json
- Fix build failure caused by `manage-baseline.test.ts` using outdated tool schema types
- Test files outside `__tests__/` directories were incorrectly compiled into the build output

## Context
On machine myia-po-2025, `npm run build` failed with 11 TypeScript errors in `manage-baseline.test.ts` (properties `name`, `branch`, `basePath` not in current schema, action type mismatch). The test file was not in `__tests__/` so it wasn't excluded from the build.

## Test plan
- [x] `npm run build` succeeds with the fix
- [x] `npx vitest run` still picks up test files (vitest uses its own config, not tsconfig)

🤖 Generated with [Claude Code](https://claude.com/claude-code)