### PR TITLE
feat(#1656): McpValidationConstants + 17 vitest tests

### DIFF
--- a/servers/roo-state-manager/src/__tests__/mcp-validation.test.ts
+++ b/servers/roo-state-manager/src/__tests__/mcp-validation.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RETIRED_MCP_NAMES,
+  CLAUDE_CRITICAL_MCPS,
+  ROO_CRITICAL_MCPS,
+  WINCLI_CANONICAL,
+  validateMcpConfig,
+  type McpServerEntry,
+} from '../services/McpValidationConstants.js';
+
+describe('McpValidationConstants', () => {
+  describe('RETIRED_MCP_NAMES', () => {
+    it('should list all retired MCPs', () => {
+      expect(RETIRED_MCP_NAMES).toContain('desktop-commander');
+      expect(RETIRED_MCP_NAMES).toContain('github-projects-mcp');
+      expect(RETIRED_MCP_NAMES).toContain('quickfiles');
+      expect(RETIRED_MCP_NAMES.length).toBe(3);
+    });
+  });
+
+  describe('CLAUDE_CRITICAL_MCPS', () => {
+    it('should require roo-state-manager', () => {
+      expect(CLAUDE_CRITICAL_MCPS).toContain('roo-state-manager');
+    });
+  });
+
+  describe('ROO_CRITICAL_MCPS', () => {
+    it('should require win-cli and roo-state-manager', () => {
+      expect(ROO_CRITICAL_MCPS).toContain('win-cli');
+      expect(ROO_CRITICAL_MCPS).toContain('roo-state-manager');
+    });
+  });
+
+  describe('WINCLI_CANONICAL', () => {
+    it('should match local fork path', () => {
+      expect(WINCLI_CANONICAL.argsPattern.test('mcps/external/win-cli/server/dist/index.js')).toBe(true);
+      expect(WINCLI_CANONICAL.argsPattern.test('mcps\\external\\win-cli\\server\\dist\\index.js')).toBe(true);
+    });
+
+    it('should reject npm references', () => {
+      expect(WINCLI_CANONICAL.argsPattern.test('@simonb97/server-win-cli@0.2.1')).toBe(false);
+      expect(WINCLI_CANONICAL.argsPattern.test('npx @simonb97/server-win-cli@0.2.1')).toBe(false);
+    });
+
+    it('should have forbidden patterns for broken npm refs', () => {
+      expect(WINCLI_CANONICAL.forbiddenPatterns.length).toBeGreaterThanOrEqual(2);
+      for (const p of WINCLI_CANONICAL.forbiddenPatterns) {
+        expect(p).toBeInstanceOf(RegExp);
+      }
+    });
+  });
+});
+
+describe('validateMcpConfig', () => {
+  const makeRsm = (overrides: Partial<McpServerEntry> = {}): McpServerEntry => ({
+    command: 'node',
+    args: ['build/index.js'],
+    transportType: 'stdio',
+    disabled: false,
+    ...overrides,
+  });
+
+  const makeWinCli = (overrides: Partial<McpServerEntry> = {}): McpServerEntry => ({
+    command: 'node',
+    args: ['d:/roo-extensions/mcps/external/win-cli/server/dist/index.js'],
+    transportType: 'stdio',
+    disabled: false,
+    ...overrides,
+  });
+
+  it('should pass for valid Claude config', () => {
+    const servers = { 'roo-state-manager': makeRsm(), 'sk-agent': makeRsm() };
+    const result = validateMcpConfig(servers, 'claude');
+    expect(result.passed).toBe(true);
+    expect(result.violations).toHaveLength(0);
+    expect(result.checks.retired).toHaveLength(0);
+    expect(result.checks.criticalMissing).toHaveLength(0);
+  });
+
+  it('should pass for valid Roo config', () => {
+    const servers = {
+      'win-cli': makeWinCli(),
+      'roo-state-manager': makeRsm(),
+    };
+    const result = validateMcpConfig(servers, 'roo');
+    expect(result.passed).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('should detect retired MCPs', () => {
+    const servers = {
+      'roo-state-manager': makeRsm(),
+      'desktop-commander': makeRsm(),
+      'quickfiles': makeRsm(),
+    };
+    const result = validateMcpConfig(servers, 'claude');
+    expect(result.passed).toBe(false);
+    expect(result.checks.retired).toContain('desktop-commander');
+    expect(result.checks.retired).toContain('quickfiles');
+    expect(result.violations.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should detect missing critical MCPs', () => {
+    const servers = { 'sk-agent': makeRsm() };
+    const result = validateMcpConfig(servers, 'claude');
+    expect(result.passed).toBe(false);
+    expect(result.checks.criticalMissing).toContain('roo-state-manager');
+  });
+
+  it('should detect disabled critical MCPs', () => {
+    const servers = { 'roo-state-manager': makeRsm({ disabled: true }) };
+    const result = validateMcpConfig(servers, 'claude');
+    expect(result.passed).toBe(false);
+    expect(result.checks.criticalMissing).toContain('roo-state-manager (disabled)');
+  });
+
+  it('should detect win-cli drift: broken npm reference', () => {
+    const servers = {
+      'win-cli': makeWinCli({ args: ['@simonb97/server-win-cli@0.2.1'] }),
+      'roo-state-manager': makeRsm(),
+    };
+    const result = validateMcpConfig(servers, 'roo');
+    expect(result.passed).toBe(false);
+    expect(result.checks.winCliDrift.length).toBeGreaterThan(0);
+    expect(result.checks.winCliDrift.some(d => d.includes('BROKEN npm reference'))).toBe(true);
+  });
+
+  it('should detect win-cli drift: wrong command', () => {
+    const servers = {
+      'win-cli': makeWinCli({ command: 'npx' }),
+      'roo-state-manager': makeRsm(),
+    };
+    const result = validateMcpConfig(servers, 'roo');
+    expect(result.passed).toBe(false);
+    expect(result.checks.winCliDrift.some(d => d.includes("command='npx'"))).toBe(true);
+  });
+
+  it('should detect win-cli drift: args not pointing to local fork', () => {
+    const servers = {
+      'win-cli': makeWinCli({ args: ['some/random/path.js'] }),
+      'roo-state-manager': makeRsm(),
+    };
+    const result = validateMcpConfig(servers, 'roo');
+    expect(result.passed).toBe(false);
+    expect(result.checks.winCliDrift.some(d => d.includes('does not point to local fork'))).toBe(true);
+  });
+
+  it('should detect win-cli missing from Roo config', () => {
+    const servers = { 'roo-state-manager': makeRsm() };
+    const result = validateMcpConfig(servers, 'roo');
+    expect(result.passed).toBe(false);
+    expect(result.checks.winCliDrift).toContain('win-cli missing from Roo mcpServers');
+  });
+
+  it('should NOT check win-cli for Claude config', () => {
+    const servers = { 'roo-state-manager': makeRsm() };
+    const result = validateMcpConfig(servers, 'claude');
+    // No win-cli checks for Claude
+    expect(result.checks.winCliDrift).toHaveLength(0);
+  });
+
+  it('should detect multiple violations simultaneously', () => {
+    const servers = {
+      'desktop-commander': makeRsm(),
+      'win-cli': makeWinCli({ command: 'npx', args: ['@simonb97/server-win-cli@0.2.1'] }),
+    };
+    const result = validateMcpConfig(servers, 'roo');
+    expect(result.passed).toBe(false);
+    expect(result.checks.retired).toContain('desktop-commander');
+    expect(result.checks.criticalMissing).toContain('roo-state-manager');
+    expect(result.checks.winCliDrift.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/servers/roo-state-manager/src/services/McpValidationConstants.ts
+++ b/servers/roo-state-manager/src/services/McpValidationConstants.ts
@@ -1,0 +1,132 @@
+/**
+ * MCP Validation Constants — Canonical configuration rules
+ *
+ * #1656 Phase A3: Single source of truth for MCP validation.
+ * Used by:
+ * - scripts/validation/validate-mcp-config-cross-machine.ps1 (PowerShell runner)
+ * - roosync_mcp_management tool (MCP server)
+ * - Tests in src/__tests__/mcp-validation.test.ts
+ */
+
+// MCP servers that must NOT be present in any config
+export const RETIRED_MCP_NAMES = [
+  'desktop-commander',
+  'github-projects-mcp',
+  'quickfiles',
+] as const;
+
+// Critical MCPs per agent
+export const CLAUDE_CRITICAL_MCPS = ['roo-state-manager'] as const;
+export const ROO_CRITICAL_MCPS = ['win-cli', 'roo-state-manager'] as const;
+
+// Win-cli canonical config (from .claude/rules/tool-availability.md, #1666 Phase A3)
+export const WINCLI_CANONICAL = {
+  command: 'node',
+  argsPattern: /mcps[\/\\]external[\/\\]win-cli[\/\\]server[\/\\]dist[\/\\]index\.js$/,
+  transportType: 'stdio',
+  disabled: false,
+  forbiddenPatterns: [
+    /@simonb97\/server-win-cli/,
+    /@anthropic\/win-cli/,
+  ],
+} as const;
+
+// Sk-agent must be in global config (~/.claude.json), NOT in project .mcp.json
+export const SK_AGENT_MUST_BE_GLOBAL = true;
+
+export interface McpServerEntry {
+  command?: string;
+  args?: string[];
+  transportType?: string;
+  disabled?: boolean;
+}
+
+export interface ValidationResult {
+  passed: boolean;
+  violations: string[];
+  checks: {
+    retired: string[];
+    criticalMissing: string[];
+    winCliDrift: string[];
+    skAgentMisplaced: boolean;
+  };
+}
+
+/**
+ * Validate MCP server configs against canonical rules
+ */
+export function validateMcpConfig(
+  servers: Record<string, McpServerEntry>,
+  agent: 'claude' | 'roo',
+): ValidationResult {
+  const violations: string[] = [];
+  const retired: string[] = [];
+  const criticalMissing: string[] = [];
+  const winCliDrift: string[] = [];
+  let skAgentMisplaced = false;
+
+  // Check retired MCPs
+  for (const name of RETIRED_MCP_NAMES) {
+    if (servers[name]) {
+      retired.push(name);
+      violations.push(`RETIRED MCP '${name}' found — must be removed`);
+    }
+  }
+
+  // Check critical MCPs
+  const required = agent === 'claude' ? CLAUDE_CRITICAL_MCPS : ROO_CRITICAL_MCPS;
+  for (const name of required) {
+    if (!servers[name]) {
+      criticalMissing.push(name);
+      violations.push(`CRITICAL MCP '${name}' missing`);
+    } else if (servers[name].disabled) {
+      criticalMissing.push(`${name} (disabled)`);
+      violations.push(`CRITICAL MCP '${name}' is disabled`);
+    }
+  }
+
+  // Check win-cli config (Roo only)
+  if (agent === 'roo') {
+    const winCli = servers['win-cli'];
+    if (!winCli) {
+      winCliDrift.push('win-cli missing from Roo mcpServers');
+      violations.push('win-cli missing from Roo mcpServers');
+    } else {
+      if (winCli.command !== WINCLI_CANONICAL.command) {
+        winCliDrift.push(`command='${winCli.command}' (expected 'node')`);
+        violations.push(`Roo win-cli drift: command='${winCli.command}'`);
+      }
+
+      const firstArg = winCli.args?.[0] ?? '';
+      if (!WINCLI_CANONICAL.argsPattern.test(firstArg)) {
+        winCliDrift.push(`args[0] does not point to local fork: '${firstArg}'`);
+        violations.push(`Roo win-cli drift: args[0]='${firstArg}'`);
+      }
+
+      for (const pattern of WINCLI_CANONICAL.forbiddenPatterns) {
+        for (const arg of (winCli.args ?? [])) {
+          if (pattern.test(arg)) {
+            winCliDrift.push(`BROKEN npm reference: '${arg}'`);
+            violations.push(`Roo win-cli drift: broken npm ref '${arg}'`);
+          }
+        }
+      }
+
+      if (winCli.disabled) {
+        winCliDrift.push('win-cli is disabled');
+        violations.push('Roo win-cli drift: disabled');
+      }
+    }
+  }
+
+  return {
+    passed: violations.length === 0,
+    violations,
+    checks: {
+      retired,
+      criticalMissing,
+      winCliDrift,
+      skAgentMisplaced,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add `src/services/McpValidationConstants.ts` — single source of truth for MCP validation rules
- Add `src/__tests__/mcp-validation.test.ts` — 17 vitest tests covering all validation scenarios

## Problem

Issue #1656 Phase A3 requires a cross-machine MCP config validation script with a shared validation logic layer. The PowerShell script (`validate-mcp-config-cross-machine.ps1`) validates both Claude Code and Roo MCP configs, but the canonical validation rules needed a TypeScript module for the MCP server to use as well.

## Solution

Created `McpValidationConstants.ts` with:
- `RETIRED_MCP_NAMES` — desktop-commander, github-projects-mcp, quickfiles
- `CLAUDE_CRITICAL_MCPS` / `ROO_CRITICAL_MCPS` — required MCPs per agent
- `WINCLI_CANONICAL` — regex patterns for fork integrity (prevents #1482 regression)
- `validateMcpConfig()` — pure function, agent-agnostic, returns structured `ValidationResult`
- TypeScript interfaces: `McpServerEntry`, `ValidationResult`

## Test proof

```
✓ src/__tests__/mcp-validation.test.ts (17 tests) 13ms
  Test Files  1 passed (1)
       Tests  17 passed (17)
```

Tests cover: valid configs (Claude + Roo), retired MCP detection, missing/disabled critical MCPs, win-cli drift (broken npm ref, wrong command, wrong args, missing entry), no win-cli checks for Claude, multi-violation scenarios.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>