### PR TITLE
fix(#1409): guard against double-prefix in buildDashboardKey

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
@@ -91,6 +91,22 @@ describe('roosync_dashboard', () => {
     expect(result.key).toBe('workspace-test-workspace');
   });
 
+  // === Test 4: Double-prefix guard (#1409 item 2) ===
+  it('prevents double-prefix when workspace already starts with workspace-', async () => {
+    // Simulate a caller that passes the full key as workspace name
+    process.env.ROOSYNC_WORKSPACE_ID = 'workspace-Argumentum';
+    const result = await roosyncDashboard({
+      action: 'write',
+      type: 'workspace',
+      content: '# Double-prefix test'
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.key).toBe('workspace-Argumentum'); // NOT workspace-workspace-Argumentum
+    // Restore for other tests
+    process.env.ROOSYNC_WORKSPACE_ID = 'test-workspace';
+  });
+
   // === Test 5: Read dashboard complet ===
   it('reads dashboard with all sections', async () => {
     await roosyncDashboard({ action: 'write', type: 'global', content: '# Test Status' });

--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -181,9 +181,13 @@ function buildDashboardKey(
     case 'global':
       return 'global';
     case 'machine':
-      return `machine-${machineId}`;
+      // Guard against double-prefix (e.g., machine-machine-foo)
+      const cleanMachineId = machineId.startsWith('machine-') ? machineId.slice('machine-'.length) : machineId;
+      return `machine-${cleanMachineId}`;
     case 'workspace':
-      return `workspace-${workspace}`;
+      // Guard against double-prefix (e.g., workspace-workspace-Argumentum → #1409 item 2)
+      const cleanWorkspace = workspace.startsWith('workspace-') ? workspace.slice('workspace-'.length) : workspace;
+      return `workspace-${cleanWorkspace}`;
     default:
       throw new Error(`Type dashboard inconnu: ${type}`);
   }


### PR DESCRIPTION
## Summary
- Fix `workspace-workspace-Argumentum` double-prefix bug (issue #1409 item 2)
- `buildDashboardKey` now strips existing `workspace-` or `machine-` prefix before constructing the key
- Prevents dashboard key collision when workspace name already includes the type prefix

## Test plan
- [x] New test: double-prefix guard produces `workspace-Argumentum` from `workspace-Argumentum` input
- [x] Existing 83 dashboard tests still pass
- [x] Build passes (tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)