### PR TITLE
fix(test): #1747 sub-issue C — correct dataSource expectation in cross-tier tests

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/skeleton-cache.service.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/skeleton-cache.service.test.ts
@@ -614,8 +614,8 @@ describe('SkeletonCacheService', () => {
 				expect(cache.size).toBe(3);
 				expect(cache.get('task-po2023')!.metadata.machineId).toBe('myia-po-2023');
 				expect(cache.get('task-web1')!.metadata.machineId).toBe('myia-web1');
-				expect(cache.get('task-po2023')!.metadata.dataSource).toBe('archive');
-				expect(cache.get('task-web1')!.metadata.dataSource).toBe('archive');
+				expect(cache.get('task-po2023')!.metadata.dataSource).toBe('gdrive-archive');
+				expect(cache.get('task-web1')!.metadata.dataSource).toBe('gdrive-archive');
 			});
 
 			test('Tier 3 handles null archive gracefully', async () => {


### PR DESCRIPTION
## Summary

Fix two test assertions in `skeleton-cache.service.test.ts` (#228 cross-tier integration tests) that expected `'archive'` as the Tier 3 dataSource value when the canonical value used elsewhere is `'gdrive-archive'`.

## Root Cause

`SkeletonCacheService.ts:452` sets:
```ts
skeleton.metadata.dataSource = 'gdrive-archive';
```

The existing test at line 426 (sub-issue B, #227) correctly uses `'gdrive-archive'`. The new sub-issue C tests at lines 617-618 had a typo, breaking CI for all downstream PRs (#230 patch pathe + #231 smart-truncation coverage).

## Verification

```bash
$ grep -n "dataSource.*=" src/services/skeleton-cache.service.ts
452:                    skeleton.metadata.dataSource = 'gdrive-archive';
```

```bash
$ grep -n "dataSource.*toBe" src/services/__tests__/skeleton-cache.service.test.ts
355: expect(cache.get('claude-proj-alpha')!.metadata.dataSource).toBe('claude');
426: expect(cache.get('archived-task-A')!.metadata.dataSource).toBe('gdrive-archive');  ← canonical
563: expect(cache.get('claude-proj-x')!.metadata.dataSource).toBe('claude');
617-618: ← FIXED by this PR
```

## Test plan
- [x] Local: this fix aligns with `'gdrive-archive'` canonical value
- [x] CI roo-state-manager job will pass once merged
- [x] Re-run CI on #230 and #231 (downstream PRs) afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)