### PR TITLE
feat(#1658): add Qdrant vector retention cleanup tool

### DIFF
--- a/servers/roo-state-manager/src/services/task-indexer.ts
+++ b/servers/roo-state-manager/src/services/task-indexer.ts
@@ -12,6 +12,7 @@ import {
     indexTask as indexTaskVector,
     resetCollection as resetCollectionVector,
     countPointsByHostOs as countPointsByHostOsVector,
+    cleanupOldVectors as cleanupOldVectorsVector,
     updateSkeletonIndexTimestamp,
     upsertPointsBatch,
     qdrantRateLimiter
@@ -191,5 +192,16 @@ export class TaskIndexer {
      */
     async countPointsByHostOs(hostOs: string): Promise<number> {
         return countPointsByHostOsVector(hostOs);
+    }
+
+    /**
+     * Supprime les vecteurs plus anciens qu'un âge donné (#1658)
+     */
+    async cleanupOldVectors(
+        maxAgeDays: number = 90,
+        dryRun: boolean = false,
+        workspaceFilter?: string
+    ): Promise<{ deletedCount: number; cutoffDate: string; workspaceFilter?: string }> {
+        return cleanupOldVectorsVector(maxAgeDays, dryRun, workspaceFilter);
     }
 }

--- a/servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts
@@ -682,3 +682,107 @@ export async function upsertPointsBatch(
         }
     }
 }
+
+/**
+ * Supprime les vecteurs plus anciens qu'un âge donné (#1658)
+ * Utilise le champ `timestamp` du payload pour filtrer par âge.
+ * @param maxAgeDays Âge maximum en jours (défaut: 90)
+ * @param dryRun Mode simulation — compte sans supprimer
+ * @param workspaceFilter Filtre optionnel par workspace_name
+ */
+export async function cleanupOldVectors(
+    maxAgeDays: number = 90,
+    dryRun: boolean = false,
+    workspaceFilter?: string
+): Promise<{ deletedCount: number; cutoffDate: string; workspaceFilter?: string }> {
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - maxAgeDays);
+    const cutoffIso = cutoffDate.toISOString();
+
+    const mustConditions: Array<{ key: string; match: { value: string } } | { key: string; range: { lt: string } }> = [
+        {
+            key: 'timestamp',
+            range: { lt: cutoffIso }
+        }
+    ];
+
+    if (workspaceFilter) {
+        mustConditions.push({
+            key: 'workspace_name',
+            match: { value: workspaceFilter }
+        });
+    }
+
+    const filter = { must: mustConditions };
+
+    // Count candidates first
+    const countResult = await retryWithBackoff(async () => {
+        const qdrant = getQdrantClient();
+        return await qdrant.count(COLLECTION_NAME, {
+            filter,
+            exact: true
+        });
+    }, `Qdrant cleanup count (age>${maxAgeDays}d)`);
+
+    const candidateCount = countResult.count;
+    networkMetrics.qdrantCalls++;
+
+    if (candidateCount === 0) {
+        return { deletedCount: 0, cutoffDate: cutoffIso, workspaceFilter };
+    }
+
+    if (dryRun) {
+        console.log(`[DRY RUN] ${candidateCount} vecteurs seraient supprimés (antérieurs à ${cutoffIso}${workspaceFilter ? `, workspace=${workspaceFilter}` : ''})`);
+        return { deletedCount: candidateCount, cutoffDate: cutoffIso, workspaceFilter };
+    }
+
+    // Delete in batches using scroll + delete pattern to avoid timeout on large sets
+    const BATCH_SIZE = 1000;
+    let totalDeleted = 0;
+    let hasMore = true;
+
+    while (hasMore) {
+        await qdrantRateLimiter.execute(async () => {
+            // Scroll to get a batch of point IDs matching the filter
+            const scrolled = await retryWithBackoff(async () => {
+                const qdrant = getQdrantClient();
+                return await qdrant.scroll(COLLECTION_NAME, {
+                    filter,
+                    limit: BATCH_SIZE,
+                    with_payload: false,
+                    with_vector: false
+                });
+            }, `Qdrant cleanup scroll (batch at ${totalDeleted})`);
+
+            networkMetrics.qdrantCalls++;
+
+            if (!scrolled.points || scrolled.points.length === 0) {
+                hasMore = false;
+                return;
+            }
+
+            const idsToDelete = scrolled.points.map((p: any) => p.id);
+
+            // Delete this batch
+            await retryWithBackoff(async () => {
+                const qdrant = getQdrantClient();
+                await qdrant.delete(COLLECTION_NAME, {
+                    points: idsToDelete,
+                    wait: true
+                });
+            }, `Qdrant cleanup delete batch (${idsToDelete.length} points)`);
+
+            networkMetrics.qdrantCalls++;
+            totalDeleted += idsToDelete.length;
+
+            console.log(`✓ Cleanup batch: ${idsToDelete.length} vecteurs supprimés (total: ${totalDeleted}/${candidateCount})`);
+
+            if (!scrolled.next_page_offset) {
+                hasMore = false;
+            }
+        });
+    }
+
+    console.log(`✅ Cleanup terminé: ${totalDeleted} vecteurs supprimés (antérieurs à ${cutoffIso}${workspaceFilter ? `, workspace=${workspaceFilter}` : ''})`);
+    return { deletedCount: totalDeleted, cutoffDate: cutoffIso, workspaceFilter };
+}

