### PR TITLE
feat(#1861): codebase_search workspace auto-detection via MCP roots

### DIFF
--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -88,6 +88,11 @@ const TOOL_CAPABILITIES: Record<string, Capability[]> = {
  * Uses static tool-definitions.ts — zero handler imports, instant startup.
  */
 export function registerListToolsHandler(server: Server): void {
+    // #1861: Inject server reference for workspace auto-detection (listRoots)
+    import('../utils/workspace-resolver.js').then(({ setServerReference }) => {
+        setServerReference(server);
+    }).catch(() => {});
+
     server.setRequestHandler(ListToolsRequestSchema, async () => {
         return {
             tools: allToolDefinitions as any[],

--- a/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
@@ -46,8 +46,8 @@ describe('search-codebase.tool', () => {
 			expect(codebaseSearchTool.name).toBe('codebase_search');
 		});
 
-		test('requires query and workspace fields', () => {
-			expect(codebaseSearchTool.inputSchema.required).toEqual(['query', 'workspace']);
+		test('requires only query field (workspace auto-detected)', () => {
+			expect(codebaseSearchTool.inputSchema.required).toEqual(['query']);
 		});
 
 		test('has workspace property', () => {
@@ -245,10 +245,11 @@ describe('search-codebase.tool', () => {
 	// ============================================================
 
 	describe('handleCodebaseSearch', () => {
-		test('returns error for missing workspace', async () => {
+		test('auto-detects workspace when not provided (falls back to cwd)', async () => {
 			const result = await handleCodebaseSearch({ query: 'test', workspace: '' });
-			expect((result as any).isError).toBe(true);
-			expect(result.content[0].text).toContain('workspace');
+			const text = typeof result.content[0].text === 'string' ? result.content[0].text : '';
+			const parsed = JSON.parse(text);
+			expect(parsed.workspace || parsed.message).toBeDefined();
 		});
 
 		test('returns error for empty query', async () => {

--- a/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
@@ -11,6 +11,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { createHash } from 'crypto';
 import OpenAI from 'openai';
 import { getQdrantClient } from '../../services/qdrant.js';
+import { resolveWorkspace } from '../../utils/workspace-resolver.js';
 
 /**
  * Génère le nom de collection Qdrant pour un workspace (même convention que Roo)
@@ -133,7 +134,7 @@ export interface CodebaseSearchArgs {
 	/** Requête de recherche sémantique */
 	query: string;
 
-	/** Chemin absolu du workspace (REQUIS — l'auto-détection pointe vers le serveur MCP) */
+	/** Chemin absolu du workspace (optionnel — auto-detecte via MCP roots ou WORKSPACE_PATH) */
 	workspace: string;
 
 	/** Préfixe de répertoire pour filtrer les résultats */
@@ -168,7 +169,7 @@ export const codebaseSearchTool: Tool = {
 			},
 			workspace: {
 				type: 'string',
-				description: 'Chemin absolu du workspace (REQUIS). Toujours passer explicitement — l\'auto-détection pointe vers le serveur MCP.'
+				description: 'Chemin absolu du workspace. Optionnel - auto-detecte via MCP roots ou WORKSPACE_PATH. Passer explicitement si le resultat semble incorrect.'
 			},
 			directory_prefix: {
 				type: 'string',
@@ -183,7 +184,7 @@ export const codebaseSearchTool: Tool = {
 				description: 'Score minimum de similarité 0-1 (défaut: 0.5)'
 			}
 		},
-		required: ['query', 'workspace']
+		required: ['query']
 	}
 };
 
@@ -240,24 +241,30 @@ function extractSnippet(codeChunk: string, query: string, maxChars: number = 500
 export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<CallToolResult> {
 	const {
 		query,
-		workspace,
+		workspace: explicitWorkspace,
 		directory_prefix,
 		limit = DEFAULT_LIMIT,
 		min_score = DEFAULT_MIN_SCORE
 	} = args;
 
-	// Validation: workspace is required (auto-detection points to MCP server dir)
-	if (!workspace || workspace.trim().length === 0) {
-		return {
-			isError: true,
-			content: [{ type: 'text', text: 'Le paramètre "workspace" est requis. Passez le chemin absolu du workspace, ex: "C:/dev/roo-extensions" ou "/home/user/project". L\'auto-détection par défaut pointe vers le répertoire du serveur MCP, pas votre projet.' }]
-		};
-	}
-
 	if (!query || query.trim().length === 0) {
 		return {
 			isError: true,
 			content: [{ type: 'text', text: 'Le paramètre "query" est requis et ne peut pas être vide.' }]
+		};
+	}
+
+	// #1861: Auto-detect workspace when not provided
+	let workspace: string;
+	let workspaceSource: string;
+	try {
+		const resolved = await resolveWorkspace(explicitWorkspace);
+		workspace = resolved.workspace;
+		workspaceSource = resolved.source;
+	} catch {
+		return {
+			isError: true,
+			content: [{ type: 'text', text: 'Le paramètre "workspace" est requis. Passez le chemin absolu du workspace, ex: "C:/dev/roo-extensions" ou "/home/user/project". L\'auto-détection n\'a pas pu résoudre le workspace (MCP roots indisponibles, WORKSPACE_PATH non configuré).' }]
 		};
 	}
 
@@ -398,6 +405,7 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 			status: 'success',
 			query: query,
 			workspace: workspace,
+			workspace_source: workspaceSource,
 			collection: collectionName,
 			results_count: results.length,
 			min_score_used: effectiveMinScore,

--- a/servers/roo-state-manager/src/utils/__tests__/workspace-resolver.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/workspace-resolver.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for workspace-resolver.ts
+ * #1861: Auto-detection of workspace for codebase_search
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { resolveWorkspace, resetWorkspaceResolver, setServerReference, getCachedRoots } from '../workspace-resolver.js';
+
+describe('workspace-resolver', () => {
+	beforeEach(() => {
+		resetWorkspaceResolver();
+		delete process.env.WORKSPACE_PATH;
+	});
+
+	describe('resolveWorkspace', () => {
+		it('returns explicit workspace with source "explicit"', async () => {
+			const result = await resolveWorkspace('C:/dev/roo-extensions');
+			expect(result).toEqual({
+				workspace: 'C:/dev/roo-extensions',
+				source: 'explicit',
+			});
+		});
+
+		it('trims and returns explicit workspace', async () => {
+			const result = await resolveWorkspace('  C:/dev/roo-extensions  ');
+			expect(result.workspace).toBe('  C:/dev/roo-extensions  ');
+			expect(result.source).toBe('explicit');
+		});
+
+		it('falls back to MCP roots when no explicit workspace', async () => {
+			const mockServer = {
+				listRoots: vi.fn().mockResolvedValue({
+					roots: [{ uri: 'file:///C:/dev/roo-extensions' }],
+				}),
+			} as any;
+
+			setServerReference(mockServer);
+			const result = await resolveWorkspace();
+			expect(result).toEqual({
+				workspace: 'C:/dev/roo-extensions',
+				source: 'mcp-roots',
+			});
+			expect(mockServer.listRoots).toHaveBeenCalledOnce();
+		});
+
+		it('handles Windows file:/// URIs correctly', async () => {
+			const mockServer = {
+				listRoots: vi.fn().mockResolvedValue({
+					roots: [{ uri: 'file:///D:/Dev/my-project' }],
+				}),
+			} as any;
+
+			setServerReference(mockServer);
+			const result = await resolveWorkspace();
+			expect(result.workspace).toBe('D:/Dev/my-project');
+			expect(result.source).toBe('mcp-roots');
+		});
+
+		it('falls back to WORKSPACE_PATH env var when MCP roots unavailable', async () => {
+			// No server reference
+			process.env.WORKSPACE_PATH = '/home/user/project';
+
+			const result = await resolveWorkspace();
+			expect(result).toEqual({
+				workspace: '/home/user/project',
+				source: 'env-var',
+			});
+		});
+
+		it('falls back to process.cwd() as last resort', async () => {
+			// No server, no env var
+			const result = await resolveWorkspace();
+			expect(result.source).toBe('cwd');
+			expect(result.workspace).toBe(process.cwd());
+		});
+
+		it('falls back from MCP roots error to env var', async () => {
+			const mockServer = {
+				listRoots: vi.fn().mockRejectedValue(new Error('Client does not support roots')),
+			} as any;
+
+			setServerReference(mockServer);
+			process.env.WORKSPACE_PATH = 'C:/fallback';
+
+			const result = await resolveWorkspace();
+			expect(result).toEqual({
+				workspace: 'C:/fallback',
+				source: 'env-var',
+			});
+		});
+
+		it('handles empty roots array', async () => {
+			const mockServer = {
+				listRoots: vi.fn().mockResolvedValue({ roots: [] }),
+			} as any;
+
+			setServerReference(mockServer);
+			process.env.WORKSPACE_PATH = 'C:/env-fallback';
+
+			const result = await resolveWorkspace();
+			expect(result.source).toBe('env-var');
+		});
+
+		it('empty string treated as missing', async () => {
+			process.env.WORKSPACE_PATH = 'C:/via-env';
+
+			const result = await resolveWorkspace('');
+			expect(result.source).toBe('env-var');
+		});
+
+		it('caches roots from listRoots call', async () => {
+			const mockServer = {
+				listRoots: vi.fn().mockResolvedValue({
+					roots: [
+						{ uri: 'file:///C:/dev/project1' },
+						{ uri: 'file:///C:/dev/project2' },
+					],
+				}),
+			} as any;
+
+			setServerReference(mockServer);
+			await resolveWorkspace();
+
+			const cached = getCachedRoots();
+			expect(cached).toEqual(['C:/dev/project1', 'C:/dev/project2']);
+		});
+	});
+});

--- a/servers/roo-state-manager/src/utils/workspace-resolver.ts
+++ b/servers/roo-state-manager/src/utils/workspace-resolver.ts
@@ -1,0 +1,107 @@
+/**
+ * Workspace Resolver — Auto-detects the calling agent's workspace
+ *
+ * #1861: Solves the auto-detection bug where codebase_search defaults to
+ * the MCP server's directory instead of the agent's project workspace.
+ *
+ * Resolution chain (first wins):
+ * 1. Explicit parameter — caller provided workspace
+ * 2. MCP roots — server.listRoots() from the connected client
+ * 3. WORKSPACE_PATH env var — configured in .claude.json
+ * 4. process.cwd() — last resort (MCP server dir, usually wrong)
+ *
+ * @version 1.0.0
+ */
+
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { createLogger } from './logger.js';
+
+const logger = createLogger('WorkspaceResolver');
+
+let _server: Server | null = null;
+let _cachedRoots: string[] | null = null;
+
+/**
+ * Inject the MCP server instance for roots/list access.
+ * Called once during handler registration.
+ */
+export function setServerReference(server: Server): void {
+	_server = server;
+}
+
+/**
+ * Resolve the workspace path for a tool call.
+ *
+ * @param explicitWorkspace - Workspace provided by the caller (highest priority)
+ * @returns Resolved workspace path
+ */
+export async function resolveWorkspace(explicitWorkspace?: string): Promise<{
+	workspace: string;
+	source: 'explicit' | 'mcp-roots' | 'env-var' | 'cwd';
+}> {
+	// 1. Explicit parameter (highest priority)
+	if (explicitWorkspace && explicitWorkspace.trim().length > 0) {
+		return { workspace: explicitWorkspace, source: 'explicit' };
+	}
+
+	// 2. MCP roots — ask the client for its workspace roots
+	if (_server) {
+		try {
+			const rootsResponse = await _server.listRoots();
+			if (rootsResponse?.roots?.length > 0) {
+				// Use the first root as the primary workspace
+				const rootUri = rootsResponse.roots[0].uri;
+				// file:// URI to path
+				let rootPath = rootUri;
+				if (rootUri.startsWith('file://')) {
+					rootPath = decodeURIComponent(rootUri.slice(7));
+					// Windows: file:///C:/dev/project → C:/dev/project
+					if (rootPath.startsWith('/') && rootPath.length > 2 && rootPath.charAt(2) === ':') {
+						rootPath = rootPath.slice(1);
+					}
+				}
+				_cachedRoots = rootsResponse.roots.map(r => {
+					let p = r.uri;
+					if (p.startsWith('file://')) {
+						p = decodeURIComponent(p.slice(7));
+						if (p.startsWith('/') && p.length > 2 && p.charAt(2) === ':') {
+							p = p.slice(1);
+						}
+					}
+					return p;
+				});
+				logger.info(`[resolveWorkspace] MCP roots: ${rootPath} (${rootsResponse.roots.length} roots)`);
+				return { workspace: rootPath, source: 'mcp-roots' };
+			}
+		} catch (err) {
+			// Client doesn't support roots, or not connected yet
+			logger.debug(`[resolveWorkspace] listRoots() failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
+	// 3. WORKSPACE_PATH env var
+	const envWorkspace = process.env.WORKSPACE_PATH;
+	if (envWorkspace) {
+		return { workspace: envWorkspace, source: 'env-var' };
+	}
+
+	// 4. Last resort: process.cwd() (usually the MCP server dir)
+	return { workspace: process.cwd(), source: 'cwd' };
+}
+
+/**
+ * Get all cached roots from the last listRoots() call.
+ * Returns empty array if roots were never fetched.
+ */
+export function getCachedRoots(): string[] {
+	return _cachedRoots ?? [];
+}
+
+/**
+ * Reset for testing.
+ * @internal
+ */
+export function resetWorkspaceResolver(): void {
+	_server = null;
+	_cachedRoots = null;
+}


### PR DESCRIPTION
## Summary
- Fix `codebase_search` workspace auto-detection bug: was defaulting to MCP server directory instead of caller's project workspace
- New `workspace-resolver.ts` with 4-level resolution chain: explicit param → MCP roots → WORKSPACE_PATH env → process.cwd()
- `workspace` parameter is now optional in `codebase_search` — auto-detected via `server.listRoots()` MCP protocol

## Root Cause
`process.cwd()` returns the MCP server directory, not the agent's project workspace. When `workspace` was omitted, searches hit the wrong Qdrant collection.

## Changes
- **New** `src/utils/workspace-resolver.ts` — resolveWorkspace() with server reference injection
- **Modified** `src/tools/search/search-codebase.tool.ts` — workspace optional, auto-detection integrated
- **Modified** `src/tools/registry.ts` — injects server reference on tools/list handler for roots access
- **New** `src/utils/__tests__/workspace-resolver.test.ts` — 10 tests
- **Modified** `src/tools/search/__tests__/search-codebase.tool.test.ts` — 2 tests updated

## Test Results
- CI suite: **9236 tests pass, 0 failures**
- New tests: 10 (workspace-resolver) + 2 updated (codebase_search)
- Build: `tsc` clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>