### PR TITLE
feat(#1410): add current_version action to roosync_baseline

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/baseline.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/baseline.test.ts
@@ -1558,4 +1558,70 @@ First release
       expect(exportedData.statistics.exportTimestamp).toBeDefined();
     });
   });
+
+  describe('action: current_version', () => {
+    test('should return current baseline version when baseline exists', async () => {
+      // Create a baseline file
+      const baselineData = {
+        version: '2026.04.25-1430',
+        baselineId: 'baseline-2026.04.25-1430',
+        machineId: 'test-machine',
+        lastUpdated: '2026-04-25T14:30:00.000Z',
+        config: { roo: {}, hardware: {}, software: {}, system: {} }
+      };
+      writeFileSync(
+        join(testSharedStatePath, 'sync-config.ref.json'),
+        JSON.stringify(baselineData, null, 2)
+      );
+
+      const result = await roosync_baseline({
+        action: 'current_version'
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe('current_version');
+      expect(result.data.exists).toBe(true);
+      expect(result.data.version).toBe('2026.04.25-1430');
+      expect(result.data.machineId).toBe('test-machine');
+      expect(result.version).toBe('2026.04.25-1430');
+    });
+
+    test('should report no baseline when file does not exist', async () => {
+      // Remove baseline file if it exists
+      const baselinePath = join(testSharedStatePath, 'sync-config.ref.json');
+      if (existsSync(baselinePath)) {
+        rmSync(baselinePath);
+      }
+
+      const result = await roosync_baseline({
+        action: 'current_version'
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data.exists).toBe(false);
+      expect(result.version).toBe('');
+    });
+
+    test('should accept explicit machineId parameter', async () => {
+      const baselineData = {
+        version: '2026.04.25-1500',
+        baselineId: 'baseline-2026.04.25-1500',
+        machineId: 'explicit-machine',
+        lastUpdated: '2026-04-25T15:00:00.000Z',
+        config: { roo: {}, hardware: {}, software: {}, system: {} }
+      };
+      writeFileSync(
+        join(testSharedStatePath, 'sync-config.ref.json'),
+        JSON.stringify(baselineData, null, 2)
+      );
+
+      const result = await roosync_baseline({
+        action: 'current_version',
+        machineId: 'explicit-machine'
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data.exists).toBe(true);
+    });
+  });
 });

--- a/servers/roo-state-manager/src/tools/roosync/baseline.ts
+++ b/servers/roo-state-manager/src/tools/roosync/baseline.ts
@@ -43,7 +43,7 @@ function getLogger(): Logger {
  * Schema de validation pour roosync_baseline
  */
 export const BaselineArgsSchema = z.object({
-  action: z.enum(['update', 'version', 'restore', 'export', 'list_versions'])
+  action: z.enum(['update', 'version', 'restore', 'export', 'list_versions', 'current_version'])
     .describe('Action à effectuer sur la baseline'),
 
   // Paramètres pour action: update
@@ -172,6 +172,8 @@ export async function roosync_baseline(args: BaselineArgs): Promise<BaselineResu
         return await handleExportAction(args, timestamp);
       case 'list_versions':
         return await handleListVersionsAction(args, timestamp);
+      case 'current_version':
+        return await handleCurrentVersionAction(args, timestamp);
       default:
         throw new RooSyncServiceError(
           `Action non supportée: ${args.action}`,
@@ -844,6 +846,64 @@ async function handleListVersionsAction(args: BaselineArgs, timestamp: string): 
         totalVersions: 0,
         message: `Impossible de lister les tags: ${(error as Error).message}`
       }
+    };
+  }
+}
+
+/**
+ * Handler pour action: current_version
+ * Reads the current baseline version from the file without creating tags
+ * #1410: Version discovery — allows agents to check baseline status
+ */
+async function handleCurrentVersionAction(args: BaselineArgs, timestamp: string): Promise<BaselineResult> {
+  const service = await getRooSyncService();
+  const config = service.getConfig();
+  const machineId = args.machineId || config.machineId;
+
+  const configService = new ConfigService(config.sharedPath);
+  const baselineService = new BaselineService(configService, null as any, null as any);
+
+  try {
+    const baseline = await baselineService.loadBaseline(machineId);
+
+    if (!baseline) {
+      return {
+        success: true,
+        action: 'current_version',
+        timestamp,
+        version: '',
+        machineId,
+        message: `Aucune baseline trouvée pour ${machineId}`,
+        data: {
+          exists: false,
+          machineId
+        }
+      };
+    }
+
+    return {
+      success: true,
+      action: 'current_version',
+      timestamp,
+      version: baseline.version || '',
+      machineId: baseline.machineId,
+      message: `Baseline actuelle: ${baseline.version || 'non-versionnée'} (${machineId})`,
+      data: {
+        exists: true,
+        machineId: baseline.machineId,
+        version: baseline.version || '',
+        lastUpdated: baseline.lastUpdated || '',
+        baselineId: (baseline as any).baselineId || ''
+      }
+    };
+  } catch (error) {
+    return {
+      success: false,
+      action: 'current_version',
+      timestamp,
+      version: '',
+      machineId,
+      message: `Erreur lors de la lecture de la baseline: ${(error as Error).message}`
     };
   }
 }

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -386,11 +386,11 @@ export const roosyncDecisionInfoDefinition = {
 
 export const roosyncBaselineDefinition = {
     name: 'roosync_baseline',
-    description: 'Outil consolidé pour gérer les baselines RooSync (update, version, restore, export)',
+    description: 'Outil consolidé pour gérer les baselines RooSync (update, version, restore, export, list_versions, current_version)',
     inputSchema: {
         type: 'object',
         properties: {
-            action: { type: 'string', enum: ['update', 'version', 'restore', 'export'], description: 'Action à effectuer sur la baseline' },
+            action: { type: 'string', enum: ['update', 'version', 'restore', 'export', 'list_versions', 'current_version'], description: 'Action à effectuer sur la baseline' },
             machineId: { type: 'string', description: '[update] ID de la machine ou nom du profil' },
             mode: { type: 'string', enum: ['standard', 'profile'], description: '[update] Mode de mise à jour' },
             aggregationConfig: { type: 'object', description: "[update] Configuration d'agrégation (mode profile uniquement)" },


### PR DESCRIPTION
## Summary
- Add `current_version` action to the `roosync_baseline` tool
- Lightweight read-only query returning baseline version for a machine
- Addresses friction from #1410 (baseline version discovery required full export)

## Changes
- `baseline.ts`: New `handleCurrentVersionAction` handler
- `tool-definitions.ts`: Added `current_version` to action enum + description
- `baseline.test.ts`: 3 new tests (exists, not-exists, explicit machineId)

## Test plan
- [x] 8800/8800 CI tests pass (`npx vitest run --config vitest.config.ci.ts`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual test: call `roosync_baseline(action: "current_version")` via MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)