--- a/servers/roo-state-manager/src/tools/indexing/__tests__/roosync-indexing.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/indexing/__tests__/roosync-indexing.tool.test.ts
@@ -76,9 +76,9 @@ describe('roosyncIndexingTool', () => {
 		expect(roosyncIndexingTool.inputSchema.required).toEqual(['action']);
 	});
 
-	test('has action enum with 6 values', () => {
+	test('has action enum with 7 values', () => {
 		const actionProp = (roosyncIndexingTool.inputSchema.properties as any).action;
-		expect(actionProp.enum).toEqual(['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status']);
+		expect(actionProp.enum).toEqual(['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'cleanup']);
 	});
 
 	// ============================================================

--- a/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
@@ -24,7 +24,7 @@ import { handleDiagnoseSemanticIndex } from './diagnose-index.tool.js';
  */
 export interface RooSyncIndexingArgs {
     /** Action d'indexation */
-    action: 'index' | 'reset' | 'rebuild' | 'diagnose' | 'archive' | 'status';
+    action: 'index' | 'reset' | 'rebuild' | 'diagnose' | 'archive' | 'status' | 'cleanup';
 
     /** ID de la tâche à indexer (requis pour action=index) */
     task_id?: string;
@@ -53,6 +53,12 @@ export interface RooSyncIndexingArgs {
     /** #604: Source de la conversation (pour action=index, détermine l'extracteur de chunks) */
     source?: 'roo' | 'claude-code';
 
+    /** #1658: Âge maximum en jours pour la rétention (pour action=cleanup). Défaut: 90 */
+    max_age_days?: number;
+
+    /** #1658: Filtre optionnel par workspace_name (pour action=cleanup) */
+    workspace_name_filter?: string;
+
     /** #1244: Activer le diagnostic approfondi (scroll sample, distribution source/workspace) — pour action=diagnose */
     deep?: boolean;
 
@@ -74,8 +80,8 @@ export const roosyncIndexingTool: Tool = {
         properties: {
             action: {
                 type: 'string',
-                enum: ['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status'],
-                description: "Action: 'index' (indexer une tâche dans Qdrant), 'reset' (réinitialiser la collection Qdrant), 'rebuild' (reconstruire l'index SQLite VS Code), 'diagnose' (diagnostic complet de l'index), 'archive' (archiver une tâche Roo ou les sessions Claude Code sur GDrive), 'status' (état du background indexer et métriques)"
+                enum: ['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'cleanup'],
+                description: "Action: 'index' (indexer une tâche dans Qdrant), 'reset' (réinitialiser la collection Qdrant), 'rebuild' (reconstruire l'index SQLite VS Code), 'diagnose' (diagnostic complet de l'index), 'archive' (archiver une tâche Roo ou les sessions Claude Code sur GDrive), 'status' (état du background indexer et métriques), 'cleanup' (supprimer les vecteurs plus anciens qu'un âge donné #1658)"
             },
             task_id: {
                 type: 'string',
@@ -118,6 +124,15 @@ export const roosyncIndexingTool: Tool = {
                 type: 'string',
                 enum: ['roo', 'claude-code'],
                 description: "#604: Source de la conversation (pour action=index). 'roo' = tâche Roo standard, 'claude-code' = session Claude Code JSONL. Par défaut: 'roo'"
+            },
+            max_age_days: {
+                type: 'number',
+                description: "#1658: Pour action=cleanup. Âge maximum en jours des vecteurs à conserver. Les vecteurs dont le timestamp est antérieur à (now - max_age_days) seront supprimés. Défaut: 90.",
+                default: 90
+            },
+            workspace_name_filter: {
+                type: 'string',
+                description: "#1658: Pour action=cleanup. Filtre optionnel par workspace_name pour limiter le cleanup à un workspace spécifique."
             },
             deep: {
                 type: 'boolean',
@@ -175,10 +190,10 @@ export async function handleRooSyncIndexing(
         };
     }
 
-    if (!['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status'].includes(args.action)) {
+    if (!['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'cleanup'].includes(args.action)) {
         return {
             isError: true,
-            content: [{ type: 'text', text: `Action "${args.action}" invalide. Valeurs possibles: index, reset, rebuild, diagnose, archive, status` }]
+            content: [{ type: 'text', text: `Action "${args.action}" invalide. Valeurs possibles: index, reset, rebuild, diagnose, archive, status, cleanup` }]
         };
     }
 
@@ -332,6 +347,41 @@ export async function handleRooSyncIndexing(
                 isError: false,
                 content: [{ type: 'text', text: JSON.stringify(status, null, 2) }]
             };
+        }
+
+        case 'cleanup': {
+            const { cleanupOldVectors } = await import('../../services/task-indexer/VectorIndexer.js');
+            const maxAgeDays = args.max_age_days || 90;
+            const isDryRun = args.dry_run ?? false;
+
+            try {
+                const result = await cleanupOldVectors(maxAgeDays, isDryRun, args.workspace_name_filter);
+
+                const mode = isDryRun ? '[DRY RUN]' : '[EXECUTED]';
+                return {
+                    isError: false,
+                    content: [{
+                        type: 'text',
+                        text: JSON.stringify({
+                            action: 'cleanup',
+                            mode: isDryRun ? 'dry_run' : 'executed',
+                            max_age_days: maxAgeDays,
+                            cutoff_date: result.cutoffDate,
+                            workspace_filter: result.workspaceFilter || null,
+                            vectors_affected: result.deletedCount,
+                            summary: `${mode} ${result.deletedCount} vecteurs ${isDryRun ? 'seraient supprimés' : 'supprimés'} (antérieurs au ${result.cutoffDate})`
+                        }, null, 2)
+                    }]
+                };
+            } catch (error: any) {
+                return {
+                    isError: true,
+                    content: [{
+                        type: 'text',
+                        text: `Erreur lors du cleanup: ${error.message}`
+                    }]
+                };
+            }
         }
 
         default:

--- a/servers/roo-state-manager/tests/unit/services/task-indexer/VectorIndexer.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/task-indexer/VectorIndexer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { indexTask, safeQdrantUpsert, QdrantRateLimiter, qdrantRateLimiter } from '../../../../src/services/task-indexer/VectorIndexer.js';
+import { indexTask, safeQdrantUpsert, QdrantRateLimiter, qdrantRateLimiter, cleanupOldVectors } from '../../../../src/services/task-indexer/VectorIndexer.js';
 import { getQdrantClient } from '../../../../src/services/qdrant.js';
 import getOpenAIClient from '../../../../src/services/openai.js';
 import { extractChunksFromTask, splitChunk } from '../../../../src/services/task-indexer/ChunkExtractor.js';
@@ -34,7 +34,10 @@ describe('VectorIndexer', () => {
     mockQdrantClient = {
       getCollections: vi.fn(),
       createCollection: vi.fn(),
-      upsert: vi.fn()
+      upsert: vi.fn(),
+      count: vi.fn(),
+      scroll: vi.fn(),
+      delete: vi.fn()
     };
     vi.mocked(getQdrantClient).mockReturnValue(mockQdrantClient);
 
@@ -150,6 +153,84 @@ describe('VectorIndexer', () => {
       vi.mocked(extractChunksFromTask).mockRejectedValue(new Error('Extraction failed'));
 
       await expect(indexTask('task-1', '/path')).rejects.toThrow('Extraction failed');
+    });
+  });
+
+  describe('cleanupOldVectors', () => {
+    it('should return 0 when no old vectors found', async () => {
+      mockQdrantClient.count.mockResolvedValue({ count: 0 });
+
+      const result = await cleanupOldVectors(90);
+
+      expect(result.deletedCount).toBe(0);
+      expect(mockQdrantClient.count).toHaveBeenCalled();
+      expect(mockQdrantClient.scroll).not.toHaveBeenCalled();
+      expect(mockQdrantClient.delete).not.toHaveBeenCalled();
+    });
+
+    it('should count but not delete in dry_run mode', async () => {
+      mockQdrantClient.count.mockResolvedValue({ count: 5000 });
+
+      const result = await cleanupOldVectors(90, true);
+
+      expect(result.deletedCount).toBe(5000);
+      expect(mockQdrantClient.scroll).not.toHaveBeenCalled();
+      expect(mockQdrantClient.delete).not.toHaveBeenCalled();
+    });
+
+    it('should delete vectors older than max_age_days', async () => {
+      mockQdrantClient.count.mockResolvedValue({ count: 3 });
+      mockQdrantClient.scroll
+        .mockResolvedValueOnce({
+          points: [{ id: 'p1' }, { id: 'p2' }, { id: 'p3' }],
+          next_page_offset: null
+        });
+      mockQdrantClient.delete.mockResolvedValue({});
+
+      const result = await cleanupOldVectors(90, false);
+
+      expect(result.deletedCount).toBe(3);
+      expect(mockQdrantClient.delete).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          points: ['p1', 'p2', 'p3'],
+          wait: true
+        })
+      );
+    });
+
+    it('should filter by workspace_name when provided', async () => {
+      mockQdrantClient.count.mockResolvedValue({ count: 0 });
+
+      const result = await cleanupOldVectors(90, false, 'roo-extensions');
+
+      expect(result.workspaceFilter).toBe('roo-extensions');
+      // Verify the count call used the workspace filter
+      const countCall = mockQdrantClient.count.mock.calls[0];
+      expect(countCall[1].filter.must).toHaveLength(2);
+      expect(countCall[1].filter.must[1]).toEqual({
+        key: 'workspace_name',
+        match: { value: 'roo-extensions' }
+      });
+    });
+
+    it('should handle multi-batch deletion', async () => {
+      mockQdrantClient.count.mockResolvedValue({ count: 5 });
+      mockQdrantClient.scroll
+        .mockResolvedValueOnce({
+          points: Array.from({ length: 3 }, (_, i) => ({ id: `p${i}` })),
+          next_page_offset: 'offset1'
+        })
+        .mockResolvedValueOnce({
+          points: [{ id: 'p3' }, { id: 'p4' }],
+          next_page_offset: null
+        });
+      mockQdrantClient.delete.mockResolvedValue({});
+
+      const result = await cleanupOldVectors(90, false);
+
+      expect(result.deletedCount).toBe(5);
+      expect(mockQdrantClient.delete).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/servers/roo-state-manager/tests/unit/tools/indexing/roosync-indexing.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/indexing/roosync-indexing.test.ts
@@ -76,9 +76,9 @@ describe('roosync_indexing - CONS-11', () => {
             expect(roosyncIndexingTool.name).toBe('roosync_indexing');
         });
 
-        it('should have action enum with 6 values', () => {
+        it('should have action enum with 7 values', () => {
             const actionProp = (roosyncIndexingTool.inputSchema as any).properties.action;
-            expect(actionProp.enum).toEqual(['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status']);
+            expect(actionProp.enum).toEqual(['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'cleanup']);
         });
 
         it('should require action parameter', () => {


### PR DESCRIPTION
## Summary
- Add `cleanupOldVectors()` function to VectorIndexer with scroll+delete batch pattern for deleting old vectors from Qdrant
- Wire `action: cleanup` in roosync_indexing tool with `max_age_days` (default 90), `workspace_name_filter`, and `dry_run` parameters
- Add facade method on TaskIndexer class

## Test plan
- [x] 5 new unit tests: empty count, dry_run mode, batch deletion, workspace filter, multi-batch pagination
- [x] Updated action enum count test (6→7)
- [x] Build passes (`npm run build`)
- [x] All 27 affected tests pass (`npx vitest run --config vitest.config.ci.ts`)

Closes #1658

🤖 Generated with [Claude Code](https://claude.com/claude-code)