### PR TITLE
fix(coverage): patch pathe normalizeWindowsPath + reportOnFailure

### DIFF
--- a/servers/roo-state-manager/package.json
+++ b/servers/roo-state-manager/package.json
@@ -30,7 +30,8 @@
     "test:hierarchy": "vitest run tests/unit/services/hierarchy-reconstruction-engine.test.ts",
     "test:baseline": "jest src/tests/BaselineService.test.ts",
     "test:baseline:watch": "jest src/tests/BaselineService.test.ts --watch",
-    "test:baseline:coverage": "jest src/tests/BaselineService.test.ts --coverage"
+    "test:baseline:coverage": "jest src/tests/BaselineService.test.ts --coverage",
+    "postinstall": "node scripts/patch-pathe.mjs"
   },
   "keywords": [
     "mcp",

--- a/servers/roo-state-manager/scripts/patch-pathe.mjs
+++ b/servers/roo-state-manager/scripts/patch-pathe.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+/**
+ * Patch pathe@2.0.3 normalizeWindowsPath to handle non-string inputs.
+ *
+ * Issue: TypeError: input.replace is not a function
+ *   at normalizeWindowsPath in pathe/dist/shared/pathe.M-eThtNZ.mjs:17:16
+ *
+ * Root cause: pathe's normalizeWindowsPath uses `if (!input)` as guard,
+ * which passes for truthy non-string values (URL objects, Buffers, etc.).
+ * When Node.js V8 coverage or vitest internals pass non-string values,
+ * input.replace() fails because replace is a string method.
+ *
+ * This patch adds a typeof check before the existing guard.
+ * Safe to re-run (idempotent). Applied as postinstall hook.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+const targets = [
+  join(root, 'node_modules', 'pathe', 'dist', 'shared', 'pathe.M-eThtNZ.mjs'),
+  join(root, 'node_modules', 'pathe', 'dist', 'shared', 'pathe.BSlhyZSM.cjs'),
+  join(root, 'node_modules', '@vitest', 'coverage-v8', 'dist', 'provider.js'),
+];
+
+const oldPattern = 'function normalizeWindowsPath(input = "") {\n  if (!input) {';
+const newPattern = 'function normalizeWindowsPath(input = "") {\n  if (typeof input !== "string") { input = String(input == null ? "" : input); }\n  if (!input) {';
+
+let patched = 0;
+let skipped = 0;
+
+for (const filePath of targets) {
+  try {
+    let content = readFileSync(filePath, 'utf8');
+    if (content.includes('typeof input !== "string"')) {
+      console.log(`[pathe-patch] Already patched: ${filePath}`);
+      skipped++;
+      continue;
+    }
+    if (!content.includes(oldPattern)) {
+      console.log(`[pathe-patch] Pattern not found (version changed?): ${filePath}`);
+      skipped++;
+      continue;
+    }
+    content = content.replace(oldPattern, newPattern);
+    writeFileSync(filePath, content, 'utf8');
+    console.log(`[pathe-patch] Patched: ${filePath}`);
+    patched++;
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      console.log(`[pathe-patch] File not found (skipping): ${filePath}`);
+      skipped++;
+    } else {
+      console.error(`[pathe-patch] Error patching ${filePath}:`, err.message);
+      process.exitCode = 1;
+    }
+  }
+}
+
+console.log(`[pathe-patch] Done: ${patched} patched, ${skipped} skipped`);

--- a/servers/roo-state-manager/vitest.config.ts
+++ b/servers/roo-state-manager/vitest.config.ts
@@ -75,6 +75,7 @@ export default defineConfig({
 
     // Coverage configuration
     coverage: {
+      reportOnFailure: true,
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],
       reportsDirectory: './coverage',
@@ -143,6 +144,7 @@ export default defineConfig({
 
     // Coverage configuration
     coverage: {
+      reportOnFailure: true,
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],
       reportsDirectory: './coverage',


### PR DESCRIPTION
## Summary
- Fix ENOENT `.tmp/coverage-*.json` errors during V8 coverage report generation
- Patch `pathe@2.0.3 normalizeWindowsPath()` to handle non-string inputs (URL objects from V8 coverage internals)
- Add `reportOnFailure: true` to vitest coverage config to ensure reports are generated even when threshold checks fail

## Root Cause
The `pathe` library's `normalizeWindowsPath()` uses `if (!input)` as a guard, which passes for truthy non-string values (URL objects, Buffers). When Node.js V8 coverage internals pass file paths as URL objects, the function crashes with `TypeError: input.replace is not a function`, causing coverage temp file writes to fail.

## Changes
- **`scripts/patch-pathe.mjs`** (new): Idempotent postinstall patch for pathe's normalizeWindowsPath
- **`package.json`**: Added `postinstall` hook to auto-apply patch on `npm install`
- **`vitest.config.ts`**: Added `reportOnFailure: true` in both coverage config sections

## Test plan
- [x] Build passes (`npm run build`)
- [x] Coverage generation succeeds without ENOENT errors
- [x] `archive-skeleton-builder.ts` coverage confirmed at 100%
- [x] All CI tests pass (9163 passed, 2 pre-existing timeout failures in tool-discoverability)