### PR TITLE
test: add coverage for NotificationService and ValidationEngine (57 tests)

### DIFF
--- a/servers/roo-state-manager/tests/unit/notifications/NotificationService.test.ts
+++ b/servers/roo-state-manager/tests/unit/notifications/NotificationService.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  NotificationService,
+  NotificationEvent,
+  NotificationListener,
+  FilterRule
+} from '../../../src/notifications/NotificationService.js';
+
+function makeEvent(overrides: Partial<NotificationEvent> = {}): NotificationEvent {
+  return {
+    type: 'tool_used',
+    source: 'test-tool',
+    priority: 'MEDIUM',
+    payload: {},
+    timestamp: new Date().toISOString(),
+    ...overrides
+  };
+}
+
+function makeListener(): NotificationListener & { events: NotificationEvent[] } {
+  const events: NotificationEvent[] = [];
+  return {
+    events,
+    onNotify: vi.fn(async (event) => { events.push(event); })
+  };
+}
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+
+  beforeEach(() => {
+    service = new NotificationService();
+  });
+
+  describe('subscribe / unsubscribe', () => {
+    it('should add and remove listeners', () => {
+      const listener = makeListener();
+      service.subscribe(listener);
+      expect(service.getStats().listenersCount).toBe(1);
+
+      service.unsubscribe(listener);
+      expect(service.getStats().listenersCount).toBe(0);
+    });
+
+    it('should not fail when unsubscribing unknown listener', () => {
+      const listener = makeListener();
+      service.unsubscribe(listener);
+      expect(service.getStats().listenersCount).toBe(0);
+    });
+
+    it('should support multiple listeners', () => {
+      const l1 = makeListener();
+      const l2 = makeListener();
+      service.subscribe(l1);
+      service.subscribe(l2);
+      expect(service.getStats().listenersCount).toBe(2);
+    });
+  });
+
+  describe('notify without filter rules', () => {
+    it('should emit event to all listeners when no rules loaded', async () => {
+      const l1 = makeListener();
+      const l2 = makeListener();
+      service.subscribe(l1);
+      service.subscribe(l2);
+
+      const event = makeEvent();
+      await service.notify(event);
+
+      expect(l1.onNotify).toHaveBeenCalledWith(event);
+      expect(l2.onNotify).toHaveBeenCalledWith(event);
+    });
+
+    it('should handle zero listeners gracefully', async () => {
+      const event = makeEvent();
+      await expect(service.notify(event)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('notify with filter rules', () => {
+    const allowRule: FilterRule = {
+      id: 'allow-all-tools',
+      eventType: 'tool_used',
+      condition: {},
+      action: 'allow',
+      notifyUser: false
+    };
+
+    const blockRule: FilterRule = {
+      id: 'block-urgent',
+      eventType: 'tool_used',
+      condition: { priority: ['URGENT'] },
+      action: 'block',
+      notifyUser: false
+    };
+
+    const approvalRule: FilterRule = {
+      id: 'approval-new-msg',
+      eventType: 'new_message',
+      condition: {},
+      action: 'require_approval',
+      notifyUser: false
+    };
+
+    it('should allow event matching an allow rule', async () => {
+      const listener = makeListener();
+      service.subscribe(listener);
+      service.loadFilterRules([allowRule]);
+
+      await service.notify(makeEvent());
+      expect(listener.onNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it('should block event matching a block rule', async () => {
+      const listener = makeListener();
+      service.subscribe(listener);
+      service.loadFilterRules([blockRule]);
+
+      await service.notify(makeEvent({ priority: 'URGENT' }));
+      expect(listener.onNotify).not.toHaveBeenCalled();
+    });
+
+    it('should block by default when rules exist but none match', async () => {
+      const listener = makeListener();
+      service.subscribe(listener);
+      service.loadFilterRules([blockRule]);
+
+      // Event type 'new_message' doesn't match blockRule (which is for 'tool_used')
+      await service.notify(makeEvent({ type: 'new_message' }));
+      expect(listener.onNotify).not.toHaveBeenCalled();
+    });
+
+    it('should queue event for require_approval action', async () => {
+      const listener = makeListener();
+      service.subscribe(listener);
+      service.loadFilterRules([approvalRule]);
+
+      await service.notify(makeEvent({ type: 'new_message' }));
+      expect(listener.onNotify).not.toHaveBeenCalled();
+      expect(service.getStats().pendingApprovalsCount).toBe(1);
+    });
+  });
+
+  describe('filter conditions', () => {
+    it('should match by sourceTool condition', async () => {
+      const listener = makeListener();
+      service.subscribe(listener);
+
+      const rule: FilterRule = {
+        id: 'src-filter',
+        eventType: 'tool_used',
+        condition: { sourceTool: ['allowed-tool'] },
+        action: 'allow',
+        notifyUser: false
+      };
+      service.loadFilterRules([rule]);
+
+      // Matching source
+      await service.notify(makeEvent({ source: 'allowed-tool' }));
+      expect(listener.onNotify).toHaveBeenCalledTimes(1);
+
+      // Non-matching source
+      await service.notify(makeEvent({ source: 'other-tool' }));
+      expect(listener.onNotify).toHaveBeenCalledTimes(1); // still 1, blocked
+    });
+
+    it('should match by priority condition', async () => {
+      const listener = makeListener();
+      service.subscribe(listener);
+
+      const rule: FilterRule = {
+        id: 'prio-filter',
+        eventType: 'tool_used',
+        condition: { priority: ['HIGH', 'URGENT'] },
+        action: 'allow',
+        notifyUser: false
+      };
+      service.loadFilterRules([rule]);
+
+      await service.notify(makeEvent({ priority: 'HIGH' }));
+      expect(listener.onNotify).toHaveBeenCalledTimes(1);
+
+      await service.notify(makeEvent({ priority: 'LOW' }));
+      expect(listener.onNotify).toHaveBeenCalledTimes(1); // blocked
+    });
+
+    it('should match by tags condition', async () => {
+      const listener = makeListener();
+      service.subscribe(listener);
+
+      const rule: FilterRule = {
+        id: 'tag-filter',
+        eventType: 'tool_used',
+        condition: { tags: ['important'] },
+        action: 'allow',
+        notifyUser: false
+      };
+      service.loadFilterRules([rule]);
+
+      await service.notify(makeEvent({ payload: { tags: ['important', 'info'] } }));
+      expect(listener.onNotify).toHaveBeenCalledTimes(1);
+
+      await service.notify(makeEvent({ payload: { tags: ['info'] } }));
+      expect(listener.onNotify).toHaveBeenCalledTimes(1); // blocked
+    });
+
+    it('should use first matching rule (rule priority)', async () => {
+      const listener = makeListener();
+      service.subscribe(listener);
+
+      const allowAll: FilterRule = {
+        id: 'allow-all',
+        eventType: 'tool_used',
+        condition: {},
+        action: 'allow',
+        notifyUser: false
+      };
+      const blockAll: FilterRule = {
+        id: 'block-all',
+        eventType: 'tool_used',
+        condition: {},
+        action: 'block',
+        notifyUser: false
+      };
+
+      // allow first → event emitted
+      service.loadFilterRules([allowAll, blockAll]);
+      await service.notify(makeEvent());
+      expect(listener.onNotify).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('pending approvals', () => {
+    it('should approve pending event and emit to listeners', async () => {
+      const listener = makeListener();
+      service.subscribe(listener);
+
+      const rule: FilterRule = {
+        id: 'approval-rule',
+        eventType: 'tool_used',
+        condition: {},
+        action: 'require_approval',
+        notifyUser: false
+      };
+      service.loadFilterRules([rule]);
+
+      const event = makeEvent();
+      await service.notify(event);
+      expect(service.getStats().pendingApprovalsCount).toBe(1);
+
+      const approved = await service.approvePending(0);
+      expect(approved).toBe(true);
+      expect(listener.onNotify).toHaveBeenCalledWith(event);
+      expect(service.getStats().pendingApprovalsCount).toBe(0);
+    });
+
+    it('should reject pending event without emitting', async () => {
+      const listener = makeListener();
+      service.subscribe(listener);
+
+      const rule: FilterRule = {
+        id: 'approval-rule',
+        eventType: 'tool_used',
+        condition: {},
+        action: 'require_approval',
+        notifyUser: false
+      };
+      service.loadFilterRules([rule]);
+
+      await service.notify(makeEvent());
+      expect(service.getStats().pendingApprovalsCount).toBe(1);
+
+      const rejected = service.rejectPending(0);
+      expect(rejected).toBe(true);
+      expect(listener.onNotify).not.toHaveBeenCalled();
+      expect(service.getStats().pendingApprovalsCount).toBe(0);
+    });
+
+    it('should return false for out-of-bounds approve/reject', async () => {
+      await expect(service.approvePending(0)).resolves.toBe(false);
+      expect(service.rejectPending(0)).toBe(false);
+      await expect(service.approvePending(-1)).resolves.toBe(false);
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return accurate stats', async () => {
+      const listener = makeListener();
+      service.subscribe(listener);
+
+      const rule: FilterRule = {
+        id: 'approval-rule',
+        eventType: 'new_message',
+        condition: {},
+        action: 'require_approval',
+        notifyUser: false
+      };
+      service.loadFilterRules([rule]);
+
+      await service.notify(makeEvent({ type: 'new_message' }));
+
+      const stats = service.getStats();
+      expect(stats.listenersCount).toBe(1);
+      expect(stats.rulesCount).toBe(1);
+      expect(stats.rules).toHaveLength(1);
+      expect(stats.pendingApprovalsCount).toBe(1);
+      expect(stats.pendingApprovals).toHaveLength(1);
+    });
+  });
+});

--- a/servers/roo-state-manager/tests/unit/validation/ValidationEngine.test.ts
+++ b/servers/roo-state-manager/tests/unit/validation/ValidationEngine.test.ts
@@ -1,0 +1,395 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ValidationEngine,
+  ToolValidationSchemas
+} from '../../../src/validation/ValidationEngine.js';
+import {
+  ToolCategory,
+  DisplayPreset,
+  DisplayOptions
+} from '../../../src/interfaces/UnifiedToolInterface.js';
+import { GenericError } from '../../../src/types/errors.js';
+
+describe('ValidationEngine', () => {
+  describe('validatePresetOptions', () => {
+    it('should validate valid display options', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.QUICK_OVERVIEW,
+        { detailLevel: 'skeleton', maxResults: 10 },
+        ToolCategory.DISPLAY
+      );
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should reject invalid detailLevel', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.QUICK_OVERVIEW,
+        { detailLevel: 'invalid' as any },
+        ToolCategory.DISPLAY
+      );
+      expect(result.isValid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should reject maxResults out of range for display', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.QUICK_OVERVIEW,
+        { maxResults: 0 },
+        ToolCategory.DISPLAY
+      );
+      // maxResults < 1 fails base validation
+      expect(result.isValid).toBe(false);
+    });
+
+    it('should validate search category options', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.SEARCH_RESULTS,
+        { searchQuery: 'test query' },
+        ToolCategory.SEARCH
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should validate export category options', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.EXPORT_FORMAT,
+        { taskId: 'task-123', outputFormat: 'json' },
+        ToolCategory.EXPORT
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should validate utility category options', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.QUICK_OVERVIEW,
+        { forceRebuild: false, dryRun: true },
+        ToolCategory.UTILITY
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should reject startIndex > endIndex in base options', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.QUICK_OVERVIEW,
+        { startIndex: 10, endIndex: 5 },
+        ToolCategory.DISPLAY
+      );
+      expect(result.isValid).toBe(false);
+      expect(result.errors.some(e => e.includes('startIndex'))).toBe(true);
+    });
+
+    it('should reject negative truncate', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.QUICK_OVERVIEW,
+        { truncate: -1 },
+        ToolCategory.DISPLAY
+      );
+      expect(result.isValid).toBe(false);
+    });
+
+    it('should reject maxResults < 1', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.QUICK_OVERVIEW,
+        { maxResults: 0 },
+        ToolCategory.DISPLAY
+      );
+      expect(result.isValid).toBe(false);
+    });
+
+    it('should reject invalid outputFormat', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.EXPORT_FORMAT,
+        { outputFormat: 'yaml' as any },
+        ToolCategory.EXPORT
+      );
+      expect(result.isValid).toBe(false);
+    });
+
+    it('should return error for unknown category', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.QUICK_OVERVIEW,
+        {},
+        'unknown' as ToolCategory
+      );
+      expect(result.isValid).toBe(false);
+      expect(result.errors.some(e => e.includes('Unknown tool category'))).toBe(true);
+    });
+  });
+
+  describe('business rules by preset', () => {
+    it('QUICK_OVERVIEW should warn on high maxResults', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.QUICK_OVERVIEW,
+        { maxResults: 200 },
+        ToolCategory.DISPLAY
+      );
+      // Valid but has warnings
+      expect(result.isValid).toBe(true);
+    });
+
+    it('SEARCH_RESULTS should require searchQuery for search category', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.SEARCH_RESULTS,
+        {},
+        ToolCategory.SEARCH
+      );
+      expect(result.isValid).toBe(false);
+      expect(result.errors.some(e => e.includes('searchQuery'))).toBe(true);
+    });
+
+    it('SEARCH_RESULTS should accept query as alternative to searchQuery', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.SEARCH_RESULTS,
+        { query: 'test' },
+        ToolCategory.SEARCH
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it('EXPORT_FORMAT should require at least one ID for export category', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.EXPORT_FORMAT,
+        {},
+        ToolCategory.EXPORT
+      );
+      expect(result.isValid).toBe(false);
+      expect(result.errors.some(e => e.includes('taskId'))).toBe(true);
+    });
+
+    it('EXPORT_FORMAT should pass with taskId', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.EXPORT_FORMAT,
+        { taskId: 't-123' },
+        ToolCategory.EXPORT
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it('TREE_NAVIGATION should warn on maxDepth > 20', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.TREE_NAVIGATION,
+        { maxDepth: 25 },
+        ToolCategory.DISPLAY
+      );
+      // maxDepth > 20 in schema is rejected, but maxDepth 25 is > max(20)
+      expect(result.isValid).toBe(false);
+    });
+
+    it('DETAILED_ANALYSIS should warn on low truncate', async () => {
+      const result = await ValidationEngine.validatePresetOptions(
+        DisplayPreset.DETAILED_ANALYSIS,
+        { truncate: 50 },
+        ToolCategory.DISPLAY
+      );
+      // Valid but with warnings
+      expect(result.isValid).toBe(true);
+    });
+  });
+
+  describe('validateToolInput', () => {
+    it('should validate search_tasks_semantic input', async () => {
+      const result = await ValidationEngine.validateToolInput(
+        'search_tasks_semantic',
+        { searchQuery: 'find stuff' },
+        ToolCategory.SEARCH
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should reject search_tasks_semantic without query', async () => {
+      const result = await ValidationEngine.validateToolInput(
+        'search_tasks_semantic',
+        {},
+        ToolCategory.SEARCH
+      );
+      expect(result.isValid).toBe(false);
+      expect(result.errors.some(e => e.includes('searchQuery'))).toBe(true);
+    });
+
+    it('should validate export_conversation_json input', async () => {
+      const result = await ValidationEngine.validateToolInput(
+        'export_conversation_json',
+        { taskId: 't-1' },
+        ToolCategory.EXPORT
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should reject export_conversation_json without taskId', async () => {
+      const result = await ValidationEngine.validateToolInput(
+        'export_conversation_json',
+        {},
+        ToolCategory.EXPORT
+      );
+      expect(result.isValid).toBe(false);
+    });
+
+    it('should validate generate_trace_summary input', async () => {
+      const result = await ValidationEngine.validateToolInput(
+        'generate_trace_summary',
+        { taskId: 't-1' },
+        ToolCategory.SUMMARY
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should reject generate_trace_summary without taskId', async () => {
+      const result = await ValidationEngine.validateToolInput(
+        'generate_trace_summary',
+        {},
+        ToolCategory.SUMMARY
+      );
+      expect(result.isValid).toBe(false);
+    });
+
+    it('should handle unknown tool name gracefully', async () => {
+      const result = await ValidationEngine.validateToolInput(
+        'unknown_tool',
+        { forceRebuild: true },
+        ToolCategory.UTILITY
+      );
+      expect(result.isValid).toBe(true);
+    });
+  });
+
+  describe('validateCacheAntiLeakCompliance', () => {
+    it('should warn on forceRebuild=true', () => {
+      const result = ValidationEngine.validateCacheAntiLeakCompliance({
+        forceRebuild: true
+      });
+      expect(result.isValid).toBe(true);
+      expect(result.warnings?.some(w => w.includes('Force rebuild'))).toBe(true);
+    });
+
+    it('should warn on large maxResults', () => {
+      const result = ValidationEngine.validateCacheAntiLeakCompliance({
+        maxResults: 2000
+      });
+      expect(result.warnings?.some(w => w.includes('Large maxResults'))).toBe(true);
+    });
+
+    it('should warn on full content export', () => {
+      const result = ValidationEngine.validateCacheAntiLeakCompliance({
+        truncate: 0,
+        includeContent: true
+      });
+      expect(result.warnings?.some(w => w.includes('Full content'))).toBe(true);
+    });
+
+    it('should pass clean options with no warnings', () => {
+      const result = ValidationEngine.validateCacheAntiLeakCompliance({
+        maxResults: 50,
+        truncate: 100
+      });
+      expect(result.isValid).toBe(true);
+      expect(result.warnings).toBeUndefined();
+    });
+  });
+
+  describe('generateValidationReport', () => {
+    it('should return validation, cache compliance, and recommendations', async () => {
+      const report = await ValidationEngine.generateValidationReport(
+        DisplayPreset.QUICK_OVERVIEW,
+        { maxResults: 200 },
+        ToolCategory.DISPLAY
+      );
+
+      expect(report.validation).toBeDefined();
+      expect(report.cacheCompliance).toBeDefined();
+      expect(report.recommendations).toBeInstanceOf(Array);
+    });
+
+    it('should recommend skeleton for quick overview', async () => {
+      const report = await ValidationEngine.generateValidationReport(
+        DisplayPreset.QUICK_OVERVIEW,
+        {},
+        ToolCategory.DISPLAY
+      );
+      expect(report.recommendations.some(r => r.includes('skeleton'))).toBe(true);
+    });
+
+    it('should recommend prettyPrint for export', async () => {
+      const report = await ValidationEngine.generateValidationReport(
+        DisplayPreset.EXPORT_FORMAT,
+        { taskId: 't-1' },
+        ToolCategory.EXPORT
+      );
+      expect(report.recommendations.some(r => r.includes('prettyPrint'))).toBe(true);
+    });
+  });
+
+  describe('ToolValidationSchemas', () => {
+    it('should parse valid display options', () => {
+      const result = ToolValidationSchemas.DISPLAY_SCHEMA.safeParse({
+        truncate: 100,
+        maxResults: 50,
+        detailLevel: 'summary',
+        viewMode: 'chain',
+        sortBy: 'lastActivity',
+        sortOrder: 'desc',
+        workspace: 'test-workspace'
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject invalid display detailLevel', () => {
+      const result = ToolValidationSchemas.DISPLAY_SCHEMA.safeParse({
+        detailLevel: 'super-detailed'
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should parse valid search options', () => {
+      const result = ToolValidationSchemas.SEARCH_SCHEMA.safeParse({
+        searchQuery: 'find tasks',
+        maxResults: 10,
+        workspace: 'ws'
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should parse valid summary options', () => {
+      const result = ToolValidationSchemas.SUMMARY_SCHEMA.safeParse({
+        taskId: 't-1',
+        detailLevel: 'Full',
+        outputFormat: 'markdown'
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should parse valid export options', () => {
+      const result = ToolValidationSchemas.EXPORT_SCHEMA.safeParse({
+        taskId: 't-1',
+        outputFormat: 'json',
+        jsonVariant: 'light',
+        prettyPrint: true
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should parse valid utility options', () => {
+      const result = ToolValidationSchemas.UTILITY_SCHEMA.safeParse({
+        forceRebuild: false,
+        dryRun: true,
+        action: 'read',
+        server_name: 'roo-state-manager'
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject negative maxResults in search', () => {
+      const result = ToolValidationSchemas.SEARCH_SCHEMA.safeParse({
+        maxResults: -1
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject maxResults > 500 in search', () => {
+      const result = ToolValidationSchemas.SEARCH_SCHEMA.safeParse({
+        maxResults: 501
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 17 tests for `NotificationService` (subscribe/unsubscribe, filter rules, pending approvals)
- Add 40 tests for `ValidationEngine` (preset options, business rules, tool input, cache compliance, Zod schemas)
- Both services previously had 0 test coverage

## Test plan
- [x] `npx vitest run tests/unit/notifications/NotificationService.test.ts` — 17/17 passed
- [x] `npx vitest run tests/unit/validation/ValidationEngine.test.ts` — 40/40 passed
- [x] `npm run build` — TypeScript compilation OK
- [x] Full CI test suite: 8857/8857 passed (+57 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>