### PR TITLE
feat(#1863): Phase D — MCP tool usage telemetry

### DIFF
--- a/servers/roo-state-manager/src/index.ts
+++ b/servers/roo-state-manager/src/index.ts
@@ -105,6 +105,7 @@ if (problems.length > 0) {
 import { createMcpServer, SERVER_CONFIG } from './config/server-config.js';
 import { registerListToolsHandler, registerCallToolHandler } from './tools/registry.js';
 import { createLogger } from './utils/logger.js';
+import { recordToolCall } from './utils/tool-call-metrics.js';
 
 const logger = createLogger('RooStateManagerServer');
 const require = createRequire(import.meta.url);
@@ -372,17 +373,26 @@ class RooStateManagerServer {
                 const helpers = await getServerHelpers();
 
                 let result;
-                if (this.toolInterceptor) {
-                    result = await this.toolInterceptor.interceptToolCall(
-                        request.params.name,
-                        request.params.arguments,
-                        async () => await originalCallTool(request)
-                    );
-                } else {
-                    result = await originalCallTool(request);
+                let hadError = false;
+                try {
+                    if (this.toolInterceptor) {
+                        result = await this.toolInterceptor.interceptToolCall(
+                            request.params.name,
+                            request.params.arguments,
+                            async () => await originalCallTool(request)
+                        );
+                    } else {
+                        result = await originalCallTool(request);
+                    }
+                } catch (toolError) {
+                    hadError = true;
+                    throw toolError;
                 }
 
                 const durationMs = Date.now() - startMs;
+                if (toolName) {
+                    recordToolCall(toolName, durationMs, hadError);
+                }
                 // Inject duration AFTER truncation so the footer is never cut off.
                 return helpers.injectDuration(helpers.truncateResult(result), durationMs, toolName);
             });

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
@@ -81,10 +81,9 @@ describe('get-status (Option B)', () => {
       expect(result.resetCache).toBe(true);
     });
 
-    test('no longer accepts includeDetails (removed in Option B)', () => {
-      // includeDetails was removed — extra properties are stripped
+    test('accepts includeDetails (re-added for tool usage telemetry)', () => {
       const result = GetStatusArgsSchema.parse({ includeDetails: true });
-      expect((result as any).includeDetails).toBeUndefined();
+      expect(result.includeDetails).toBe(true);
     });
   });
 

--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import { getRooSyncService, RooSyncServiceError } from '../../services/lazy-roosync.js';
 import { getMessageManager } from '../../services/MessageManager.js';
 import { getSharedStatePath } from '../../utils/shared-state-path.js';
+import { getToolUsageSnapshot, type ToolUsageSnapshot } from '../../utils/tool-call-metrics.js';
 import { join } from 'path';
 import { readdirSync, readFileSync, statSync } from 'fs';
 
@@ -36,7 +37,9 @@ export const GetStatusArgsSchema = z.object({
   resetCache: z.boolean().optional()
     .describe('Forcer la réinitialisation du cache du service (défaut: false)'),
   detail: z.enum(['compact', 'full']).optional()
-    .describe('Niveau de détail: "compact" (défaut) = status minimal, "full" = ajoute claims actifs et stages pipeline (#1855 HUD)')
+    .describe('Niveau de détail: "compact" (défaut) = status minimal, "full" = ajoute claims actifs et stages pipeline (#1855 HUD)'),
+  includeDetails: z.boolean().optional()
+    .describe('Inclure les statistiques détaillées (tool usage, etc.). Défaut: false')
 });
 
 export type GetStatusArgs = z.infer<typeof GetStatusArgsSchema>;
@@ -66,6 +69,28 @@ export const GetStatusResultSchema = z.object({
   dashboards: z.object({
     active: z.number()
   }).describe('Dashboards avec activité récente (<24h)'),
+
+  toolUsage: z.object({
+    sessionStartAt: z.string(),
+    totalCalls: z.number(),
+    uniqueTools: z.number(),
+    topTools: z.array(z.object({
+      name: z.string(),
+      count: z.number(),
+      avgMs: z.number(),
+      lastCallAt: z.string()
+    })),
+    bottomTools: z.array(z.object({
+      name: z.string(),
+      count: z.number(),
+      avgMs: z.number(),
+      lastCallAt: z.string()
+    })),
+    errorTools: z.array(z.object({
+      name: z.string(),
+      errorCount: z.number()
+    }))
+  }).describe('Per-tool usage stats for current session').optional(),
 
   flags: z.array(z.string())
     .describe('Flags actionnables (ex: HEARTBEAT_STALE:myia-po-2025)'),
@@ -331,7 +356,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
       }
     }
 
-    return {
+    const result: any = {
       status,
       machines: {
         online: filteredOnlineMachines.length,
@@ -369,6 +394,12 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
         return { hud: hudData };
       })() : {})
     };
+
+    if (args.includeDetails) {
+      result.toolUsage = getToolUsageSnapshot();
+    }
+
+    return result;
   } catch (error) {
     if (error instanceof RooSyncServiceError) {
       throw error;

--- a/servers/roo-state-manager/src/utils/__tests__/tool-call-metrics.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/tool-call-metrics.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+describe('tool-call-metrics', () => {
+  let recordToolCall: typeof import('../tool-call-metrics.js')['recordToolCall'];
+  let getToolUsageSnapshot: typeof import('../tool-call-metrics.js')['getToolUsageSnapshot'];
+  let resetMetrics: typeof import('../tool-call-metrics.js')['resetMetrics'];
+
+  beforeEach(async () => {
+    const mod = await import('../tool-call-metrics.js');
+    recordToolCall = mod.recordToolCall;
+    getToolUsageSnapshot = mod.getToolUsageSnapshot;
+    resetMetrics = mod.resetMetrics;
+    resetMetrics();
+  });
+
+  it('should start with empty metrics', () => {
+    const snapshot = getToolUsageSnapshot();
+    expect(snapshot.totalCalls).toBe(0);
+    expect(snapshot.uniqueTools).toBe(0);
+    expect(snapshot.topTools).toHaveLength(0);
+    expect(snapshot.bottomTools).toHaveLength(0);
+  });
+
+  it('should record a single tool call', () => {
+    recordToolCall('roosync_read', 150, false);
+    const snapshot = getToolUsageSnapshot();
+    expect(snapshot.totalCalls).toBe(1);
+    expect(snapshot.uniqueTools).toBe(1);
+    expect(snapshot.topTools[0].name).toBe('roosync_read');
+    expect(snapshot.topTools[0].count).toBe(1);
+    expect(snapshot.topTools[0].avgMs).toBe(150);
+  });
+
+  it('should accumulate calls for same tool', () => {
+    recordToolCall('roosync_read', 100, false);
+    recordToolCall('roosync_read', 200, false);
+    recordToolCall('roosync_read', 300, false);
+    const snapshot = getToolUsageSnapshot();
+    expect(snapshot.totalCalls).toBe(3);
+    expect(snapshot.uniqueTools).toBe(1);
+    expect(snapshot.topTools[0].count).toBe(3);
+    expect(snapshot.topTools[0].avgMs).toBe(200);
+  });
+
+  it('should track multiple tools and rank by count', () => {
+    recordToolCall('roosync_dashboard', 50, false);
+    recordToolCall('roosync_dashboard', 60, false);
+    recordToolCall('roosync_dashboard', 70, false);
+    recordToolCall('roosync_read', 100, false);
+    recordToolCall('roosync_read', 200, false);
+    recordToolCall('conversation_browser', 500, false);
+
+    const snapshot = getToolUsageSnapshot();
+    expect(snapshot.totalCalls).toBe(6);
+    expect(snapshot.uniqueTools).toBe(3);
+    expect(snapshot.topTools[0].name).toBe('roosync_dashboard');
+    expect(snapshot.topTools[0].count).toBe(3);
+    expect(snapshot.bottomTools[0].name).toBe('conversation_browser');
+    expect(snapshot.bottomTools[0].count).toBe(1);
+  });
+
+  it('should track error counts', () => {
+    recordToolCall('roosync_send', 100, false);
+    recordToolCall('roosync_send', 200, true);
+    recordToolCall('roosync_send', 50, true);
+
+    const snapshot = getToolUsageSnapshot();
+    expect(snapshot.errorTools).toHaveLength(1);
+    expect(snapshot.errorTools[0].name).toBe('roosync_send');
+    expect(snapshot.errorTools[0].errorCount).toBe(2);
+  });
+
+  it('should reset metrics', () => {
+    recordToolCall('roosync_read', 100, false);
+    resetMetrics();
+    const snapshot = getToolUsageSnapshot();
+    expect(snapshot.totalCalls).toBe(0);
+    expect(snapshot.uniqueTools).toBe(0);
+  });
+
+  it('should return top 5 and bottom 5 by default', () => {
+    for (let i = 1; i <= 8; i++) {
+      for (let j = 0; j < i; j++) {
+        recordToolCall(`tool_${i}`, 10, false);
+      }
+    }
+    const snapshot = getToolUsageSnapshot(5, 5);
+    expect(snapshot.topTools).toHaveLength(5);
+    expect(snapshot.bottomTools).toHaveLength(5);
+    expect(snapshot.topTools[0].name).toBe('tool_8');
+    expect(snapshot.bottomTools[0].name).toBe('tool_1');
+  });
+});

--- a/servers/roo-state-manager/src/utils/tool-call-metrics.ts
+++ b/servers/roo-state-manager/src/utils/tool-call-metrics.ts
@@ -1,0 +1,88 @@
+/**
+ * Tool Call Metrics — In-memory per-tool usage tracking
+ *
+ * Counts every MCP tool call, tracking call count, total duration,
+ * and last call timestamp. Stats are exposed via roosync_get_status.
+ *
+ * @module utils/tool-call-metrics
+ */
+
+interface ToolStats {
+  count: number;
+  totalMs: number;
+  lastCallAt: string;
+  errorCount: number;
+}
+
+const metrics = new Map<string, ToolStats>();
+let sessionStartAt: string = new Date().toISOString();
+
+export function recordToolCall(toolName: string, durationMs: number, hadError: boolean): void {
+  const existing = metrics.get(toolName);
+  if (existing) {
+    existing.count++;
+    existing.totalMs += durationMs;
+    existing.lastCallAt = new Date().toISOString();
+    if (hadError) existing.errorCount++;
+  } else {
+    metrics.set(toolName, {
+      count: 1,
+      totalMs: durationMs,
+      lastCallAt: new Date().toISOString(),
+      errorCount: hadError ? 1 : 0,
+    });
+  }
+}
+
+export interface ToolUsageSnapshot {
+  sessionStartAt: string;
+  totalCalls: number;
+  uniqueTools: number;
+  topTools: Array<{ name: string; count: number; avgMs: number; lastCallAt: string }>;
+  bottomTools: Array<{ name: string; count: number; avgMs: number; lastCallAt: string }>;
+  errorTools: Array<{ name: string; errorCount: number }>;
+}
+
+export function getToolUsageSnapshot(topN = 5, bottomN = 5): ToolUsageSnapshot {
+  const entries = Array.from(metrics.entries()).map(([name, stats]) => ({
+    name,
+    count: stats.count,
+    avgMs: Math.round(stats.totalMs / stats.count),
+    lastCallAt: stats.lastCallAt,
+    errorCount: stats.errorCount,
+  }));
+
+  const totalCalls = entries.reduce((sum, e) => sum + e.count, 0);
+
+  const byCount = [...entries].sort((a, b) => b.count - a.count);
+  const topTools = byCount.slice(0, topN).map(({ name, count, avgMs, lastCallAt }) => ({
+    name,
+    count,
+    avgMs,
+    lastCallAt,
+  }));
+
+  const bottomTools = byCount
+    .slice(Math.max(0, byCount.length - bottomN))
+    .reverse()
+    .map(({ name, count, avgMs, lastCallAt }) => ({ name, count, avgMs, lastCallAt }));
+
+  const errorTools = entries
+    .filter((e) => e.errorCount > 0)
+    .sort((a, b) => b.errorCount - a.errorCount)
+    .map(({ name, errorCount }) => ({ name, errorCount }));
+
+  return {
+    sessionStartAt,
+    totalCalls,
+    uniqueTools: entries.length,
+    topTools,
+    bottomTools,
+    errorTools,
+  };
+}
+
+export function resetMetrics(): void {
+  metrics.clear();
+  sessionStartAt = new Date().toISOString();
+}


### PR DESCRIPTION
## Summary

- Per-tool call counting and timing via in-memory `tool-call-metrics.ts` module
- Integrated into outermost `tools/call` handler in `index.ts` (after each tool execution)
- Exposed through `roosync_get_status(includeDetails: true)` with top/bottom/error tools breakdown
- 7 new unit tests + 1 updated schema test (9157 total CI tests passing)

## Changes

| File | Change |
|------|--------|
| `src/utils/tool-call-metrics.ts` | **New** — `recordToolCall()`, `getToolUsageSnapshot()`, `resetMetrics()` |
| `src/utils/__tests__/tool-call-metrics.test.ts` | **New** — 7 tests (empty, single, accumulate, ranking, errors, reset, top/bottom N) |
| `src/index.ts` | Modified — call `recordToolCall(toolName, durationMs, hadError)` after each tool call |
| `src/tools/roosync/get-status.ts` | Modified — `includeDetails` param + optional `toolUsage` section |
| `src/tools/roosync/__tests__/get-status.test.ts` | Modified — updated test for `includeDetails` acceptance |

## Architecture

- **Collection point**: Outermost `tools/call` wrapper in `index.ts`
- **Storage**: In-memory `Map<string, ToolStats>` — session-scoped, resets on MCP restart
- **Access**: `roosync_get_status({ includeDetails: true })` returns `toolUsage` section

## Test plan

- [x] `npx vitest run --config vitest.config.ci.ts` — 9157 passed, 18 skipped, 0 failed
- [x] `npm run build` — clean
- [x] New `tool-call-metrics.test.ts` — 7/7 passing
- [x] Updated `get-status.test.ts` — 22/22 passing (schema + integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)