### PR TITLE
fix(#1758): add hard chunk limit per task_id to prevent Qdrant bloat

### DIFF
--- a/servers/roo-state-manager/src/services/task-indexer/ChunkExtractor.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/ChunkExtractor.ts
@@ -16,6 +16,21 @@ const UUID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
 const MAX_INDEXABLE_CONTENT_SIZE = parseInt(process.env.MAX_INDEXABLE_CONTENT_SIZE || '20000', 10);
 
 /**
+ * #1758: Maximum chunks per task_id before hard truncation.
+ * Prevents runaway indexing of worker sessions with 200K+ messages.
+ * Default: 50,000 chunks ≈ ~2000 messages (25 chunks/msg average).
+ * Configurable via MAX_CHUNKS_PER_TASK env var.
+ */
+export const MAX_CHUNKS_PER_TASK = parseInt(process.env.MAX_CHUNKS_PER_TASK || '50000', 10);
+
+/**
+ * #1758: Maximum messages per task before warning + early truncation.
+ * Sessions exceeding this are likely runaway workers (--continue loops).
+ * Default: 10,000 messages. Configurable via MAX_MESSAGES_PER_TASK env var.
+ */
+export const MAX_MESSAGES_PER_TASK = parseInt(process.env.MAX_MESSAGES_PER_TASK || '10000', 10);
+
+/**
  * Truncate content to MAX_INDEXABLE_CONTENT_SIZE, preserving start and end.
  * Keeps first 70% and last 30% to capture both the beginning context and final results.
  */
@@ -148,7 +163,14 @@ export async function extractChunksFromTask(taskId: string, taskPath: string): P
         const apiHistoryContent = await fs.readFile(apiHistoryPath, 'utf-8');
         const apiMessages: ApiMessage[] = JSON.parse(apiHistoryContent);
 
-        for (const msg of apiMessages) {
+        // #1758: Early warning for abnormally large sessions
+        if (apiMessages.length > MAX_MESSAGES_PER_TASK) {
+            console.warn(`⚠️ [#1758] Task ${taskId} has ${apiMessages.length} messages — exceeding MAX_MESSAGES_PER_TASK=${MAX_MESSAGES_PER_TASK}. Processing first ${MAX_MESSAGES_PER_TASK} only.`);
+        }
+
+        const messagesToProcess = apiMessages.slice(0, MAX_MESSAGES_PER_TASK);
+
+        for (const msg of messagesToProcess) {
             if (msg.role === 'system') continue;
             if (msg.content) {
                 messageIndex++;
@@ -407,7 +429,14 @@ export async function extractChunksFromClaudeSession(
                 const lines = content.split('\n').filter(line => line.trim());
                 let fileMessageCount = 0;
 
-                for (const line of lines) {
+                // #1758: Early stop for large JSONL files
+                if (lines.length > MAX_MESSAGES_PER_TASK) {
+                    console.warn(`⚠️ [#1758] Claude session ${taskId} has ${lines.length} lines — exceeding MAX_MESSAGES_PER_TASK=${MAX_MESSAGES_PER_TASK}. Processing first ${MAX_MESSAGES_PER_TASK} only.`);
+                }
+
+                const linesToProcess = lines.slice(0, MAX_MESSAGES_PER_TASK);
+
+                for (const line of linesToProcess) {
                     try {
                         const entry = JSON.parse(line);
 

--- a/servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts
@@ -5,7 +5,7 @@ import { Schemas } from '@qdrant/js-client-rest';
 import { getQdrantClient } from '../qdrant.js';
 import getOpenAIClient, { getEmbeddingModel, getEmbeddingDimensions } from '../openai.js';
 import { validateVectorGlobal, sanitizePayload } from './EmbeddingValidator.js';
-import { extractChunksFromTask, extractChunksFromClaudeSession, splitChunk, Chunk } from './ChunkExtractor.js';
+import { extractChunksFromTask, extractChunksFromClaudeSession, splitChunk, Chunk, MAX_CHUNKS_PER_TASK } from './ChunkExtractor.js';
 import { networkMetrics } from './QdrantHealthMonitor.js';
 import { GenericError, GenericErrorCode } from '../../types/errors.js';
 
@@ -382,6 +382,12 @@ export async function indexTask(taskId: string, taskPath: string, source: 'roo' 
         if (chunks.length === 0) {
             console.log(`No chunks found for task ${taskId}. Skipping.`);
             return [];
+        }
+
+        // #1758: Hard limit on chunks per task to prevent runaway indexing
+        if (chunks.length > MAX_CHUNKS_PER_TASK) {
+            console.warn(`⚠️ [#1758] Task ${taskId} has ${chunks.length} chunks — exceeding MAX_CHUNKS_PER_TASK=${MAX_CHUNKS_PER_TASK}. Truncating to first ${MAX_CHUNKS_PER_TASK} chunks.`);
+            chunks.length = MAX_CHUNKS_PER_TASK;
         }
 
         const pointsToIndex: PointStruct[] = [];

--- a/servers/roo-state-manager/tests/unit/services/task-indexer/VectorIndexer.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/task-indexer/VectorIndexer.test.ts
@@ -18,7 +18,9 @@ vi.mock('../../../../src/services/openai.js', () => ({
 
 vi.mock('../../../../src/services/task-indexer/ChunkExtractor.js', () => ({
   extractChunksFromTask: vi.fn(),
-  splitChunk: vi.fn()
+  splitChunk: vi.fn(),
+  MAX_CHUNKS_PER_TASK: 50000,
+  MAX_MESSAGES_PER_TASK: 10000
 }));
 
 vi.mock('../../../../src/services/task-indexer/EmbeddingValidator.js', () => ({


### PR DESCRIPTION
## Summary
- Add `MAX_CHUNKS_PER_TASK` (default 50,000) hard limit in VectorIndexer to truncate oversized chunk arrays before embedding generation
- Add `MAX_MESSAGES_PER_TASK` (default 10,000) early truncation in ChunkExtractor for both Roo tasks and Claude Code sessions
- Both limits configurable via env vars (`MAX_CHUNKS_PER_TASK`, `MAX_MESSAGES_PER_TASK`)

## Root Cause (#1758)
Worker scheduled sessions running in `--continue` mode accumulate 200K+ messages without session rotation, generating 5.66M chunks for a single task_id. This caused 65.5M points (734 GB) in Qdrant, saturating the VHDX disk.

## Protection Layers
1. **ChunkExtractor** (extraction time): Truncates message arrays to 10,000 before chunk creation
2. **VectorIndexer** (indexing time): Hard limit of 50,000 chunks before embedding generation (safety net)
3. **Configurable**: Both limits via env vars for tuning without code changes

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 460 CI test files pass (9128 tests, 0 failures)
- [ ] Manual: verify log warnings appear for oversized tasks
- [ ] Monitor Qdrant growth after deployment

## Files Modified
- `servers/roo-state-manager/src/services/task-indexer/ChunkExtractor.ts` (+31 lines)
- `servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts` (+7 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)