### PR TITLE
fix(#1861): require explicit workspace in codebase_search

### DIFF
--- a/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
@@ -46,8 +46,8 @@ describe('search-codebase.tool', () => {
 			expect(codebaseSearchTool.name).toBe('codebase_search');
 		});
 
-		test('requires query field', () => {
-			expect(codebaseSearchTool.inputSchema.required).toEqual(['query']);
+		test('requires query and workspace fields', () => {
+			expect(codebaseSearchTool.inputSchema.required).toEqual(['query', 'workspace']);
 		});
 
 		test('has workspace property', () => {
@@ -245,14 +245,20 @@ describe('search-codebase.tool', () => {
 	// ============================================================
 
 	describe('handleCodebaseSearch', () => {
+		test('returns error for missing workspace', async () => {
+			const result = await handleCodebaseSearch({ query: 'test', workspace: '' });
+			expect((result as any).isError).toBe(true);
+			expect(result.content[0].text).toContain('workspace');
+		});
+
 		test('returns error for empty query', async () => {
-			const result = await handleCodebaseSearch({ query: '' });
+			const result = await handleCodebaseSearch({ query: '', workspace: '/ws' });
 			expect((result as any).isError).toBe(true);
 			expect(result.content[0].text).toContain('query');
 		});
 
 		test('returns error for whitespace-only query', async () => {
-			const result = await handleCodebaseSearch({ query: '   ' });
+			const result = await handleCodebaseSearch({ query: '   ', workspace: '/ws' });
 			expect((result as any).isError).toBe(true);
 		});
 

--- a/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
@@ -133,8 +133,8 @@ export interface CodebaseSearchArgs {
 	/** Requête de recherche sémantique */
 	query: string;
 
-	/** Chemin du workspace (défaut: process.cwd()) */
-	workspace?: string;
+	/** Chemin absolu du workspace (REQUIS — l'auto-détection pointe vers le serveur MCP) */
+	workspace: string;
 
 	/** Préfixe de répertoire pour filtrer les résultats */
 	directory_prefix?: string;
@@ -168,7 +168,7 @@ export const codebaseSearchTool: Tool = {
 			},
 			workspace: {
 				type: 'string',
-				description: 'Chemin absolu du workspace (défaut: répertoire courant)'
+				description: 'Chemin absolu du workspace (REQUIS). Toujours passer explicitement — l\'auto-détection pointe vers le serveur MCP.'
 			},
 			directory_prefix: {
 				type: 'string',
@@ -183,7 +183,7 @@ export const codebaseSearchTool: Tool = {
 				description: 'Score minimum de similarité 0-1 (défaut: 0.5)'
 			}
 		},
-		required: ['query']
+		required: ['query', 'workspace']
 	}
 };
 
@@ -240,13 +240,20 @@ function extractSnippet(codeChunk: string, query: string, maxChars: number = 500
 export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<CallToolResult> {
 	const {
 		query,
-		workspace = process.cwd(),
+		workspace,
 		directory_prefix,
 		limit = DEFAULT_LIMIT,
 		min_score = DEFAULT_MIN_SCORE
 	} = args;
 
-	// Validation
+	// Validation: workspace is required (auto-detection points to MCP server dir)
+	if (!workspace || workspace.trim().length === 0) {
+		return {
+			isError: true,
+			content: [{ type: 'text', text: 'Le paramètre "workspace" est requis. Passez le chemin absolu du workspace, ex: "C:/dev/roo-extensions" ou "/home/user/project". L\'auto-détection par défaut pointe vers le répertoire du serveur MCP, pas votre projet.' }]
+		};
+	}
+
 	if (!query || query.trim().length === 0) {
 		return {
 			isError: true,

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -159,12 +159,12 @@ export const codebaseSearchDefinition = {
         type: 'object',
         properties: {
             query: { type: 'string', description: 'Requête de recherche sémantique (concept, pas texte exact). Ex: "rate limiting for embeddings", "authentication middleware"' },
-            workspace: { type: 'string', description: 'Chemin absolu du workspace (défaut: répertoire courant)' },
+            workspace: { type: 'string', description: 'Chemin absolu du workspace (REQUIS). Toujours passer explicitement.' },
             directory_prefix: { type: 'string', description: 'Préfixe de répertoire pour filtrer. Ex: "src/services", "mcps/internal"' },
             limit: { type: 'number', description: 'Nombre max de résultats (défaut: 10, max: 30)' },
             min_score: { type: 'number', description: 'Score minimum de similarité 0-1 (défaut: 0.5)' }
         },
-        required: ['query']
+        required: ['query', 'workspace']
     }
 };
 

--- a/servers/roo-state-manager/tests/unit/tools/search/codebase-search-errors.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/search/codebase-search-errors.test.ts
@@ -83,7 +83,7 @@ describe('codebase_search - handleCodebaseSearch - Error paths', () => {
 	it('retourne qdrant_connection_error quand fetch failed', async () => {
 		mockQuery.mockRejectedValue(new Error('fetch failed ECONNREFUSED 127.0.0.1:6333'));
 
-		const result = await hcs({ query: 'test connection error' });
+		const result = await hcs({ query: 'test connection error', workspace: '/test' });
 
 		expect(result.isError).toBe(true);
 		const response = JSON.parse(result.content[0].text);
@@ -96,7 +96,7 @@ describe('codebase_search - handleCodebaseSearch - Error paths', () => {
 	it('retourne qdrant_connection_error quand ECONNREFUSED', async () => {
 		mockQuery.mockRejectedValue(new Error('connect ECONNREFUSED ::1:6333'));
 
-		const result = await hcs({ query: 'test econnrefused' });
+		const result = await hcs({ query: 'test econnrefused', workspace: '/test' });
 
 		expect(result.isError).toBe(true);
 		const response = JSON.parse(result.content[0].text);
@@ -106,7 +106,7 @@ describe('codebase_search - handleCodebaseSearch - Error paths', () => {
 	it('retourne auth_error quand API key invalide', async () => {
 		mockEmbeddingsCreate.mockRejectedValue(new Error('Invalid API key provided'));
 
-		const result = await hcs({ query: 'test auth error' });
+		const result = await hcs({ query: 'test auth error', workspace: '/test' });
 
 		expect(result.isError).toBe(true);
 		const response = JSON.parse(result.content[0].text);
@@ -118,7 +118,7 @@ describe('codebase_search - handleCodebaseSearch - Error paths', () => {
 	it('retourne auth_error quand Unauthorized', async () => {
 		mockEmbeddingsCreate.mockRejectedValue(new Error('Unauthorized: token expired'));
 
-		const result = await hcs({ query: 'test unauthorized' });
+		const result = await hcs({ query: 'test unauthorized', workspace: '/test' });
 
 		expect(result.isError).toBe(true);
 		const response = JSON.parse(result.content[0].text);
@@ -128,7 +128,7 @@ describe('codebase_search - handleCodebaseSearch - Error paths', () => {
 	it('retourne error générique pour toute autre erreur', async () => {
 		mockQuery.mockRejectedValue(new Error('Unexpected server error: timeout'));
 
-		const result = await hcs({ query: 'test generic error' });
+		const result = await hcs({ query: 'test generic error', workspace: '/test' });
 
 		expect(result.isError).toBe(true);
 		const response = JSON.parse(result.content[0].text);

--- a/servers/roo-state-manager/tests/unit/tools/search/codebase-search-execution.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/search/codebase-search-execution.test.ts
@@ -115,18 +115,18 @@ describe('codebase_search - handleCodebaseSearch - Validation', () => {
 	});
 
 	it('devrait rejeter une query vide', async () => {
-		const result = await handleCodebaseSearch({ query: '' });
+		const result = await handleCodebaseSearch({ query: '', workspace: '/test' });
 		expect(result.isError).toBe(true);
 		expect(result.content[0].text).toContain('requis');
 	});
 
 	it('devrait rejeter une query avec seulement des espaces', async () => {
-		const result = await handleCodebaseSearch({ query: '   ' });
+		const result = await handleCodebaseSearch({ query: '   ', workspace: '/test' });
 		expect(result.isError).toBe(true);
 	});
 
 	it('devrait rejeter query undefined', async () => {
-		const result = await handleCodebaseSearch({ query: undefined as any });
+		const result = await handleCodebaseSearch({ query: undefined as any, workspace: '/test' });
 		expect(result.isError).toBe(true);
 	});
 });
@@ -149,7 +149,7 @@ describe('codebase_search - handleCodebaseSearch - Collection not found', () => 
 	});
 
 	it('devrait retourner collection_not_found si aucune collection trouvée', async () => {
-		const result = await handleCodebaseSearch({ query: 'test' });
+		const result = await handleCodebaseSearch({ query: 'test', workspace: '/test' });
 		expect(result.isError).toBe(false);
 		const response = JSON.parse(result.content[0].text);
 		expect(response.status).toBe('collection_not_found');
@@ -186,7 +186,7 @@ describe('codebase_search - handleCodebaseSearch - Search success', () => {
 	});
 
 	it('devrait retourner les résultats formatés', async () => {
-		const result = await hcs({ query: 'test function' });
+		const result = await hcs({ query: 'test function', workspace: '/test' });
 		expect(result.isError).toBe(false);
 		const response = JSON.parse(result.content[0].text);
 		expect(response.status).toBe('success');
@@ -194,7 +194,7 @@ describe('codebase_search - handleCodebaseSearch - Search success', () => {
 	});
 
 	it('devrait inclure le score et la relevance', async () => {
-		const result = await hcs({ query: 'test' });
+		const result = await hcs({ query: 'test', workspace: '/test' });
 		const response = JSON.parse(result.content[0].text);
 		expect(response.results[0].score).toBe(0.95);
 		expect(response.results[0].relevance).toBe('excellent');
@@ -202,14 +202,14 @@ describe('codebase_search - handleCodebaseSearch - Search success', () => {
 	});
 
 	it('devrait inclure un snippet extrait', async () => {
-		const result = await hcs({ query: 'function' });
+		const result = await hcs({ query: 'function', workspace: '/test' });
 		const response = JSON.parse(result.content[0].text);
 		expect(response.results[0].snippet).toBeDefined();
 		expect(response.results[0].snippet).toContain('function');
 	});
 
 	it('devrait inclure les numéros de ligne', async () => {
-		const result = await hcs({ query: 'test' });
+		const result = await hcs({ query: 'test', workspace: '/test' });
 		const response = JSON.parse(result.content[0].text);
 		expect(response.results[0].lines).toBe('10-12');
 		expect(response.results[0].start_line).toBe(10);
@@ -217,7 +217,7 @@ describe('codebase_search - handleCodebaseSearch - Search success', () => {
 	});
 
 	it('devrait respecter le paramètre limit', async () => {
-		await hcs({ query: 'test', limit: 5 });
+		await hcs({ query: 'test', workspace: '/test', limit: 5 });
 		expect(mockQuery).toHaveBeenCalledWith(
 			expect.anything(),
 			expect.objectContaining({ limit: 5 })
@@ -225,7 +225,7 @@ describe('codebase_search - handleCodebaseSearch - Search success', () => {
 	});
 
 	it('devrait plafonner le limit à MAX_LIMIT', async () => {
-		await hcs({ query: 'test', limit: 100 });
+		await hcs({ query: 'test', workspace: '/test', limit: 100 });
 		expect(mockQuery).toHaveBeenCalledWith(
 			expect.anything(),
 			expect.objectContaining({ limit: 50 })
@@ -233,7 +233,7 @@ describe('codebase_search - handleCodebaseSearch - Search success', () => {
 	});
 
 	it('devrait utiliser le min_score fourni', async () => {
-		await hcs({ query: 'test', min_score: 0.8 });
+		await hcs({ query: 'test', workspace: '/test', min_score: 0.8 });
 		expect(mockQuery).toHaveBeenCalledWith(
 			expect.anything(),
 			expect.objectContaining({ score_threshold: 0.8 })
@@ -241,7 +241,7 @@ describe('codebase_search - handleCodebaseSearch - Search success', () => {
 	});
 
 	it('devrait utiliser le workspace par défaut si non fourni', async () => {
-		const result = await hcs({ query: 'test' });
+		const result = await hcs({ query: 'test', workspace: '/test' });
 		const response = JSON.parse(result.content[0].text);
 		expect(response.workspace).toBeDefined();
 	});
@@ -267,7 +267,7 @@ describe('codebase_search - handleCodebaseSearch - Directory filter', () => {
 	});
 
 	it('devrait construire un filtre pour directory_prefix', async () => {
-		await hcs({ query: 'test', directory_prefix: 'src/services' });
+		await hcs({ query: 'test', workspace: '/test', directory_prefix: 'src/services' });
 		expect(mockQuery).toHaveBeenCalledWith(
 			expect.anything(),
 			expect.objectContaining({
@@ -282,7 +282,7 @@ describe('codebase_search - handleCodebaseSearch - Directory filter', () => {
 	});
 
 	it('devrait normaliser les séparateurs', async () => {
-		await hcs({ query: 'test', directory_prefix: 'src\\services' });
+		await hcs({ query: 'test', workspace: '/test', directory_prefix: 'src\\services' });
 		expect(mockQuery).toHaveBeenCalledWith(
 			expect.anything(),
 			expect.objectContaining({
@@ -296,7 +296,7 @@ describe('codebase_search - handleCodebaseSearch - Directory filter', () => {
 	});
 
 	it('devrait ignorer les segments vides', async () => {
-		await hcs({ query: 'test', directory_prefix: 'src//services/' });
+		await hcs({ query: 'test', workspace: '/test', directory_prefix: 'src//services/' });
 		expect(mockQuery).toHaveBeenCalled();
 	});
 });
@@ -327,7 +327,7 @@ describe('codebase_search - handleCodebaseSearch - Results filtering', () => {
 			]
 		});
 
-		const result = await hcs({ query: 'test' });
+		const result = await hcs({ query: 'test', workspace: '/test' });
 		const response = JSON.parse(result.content[0].text);
 		expect(response.results_count).toBe(1);
 		expect(response.results[0].file_path).toBe('valid.ts');
@@ -341,7 +341,7 @@ describe('codebase_search - handleCodebaseSearch - Results filtering', () => {
 			]
 		});
 
-		const result = await hcs({ query: 'test' });
+		const result = await hcs({ query: 'test', workspace: '/test' });
 		const response = JSON.parse(result.content[0].text);
 		expect(response.results_count).toBe(1);
 		expect(response.results[0].file_path).toBe('valid.ts');
@@ -354,7 +354,7 @@ describe('codebase_search - handleCodebaseSearch - Results filtering', () => {
 			]
 		});
 
-		const result = await hcs({ query: 'test' });
+		const result = await hcs({ query: 'test', workspace: '/test' });
 		const response = JSON.parse(result.content[0].text);
 		expect(response.results[0].lines).toBeUndefined();
 	});


### PR DESCRIPTION
## Summary
- Remove `process.cwd()` default that always pointed to MCP server directory instead of user's workspace
- Make `workspace` a required parameter with clear error message when missing
- Fixes the core SDDD reliability bug where semantic searches operated on wrong workspace

## Root Cause
`search-codebase.tool.ts:243` had `workspace = process.cwd()` as default. The MCP server's cwd is fixed to its own directory (`mcps/internal/servers/roo-state-manager/`), so searches without explicit workspace would either fail or silently search the wrong workspace via the Qdrant fallback mechanism.

## Changes
- `search-codebase.tool.ts`: Remove default, add validation with helpful error message
- `tool-definitions.ts`: Add `workspace` to `required` array
- `search-codebase.tool.test.ts`: Update required assertion, add missing workspace test (37 tests pass)

## Test plan
- [x] Build passes (`npm run build`)
- [x] 37 codebase_search tests pass
- [ ] CI suite passes (`vitest run --config vitest.config.ci.ts`)
- [ ] Manual test: call `codebase_search` without workspace → clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)