### PR TITLE
feat(#1747): sub-issue B — skeleton cache tier diagnostics + health-check

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/skeleton-cache.service.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/skeleton-cache.service.test.ts
@@ -423,7 +423,7 @@ describe('SkeletonCacheService', () => {
 			expect(cache.has('roo-1')).toBe(true);
 			expect(cache.has('archived-task-A')).toBe(true);
 			expect(cache.has('archived-task-B')).toBe(true);
-			expect(cache.get('archived-task-A')!.metadata.dataSource).toBe('archive');
+			expect(cache.get('archived-task-A')!.metadata.dataSource).toBe('gdrive-archive');
 			expect(cache.get('archived-task-A')!.metadata.machineId).toBe('myia-po-2025');
 		});
 

--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -528,6 +528,16 @@ export async function initializeBackgroundServices(state: ServerState): Promise<
             state.lastSkeletonRefreshAt = Date.now();
             // Once index is loaded, discover Claude sessions too
             return loadClaudeCodeSessions(state.conversationCache);
+        }).then(() => {
+            // #1747 sub-issue B: Log tier summary after all background loading completes
+            const instance = SkeletonCacheService.getInstance();
+            const stats = instance.getCacheTierStats();
+            console.log(
+                `✅ Skeleton cache loaded: Tier1(Roo)=${stats.tier1_roo} ` +
+                `Tier2(Claude)=${stats.config.enableClaudeTier ? stats.tier2_claude : 'OFF'} ` +
+                `Tier3(Archives)=${stats.config.enableArchiveTier ? stats.tier3_archives : 'OFF'} ` +
+                `— Total: ${stats.total}`
+            );
         }).catch((error: any) => {
             console.warn('[Startup] Background skeleton/Claude load failed (non-blocking):', error?.message || error);
         });

--- a/servers/roo-state-manager/src/services/skeleton-cache.service.ts
+++ b/servers/roo-state-manager/src/services/skeleton-cache.service.ts
@@ -448,6 +448,8 @@ export class SkeletonCacheService {
                         continue;
                     }
                     const skeleton = archiveToSkeleton(archive);
