### PR TITLE
feat(#1747): activate skeleton-cache Tier 2/3 at startup (EPIC sub-issue A)

### DIFF
--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -11,6 +11,7 @@ import { RooStorageDetector } from '../utils/roo-storage-detector.js';
 import { ServerState } from './state-manager.service.js';
 import { ANTI_LEAK_CONFIG } from '../config/server-config.js';
 import { TaskIndexer, getHostIdentifier } from './task-indexer.js';
+import { SkeletonCacheService } from './skeleton-cache.service.js';
 // REMOVED: import * as toolExports — was unused, added 6s to startup by importing ALL tools
 import { RooStorageDetectorError, RooStorageDetectorErrorCode } from '../types/errors.js';
 // #1140: Lazy import — RooSyncService loads 17 heavy modules (~6s).
@@ -508,6 +509,13 @@ export function startSkeletonRefreshWorker(state: ServerState): void {
 export async function initializeBackgroundServices(state: ServerState): Promise<void> {
     try {
         console.log('🚀 Initialisation des services background (zero blocking I/O)...');
+
+        // #1747 — Activate skeleton-cache Tier 2 (Claude local) and Tier 3 (GDrive archives).
+        // Default ON; rollback via SKELETON_CLAUDE_TIER=false / SKELETON_ARCHIVE_TIER=false in .env.
+        const enableClaudeTier = process.env.SKELETON_CLAUDE_TIER !== 'false';
+        const enableArchiveTier = process.env.SKELETON_ARCHIVE_TIER !== 'false';
+        SkeletonCacheService.configure({ enableClaudeTier, enableArchiveTier });
+        console.log(`🗂️  Skeleton cache tiers: Tier1=ON Tier2=${enableClaudeTier ? 'ON' : 'OFF'} Tier3=${enableArchiveTier ? 'ON' : 'OFF'}`);
 
         // ===== ALL NON-BLOCKING (fire-and-forget) =====
 


### PR DESCRIPTION
## Summary

Activates the **dormant** skeleton-cache Tier 2 (Claude local) and Tier 3 (GDrive archives) at production startup. **8-line additive change**, no behavior modification on the existing Tier 1 path.

## Context

EPIC parent: jsboige/roo-extensions#1747 — SDDD Unified Task Storage. This is **sub-issue A** (the quick-win that unblocks all downstream work).

The 3-tier architecture (Issue jsboige/roo-extensions#1244) was fully coded but \`SkeletonCacheService.configure()\` was never called at startup. Result: conversation_browser only saw Roo local conversations.

## Change

\`\`\`typescript
// In initializeBackgroundServices()
const enableClaudeTier = process.env.SKELETON_CLAUDE_TIER !== 'false';
const enableArchiveTier = process.env.SKELETON_ARCHIVE_TIER !== 'false';
SkeletonCacheService.configure({ enableClaudeTier, enableArchiveTier });
console.log(\`🗂️  Skeleton cache tiers: Tier1=ON Tier2=\${enableClaudeTier ? 'ON' : 'OFF'} Tier3=\${enableArchiveTier ? 'ON' : 'OFF'}\`);
\`\`\`

- Default **ON** for both tiers
- Rollback via \`.env\` flags \`SKELETON_CLAUDE_TIER=false\` / \`SKELETON_ARCHIVE_TIER=false\`
- Startup log makes the tier state visible

## Test plan

- [x] \`npm run build\` passes (TypeScript clean)
- [x] \`npx vitest run --config vitest.config.ci.ts\` — **9128 passed / 18 skipped / 0 failed**
- [x] Existing skeleton-cache.service.test.ts unchanged (tests call configure() explicitly with the merge-flags pattern, so the new default-ON in production doesn't break test isolation)

## Risk assessment

- **Low risk**: 8-line additive change, no API change, no removal
- Worst case rollback: set both env vars to \`false\` — restores historical behavior
- Tier 2/3 loaders are already exercised by existing tests with \`enableClaudeTier: true\` / \`enableArchiveTier: true\`

## What this unblocks

Subsequent sub-issues B-E of #1747:
- Diagnostics startup logs (richer visibility)
- Cross-tier integration tests
- Validation cross-machine (\`conversation_browser\` from ai-01 listing po-2025 conversations)
- Meta-analyste cross-cluster

## Refs

- EPIC: jsboige/roo-extensions#1747
- Architecture: jsboige/roo-extensions#1244 (Couches 2.1, 2.2, 2.6, 2.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)