### PR TITLE
fix(#1674): atomic writes prevent 0-byte heartbeat corruption

### DIFF
--- a/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
+++ b/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
@@ -18,6 +18,26 @@ import { createLogger } from '../../utils/logger.js';
 const logger = createLogger('HeartbeatService');
 
 /**
+ * Atomic write: write to .tmp then rename. Prevents 0-byte corruption on GDrive/Windows
+ * when the process is interrupted mid-write.
+ */
+async function atomicWriteFile(filePath: string, data: string): Promise<void> {
+  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  await fs.writeFile(tmpPath, data, 'utf-8');
+  await fs.rename(tmpPath, filePath);
+}
+
+/**
+ * Synchronous atomic write for use during migration (called from sync context).
+ */
+function atomicWriteFileSync(filePath: string, data: string): void {
+  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmpPath, data, 'utf-8');
+  const { renameSync } = require('fs');
+  renameSync(tmpPath, filePath);
+}
+
+/**
  * Configuration du heartbeat
  */
 export interface HeartbeatConfig {
@@ -257,6 +277,15 @@ export class HeartbeatService {
       for (const file of jsonFiles) {
         try {
           const filePath = join(this.heartbeatsDir, file);
+
+          // Clean up 0-byte files (corruption from interrupted non-atomic writes)
+          const stat = require('fs').statSync(filePath);
+          if (stat.size === 0) {
+            logger.warn(`Suppression fichier heartbeat vide (0 bytes): ${file}`);
+            try { unlinkSync(filePath); } catch (_) { /* ignore cleanup failure */ }
+            continue;
+          }
+
           const content = readFileSync(filePath, 'utf-8');
           const data = JSON.parse(content) as HeartbeatData;
           const machineId = data.machineId?.toLowerCase() || file.replace('.json', '').toLowerCase();
@@ -265,8 +294,59 @@ export class HeartbeatService {
           logger.warn(`Erreur lecture fichier heartbeat ${file}`, { error: String(fileError) });
         }
       }
+
+      // Identity dedup: merge stale unprefixed files into myia-prefixed ones
+      // e.g. po-2025.json → myia-po-2025.json (the canonical identity)
+      this.dedupMachineIdentities();
     } catch (error) {
       logger.error('Erreur lecture répertoire heartbeats', error);
+    }
+  }
+
+  /**
+   * Deduplicate heartbeat files where a machine has both "shortname" and "myia-shortname" entries.
+   * Keeps the more recent entry, removes the stale one.
+   */
+  private dedupMachineIdentities(): void {
+    const entries = Array.from(this.state.heartbeats.entries());
+    const toRemove: string[] = [];
+
+    for (const [machineId, data] of entries) {
+      // Check if this is an unprefixed variant of a myia-prefixed machine
+      if (!machineId.startsWith('myia-')) {
+        const prefixedId = `myia-${machineId}`;
+        if (this.state.heartbeats.has(prefixedId)) {
+          const prefixedData = this.state.heartbeats.get(prefixedId)!;
+          // Keep the one with the most recent timestamp
+          const unprefixedTime = new Date(data.lastHeartbeat || 0).getTime();
+          const prefixedTime = new Date(prefixedData.lastHeartbeat || 0).getTime();
+
+          if (prefixedTime >= unprefixedTime) {
+            // Prefixed is newer or same — remove unprefixed
+            toRemove.push(machineId);
+            logger.info(`Dedup: suppression identité dupliquée ${machineId} (conserve ${prefixedId})`);
+          } else {
+            // Unprefixed is newer — merge into prefixed, remove unprefixed
+            this.state.heartbeats.set(prefixedId, data);
+            toRemove.push(machineId);
+            logger.info(`Dedup: fusion ${machineId} → ${prefixedId} (données plus récentes)`);
+          }
+
+          // Clean up the orphan file
+          try {
+            const orphanPath = this.getMachineFilePath(machineId);
+            if (existsSync(orphanPath)) {
+              unlinkSync(orphanPath);
+            }
+          } catch (e) {
+            logger.warn(`Dedup: impossible de supprimer fichier orphelin pour ${machineId}`, { error: String(e) });
+          }
+        }
+      }
+    }
+
+    for (const id of toRemove) {
+      this.state.heartbeats.delete(id);
     }
   }
 
@@ -289,7 +369,7 @@ export class HeartbeatService {
         // Write individual file
         try {
           const filePath = this.getMachineFilePath(machineId);
-          writeFileSync(filePath, JSON.stringify(heartbeatData, null, 2));
+          atomicWriteFileSync(filePath, JSON.stringify(heartbeatData, null, 2));
         } catch (writeError) {
           logger.warn(`Erreur écriture heartbeat ${machineId} pendant migration`, { error: String(writeError) });
         }
@@ -329,7 +409,7 @@ export class HeartbeatService {
       if (!heartbeatData) return;
 
       const filePath = this.getMachineFilePath(machineId);
-      await fs.writeFile(filePath, JSON.stringify(heartbeatData, null, 2));
+      await atomicWriteFile(filePath, JSON.stringify(heartbeatData, null, 2));
     } catch (error) {
       logger.error(`Erreur sauvegarde heartbeat pour ${machineId}`, error);
     }
@@ -358,7 +438,7 @@ export class HeartbeatService {
 
       for (const [machineId, heartbeatData] of this.state.heartbeats.entries()) {
         const filePath = this.getMachineFilePath(machineId);
-        await fs.writeFile(filePath, JSON.stringify(heartbeatData, null, 2));
+        await atomicWriteFile(filePath, JSON.stringify(heartbeatData, null, 2));
       }
     } catch (error) {
       logger.error('Erreur sauvegarde état', error);

--- a/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
+++ b/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
@@ -11,7 +11,7 @@
  * @version 3.1.0
  */
 
-import { promises as fs, existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync, unlinkSync } from 'fs';
+import { promises as fs, existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync, unlinkSync, statSync, renameSync as fsRenameSync } from 'fs';
 import { join } from 'path';
 import { createLogger } from '../../utils/logger.js';
 
@@ -33,8 +33,7 @@ async function atomicWriteFile(filePath: string, data: string): Promise<void> {
 function atomicWriteFileSync(filePath: string, data: string): void {
   const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
   writeFileSync(tmpPath, data, 'utf-8');
-  const { renameSync } = require('fs');
-  renameSync(tmpPath, filePath);
+  fsRenameSync(tmpPath, filePath);
 }
 
 /**
@@ -279,7 +278,7 @@ export class HeartbeatService {
           const filePath = join(this.heartbeatsDir, file);
 
           // Clean up 0-byte files (corruption from interrupted non-atomic writes)
-          const stat = require('fs').statSync(filePath);
+          const stat = statSync(filePath);
           if (stat.size === 0) {
             logger.warn(`Suppression fichier heartbeat vide (0 bytes): ${file}`);
             try { unlinkSync(filePath); } catch (_) { /* ignore cleanup failure */ }

--- a/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
@@ -33,9 +33,12 @@ const {
   mockMkdirSync,
   mockWriteFileSync,
   mockUnlinkSync,
+  mockStatSync,
+  mockRenameSync,
   mockWriteFile,
   mockMkdir,
   mockUnlink,
+  mockRename,
 } = vi.hoisted(() => ({
   mockExistsSync: vi.fn().mockReturnValue(false),
   mockReadFileSync: vi.fn().mockReturnValue('{}'),
@@ -43,9 +46,12 @@ const {
   mockMkdirSync: vi.fn(),
   mockWriteFileSync: vi.fn(),
   mockUnlinkSync: vi.fn(),
+  mockStatSync: vi.fn().mockReturnValue({ size: 100 }),
+  mockRenameSync: vi.fn(),
   mockWriteFile: vi.fn().mockResolvedValue(undefined),
   mockMkdir: vi.fn().mockResolvedValue(undefined),
   mockUnlink: vi.fn().mockResolvedValue(undefined),
+  mockRename: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('fs', () => ({
@@ -55,10 +61,13 @@ vi.mock('fs', () => ({
   mkdirSync: mockMkdirSync,
   writeFileSync: mockWriteFileSync,
   unlinkSync: mockUnlinkSync,
+  statSync: mockStatSync,
+  renameSync: mockRenameSync,
   promises: {
     writeFile: (...args: any[]) => mockWriteFile(...args),
     mkdir: (...args: any[]) => mockMkdir(...args),
     unlink: (...args: any[]) => mockUnlink(...args),
+    rename: (...args: any[]) => mockRename(...args),
   },
 }));
 
@@ -136,9 +145,11 @@ beforeEach(() => {
   mockExistsSync.mockReturnValue(false);
   mockReadFileSync.mockReturnValue('{}');
   mockReaddirSync.mockReturnValue([]);
+  mockStatSync.mockReturnValue({ size: 100 });
   mockWriteFile.mockResolvedValue(undefined);
   mockMkdir.mockResolvedValue(undefined);
   mockUnlink.mockResolvedValue(undefined);
+  mockRename.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -336,10 +347,11 @@ describe('HeartbeatService', () => {
       await service.registerHeartbeat('machine-y');
 
       expect(mockMkdir).toHaveBeenCalledWith(HEARTBEATS_DIR, { recursive: true });
-      expect(mockWriteFile).toHaveBeenCalledWith(
-        join(HEARTBEATS_DIR, 'machine-y.json'),
-        expect.any(String)
-      );
+      // Atomic write: writeFile gets .tmp path, then rename to final path
+      const writeFileCalls = mockWriteFile.mock.calls;
+      expect(writeFileCalls.length).toBeGreaterThanOrEqual(1);
+      expect(writeFileCalls[0][0]).toContain(join(HEARTBEATS_DIR, 'machine-y.json'));
+      expect(mockRename).toHaveBeenCalled();
     });
 
     test('enregistre plusieurs machines indépendamment', async () => {
@@ -361,10 +373,10 @@ describe('HeartbeatService', () => {
       await service.registerHeartbeat('MyIA-AI-01');
 
       expect(service.getHeartbeatData('myia-ai-01')).toBeDefined();
-      expect(mockWriteFile).toHaveBeenCalledWith(
-        join(HEARTBEATS_DIR, 'myia-ai-01.json'),
-        expect.any(String)
-      );
+      // Atomic write: writeFile gets .tmp path
+      const writeFileCalls = mockWriteFile.mock.calls;
+      expect(writeFileCalls.length).toBeGreaterThanOrEqual(1);
+      expect(writeFileCalls[0][0]).toContain(join(HEARTBEATS_DIR, 'myia-ai-01.json'));
     });
   });
 
@@ -736,10 +748,11 @@ describe('HeartbeatService', () => {
       await service.stopHeartbeatService();
 
       expect(mockMkdir).toHaveBeenCalledWith(HEARTBEATS_DIR, { recursive: true });
-      expect(mockWriteFile).toHaveBeenCalledWith(
-        join(HEARTBEATS_DIR, 'persisted-machine.json'),
-        expect.any(String)
-      );
+      // Atomic write: writeFile gets .tmp path, then rename to final path
+      const writeFileCalls = mockWriteFile.mock.calls;
+      expect(writeFileCalls.length).toBeGreaterThanOrEqual(1);
+      expect(writeFileCalls[0][0]).toContain(join(HEARTBEATS_DIR, 'persisted-machine.json'));
+      expect(mockRename).toHaveBeenCalled();
     });
   });
 

--- a/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
@@ -611,4 +611,91 @@ describe('HeartbeatService - Tests Unitaires', () => {
       expect(newService.getHeartbeatData('machine-2')).toBeDefined();
     });
   });
+
+  describe('Atomic writes (#1674)', () => {
+    it('should write heartbeat files atomically (no 0-byte on interrupt)', async () => {
+      await heartbeatService.registerHeartbeat('test-atomic');
+
+      // Verify the heartbeat file exists and is valid JSON
+      const heartbeatDir = join(sharedPath, 'heartbeats');
+      const filePath = join(heartbeatDir, 'test-atomic.json');
+      expect(existsSync(filePath)).toBe(true);
+
+      const content = await fs.readFile(filePath, 'utf-8');
+      const parsed = JSON.parse(content);
+      expect(parsed.machineId).toBe('test-atomic');
+      expect(parsed.status).toBe('online');
+    });
+
+    it('should clean up 0-byte heartbeat files on load', async () => {
+      // Register a machine first
+      await heartbeatService.registerHeartbeat('machine-clean');
+
+      // Create a 0-byte file simulating corruption
+      const heartbeatDir = join(sharedPath, 'heartbeats');
+      const corruptPath = join(heartbeatDir, 'corrupt-machine.json');
+      await fs.writeFile(corruptPath, '', 'utf-8'); // 0-byte file
+
+      expect(existsSync(corruptPath)).toBe(true);
+
+      // Stop and reload — should clean up the 0-byte file
+      await heartbeatService.stopHeartbeatService();
+      const newService = new HeartbeatService(sharedPath, {
+        heartbeatInterval: 30000,
+        offlineTimeout: 120000,
+        missedHeartbeatThreshold: 4,
+        autoSyncEnabled: false,
+        autoSyncInterval: 60000
+      });
+
+      const state = newService.getState();
+      expect(state.statistics.totalMachines).toBe(1);
+      expect(newService.getHeartbeatData('machine-clean')).toBeDefined();
+      expect(existsSync(corruptPath)).toBe(false); // 0-byte file removed
+    });
+  });
+
+  describe('Identity dedup (#1674)', () => {
+    it('should deduplicate shortname and myia-prefixed identities', async () => {
+      const heartbeatDir = join(sharedPath, 'heartbeats');
+      await mkdir(heartbeatDir, { recursive: true });
+
+      // Create a stale unprefixed file
+      const staleData: HeartbeatData = {
+        machineId: 'po-2025',
+        status: 'offline',
+        lastHeartbeat: new Date(Date.now() - 86400000).toISOString(),
+        missedHeartbeats: 5,
+        metadata: { firstSeen: new Date().toISOString(), lastUpdated: new Date().toISOString() }
+      };
+      await fs.writeFile(join(heartbeatDir, 'po-2025.json'), JSON.stringify(staleData, null, 2));
+
+      // Create a fresh myia-prefixed file
+      const freshData: HeartbeatData = {
+        machineId: 'myia-po-2025',
+        status: 'online',
+        lastHeartbeat: new Date().toISOString(),
+        missedHeartbeats: 0,
+        metadata: { firstSeen: new Date().toISOString(), lastUpdated: new Date().toISOString() }
+      };
+      await fs.writeFile(join(heartbeatDir, 'myia-po-2025.json'), JSON.stringify(freshData, null, 2));
+
+      // Load service — should deduplicate
+      const service = new HeartbeatService(sharedPath, {
+        heartbeatInterval: 30000,
+        offlineTimeout: 120000,
+        missedHeartbeatThreshold: 4,
+        autoSyncEnabled: false,
+        autoSyncInterval: 60000
+      });
+
+      const state = service.getState();
+      // Should only have the myia-prefixed entry
+      expect(state.statistics.totalMachines).toBe(1);
+      expect(service.getHeartbeatData('myia-po-2025')).toBeDefined();
+      expect(service.getHeartbeatData('myia-po-2025')?.status).toBe('online');
+      // Unprefixed file should be gone
+      expect(existsSync(join(heartbeatDir, 'po-2025.json'))).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Replace 3 non-atomic `writeFile`/`writeFileSync` calls in HeartbeatService with `.tmp` + `rename()` atomic pattern
- Add 0-byte file cleanup on boot (detect and remove corrupt heartbeat files from interrupted writes)
- Add identity dedup for `po-XXXX` vs `myia-po-XXXX` machine entries (keeps freshest, removes stale)

## Root Cause
GDrive sync + Windows can interrupt mid-write, leaving 0-byte heartbeat files. Next boot, JSON.parse fails on empty content, losing machine heartbeats.

## Test plan
- [x] 3 new unit tests: atomic write verification, 0-byte cleanup, identity dedup
- [x] All 19 HeartbeatService tests pass
- [x] Full CI suite: 8574 passed / 39 failed (pre-existing worker timeouts)
- [ ] Verify on production GDrive that 0-byte files are cleaned up on next boot

Fixes #1674

🤖 Generated with [Claude Code](https://claude.com/claude-code)