+                    if (!skeleton.metadata) skeleton.metadata = {} as any;
+                    skeleton.metadata.dataSource = 'gdrive-archive';
                     this.cache.set(skeleton.taskId, skeleton);
                     loaded++;
                 } catch (error) {
@@ -463,6 +465,47 @@ export class SkeletonCacheService {
         } catch (error) {
             console.warn('[SkeletonCacheService] Tier 3 (archives): chargement non-bloquant a echoue:', error);
         }
+    }
+
+    /**
+     * #1747 sub-issue B: Return per-tier skeleton counts for health-check.
+     * Classifies cache entries by their metadata.dataSource tag:
+     *   - undefined/default → Tier 1 (Roo local)
+     *   - 'claude'          → Tier 2 (Claude local)
+     *   - 'gdrive-archive'  → Tier 3 (GDrive archives)
+     */
+    public getCacheTierStats(): {
+        tier1_roo: number;
+        tier2_claude: number;
+        tier3_archives: number;
+        total: number;
+        config: { enableClaudeTier: boolean; enableArchiveTier: boolean };
+    } {
+        let tier1 = 0;
+        let tier2 = 0;
+        let tier3 = 0;
+
+        for (const skeleton of this.cache.values()) {
+            const source = (skeleton as any).metadata?.dataSource;
+            if (source === 'claude') {
+                tier2++;
+            } else if (source === 'gdrive-archive') {
+                tier3++;
+            } else {
+                tier1++;
+            }
+        }
+
+        return {
+            tier1_roo: tier1,
+            tier2_claude: tier2,
+            tier3_archives: tier3,
+            total: this.cache.size,
+            config: {
+                enableClaudeTier: !!SkeletonCacheService.config.enableClaudeTier,
+                enableArchiveTier: !!SkeletonCacheService.config.enableArchiveTier,
+            },
+        };
     }
 
     /**

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/diagnose.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/diagnose.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { roosyncDiagnose, DiagnoseArgs, DiagnoseResult } from '../diagnose.js';
 import { RooSyncService, RooSyncServiceError, getRooSyncService } from '../../../services/RooSyncService.js';
+import { SkeletonCacheService } from '../../../services/skeleton-cache.service.js';
 import * as fs from 'fs/promises';
 
 // Mock du module fs
@@ -254,6 +255,75 @@ describe('roosync_diagnose', () => {
       expect(result.success).toBe(true);
       expect(result.action).toBe('test');
       expect(result.data.testMessage).toBe(customMessage);
+    });
+  });
+
+  // ============================================================
+  // Tests action: 'health' (#1747 sub-issue B)
+  // ============================================================
+
+  describe('action: health', () => {
+    it('should return skeleton cache tier statistics', async () => {
+      const mockStats = {
+        tier1_roo: 652,
+        tier2_claude: 9,
+        tier3_archives: 11562,
+        total: 12223,
+        config: { enableClaudeTier: true, enableArchiveTier: true },
+      };
+      vi.spyOn(SkeletonCacheService, 'getInstance').mockReturnValue({
+        getCacheTierStats: vi.fn(() => mockStats),
+      } as any);
+
+      const result = await roosyncDiagnose({ action: 'health' });
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe('health');
+      expect(result.message).toContain('Tier1(Roo): 652');
+      expect(result.message).toContain('Tier2(Claude): 9');
+      expect(result.message).toContain('Tier3(Archives): 11562');
+      expect(result.message).toContain('Total: 12223');
+      expect(result.data.tiers.tier1_roo.count).toBe(652);
+      expect(result.data.tiers.tier2_claude.enabled).toBe(true);
+      expect(result.data.tiers.tier2_claude.count).toBe(9);
+      expect(result.data.tiers.tier3_archives.enabled).toBe(true);
+      expect(result.data.totalSkeletons).toBe(12223);
+      expect(result.data.envConfig.SKELETON_CLAUDE_TIER).toBe(true);
+    });
+
+    it('should show OFF for disabled tiers', async () => {
+      const mockStats = {
+        tier1_roo: 100,
+        tier2_claude: 0,
+        tier3_archives: 0,
+        total: 100,
+        config: { enableClaudeTier: false, enableArchiveTier: false },
+      };
+      vi.spyOn(SkeletonCacheService, 'getInstance').mockReturnValue({
+        getCacheTierStats: vi.fn(() => mockStats),
+      } as any);
+
+      const result = await roosyncDiagnose({ action: 'health' });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('Tier2(Claude): OFF');
+      expect(result.message).toContain('Tier3(Archives): OFF');
+      expect(result.data.tiers.tier2_claude.enabled).toBe(false);
+      expect(result.data.tiers.tier3_archives.enabled).toBe(false);
+    });
+
+    it('should return valid ISO timestamp', async () => {
+      const mockStats = {
+        tier1_roo: 0, tier2_claude: 0, tier3_archives: 0, total: 0,
+        config: { enableClaudeTier: false, enableArchiveTier: false },
+      };
+      vi.spyOn(SkeletonCacheService, 'getInstance').mockReturnValue({
+        getCacheTierStats: vi.fn(() => mockStats),
+      } as any);
+
+      const result = await roosyncDiagnose({ action: 'health' });
+
+      expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     });
   });
 

--- a/servers/roo-state-manager/src/tools/roosync/diagnose.ts
+++ b/servers/roo-state-manager/src/tools/roosync/diagnose.ts
@@ -18,8 +18,8 @@ import * as os from 'os';
 // ====================================================================
 
 export const DiagnoseArgsSchema = z.object({
-  action: z.enum(['env', 'debug', 'reset', 'test'])
-    .describe('Type d\'opération: env (environnement), debug (dashboard), reset (service), test (minimal)'),
+  action: z.enum(['env', 'debug', 'reset', 'test', 'health'])
+    .describe('Type d\'opération: env (environnement), debug (dashboard), reset (service), test (minimal), health (skeleton cache tiers)'),
 
   // Paramètres pour action: 'env'
   checkDiskSpace: z.boolean().optional()
@@ -45,7 +45,7 @@ export type DiagnoseArgs = z.infer<typeof DiagnoseArgsSchema>;
 export const DiagnoseResultSchema = z.object({
   success: z.boolean()
     .describe('Indique si l\'opération a réussi'),
-  action: z.enum(['env', 'debug', 'reset', 'test'])
+  action: z.enum(['env', 'debug', 'reset', 'test', 'health'])
     .describe('Type d\'opération effectuée'),
   timestamp: z.string()
     .describe('Timestamp de l\'opération (ISO 8601)'),
@@ -84,6 +84,9 @@ export async function roosyncDiagnose(args: DiagnoseArgs): Promise<DiagnoseResul
 
       case 'test':
         return await handleTestAction(args, timestamp);
+
+      case 'health':
+        return await handleHealthAction(args, timestamp);
 
       default:
         throw new RooSyncServiceError(
@@ -301,18 +304,55 @@ async function handleTestAction(
 }
 
 /**
+ * #1747 sub-issue B: Health-check du cache skeleton 3-tier.
+ * Retourne le nombre de skeletons par tier et la configuration active.
+ */
+async function handleHealthAction(
+  _args: DiagnoseArgs,
+  timestamp: string
+): Promise<DiagnoseResult> {
+  const { SkeletonCacheService } = await import('../../services/skeleton-cache.service.js');
+  const instance = SkeletonCacheService.getInstance();
+  const stats = instance.getCacheTierStats();
+
+  const tierSummary =
+    `Tier1(Roo): ${stats.tier1_roo} | ` +
+    `Tier2(Claude): ${stats.config.enableClaudeTier ? stats.tier2_claude : 'OFF'} | ` +
+    `Tier3(Archives): ${stats.config.enableArchiveTier ? stats.tier3_archives : 'OFF'}`;
+
+  return {
+    success: true,
+    action: 'health',
+    timestamp,
+    message: `Skeleton cache health: ${tierSummary} — Total: ${stats.total}`,
+    data: {
+      tiers: {
+        tier1_roo: { enabled: true, count: stats.tier1_roo },
+        tier2_claude: { enabled: stats.config.enableClaudeTier, count: stats.tier2_claude },
+        tier3_archives: { enabled: stats.config.enableArchiveTier, count: stats.tier3_archives },
+      },
+      totalSkeletons: stats.total,
+      envConfig: {
+        SKELETON_CLAUDE_TIER: stats.config.enableClaudeTier,
+        SKELETON_ARCHIVE_TIER: stats.config.enableArchiveTier,
+      },
+    },
+  };
+}
+
+/**
  * Métadonnées de l'outil pour l'enregistrement MCP
  */
 export const diagnoseToolMetadata = {
   name: 'roosync_diagnose',
-  description: 'Outil de diagnostic et debug complet pour RooSync. Actions disponibles : env (diagnostic environnement système), debug (debug dashboard avec reset instance), reset (réinitialisation service avec confirmation), test (test minimal MCP).',
+  description: 'Outil de diagnostic et debug complet pour RooSync. Actions disponibles : env (diagnostic environnement système), debug (debug dashboard avec reset instance), reset (réinitialisation service avec confirmation), test (test minimal MCP), health (skeleton cache tiers status).',
   inputSchema: {
     type: 'object' as const,
     properties: {
       action: {
         type: 'string',
-        enum: ['env', 'debug', 'reset', 'test'],
-        description: 'Type d\'opération: env (environnement), debug (dashboard), reset (service), test (minimal)'
+        enum: ['env', 'debug', 'reset', 'test', 'health'],
+        description: 'Type d\'opération: env (environnement), debug (dashboard), reset (service), test (minimal), health (skeleton cache tiers)'
       },
       checkDiskSpace: {
         type: 'boolean',


### PR DESCRIPTION
## Summary
- Add `getCacheTierStats()` to SkeletonCacheService for per-tier skeleton counts (Tier1 Roo, Tier2 Claude, Tier3 GDrive archives)
- Add `health` action to `roosync_diagnose` tool exposing tier status, counts, and env config
- Enhance startup log with tier summary after background loading completes
- Tag Tier 3 archive skeletons with `metadata.dataSource = 'gdrive-archive'` for tier classification

## Test plan
- [x] Build passes (`npm run build`)
- [x] CI tests pass: 460/462 test files, 9165 tests (0 failures)
- [x] Existing multi-tier tests updated for new dataSource tag
- [ ] Manual: `roosync_diagnose(action: "health")` returns tier counts
- [ ] Manual: Startup logs show tier summary with actual counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>