### PR TITLE
test(utils): deepen path-normalizer edge cases (#1666 phase D)

### DIFF
--- a/servers/roo-state-manager/src/utils/__tests__/path-normalizer.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/path-normalizer.test.ts
@@ -106,5 +106,141 @@ describe('normalizePath', () => {
 			const b = normalizePath('c:/users/myia/roo-extensions');
 			expect(a).toBe(b);
 		});
+
+		// ============================================================
+		// UNC paths
+		// ============================================================
+
+		describe('UNC paths', () => {
+			test('normalizes UNC path with backslashes', () => {
+				expect(normalizePath('\\\\server\\share\\path')).toBe('//server/share/path');
+			});
+
+			test('normalizes UNC path with forward slashes', () => {
+				expect(normalizePath('//server/share/path')).toBe('//server/share/path');
+			});
+
+			test('normalizes UNC root only', () => {
+				expect(normalizePath('\\\\server\\share')).toBe('//server/share');
+			});
+		});
+
+		// ============================================================
+		// Trailing dots and spaces (Windows-specific edge cases)
+		// ============================================================
+
+		describe('trailing dots and spaces', () => {
+			test('preserves trailing dots in directory name', () => {
+				expect(normalizePath('C:\\path\\dir.')).toBe('c:/path/dir.');
+			});
+
+			test('preserves trailing spaces in directory name', () => {
+				expect(normalizePath('C:\\path\\dir ')).toBe('c:/path/dir ');
+			});
+
+			test('handles multiple trailing dots', () => {
+				expect(normalizePath('/path/dir...')).toBe('/path/dir...');
+			});
+		});
+
+		// ============================================================
+		// Multi-trailing-slash
+		// ============================================================
+
+		describe('multi-trailing-slash removal', () => {
+			test('removes multiple trailing slashes', () => {
+				expect(normalizePath('/path/to/dir///')).toBe('/path/to/dir');
+			});
+
+			test('removes multiple trailing backslashes after conversion', () => {
+				expect(normalizePath('C:\\path\\\\\\')).toBe('c:/path');
+			});
+		});
+
+		// ============================================================
+		// Unicode paths
+		// ============================================================
+
+		describe('Unicode paths', () => {
+			test('handles CJK characters', () => {
+				expect(normalizePath('/用户/项目/文件')).toBe('/用户/项目/文件');
+			});
+
+			test('handles emoji in paths', () => {
+				expect(normalizePath('/home/📦/project')).toBe('/home/📦/project');
+			});
+
+			test('handles French accented characters (lowercased)', () => {
+				expect(normalizePath('C:\\Utilisateur\\Données')).toBe('c:/utilisateur/données');
+			});
+
+			test('handles mixed Unicode and ASCII', () => {
+				expect(normalizePath('/home/café/project')).toBe('/home/café/project');
+			});
+		});
+
+		// ============================================================
+		// ~ home prefix
+		// ============================================================
+
+		describe('~ home prefix', () => {
+			test('preserves tilde in path (no expansion)', () => {
+				expect(normalizePath('~/project/src')).toBe('~/project/src');
+			});
+
+			test('preserves tilde with backslashes', () => {
+				expect(normalizePath('~\\project\\src')).toBe('~/project/src');
+			});
+		});
+
+		// ============================================================
+		// . and .. segments
+		// ============================================================
+
+		describe('. and .. segments', () => {
+			test('preserves . segments (no resolution)', () => {
+				expect(normalizePath('/path/./to/file')).toBe('/path/./to/file');
+			});
+
+			test('preserves .. segments (no resolution)', () => {
+				expect(normalizePath('/path/../other')).toBe('/path/../other');
+			});
+
+			test('preserves mixed . and .. segments', () => {
+				expect(normalizePath('/a/./b/../c')).toBe('/a/./b/../c');
+			});
+		});
+
+		// ============================================================
+		// Long Windows paths (>260 chars)
+		// ============================================================
+
+		describe('long Windows paths', () => {
+			test('handles path longer than 260 characters', () => {
+				const longSegment = 'a'.repeat(260);
+				const input = `C:\\path\\${longSegment}\\file.txt`;
+				const result = normalizePath(input);
+				expect(result).toContain(longSegment);
+				expect(result.startsWith('c:/path/')).toBe(true);
+			});
+
+			test('handles \\\\?\\ prefix', () => {
+				expect(normalizePath('\\\\?\\C:\\very\\long\\path')).toBe('//?/c:/very/long/path');
+			});
+		});
+
+		// ============================================================
+		// file:/// URL
+		// ============================================================
+
+		describe('file:/// URL', () => {
+			test('preserves file:/// URL structure', () => {
+				expect(normalizePath('file:///C:/Users/project')).toBe('file:///c:/users/project');
+			});
+
+			test('preserves file:// URL', () => {
+				expect(normalizePath('file://server/share')).toBe('file://server/share');
+			});
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- 21 new tests for `path-normalizer.ts` utility function
- Coverage expanded from 16 → 37 tests

### New test areas
- **UNC paths**: `\server\share`, forward-slash UNC, root-only
- **Trailing dots/spaces**: Windows-specific edge cases
- **Multi-trailing-slash**: multiple `///` and `\\` removal
- **Unicode**: CJK characters, emoji, French accents, mixed
- **~ home prefix**: preserved without expansion
- **. and .. segments**: preserved without resolution
- **Long Windows paths**: >260 chars, `\?\` prefix
- **file:/// URLs**: URL structure preserved

## Test plan
- [x] `npx vitest run --config vitest.config.ci.ts src/utils/__tests__/path-normalizer.test.ts` — 37/37 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)