### PR TITLE
test(robustness): 97 tests for ConfigHealthCheckService + background-services startup

### DIFF
--- a/servers/roo-state-manager/tests/unit/services/ConfigHealthCheckService.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/ConfigHealthCheckService.test.ts
@@ -1,0 +1,828 @@
+/**
+ * Comprehensive unit tests for ConfigHealthCheckService
+ *
+ * Covers all public methods (checkHealth, quickCheck, checkBatch)
+ * and exercises private methods through the public API:
+ *   - checkFileReadable
+ *   - checkJsonValid
+ *   - checkRequiredFields
+ *   - checkMcpLoadable
+ *
+ * Uses real temp files (os.tmpdir()) for file-based checks.
+ * No filesystem mocking -- tests verify actual I/O behavior.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, writeFile, rm, mkdir } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { existsSync } from 'fs';
+import { ConfigHealthCheckService } from '../../../src/services/ConfigHealthCheckService.js';
+import type { ConfigType, HealthCheckResult } from '../../../src/services/ConfigHealthCheckService.js';
+
+// Logger stub -- matches the Logger class interface (info, warn, error, debug)
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  } as any;
+}
+
+describe('ConfigHealthCheckService', () => {
+  let healthCheck: ConfigHealthCheckService;
+  let mockLogger: ReturnType<typeof createMockLogger>;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    mockLogger = createMockLogger();
+    healthCheck = new ConfigHealthCheckService(mockLogger);
+    tempDir = await mkdtemp(join(tmpdir(), 'healthcheck-unit-'));
+  });
+
+  afterEach(async () => {
+    if (existsSync(tempDir)) {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  // ================================================================
+  // checkHealth -- file_readable
+  // ================================================================
+  describe('checkHealth -- file_readable check', () => {
+    it('should pass file_readable for an existing file', async () => {
+      const filePath = join(tempDir, 'exists.json');
+      await writeFile(filePath, '{}');
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config');
+
+      const fileCheck = result.checks.find(c => c.name === 'file_readable');
+      expect(fileCheck).toBeDefined();
+      expect(fileCheck!.passed).toBe(true);
+      expect(fileCheck!.message).toContain('accessible');
+    });
+
+    it('should fail file_readable for non-existent file and return early', async () => {
+      const filePath = join(tempDir, 'nonexistent.json');
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config');
+
+      expect(result.healthy).toBe(false);
+      const fileCheck = result.checks.find(c => c.name === 'file_readable');
+      expect(fileCheck!.passed).toBe(false);
+      expect(result.checks.map(c => c.name)).not.toContain('json_valid');
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toContain('accessible');
+    });
+
+    it('should pass file_readable for a directory path', async () => {
+      const dirPath = join(tempDir, 'subdir');
+      await mkdir(dirPath);
+
+      const result = await healthCheck.checkHealth(dirPath, 'mcp_config');
+
+      const fileCheck = result.checks.find(c => c.name === 'file_readable');
+      expect(fileCheck!.passed).toBe(true);
+    });
+  });
+
+  // ================================================================
+  // checkHealth -- json_valid
+  // ================================================================
+  describe('checkHealth -- json_valid check', () => {
+    it('should pass json_valid for well-formed JSON', async () => {
+      const filePath = join(tempDir, 'valid.json');
+      await writeFile(filePath, JSON.stringify({ mcpServers: {} }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config');
+
+      const jsonCheck = result.checks.find(c => c.name === 'json_valid');
+      expect(jsonCheck!.passed).toBe(true);
+      expect(jsonCheck!.message).toContain('valide');
+      expect(jsonCheck!.details?.parsed).toEqual({ mcpServers: {} });
+    });
+
+    it('should fail json_valid for malformed JSON', async () => {
+      const filePath = join(tempDir, 'bad.json');
+      await writeFile(filePath, '{ "broken": ');
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config');
+
+      expect(result.healthy).toBe(false);
+      const jsonCheck = result.checks.find(c => c.name === 'json_valid');
+      expect(jsonCheck!.passed).toBe(false);
+      expect(jsonCheck!.message).toContain('invalide');
+      expect(result.errors.some(e => e.includes('invalide'))).toBe(true);
+    });
+
+    it('should handle JSON with trailing commas (invalid JSON)', async () => {
+      const filePath = join(tempDir, 'trailing.json');
+      await writeFile(filePath, '{ "key": "value", }');
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config');
+
+      const jsonCheck = result.checks.find(c => c.name === 'json_valid');
+      expect(jsonCheck!.passed).toBe(false);
+    });
+
+    it('should pass json_valid for an empty JSON object', async () => {
+      const filePath = join(tempDir, 'empty.json');
+      await writeFile(filePath, '{}');
+
+      const result = await healthCheck.checkHealth(filePath, 'settings_config');
+
+      const jsonCheck = result.checks.find(c => c.name === 'json_valid');
+      expect(jsonCheck!.passed).toBe(true);
+    });
+
+    it('should pass json_valid for a JSON array at top level', async () => {
+      const filePath = join(tempDir, 'array.json');
+      await writeFile(filePath, '[]');
+
+      const result = await healthCheck.checkHealth(filePath, 'rules_config');
+
+      const jsonCheck = result.checks.find(c => c.name === 'json_valid');
+      expect(jsonCheck!.passed).toBe(true);
+    });
+  });
+
+  // ================================================================
+  // checkHealth -- BOM handling
+  // ================================================================
+  describe('checkHealth -- BOM handling', () => {
+    it('should strip UTF-8 BOM and parse valid JSON', async () => {
+      const filePath = join(tempDir, 'bom.json');
+      const bomContent = '﻿' + JSON.stringify({ mcpServers: {} });
+      await writeFile(filePath, bomContent);
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config');
+
+      expect(result.healthy).toBe(true);
+      const jsonCheck = result.checks.find(c => c.name === 'json_valid');
+      expect(jsonCheck!.passed).toBe(true);
+    });
+
+    it('should strip BOM from invalid JSON and still report failure', async () => {
+      const filePath = join(tempDir, 'bom-bad.json');
+      const bomContent = '﻿{ broken }';
+      await writeFile(filePath, bomContent);
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config');
+
+      const jsonCheck = result.checks.find(c => c.name === 'json_valid');
+      expect(jsonCheck!.passed).toBe(false);
+    });
+  });
+
+  // ================================================================
+  // checkHealth -- required_fields
+  // ================================================================
+  describe('checkHealth -- required_fields check', () => {
+    it('should pass when all required fields are present for mcp_config', async () => {
+      const filePath = join(tempDir, 'mcp.json');
+      await writeFile(filePath, JSON.stringify({ mcpServers: {} }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config');
+
+      const fieldsCheck = result.checks.find(c => c.name === 'required_fields');
+      expect(fieldsCheck!.passed).toBe(true);
+      expect(fieldsCheck!.message).toContain('1');
+    });
+
+    it('should warn when required fields are missing', async () => {
+      const filePath = join(tempDir, 'missing.json');
+      await writeFile(filePath, JSON.stringify({ otherStuff: true }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config');
+
+      const fieldsCheck = result.checks.find(c => c.name === 'required_fields');
+      expect(fieldsCheck!.passed).toBe(false);
+      expect(fieldsCheck!.message).toContain('mcpServers');
+      expect(fieldsCheck!.details?.missing).toContain('mcpServers');
+      expect(result.warnings.length).toBeGreaterThan(0);
+    });
+
+    it('should pass required_fields for mode_definition with all fields', async () => {
+      const filePath = join(tempDir, 'mode.json');
+      await writeFile(filePath, JSON.stringify({
+        slug: 'test', name: 'Test', roleDefinition: 'A role'
+      }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mode_definition');
+
+      const fieldsCheck = result.checks.find(c => c.name === 'required_fields');
+      expect(fieldsCheck!.passed).toBe(true);
+    });
+
+    it('should warn on missing slug in mode_definition', async () => {
+      const filePath = join(tempDir, 'partial-mode.json');
+      await writeFile(filePath, JSON.stringify({
+        name: 'Test', roleDefinition: 'A role'
+      }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mode_definition');
+
+      const fieldsCheck = result.checks.find(c => c.name === 'required_fields');
+      expect(fieldsCheck!.passed).toBe(false);
+      expect(fieldsCheck!.details?.missing).toContain('slug');
+    });
+
+    it('should pass required_fields for profile_settings with all fields', async () => {
+      const filePath = join(tempDir, 'profiles.json');
+      await writeFile(filePath, JSON.stringify({ profiles: {}, apiConfigs: {} }));
+
+      const result = await healthCheck.checkHealth(filePath, 'profile_settings');
+
+      const fieldsCheck = result.checks.find(c => c.name === 'required_fields');
+      expect(fieldsCheck!.passed).toBe(true);
+    });
+
+    it('should pass for rules_config with empty required fields', async () => {
+      const filePath = join(tempDir, 'rules.json');
+      await writeFile(filePath, JSON.stringify({ anything: 'goes' }));
+
+      const result = await healthCheck.checkHealth(filePath, 'rules_config');
+
+      const fieldsCheck = result.checks.find(c => c.name === 'required_fields');
+      expect(fieldsCheck!.passed).toBe(true);
+      expect(fieldsCheck!.message).toContain('Aucun champ requis');
+    });
+
+    it('should pass for settings_config with empty required fields', async () => {
+      const filePath = join(tempDir, 'settings.json');
+      await writeFile(filePath, JSON.stringify({ customSetting: 42 }));
+
+      const result = await healthCheck.checkHealth(filePath, 'settings_config');
+
+      const fieldsCheck = result.checks.find(c => c.name === 'required_fields');
+      expect(fieldsCheck!.passed).toBe(true);
+    });
+
+    it('should use custom requiredFields from options over defaults', async () => {
+      const filePath = join(tempDir, 'custom.json');
+      await writeFile(filePath, JSON.stringify({ customField: 'present' }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config', {
+        requiredFields: ['customField']
+      });
+
+      const fieldsCheck = result.checks.find(c => c.name === 'required_fields');
+      expect(fieldsCheck!.passed).toBe(true);
+    });
+
+    it('should skip required_fields when JSON parsing failed', async () => {
+      const filePath = join(tempDir, 'broken.json');
+      await writeFile(filePath, '{ invalid }');
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config');
+
+      expect(result.checks.map(c => c.name)).not.toContain('required_fields');
+    });
+  });
+
+  // ================================================================
+  // checkHealth -- mcp_loadable
+  // ================================================================
+  describe('checkHealth -- mcp_loadable check', () => {
+    it('should pass for valid MCP config with servers', async () => {
+      const filePath = join(tempDir, 'mcp.json');
+      await writeFile(filePath, JSON.stringify({
+        mcpServers: { 'test-server': { command: 'node', args: ['server.js'] } }
+      }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config', {
+        checks: ['json_valid', 'required_fields', 'mcp_loadable']
+      });
+
+      const mcpCheck = result.checks.find(c => c.name === 'mcp_loadable');
+      expect(mcpCheck!.passed).toBe(true);
+      expect(mcpCheck!.message).toContain('1 serveurs');
+    });
+
+    it('should pass when no mcpServers key exists', async () => {
+      const filePath = join(tempDir, 'no-mcp.json');
+      await writeFile(filePath, JSON.stringify({ otherConfig: true }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config', {
+        checks: ['json_valid', 'mcp_loadable']
+      });
+
+      const mcpCheck = result.checks.find(c => c.name === 'mcp_loadable');
+      expect(mcpCheck!.passed).toBe(true);
+      expect(mcpCheck!.message).toContain('Pas de mcpServers');
+    });
+
+    it('should warn on MCP server missing command (not disabled)', async () => {
+      const filePath = join(tempDir, 'no-cmd.json');
+      await writeFile(filePath, JSON.stringify({
+        mcpServers: { 'broken': { args: ['file.js'] } }
+      }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config', {
+        checks: ['json_valid', 'mcp_loadable']
+      });
+
+      const mcpCheck = result.checks.find(c => c.name === 'mcp_loadable');
+      expect(mcpCheck!.passed).toBe(false);
+      expect(mcpCheck!.message).toContain('command');
+      expect(result.warnings.length).toBeGreaterThan(0);
+    });
+
+    it('should accept disabled server without command', async () => {
+      const filePath = join(tempDir, 'disabled.json');
+      await writeFile(filePath, JSON.stringify({
+        mcpServers: { 'disabled-srv': { disabled: true } }
+      }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config', {
+        checks: ['json_valid', 'mcp_loadable']
+      });
+
+      const mcpCheck = result.checks.find(c => c.name === 'mcp_loadable');
+      expect(mcpCheck!.passed).toBe(true);
+    });
+
+    it('should warn when disabled is not a boolean', async () => {
+      const filePath = join(tempDir, 'bad-disabled.json');
+      await writeFile(filePath, JSON.stringify({
+        mcpServers: { 'srv': { disabled: 'yes', command: 'node' } }
+      }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config', {
+        checks: ['json_valid', 'mcp_loadable']
+      });
+
+      const mcpCheck = result.checks.find(c => c.name === 'mcp_loadable');
+      expect(mcpCheck!.passed).toBe(false);
+      expect(mcpCheck!.message).toContain('disabled');
+    });
+
+    it('should warn when args is not an array', async () => {
+      const filePath = join(tempDir, 'bad-args.json');
+      await writeFile(filePath, JSON.stringify({
+        mcpServers: { 'srv': { command: 'node', args: 'not-an-array' } }
+      }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config', {
+        checks: ['json_valid', 'mcp_loadable']
+      });
+
+      const mcpCheck = result.checks.find(c => c.name === 'mcp_loadable');
+      expect(mcpCheck!.passed).toBe(false);
+      expect(mcpCheck!.message).toContain('args');
+    });
+
+    it('should report multiple MCP issues in a single check', async () => {
+      const filePath = join(tempDir, 'multi-issues.json');
+      await writeFile(filePath, JSON.stringify({
+        mcpServers: {
+          'srv1': { args: 'string' },
+          'srv2': { disabled: 'true' }
+        }
+      }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config', {
+        checks: ['json_valid', 'mcp_loadable']
+      });
+
+      const mcpCheck = result.checks.find(c => c.name === 'mcp_loadable');
+      expect(mcpCheck!.passed).toBe(false);
+      expect(mcpCheck!.details?.issues.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should skip mcp_loadable for non-mcp_config types', async () => {
+      const filePath = join(tempDir, 'mode.json');
+      await writeFile(filePath, JSON.stringify({
+        slug: 'test', name: 'Test', roleDefinition: 'Role'
+      }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mode_definition', {
+        checks: ['json_valid', 'mcp_loadable']
+      });
+
+      expect(result.checks.map(c => c.name)).not.toContain('mcp_loadable');
+    });
+
+    it('should skip mcp_loadable when JSON is invalid', async () => {
+      const filePath = join(tempDir, 'bad.json');
+      await writeFile(filePath, '{ broken }');
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config', {
+        checks: ['json_valid', 'mcp_loadable']
+      });
+
+      expect(result.checks.map(c => c.name)).not.toContain('mcp_loadable');
+    });
+  });
+
+  // ================================================================
+  // checkHealth -- selective check execution
+  // ================================================================
+  describe('checkHealth -- selective check execution', () => {
+    it('should run only file_readable when specified', async () => {
+      const filePath = join(tempDir, 'config.json');
+      await writeFile(filePath, '{}');
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config', {
+        checks: ['file_readable']
+      });
+
+      expect(result.checks).toHaveLength(1);
+      expect(result.checks[0].name).toBe('file_readable');
+    });
+
+    it('should run only json_valid when specified', async () => {
+      const filePath = join(tempDir, 'config.json');
+      await writeFile(filePath, '{"mcpServers":{}}');
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config', {
+        checks: ['json_valid']
+      });
+
+      expect(result.checks).toHaveLength(1);
+      expect(result.checks[0].name).toBe('json_valid');
+    });
+
+    it('should run default checks when options.checks is not provided', async () => {
+      const filePath = join(tempDir, 'config.json');
+      await writeFile(filePath, '{"mcpServers":{}}');
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config');
+
+      expect(result.checks.map(c => c.name)).toEqual([
+        'file_readable', 'json_valid', 'required_fields'
+      ]);
+    });
+  });
+
+  // ================================================================
+  // checkHealth -- result structure
+  // ================================================================
+  describe('checkHealth -- result structure', () => {
+    it('should include correct filePath and configType in result', async () => {
+      const filePath = join(tempDir, 'config.json');
+      await writeFile(filePath, '{}');
+
+      const result = await healthCheck.checkHealth(filePath, 'roomodes_config');
+
+      expect(result.filePath).toBe(filePath);
+      expect(result.configType).toBe('roomodes_config');
+    });
+
+    it('should include a valid timestamp', async () => {
+      const filePath = join(tempDir, 'config.json');
+      await writeFile(filePath, '{}');
+
+      const before = new Date();
+      const result = await healthCheck.checkHealth(filePath, 'rules_config');
+      const after = new Date();
+
+      expect(result.timestamp.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(result.timestamp.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+
+    it('should have healthy=true when no errors', async () => {
+      const filePath = join(tempDir, 'config.json');
+      await writeFile(filePath, JSON.stringify({ mcpServers: {} }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config');
+
+      expect(result.healthy).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should have healthy=false when errors exist', async () => {
+      const filePath = join(tempDir, 'config.json');
+      await writeFile(filePath, '{ invalid }');
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config');
+
+      expect(result.healthy).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should log start and completion messages', async () => {
+      const filePath = join(tempDir, 'config.json');
+      await writeFile(filePath, '{}');
+
+      await healthCheck.checkHealth(filePath, 'rules_config');
+
+      expect(mockLogger.info).toHaveBeenCalledTimes(2);
+      expect(mockLogger.info).toHaveBeenNthCalledWith(1,
+        expect.stringContaining('marr'),
+        expect.objectContaining({ configType: 'rules_config' })
+      );
+      expect(mockLogger.info).toHaveBeenNthCalledWith(2,
+        expect.stringContaining('termin'),
+        expect.any(Object)
+      );
+    });
+  });
+
+  // ================================================================
+  // quickCheck
+  // ================================================================
+  describe('quickCheck()', () => {
+    it('should return true for valid JSON file', async () => {
+      const filePath = join(tempDir, 'valid.json');
+      await writeFile(filePath, JSON.stringify({ key: 'value' }));
+
+      expect(await healthCheck.quickCheck(filePath)).toBe(true);
+    });
+
+    it('should return true for empty JSON object', async () => {
+      const filePath = join(tempDir, 'empty.json');
+      await writeFile(filePath, '{}');
+
+      expect(await healthCheck.quickCheck(filePath)).toBe(true);
+    });
+
+    it('should return false for invalid JSON', async () => {
+      const filePath = join(tempDir, 'bad.json');
+      await writeFile(filePath, 'not json at all');
+
+      expect(await healthCheck.quickCheck(filePath)).toBe(false);
+    });
+
+    it('should return false for non-existent file', async () => {
+      expect(await healthCheck.quickCheck('/nonexistent/path/file.json')).toBe(false);
+    });
+
+    it('should return false for empty file', async () => {
+      const filePath = join(tempDir, 'empty-file.json');
+      await writeFile(filePath, '');
+
+      expect(await healthCheck.quickCheck(filePath)).toBe(false);
+    });
+  });
+
+  // ================================================================
+  // checkBatch
+  // ================================================================
+  describe('checkBatch()', () => {
+    it('should process multiple files and report all healthy', async () => {
+      const file1 = join(tempDir, 'a.json');
+      const file2 = join(tempDir, 'b.json');
+      await writeFile(file1, JSON.stringify({ mcpServers: {} }));
+      await writeFile(file2, JSON.stringify({ mcpServers: {} }));
+
+      const batch = await healthCheck.checkBatch([
+        { path: file1, type: 'mcp_config' },
+        { path: file2, type: 'mcp_config' }
+      ]);
+
+      expect(batch.healthy).toBe(true);
+      expect(batch.summary.passed).toBe(2);
+      expect(batch.summary.failed).toBe(0);
+      expect(batch.results.size).toBe(2);
+      expect(batch.results.has(file1)).toBe(true);
+      expect(batch.results.has(file2)).toBe(true);
+    });
+
+    it('should report healthy=false when any file fails', async () => {
+      const good = join(tempDir, 'good.json');
+      const bad = join(tempDir, 'bad.json');
+      await writeFile(good, JSON.stringify({ mcpServers: {} }));
+      await writeFile(bad, '{ broken }');
+
+      const batch = await healthCheck.checkBatch([
+        { path: good, type: 'mcp_config' },
+        { path: bad, type: 'mcp_config' }
+      ]);
+
+      expect(batch.healthy).toBe(false);
+      expect(batch.summary.passed).toBe(1);
+      expect(batch.summary.failed).toBe(1);
+    });
+
+    it('should report all failed when all files fail', async () => {
+      const bad1 = join(tempDir, 'bad1.json');
+      const bad2 = join(tempDir, 'bad2.json');
+      await writeFile(bad1, '{ bad');
+      await writeFile(bad2, '{ also bad');
+
+      const batch = await healthCheck.checkBatch([
+        { path: bad1, type: 'mcp_config' },
+        { path: bad2, type: 'mcp_config' }
+      ]);
+
+      expect(batch.healthy).toBe(false);
+      expect(batch.summary.failed).toBe(2);
+      expect(batch.summary.passed).toBe(0);
+    });
+
+    it('should aggregate warnings from all files', async () => {
+      const file1 = join(tempDir, 'w1.json');
+      const file2 = join(tempDir, 'w2.json');
+      await writeFile(file1, JSON.stringify({ other: 1 }));
+      await writeFile(file2, JSON.stringify({ other: 2 }));
+
+      const batch = await healthCheck.checkBatch([
+        { path: file1, type: 'mcp_config' },
+        { path: file2, type: 'mcp_config' }
+      ]);
+
+      expect(batch.summary.warnings).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should handle empty file list', async () => {
+      const batch = await healthCheck.checkBatch([]);
+
+      expect(batch.healthy).toBe(true);
+      expect(batch.summary.passed).toBe(0);
+      expect(batch.summary.failed).toBe(0);
+      expect(batch.results.size).toBe(0);
+    });
+
+    it('should handle mixed config types in a single batch', async () => {
+      const mcpFile = join(tempDir, 'mcp.json');
+      const modeFile = join(tempDir, 'mode.json');
+      const rulesFile = join(tempDir, 'rules.json');
+
+      await writeFile(mcpFile, JSON.stringify({ mcpServers: {} }));
+      await writeFile(modeFile, JSON.stringify({ slug: 'x', name: 'X', roleDefinition: 'R' }));
+      await writeFile(rulesFile, JSON.stringify({}));
+
+      const batch = await healthCheck.checkBatch([
+        { path: mcpFile, type: 'mcp_config' },
+        { path: modeFile, type: 'mode_definition' },
+        { path: rulesFile, type: 'rules_config' }
+      ]);
+
+      expect(batch.healthy).toBe(true);
+      expect(batch.results.size).toBe(3);
+    });
+
+    it('should pass options to each individual check', async () => {
+      const file1 = join(tempDir, 'opt1.json');
+      const file2 = join(tempDir, 'opt2.json');
+      await writeFile(file1, '{}');
+      await writeFile(file2, '{}');
+
+      const batch = await healthCheck.checkBatch(
+        [
+          { path: file1, type: 'rules_config' },
+          { path: file2, type: 'rules_config' }
+        ],
+        { checks: ['file_readable'] }
+      );
+
+      for (const result of batch.results.values()) {
+        expect(result.checks).toHaveLength(1);
+        expect(result.checks[0].name).toBe('file_readable');
+      }
+    });
+  });
+
+  // ================================================================
+  // roomodes_config type
+  // ================================================================
+  describe('roomodes_config type', () => {
+    it('should pass for valid roomodes config', async () => {
+      const filePath = join(tempDir, 'roomodes.json');
+      await writeFile(filePath, JSON.stringify({
+        customModes: [{ slug: 'mode1', name: 'Mode 1' }]
+      }));
+
+      const result = await healthCheck.checkHealth(filePath, 'roomodes_config');
+
+      expect(result.healthy).toBe(true);
+      const fieldsCheck = result.checks.find(c => c.name === 'required_fields');
+      expect(fieldsCheck!.passed).toBe(true);
+    });
+
+    it('should warn when customModes is missing', async () => {
+      const filePath = join(tempDir, 'roomodes-empty.json');
+      await writeFile(filePath, JSON.stringify({ modes: [] }));
+
+      const result = await healthCheck.checkHealth(filePath, 'roomodes_config');
+
+      const fieldsCheck = result.checks.find(c => c.name === 'required_fields');
+      expect(fieldsCheck!.passed).toBe(false);
+      expect(fieldsCheck!.details?.missing).toContain('customModes');
+    });
+  });
+
+  // ================================================================
+  // model_config type
+  // ================================================================
+  describe('model_config type', () => {
+    it('should pass for valid model config', async () => {
+      const filePath = join(tempDir, 'model.json');
+      await writeFile(filePath, JSON.stringify({
+        profiles: { default: {} }, apiConfigs: { default: {} }
+      }));
+
+      const result = await healthCheck.checkHealth(filePath, 'model_config');
+
+      const fieldsCheck = result.checks.find(c => c.name === 'required_fields');
+      expect(fieldsCheck!.passed).toBe(true);
+    });
+
+    it('should warn when profiles is missing', async () => {
+      const filePath = join(tempDir, 'model-partial.json');
+      await writeFile(filePath, JSON.stringify({ apiConfigs: {} }));
+
+      const result = await healthCheck.checkHealth(filePath, 'model_config');
+
+      const fieldsCheck = result.checks.find(c => c.name === 'required_fields');
+      expect(fieldsCheck!.passed).toBe(false);
+      expect(fieldsCheck!.details?.missing).toContain('profiles');
+    });
+
+    it('should warn when apiConfigs is missing', async () => {
+      const filePath = join(tempDir, 'model-partial2.json');
+      await writeFile(filePath, JSON.stringify({ profiles: {} }));
+
+      const result = await healthCheck.checkHealth(filePath, 'model_config');
+
+      const fieldsCheck = result.checks.find(c => c.name === 'required_fields');
+      expect(fieldsCheck!.passed).toBe(false);
+      expect(fieldsCheck!.details?.missing).toContain('apiConfigs');
+    });
+  });
+
+  // ================================================================
+  // Edge cases
+  // ================================================================
+  describe('edge cases', () => {
+    it('should handle deeply nested JSON without issue', async () => {
+      const filePath = join(tempDir, 'deep.json');
+      const deep: Record<string, any> = { mcpServers: {} };
+      let current: any = deep;
+      for (let i = 0; i < 50; i++) {
+        current.nested = { level: i };
+        current = current.nested;
+      }
+      await writeFile(filePath, JSON.stringify(deep));
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config');
+      expect(result.healthy).toBe(true);
+    });
+
+    it('should handle file with only whitespace', async () => {
+      const filePath = join(tempDir, 'whitespace.json');
+      await writeFile(filePath, '   \n\t  ');
+
+      const result = await healthCheck.checkHealth(filePath, 'rules_config');
+
+      const jsonCheck = result.checks.find(c => c.name === 'json_valid');
+      expect(jsonCheck!.passed).toBe(false);
+    });
+
+    it('should handle file with null JSON value', async () => {
+      const filePath = join(tempDir, 'null.json');
+      await writeFile(filePath, 'null');
+
+      const result = await healthCheck.checkHealth(filePath, 'rules_config');
+
+      const jsonCheck = result.checks.find(c => c.name === 'json_valid');
+      expect(jsonCheck!.passed).toBe(true);
+    });
+
+    it('should handle large JSON file with many servers', async () => {
+      const filePath = join(tempDir, 'large.json');
+      const largeServers: Record<string, any> = {};
+      for (let i = 0; i < 100; i++) {
+        largeServers['server-' + i] = { command: 'node', args: ['s' + i + '.js'] };
+      }
+      await writeFile(filePath, JSON.stringify({ mcpServers: largeServers }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config', {
+        checks: ['json_valid', 'required_fields', 'mcp_loadable']
+      });
+
+      expect(result.healthy).toBe(true);
+      const mcpCheck = result.checks.find(c => c.name === 'mcp_loadable');
+      expect(mcpCheck!.passed).toBe(true);
+      expect(mcpCheck!.message).toContain('100 serveurs');
+    });
+
+    it('should handle file paths with spaces', async () => {
+      const dirPath = join(tempDir, 'path with spaces');
+      await mkdir(dirPath);
+      const filePath = join(dirPath, 'config file.json');
+      await writeFile(filePath, JSON.stringify({ mcpServers: {} }));
+
+      const result = await healthCheck.checkHealth(filePath, 'mcp_config');
+      expect(result.healthy).toBe(true);
+    });
+  });
+
+  // ================================================================
+  // timeout option
+  // ================================================================
+  describe('timeout option', () => {
+    it('should accept a timeout option without error', async () => {
+      const filePath = join(tempDir, 'config.json');
+      await writeFile(filePath, '{}');
+
+      const result = await healthCheck.checkHealth(filePath, 'rules_config', {
+        timeout: 1000
+      });
+
+      expect(result.healthy).toBe(true);
+    });
+  });
+});

--- a/servers/roo-state-manager/tests/unit/services/background-services.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/background-services.test.ts
@@ -1,0 +1,678 @@
+/**
+ * Unit tests for background-services.ts
+ *
+ * Covers:
+ * - toHeader: pure function extracting SkeletonHeader from ConversationSkeleton
+ * - loadSkeletonsFromDisk: loads skeleton index from _skeleton_index.json
+ *   (exercises the private loadSkeletonsFromIndex internally)
+ * - saveSkeletonIndex: writes index from cache to disk
+ * - loadFullSkeleton: loads a single full skeleton on demand
+ * - classifyIndexingError: error classification for Qdrant indexing
+ *
+ * Issue: #1110 (startup speed)
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+// Mock fs module
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    promises: {
+      readdir: vi.fn(),
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      stat: vi.fn(),
+      access: vi.fn(),
+      mkdir: vi.fn(),
+    },
+  };
+});
+
+// Mock RooStorageDetector
+vi.mock('../../../src/utils/roo-storage-detector.js', () => ({
+  RooStorageDetector: {
+    detectStorageLocations: vi.fn(),
+    analyzeConversation: vi.fn(),
+    findConversationById: vi.fn(),
+  },
+}));
+
+// Mock TaskArchiver (dynamically imported)
+vi.mock('../../../src/services/task-archiver/index.js', () => ({
+  TaskArchiver: {
+    archiveTask: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Mock TaskIndexer
+vi.mock('../../../src/services/task-indexer.js', () => {
+  const indexTaskSpy = vi.fn().mockResolvedValue([]);
+  const countPointsByHostOsSpy = vi.fn().mockResolvedValue(0);
+
+  class MockTaskIndexer {
+    async indexTask(taskId: string, source: 'roo' | 'claude-code') {
+      return indexTaskSpy(taskId, source);
+    }
+    async countPointsByHostOs(hostOs: string) {
+      return countPointsByHostOsSpy(hostOs);
+    }
+  }
+
+  (MockTaskIndexer as any).indexTaskSpy = indexTaskSpy;
+  (MockTaskIndexer as any).countPointsByHostOsSpy = countPointsByHostOsSpy;
+
+  return {
+    TaskIndexer: MockTaskIndexer,
+    getHostIdentifier: vi.fn().mockReturnValue('test-host'),
+  };
+});
+
+import {
+  toHeader,
+  loadSkeletonsFromDisk,
+  saveSkeletonIndex,
+  loadFullSkeleton,
+  classifyIndexingError,
+} from '../../../src/services/background-services.js';
+import { RooStorageDetector } from '../../../src/utils/roo-storage-detector.js';
+import type { ConversationSkeleton, SkeletonHeader, SkeletonMetadata } from '../../../src/types/conversation.js';
+
+// Typed mock accessors
+const mockFs = fs as unknown as {
+  readdir: ReturnType<typeof vi.fn>;
+  readFile: ReturnType<typeof vi.fn>;
+  writeFile: ReturnType<typeof vi.fn>;
+  stat: ReturnType<typeof vi.fn>;
+  access: ReturnType<typeof vi.fn>;
+  mkdir: ReturnType<typeof vi.fn>;
+};
+
+const mockDetector = RooStorageDetector as unknown as {
+  detectStorageLocations: ReturnType<typeof vi.fn>;
+  analyzeConversation: ReturnType<typeof vi.fn>;
+  findConversationById: ReturnType<typeof vi.fn>;
+};
+
+// === Helpers ===
+
+function makeMetadata(overrides?: Partial<SkeletonMetadata>): SkeletonMetadata {
+  return {
+    title: 'Test Task',
+    lastActivity: '2026-04-25T12:00:00Z',
+    createdAt: '2026-04-25T10:00:00Z',
+    messageCount: 5,
+    actionCount: 2,
+    totalSize: 2048,
+    ...overrides,
+  };
+}
+
+function makeSkeleton(taskId: string, overrides?: Partial<ConversationSkeleton>): ConversationSkeleton {
+  return {
+    taskId,
+    parentTaskId: undefined,
+    metadata: makeMetadata(),
+    isCompleted: false,
+    truncatedInstruction: 'Do something useful',
+    childTaskInstructionPrefixes: ['prefix-1', 'prefix-2'],
+    sequence: [
+      { role: 'user', content: 'Hello', timestamp: '2026-04-25T10:00:00Z', isTruncated: false },
+      { role: 'assistant', content: 'Hi there', timestamp: '2026-04-25T10:01:00Z', isTruncated: false },
+    ],
+    ...overrides,
+  };
+}
+
+function makeHeader(entry: { taskId: string; parentTaskId?: string; metadata?: SkeletonMetadata }): SkeletonHeader {
+  return {
+    taskId: entry.taskId,
+    parentTaskId: entry.parentTaskId,
+    metadata: entry.metadata ?? makeMetadata(),
+    isCompleted: false,
+  };
+}
+
+function makeIndex(entries: SkeletonHeader[]) {
+  return {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    count: entries.length,
+    entries,
+  };
+}
+
+// ===================================================================
+// toHeader - pure function, no mocking needed
+// ===================================================================
+describe('toHeader', () => {
+  it('should extract all header fields from a full skeleton', () => {
+    const skeleton = makeSkeleton('task-001');
+
+    const header = toHeader(skeleton);
+
+    expect(header.taskId).toBe('task-001');
+    expect(header.parentTaskId).toBeUndefined();
+    expect(header.metadata).toBe(skeleton.metadata);
+    expect(header.isCompleted).toBe(false);
+    expect(header.truncatedInstruction).toBe('Do something useful');
+    expect(header.childTaskInstructionPrefixes).toEqual(['prefix-1', 'prefix-2']);
+  });
+
+  it('should NOT include sequence data in the header', () => {
+    const skeleton = makeSkeleton('task-002');
+
+    const header = toHeader(skeleton);
+
+    expect((header as any).sequence).toBeUndefined();
+  });
+
+  it('should preserve parentTaskId when present', () => {
+    const skeleton = makeSkeleton('task-child', { parentTaskId: 'task-parent' });
+
+    const header = toHeader(skeleton);
+
+    expect(header.parentTaskId).toBe('task-parent');
+  });
+
+  it('should preserve isCompleted=true', () => {
+    const skeleton = makeSkeleton('task-done', { isCompleted: true });
+
+    const header = toHeader(skeleton);
+
+    expect(header.isCompleted).toBe(true);
+  });
+
+  it('should handle missing optional fields', () => {
+    const skeleton: ConversationSkeleton = {
+      taskId: 'task-minimal',
+      metadata: makeMetadata(),
+      isCompleted: false,
+      sequence: [],
+    };
+
+    const header = toHeader(skeleton);
+
+    expect(header.taskId).toBe('task-minimal');
+    expect(header.truncatedInstruction).toBeUndefined();
+    expect(header.childTaskInstructionPrefixes).toBeUndefined();
+    expect(header.parentTaskId).toBeUndefined();
+  });
+
+  it('should handle empty childTaskInstructionPrefixes array', () => {
+    const skeleton = makeSkeleton('task-003', { childTaskInstructionPrefixes: [] });
+
+    const header = toHeader(skeleton);
+
+    expect(header.childTaskInstructionPrefixes).toEqual([]);
+  });
+
+  it('should preserve metadata reference (not deep clone)', () => {
+    const skeleton = makeSkeleton('task-ref');
+
+    const header = toHeader(skeleton);
+
+    // Same reference - toHeader does not clone metadata
+    expect(header.metadata).toBe(skeleton.metadata);
+  });
+
+  it('should handle complex metadata with indexingState', () => {
+    const metadata = makeMetadata({
+      indexingState: {
+        indexStatus: 'indexed',
+        lastIndexedAt: '2026-04-25T11:00:00Z',
+        indexVersion: 3,
+        indexAttempts: 1,
+        skipReason: undefined,
+      },
+      dataSource: 'roo',
+      source: 'roo',
+      qdrantIndexedAt: '2026-04-25T11:00:00Z',
+    });
+    const skeleton = makeSkeleton('task-complex', { metadata });
+
+    const header = toHeader(skeleton);
+
+    expect(header.metadata.indexingState?.indexStatus).toBe('indexed');
+    expect(header.metadata.dataSource).toBe('roo');
+  });
+
+  it('should produce an object with no sequence property', () => {
+    const skeleton = makeSkeleton('task-no-seq-check');
+    const header = toHeader(skeleton);
+
+    const keys = Object.keys(header);
+    expect(keys).not.toContain('sequence');
+  });
+});
+
+// ===================================================================
+// loadSkeletonsFromDisk - exercises loadSkeletonsFromIndex internally
+// ===================================================================
+describe('loadSkeletonsFromDisk', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should populate cache from a valid index file', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+    const headers = [
+      makeHeader({ taskId: 'task-a' }),
+      makeHeader({ taskId: 'task-b', parentTaskId: 'task-a' }),
+    ];
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockResolvedValue(JSON.stringify(makeIndex(headers)));
+
+    await loadSkeletonsFromDisk(cache);
+
+    expect(cache.size).toBe(2);
+    expect(cache.get('task-a')?.taskId).toBe('task-a');
+    expect(cache.get('task-b')?.parentTaskId).toBe('task-a');
+  });
+
+  it('should load entries that have no parentTaskId', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+    const header = makeHeader({ taskId: 'task-orphan' });
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockResolvedValue(JSON.stringify(makeIndex([header])));
+
+    await loadSkeletonsFromDisk(cache);
+
+    expect(cache.size).toBe(1);
+    expect(cache.get('task-orphan')?.parentTaskId).toBeUndefined();
+  });
+
+  it('should handle no storage locations gracefully', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+
+    mockDetector.detectStorageLocations.mockResolvedValue([]);
+
+    await loadSkeletonsFromDisk(cache);
+
+    expect(cache.size).toBe(0);
+  });
+
+  it('should handle missing index file (ENOENT) gracefully', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockRejectedValue(new Error('ENOENT: no such file'));
+
+    await loadSkeletonsFromDisk(cache);
+
+    expect(cache.size).toBe(0);
+  });
+
+  it('should handle corrupted index (invalid JSON) gracefully', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockResolvedValue('not valid json {{{');
+
+    await loadSkeletonsFromDisk(cache);
+
+    expect(cache.size).toBe(0);
+  });
+
+  it('should handle index with missing entries array', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ version: 1, generatedAt: '2026-04-25', count: 0 }));
+
+    await loadSkeletonsFromDisk(cache);
+
+    // entries is missing, treated as invalid format
+    expect(cache.size).toBe(0);
+  });
+
+  it('should handle index with entries that is not an array', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ version: 1, entries: 'not-array' }));
+
+    await loadSkeletonsFromDisk(cache);
+
+    expect(cache.size).toBe(0);
+  });
+
+  it('should skip entries with no taskId', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+    const headers = [
+      { metadata: makeMetadata() }, // no taskId
+      makeHeader({ taskId: 'task-valid' }),
+    ];
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockResolvedValue(JSON.stringify(makeIndex(headers as any)));
+
+    await loadSkeletonsFromDisk(cache);
+
+    expect(cache.size).toBe(1);
+    expect(cache.has('task-valid')).toBe(true);
+  });
+
+  it('should handle BOM-prefixed UTF-8 index file', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+    const headers = [makeHeader({ taskId: 'task-bom' })];
+    const indexContent = '﻿' + JSON.stringify(makeIndex(headers));
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockResolvedValue(indexContent);
+
+    await loadSkeletonsFromDisk(cache);
+
+    expect(cache.size).toBe(1);
+    expect(cache.get('task-bom')?.taskId).toBe('task-bom');
+  });
+
+  it('should handle detectStorageLocations throwing an error', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+
+    mockDetector.detectStorageLocations.mockRejectedValue(new Error('Permission denied'));
+
+    await loadSkeletonsFromDisk(cache);
+
+    expect(cache.size).toBe(0);
+  });
+
+  it('should handle empty entries array', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockResolvedValue(JSON.stringify(makeIndex([])));
+
+    await loadSkeletonsFromDisk(cache);
+
+    // Empty entries means size stays 0
+    expect(cache.size).toBe(0);
+  });
+
+  it('should overwrite existing cache entries with same taskId', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+    const oldHeader = makeHeader({ taskId: 'task-dup' });
+    oldHeader.metadata.title = 'Old Title';
+    cache.set('task-dup', oldHeader);
+
+    const newHeader = makeHeader({ taskId: 'task-dup' });
+    newHeader.metadata.title = 'New Title';
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockResolvedValue(JSON.stringify(makeIndex([newHeader])));
+
+    await loadSkeletonsFromDisk(cache);
+
+    expect(cache.size).toBe(1);
+    expect(cache.get('task-dup')?.metadata.title).toBe('New Title');
+  });
+
+  it('should use the first storage location for index path', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/first', '/second']);
+    mockFs.readFile.mockResolvedValue(JSON.stringify(makeIndex([makeHeader({ taskId: 't1' })])));
+
+    await loadSkeletonsFromDisk(cache);
+
+    const readPath = mockFs.readFile.mock.calls[0]?.[0] as string;
+    // path.join uses backslashes on Windows, forward slashes on Unix
+    expect(readPath).toContain('first');
+    expect(readPath).toContain('_skeleton_index.json');
+  });
+});
+
+// ===================================================================
+// saveSkeletonIndex
+// ===================================================================
+describe('saveSkeletonIndex', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should write index file from cache entries', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+    cache.set('t1', makeHeader({ taskId: 't1' }));
+    cache.set('t2', makeHeader({ taskId: 't2' }));
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.writeFile.mockResolvedValue(undefined);
+
+    await saveSkeletonIndex(cache);
+
+    expect(mockFs.mkdir).toHaveBeenCalledWith(
+      expect.stringContaining('.skeletons'),
+      { recursive: true },
+    );
+    expect(mockFs.writeFile).toHaveBeenCalledTimes(1);
+
+    const writtenPath = mockFs.writeFile.mock.calls[0]?.[0] as string;
+    const writtenContent = mockFs.writeFile.mock.calls[0]?.[1] as string;
+    expect(writtenPath).toContain('_skeleton_index.json');
+
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.version).toBe(1);
+    expect(parsed.count).toBe(2);
+    expect(parsed.entries).toHaveLength(2);
+    expect(parsed.generatedAt).toBeDefined();
+  });
+
+  it('should handle no storage locations', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+    cache.set('t1', makeHeader({ taskId: 't1' }));
+
+    mockDetector.detectStorageLocations.mockResolvedValue([]);
+
+    await saveSkeletonIndex(cache);
+
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('should handle write errors gracefully', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+    cache.set('t1', makeHeader({ taskId: 't1' }));
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.writeFile.mockRejectedValue(new Error('Disk full'));
+
+    // Should not throw - errors are caught internally
+    await expect(saveSkeletonIndex(cache)).resolves.not.toThrow();
+  });
+
+  it('should produce valid JSON without BOM', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+    cache.set('t1', makeHeader({ taskId: 't1' }));
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.writeFile.mockResolvedValue(undefined);
+
+    await saveSkeletonIndex(cache);
+
+    const writtenContent = mockFs.writeFile.mock.calls[0]?.[1] as string;
+    // First char should not be BOM
+    expect(writtenContent.charCodeAt(0)).not.toBe(0xFEFF);
+    // Should be parseable JSON
+    expect(() => JSON.parse(writtenContent)).not.toThrow();
+  });
+});
+
+// ===================================================================
+// loadFullSkeleton
+// ===================================================================
+describe('loadFullSkeleton', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should load and return a full skeleton with sequence', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+    const skeleton = makeSkeleton('task-full');
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockResolvedValue(JSON.stringify(skeleton));
+
+    const result = await loadFullSkeleton('task-full', cache);
+
+    expect(result).not.toBeNull();
+    expect(result?.taskId).toBe('task-full');
+    expect(result?.sequence).toHaveLength(2);
+    // Cache should be updated with the header
+    expect(cache.get('task-full')?.taskId).toBe('task-full');
+    // Cache entry should NOT have sequence
+    expect((cache.get('task-full') as any)?.sequence).toBeUndefined();
+  });
+
+  it('should return null for skeleton without sequence', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+    const headerOnly = makeSkeleton('task-header-only', { sequence: [] });
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockResolvedValue(JSON.stringify(headerOnly));
+
+    const result = await loadFullSkeleton('task-header-only', cache);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when no storage locations', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+
+    mockDetector.detectStorageLocations.mockResolvedValue([]);
+
+    const result = await loadFullSkeleton('task-x', cache);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when file not found', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockRejectedValue(new Error('ENOENT'));
+
+    const result = await loadFullSkeleton('task-missing', cache);
+
+    expect(result).toBeNull();
+  });
+
+  it('should handle BOM in skeleton file', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+    const skeleton = makeSkeleton('task-bom');
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockResolvedValue('﻿' + JSON.stringify(skeleton));
+
+    const result = await loadFullSkeleton('task-bom', cache);
+
+    expect(result).not.toBeNull();
+    expect(result?.taskId).toBe('task-bom');
+  });
+
+  it('should return null for invalid JSON in skeleton file', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockResolvedValue('{{invalid json}}');
+
+    const result = await loadFullSkeleton('task-bad', cache);
+
+    expect(result).toBeNull();
+  });
+
+  it('should update cache with header even for newly loaded skeletons', async () => {
+    const cache = new Map<string, SkeletonHeader>();
+    const skeleton = makeSkeleton('task-new', {
+      metadata: makeMetadata({ title: 'Loaded' }),
+    });
+
+    mockDetector.detectStorageLocations.mockResolvedValue(['/mock/storage']);
+    mockFs.readFile.mockResolvedValue(JSON.stringify(skeleton));
+
+    await loadFullSkeleton('task-new', cache);
+
+    const cached = cache.get('task-new');
+    expect(cached).toBeDefined();
+    expect(cached?.metadata.title).toBe('Loaded');
+    // Cached entry must not have sequence
+    expect((cached as any)?.sequence).toBeUndefined();
+  });
+});
+
+// ===================================================================
+// classifyIndexingError
+// ===================================================================
+describe('classifyIndexingError', () => {
+  it('should classify permanent errors as true', () => {
+    const errors = [
+      new Error('file not found'),
+      new Error('not found in storage'),
+      new Error('access denied for user'),
+      new Error('permission denied: readonly'),
+      new Error('invalid format detected'),
+      new Error('corrupted data stream'),
+      new Error('authentication failed for API'),
+      new Error('quota exceeded permanently'),
+    ];
+
+    for (const error of errors) {
+      expect(classifyIndexingError(error)).toBe(true);
+    }
+  });
+
+  it('should classify temporary errors as false', () => {
+    const errors = [
+      new Error('network error during fetch'),
+      new Error('connection timeout after 30s'),
+      new Error('rate limit hit'),
+      new Error('service unavailable (503)'),
+      new Error('timeout waiting for response'),
+      new Error('ECONNRESET by peer'),
+      new Error('ENOTFOUND dns failure'),
+    ];
+
+    for (const error of errors) {
+      expect(classifyIndexingError(error)).toBe(false);
+    }
+  });
+
+  it('should default to false for unrecognized errors', () => {
+    expect(classifyIndexingError(new Error('something unexpected'))).toBe(false);
+    expect(classifyIndexingError(new Error(''))).toBe(false);
+  });
+
+  it('should handle errors without message property', () => {
+    expect(classifyIndexingError({})).toBe(false);
+    expect(classifyIndexingError({ message: null })).toBe(false);
+    expect(classifyIndexingError({ message: undefined })).toBe(false);
+  });
+
+  it('should be case-insensitive', () => {
+    expect(classifyIndexingError(new Error('FILE NOT FOUND'))).toBe(true);
+    expect(classifyIndexingError(new Error('Access Denied'))).toBe(true);
+    expect(classifyIndexingError(new Error('Network Error'))).toBe(false);
+    expect(classifyIndexingError(new Error('TIMEOUT'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- **59 tests** for `ConfigHealthCheckService` — JSON validation, BOM handling, required fields, MCP structure validation, batch processing, edge cases
- **38 tests** for `background-services` — skeleton index loading, `toHeader` extraction, `saveSkeletonIndex`, `loadFullSkeleton`, error classification

## Context
Incident 2026-04-25: MCP roo-state-manager not visible after pull+rebuild on 2 machines (ai-01, po-2023). Root cause: startup path modules had zero test coverage. These tests target the modules that impact MCP startup reliability.

## Test plan
- [x] All 97 new tests pass (`npx vitest run --config vitest.config.ci.ts`)
- [x] Build clean (`npm run build` → tsc, no errors)
- [x] No source code changes — test-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)