### PR TITLE
feat(#1410): report failed_ids in bulk cleanup operations (recovered #207)

### DIFF
--- a/servers/roo-state-manager/src/services/MessageManager.ts
+++ b/servers/roo-state-manager/src/services/MessageManager.ts
@@ -1059,18 +1059,20 @@ export class MessageManager {
     processed: number;
     errors: number;
     message_ids: string[];
+    failed_ids: string[];
   }> {
     const effectiveWorkspaceId = workspaceId || getLocalWorkspaceId();
     logger.info(`Bulk ${operation} for ${machineId}:${effectiveWorkspaceId}`, { filters });
 
     if (!existsSync(this.inboxPath)) {
-      return { operation, matched: 0, processed: 0, errors: 0, message_ids: [] };
+      return { operation, matched: 0, processed: 0, errors: 0, message_ids: [], failed_ids: [] };
     }
 
     // Use cached data for filtering (#638 perf optimization)
     const { items, full } = await this.ensureInboxCache();
     const matchedIds: string[] = [];
     let errors = 0;
+    const failedIds: string[] = [];
 
     for (const item of items) {
       const message = full.get(item.id);
@@ -1119,15 +1121,16 @@ export class MessageManager {
         if (operation === 'mark_read') {
           const success = await this.markAsRead(id, machineId);
           if (success) processed++;
-          else errors++;
+          else { errors++; failedIds.push(id); }
         } else if (operation === 'archive') {
           const success = await this.archiveMessage(id);
           if (success) processed++;
-          else errors++;
+          else { errors++; failedIds.push(id); }
         }
       } catch (error) {
         logger.error(`Error processing message ${id}`, error);
         errors++;
+        failedIds.push(id);
       }
     }
 
@@ -1137,7 +1140,8 @@ export class MessageManager {
       matched: matchedIds.length,
       processed,
       errors,
-      message_ids: matchedIds
+      message_ids: matchedIds,
+      failed_ids: failedIds
     };
   }
 

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/cleanup.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/cleanup.test.ts
@@ -6,41 +6,41 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 
 const { mockBulkOperation } = vi.hoisted(() => ({
-	mockBulkOperation: vi.fn()
+  mockBulkOperation: vi.fn()
 }));
 
 const { mockGetSharedStatePath } = vi.hoisted(() => ({
-	mockGetSharedStatePath: vi.fn()
+  mockGetSharedStatePath: vi.fn()
 }));
 
 const { mockGetLocalMachineId } = vi.hoisted(() => ({
-	mockGetLocalMachineId: vi.fn()
+  mockGetLocalMachineId: vi.fn()
 }));
 
 vi.mock('../../../services/MessageManager.js', () => {
-	const mockInstance = {
-		bulkOperation: (...args: any[]) => mockBulkOperation(...args),
-	};
-	return {
-		MessageManager: class {
-			constructor() {}
-			bulkOperation(...args: any[]) { return mockBulkOperation(...args); }
-		},
-		getMessageManager: () => mockInstance,
-	};
+  const mockInstance = {
+    bulkOperation: (...args: any[]) => mockBulkOperation(...args),
+  };
+  return {
+    MessageManager: class {
+      constructor() {}
+      bulkOperation(...args: any[]) { return mockBulkOperation(...args); }
+    },
+    getMessageManager: () => mockInstance,
+  };
 });
 
 vi.mock('../../../utils/server-helpers.js', () => ({
-	getSharedStatePath: mockGetSharedStatePath
+  getSharedStatePath: mockGetSharedStatePath
 }));
 
 vi.mock('../../../utils/message-helpers.js', () => ({
-	getLocalMachineId: mockGetLocalMachineId
+  getLocalMachineId: mockGetLocalMachineId
 }));
 
 vi.mock('../../../utils/logger.js', () => ({
-	createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
-	Logger: class {}
+  createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+  Logger: class {}
 }));
 
 // Fix #636 timeout: Use static import instead of dynamic imports
@@ -60,9 +60,6 @@ describe('cleanup', () => {
 	});
 
 	test('exports CleanupMessagesArgs type', async () => {
-		// Type is exported but not a runtime value, so we can't test it directly
-		// The compilation would fail if the type wasn't exported
-		// We can at least verify the module loaded successfully
 		expect(cleanupMessages).toBeDefined();
 	});
 
@@ -219,6 +216,44 @@ describe('cleanup', () => {
 		expect(text).toContain('**Messages correspondants :** 10');
 		expect(text).toContain('**Messages traités :** 8');
 		expect(text).toContain('**Erreurs :** 2');
+	});
+
+	test('reports failed_ids when messages fail', async () => {
+		mockBulkOperation.mockResolvedValue({
+			operation: 'mark_read',
+			matched: 5,
+			processed: 3,
+			errors: 2,
+			message_ids: ['msg-1', 'msg-2', 'msg-3', 'msg-4', 'msg-5'],
+			failed_ids: ['msg-4', 'msg-5']
+		});
+
+		const result = await cleanupMessages({
+			operation: 'mark_read'
+		});
+
+		const text = result.content[0].text;
+		expect(text).toContain('**IDs en échec** (2)');
+		expect(text).toContain('❌ msg-4');
+		expect(text).toContain('❌ msg-5');
+	});
+
+	test('hides failed_ids section when no failures', async () => {
+		mockBulkOperation.mockResolvedValue({
+			operation: 'mark_read',
+			matched: 3,
+			processed: 3,
+			errors: 0,
+			message_ids: ['msg-1', 'msg-2', 'msg-3'],
+			failed_ids: []
+		});
+
+		const result = await cleanupMessages({
+			operation: 'mark_read'
+		});
+
+		const text = result.content[0].text;
+		expect(text).not.toContain('IDs en échec');
 	});
 
 	test('inputSchema metadata is valid', async () => {

--- a/servers/roo-state-manager/src/tools/roosync/cleanup.ts
+++ b/servers/roo-state-manager/src/tools/roosync/cleanup.ts
@@ -77,11 +77,21 @@ function formatCleanupResult(result: {
   processed: number;
   errors: number;
   message_ids: string[];
+  failed_ids?: string[];
 }, verbose: boolean = true): string {
   let output = `## 🧹 Cleanup RooSync - ${result.operation}\n\n`;
   output += `**Messages correspondants :** ${result.matched}\n`;
   output += `**Messages traités :** ${result.processed}\n`;
   output += `**Erreurs :** ${result.errors}\n\n`;
+
+  const failedIds = result.failed_ids ?? [];
+  if (failedIds.length > 0) {
+    output += `**IDs en échec** (${failedIds.length}) :\n\n`;
+    for (const id of failedIds) {
+      output += `- ❌ ${id}\n`;
+    }
+    output += '\n';
+  }
 
   if (verbose && result.message_ids.length > 0) {
     const maxDisplay = 20;

--- a/servers/roo-state-manager/src/tools/roosync/manage.ts
+++ b/servers/roo-state-manager/src/tools/roosync/manage.ts
@@ -281,6 +281,11 @@ async function bulkOperationHandler(
   if (args.subject_contains) filtersDesc.push(`sujet contient: "${args.subject_contains}"`);
   if (args.tag) filtersDesc.push(`tag: ${args.tag}`);
 
+  const failedIds = result.failed_ids ?? [];
+  const failedSection = failedIds.length > 0
+    ? `\n\n**IDs en échec (${failedIds.length}) :** ${failedIds.slice(0, 10).map(id => `❌ \`${id}\``).join(', ')}${failedIds.length > 10 ? ` ... et ${failedIds.length - 10} autres` : ''}`
+    : '';
+
   return `✅ **Opération bulk terminée : ${opName}**
 
 ---
@@ -288,7 +293,7 @@ async function bulkOperationHandler(
 **Filtres appliqués :** ${filtersDesc.length > 0 ? filtersDesc.join(', ') : 'aucun (tous les messages)'}
 **Messages trouvés :** ${result.matched}
 **Messages traités :** ${result.processed}
-**Erreurs :** ${result.errors}
+**Erreurs :** ${result.errors}${failedSection}
 
 ${result.message_ids.length > 0 ? `**IDs traités :** ${result.message_ids.slice(0, 10).map(id => `\`${id}\``).join(', ')}${result.message_ids.length > 10 ? ` ... et ${result.message_ids.length - 10} autres` : ''}` : '**Aucun message ne correspond aux filtres.**'}`;
 }


### PR DESCRIPTION
Recovered after #207 was prematurely closed during a failed merge attempt that deleted the branch despite the merge not completing.

Original PR: #207
Recovered SHA: 43ba040d89db1f5b1391a6c1f45eee8354650189

bulkOperation now returns failed_ids: string[] for messages in error. Displayed in cleanup.ts and manage.ts. 2 tests added (13/13 pass).

Closes #1410

🤖 Recovered by ai-01 coordinateur cycle 14.