### PR TITLE
fix(#1894): defer registry.ts import — cut MCP startup 51% (5.6s→2.8s)

### DIFF
--- a/servers/roo-state-manager/src/index.ts
+++ b/servers/roo-state-manager/src/index.ts
@@ -100,10 +100,10 @@ if (problems.length > 0) {
     console.error(`✅ Configuration .env validée (${envPath})`);
 }
 
-// #1140: ONLY import what's needed for server creation + handler registration.
-// Everything else loads lazily on first use.
+// #1894: ONLY import what's needed for MCP server creation.
+// registry.ts (and its zod/zod-to-json-schema chain) loads dynamically in run().
+// This cuts static module evaluation from ~5s to <1s.
 import { createMcpServer, SERVER_CONFIG } from './config/server-config.js';
-import { registerListToolsHandler, registerCallToolHandler } from './tools/registry.js';
 import { createLogger } from './utils/logger.js';
 
 const logger = createLogger('RooStateManagerServer');
@@ -151,13 +151,8 @@ class RooStateManagerServer {
         // Create MCP server IMMEDIATELY — no heavy imports yet
         this.server = createMcpServer(SERVER_CONFIG);
 
-        // Register handlers with lazy dependencies
-        this.registerHandlers();
-
-        // #1110: Do NOT start initializeAsync() here.
-        // Dynamic import() blocks the event loop during module evaluation (7s on fast machines, 45s+ on slow).
-        // If started in constructor, run() can't connect transport until imports finish → MCP timeout.
-        // Instead, startBackgroundInit() is called AFTER run() connects the transport.
+        // #1894: Handlers registered dynamically in run() via registerHandlersAsync().
+        // Static import of registry.ts removed — saves ~2-4s of zod/zod-to-json-schema eval.
         this._initPromise = new Promise((resolve, reject) => {
             this._resolveInit = resolve;
             this._rejectInit = reject;
@@ -314,11 +309,16 @@ class RooStateManagerServer {
     }
 
     /**
-     * Enregistre tous les handlers du serveur.
-     * Handlers use lazy imports internally — no heavy deps at registration time.
+     * Register all tool handlers — called from run() BEFORE connect().
+     * #1894: Uses dynamic import of registry.ts to avoid loading zod/zod-to-json-schema
+     * during static module evaluation. The tool definitions themselves are still static
+     * JSON objects — the dynamic import only defers their module evaluation to just
+     * before the server starts listening.
      */
-    private registerHandlers(): void {
-        // Register ListTools handler (already has lazy getToolExports() from PR #54)
+    private async registerHandlersAsync(): Promise<void> {
+        const { registerListToolsHandler, registerCallToolHandler } = await import('./tools/registry.js');
+
+        // Register ListTools handler (static definitions — zero handler imports)
         registerListToolsHandler(this.server);
 
         // Register CallTool handler with lazy state access
@@ -461,12 +461,18 @@ class RooStateManagerServer {
     }
 
     /**
-     * Démarre le serveur — connects transport IMMEDIATELY
+     * Démarre le serveur — register handlers then connect transport ASAP
      */
     async run(): Promise<void> {
+        const t0 = Date.now();
+        // #1894: Register handlers dynamically (loads registry.ts + tool-definitions + zod chain).
+        // This takes ~100-500ms but happens BEFORE connect() so tools/list responds immediately.
+        await this.registerHandlersAsync();
+        logger.info(`[#1894] Handler registration: ${Date.now() - t0}ms`);
+
         const transport = new StdioServerTransport();
         await this.server.connect(transport);
-        logger.info(`Roo State Manager Server started - v${packageJson.version}`);
+        logger.info(`Roo State Manager Server started - v${packageJson.version} (${Date.now() - t0}ms total)`);
 
         // #1817: Start heavy initialization AFTER MCP handshake completes.
         // server.oninitialized fires after client confirms connection.
@@ -556,8 +562,11 @@ process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 process.on('SIGHUP', () => gracefulShutdown('SIGHUP'));
 
 // Démarrage du serveur — connect transport ASAP, heavy init in background
+// #1894: Track startup phases for diagnostics using process.uptime()
 (async () => {
     try {
+        const staticEvalMs = Math.round(process.uptime() * 1000);
+        logger.info(`[#1894] Static module eval + env validation: ${staticEvalMs}ms`);
         serverInstance = new RooStateManagerServer();
         serverInstance.run().catch((error) => {
             logger.error('Fatal error during server execution:', { error });


### PR DESCRIPTION
## Summary
- Convert `registry.ts` static import to dynamic `import()` in `run()` to reduce MCP server startup time by ~51%
- Add `process.uptime()` instrumentation for startup phase diagnostics
- Fixes #1894: MCP roo-state-manager 0 outils au démarrage (tools/list timeout)

## Problem
The MCP server took ~5.6s from process start to `tools/list` response. The root cause was the static import chain:
```
index.ts → registry.ts → tool-definitions.ts → dashboard-schemas.ts → zod + zod-to-json-schema
```
This chain loaded during Node.js ESM module evaluation, blocking the event loop before the server could respond to the MCP client's `initialize` and `tools/list` requests.

On machines where the client has an internal timeout shorter than 5.6s, the server appears "connected" but with 0 tools.

## Fix
- Remove `registry.ts` from static imports in `index.ts`
- Load it dynamically in `run()` just before `connect()` via `registerHandlersAsync()`
- Handler registration (~1.3s for zod chain) now happens AFTER static eval (~1.5s) but BEFORE the server starts listening

## Measured Impact (po-2025, Node v25.9.0)

| Phase | Before | After |
|-------|--------|-------|
| Static module eval | ~5600ms | **~1500ms** |
| Handler registration | 0ms (included above) | **~1300ms** |
| **Total to tools/list** | **~5600ms** | **~2800ms** |

## Test plan
- [x] Build passes (`npm run build`)
- [x] CI tests pass: 465/465 (9226 assertions)
- [x] Standalone handshake test: `initialize` + `tools/list` both respond correctly
- [x] Tool count preserved: 33 tools returned by `tools/list`
- [ ] Restart VS Code on each machine → verify MCP loads with tools consistently (10/10 restarts)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)