### PR TITLE
fix(mcp): resolve tools/list timeout race condition

### DIFF
--- a/servers/roo-state-manager/src/index.ts
+++ b/servers/roo-state-manager/src/index.ts
@@ -166,11 +166,17 @@ class RooStateManagerServer {
 
     /**
      * Start heavy initialization in background AFTER transport is connected.
-     * Uses setImmediate to yield the event loop first, so the MCP handshake
-     * (initialize request) can be processed before imports block the event loop.
+     * Uses setTimeout(2000) instead of setImmediate to give the MCP client time
+     * to send tools/list and receive the response before dynamic imports block
+     * the event loop during module evaluation (~70s total on this machine).
+     *
+     * Race condition fixed: setImmediate fires before I/O callbacks (poll phase),
+     * so tools/list was queued but couldn't be processed while imports blocked.
+     * With a 2-second delay, the client sends tools/list, server responds instantly
+     * (static tool definitions), and THEN heavy initialization starts.
      */
     startBackgroundInit(): void {
-        setImmediate(() => {
+        setTimeout(() => {
             this.initializeAsync()
                 .then(() => this._resolveInit())
                 .catch((error: Error) => {
@@ -178,7 +184,7 @@ class RooStateManagerServer {
                     this._initError = error;
                     this._rejectInit(error);
                 });
-        });
+        }, 2000);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Replace `setImmediate` with `setTimeout(2000)` in `startBackgroundInit()` to fix tools/list timeout
- Root cause: dynamic imports in `initializeAsync()` block the Node.js event loop for ~70s during ESM module evaluation, exceeding Claude Code's 60s tools/list timeout
- `setImmediate` fires before I/O callbacks (poll phase), so the tools/list request was queued but couldn't be processed

## Evidence (from per-PID logs on myia-po-2024)
```
Instance 1: init 21:19:14 → ColdStart 21:20:24 = 70s (>60s timeout)
Instance 2: init 21:19:20 → ColdStart 21:20:29 = 69s (>60s timeout)
Instance 3: init 21:19:22 → ColdStart 21:20:32 = 70s (>60s timeout)
```

## Fix
2-second `setTimeout` gives the MCP client time to send tools/list and receive the response (instant — static tool definitions) before heavy initialization starts blocking the event loop.

## Test plan
- [x] Build passes (`tsc`)
- [x] 462 CI tests pass (9223 assertions)
- [x] Standalone test: tools/list responds before heavy init
- [ ] Manual: MCP loads in Claude Code session on myia-po-2024

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>