### PR TITLE
audit(cycle-17): add CODEOWNERS — require jsboige + myia-ai-01 review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners for jsboige/jsboige-mcp-servers
+#
+# These users must approve every PR before it can be merged.
+# This is a guard rail to ensure that high-capability models (Opus)
+# always vet PRs before merge, even when other identities (e.g.
+# clusterManager-Myia / GLM) have already reviewed.
+#
+# See: cycle 17 audit, 2026-04-26 — clusterManager-Myia merged
+# submod #212+#213 autonomously without Opus review.
+
+* @jsboige @myia-ai-01


### PR DESCRIPTION
## Summary

Cycle 17 audit response. Adds `.github/CODEOWNERS` requiring an Opus-class identity (`@jsboige` interactive or `@myia-ai-01` scheduled) to approve every PR before merge.

This will be enforced by setting `require_code_owner_reviews: true` on main branch protection (separate API call, not in this PR).

**Why:** On 2026-04-26 ~06:16 UTC, `clusterManager-Myia` (NanoClaw V2, GLM-backed) self-approved and self-merged this repo's #213 (single-reviewer-self-approve) and #212 (only own approving review counted). Both fixes are sound (audit retroactif: 9174 tests pass, 0 fail), but the pattern bypasses the explicit user intent that every merge be vetted by an Opus-class identity.

After merge + protection activation:
- clusterManager-Myia approval is welcome but doesn't satisfy code owner requirement
- A PR needs at least 1 approval from `@jsboige` or `@myia-ai-01` to be mergeable
- Merge button is procedural; quality gate is the code owner approval

## Refs

- Parent PR: jsboige/roo-extensions#1744
- Submod #212 (autonomous self-merge): jsboige/jsboige-mcp-servers#212
- Submod #213 (autonomous self-approve+merge): jsboige/jsboige-mcp-servers#213

🤖 Generated with [Claude Code](https://claude.com/claude-code)