### PR TITLE
feat(#1791): Auto-register heartbeat on dashboard activity (rebased)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -47,6 +47,7 @@ import {
   resolveMentionTarget
 } from '../../utils/dashboard-helpers.js';
 import type OpenAI from 'openai';
+import { recordRooSyncActivityAsync } from './heartbeat-activity.js';
 
 // #1470: Single source of truth schemas from dedicated module
 // No handler logic imported — safe circular-dep-free module
@@ -1686,6 +1687,10 @@ async function handleWrite(
   };
 
   await writeDashboardFile(key, dashboard);
+
+  // #1791: Auto-register heartbeat on dashboard write (fire-and-forget)
+  recordRooSyncActivityAsync('dashboard-write', { key, type: args.type });
+
   return {
     success: true,
     action: 'write',
@@ -2001,6 +2006,9 @@ async function handleAppend(
 
   const totalMs = Date.now() - appendStart;
   const splitSuffix = isMultiPart ? ` [split en ${newMessages.length} parts]` : '';
+
+  // #1791: Auto-register heartbeat on dashboard append (fire-and-forget)
+  recordRooSyncActivityAsync('dashboard-append', { key, type: args.type });
 
   return {
     success: true,


### PR DESCRIPTION
## Summary
- Rebase of heartbeat auto-registration onto main (without circuit breaker dependency)
- Auto-register heartbeat on dashboard write and append operations
- Fire-and-forget pattern, no blocking

## Context
Original PR branch `feat/1791-dashboard-heartbeat-auto-register` was built on top of the circuit breaker commit. User review on parent PR #1815 requested a clean rebase onto main without the circuit breaker.

## Test plan
- [x] Build passes
- [x] 9223 tests pass (CI config)
- [ ] CI green on this PR