### PR TITLE
fix(#1701): apply #1623 corrupt JSON fix to proper-lockfile FileLockManager

### DIFF
--- a/servers/roo-state-manager/src/services/roosync/FileLockManager.ts
+++ b/servers/roo-state-manager/src/services/roosync/FileLockManager.ts
@@ -207,20 +207,31 @@ export class FileLockManager {
    */
   async updateJsonWithLock<T>(
     filePath: string,
-    updateFn: (data: T) => T,
+    updateFn: (data: T | undefined) => T,
     options: LockOptions = {}
   ): Promise<LockOperationResult<T>> {
     return this.withLock<T>(filePath, async () => {
       // Lire le fichier existant
-      const content = await fs.readFile(filePath, 'utf-8');
-      const data = JSON.parse(content) as T;
-      
+      let data: T | undefined;
+      try {
+        const content = await fs.readFile(filePath, 'utf-8');
+        data = JSON.parse(content) as T;
+      } catch (error: any) {
+        if (error.code === 'ENOENT') {
+          // Fichier n'existe pas - data reste undefined
+        } else {
+          // Corrupt/empty file — treat as missing, updater will recreate (#1623)
+          console.warn(`[FileLockManager] Corrupt JSON in ${filePath}, treating as empty: ${error.message}`);
+          data = undefined;
+        }
+      }
+
       // Appliquer la mise à jour
       const updatedData = updateFn(data);
-      
+
       // Écrire le fichier mis à jour
       await fs.writeFile(filePath, JSON.stringify(updatedData, null, 2), 'utf-8');
-      
+
       console.log(`[FileLockManager] Fichier JSON mis à jour avec succès: ${filePath}`);
       return updatedData;
     }, options);

--- a/servers/roo-state-manager/src/services/roosync/__tests__/FileLockManager.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/FileLockManager.test.ts
@@ -332,10 +332,18 @@ describe('FileLockManager', () => {
       );
     });
 
-    test('retourne success=false si JSON invalide', async () => {
+    test('corrupt JSON treated as missing — updater can recreate (#1623)', async () => {
       mockReadFile.mockResolvedValue('invalid-json{{{');
       const result = await manager.updateJsonWithLock('/tmp/bad.json', (d) => d);
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
+      expect(result.data).toBeUndefined();
+    });
+
+    test('corrupt JSON passes undefined to updater for recreation (#1623)', async () => {
+      mockReadFile.mockResolvedValue('invalid-json{{{');
+      const result = await manager.updateJsonWithLock<any>('/tmp/bad.json', (d) => ({ recreated: true }));
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ recreated: true });
     });
   });
 


### PR DESCRIPTION
## Summary
- Apply the #1623 corrupt JSON auto-repair fix to `FileLockManager.ts` (proper-lockfile version), matching the fix already in `FileLockManager.simple.ts`
- Update test assertions to expect `success=true` for corrupt JSON (auto-repair behavior)
- 66/66 tests pass, build succeeds

## Root Cause
The #1623 fix was only applied to `FileLockManager.simple.ts` but not the main `FileLockManager.ts`. This caused inconsistent behavior between the two implementations and CI test failures on `updateJsonWithLock > retourne success=false si JSON invalide`.

## Test Plan
- [x] `npx vitest run src/services/roosync/__tests__/FileLockManager.test.ts` — 46/46 pass
- [x] `npx vitest run src/services/roosync/__tests__/FileLockManager.simple.test.ts` — 20/20 pass
- [x] `npm run build` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)