### PR TITLE
fix(#1910): lazy-load RooSyncService in diagnose to prevent test action hang

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/diagnose.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/diagnose.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { roosyncDiagnose, DiagnoseArgs, DiagnoseResult } from '../diagnose.js';
-import { RooSyncService, RooSyncServiceError, getRooSyncService } from '../../../services/RooSyncService.js';
+import { RooSyncService, getRooSyncService } from '../../../services/RooSyncService.js';
 import { SkeletonCacheService } from '../../../services/skeleton-cache.service.js';
 import * as fs from 'fs/promises';
 
@@ -337,7 +337,6 @@ describe('roosync_diagnose', () => {
         action: 'unknown_action'
       };
 
-      await expect(roosyncDiagnose(args)).rejects.toThrow(RooSyncServiceError);
       await expect(roosyncDiagnose(args)).rejects.toThrow(/Action non reconnue/);
     });
 
@@ -360,7 +359,6 @@ describe('roosync_diagnose', () => {
         action: 'debug'
       };
 
-      await expect(roosyncDiagnose(args)).rejects.toThrow(RooSyncServiceError);
       await expect(roosyncDiagnose(args)).rejects.toThrow(/Dashboard error/);
     });
   });

--- a/servers/roo-state-manager/src/tools/roosync/diagnose.ts
+++ b/servers/roo-state-manager/src/tools/roosync/diagnose.ts
@@ -8,10 +8,20 @@
  */
 
 import { z } from 'zod';
-import { RooSyncService, RooSyncServiceError, getRooSyncService } from '../../services/lazy-roosync.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
+
+// Lazy imports — only loaded when needed by debug/reset actions.
+// Static import was causing hangs on action="test" when RooSyncService init blocked (#1910).
+type LazyRooSyncModule = typeof import('../../services/lazy-roosync.js');
+let _lazyModule: LazyRooSyncModule | null = null;
+async function getLazyModule(): Promise<LazyRooSyncModule> {
+  if (!_lazyModule) {
+    _lazyModule = await import('../../services/lazy-roosync.js');
+  }
+  return _lazyModule;
+}
 
 // ====================================================================
 // SCHEMAS DE VALIDATION
@@ -89,20 +99,10 @@ export async function roosyncDiagnose(args: DiagnoseArgs): Promise<DiagnoseResul
         return await handleHealthAction(args, timestamp);
 
       default:
-        throw new RooSyncServiceError(
-          `Action non reconnue: ${action}`,
-          'UNKNOWN_ACTION'
-        );
+        throw new Error(`Action non reconnue: ${action}`);
     }
   } catch (error) {
-    if (error instanceof RooSyncServiceError) {
-      throw error;
-    }
-
-    throw new RooSyncServiceError(
-      `Erreur lors du diagnostic ${args.action}: ${(error as Error).message}`,
-      `DIAGNOSE_${args.action.toUpperCase()}_FAILED`
-    );
+    throw new Error(`Erreur lors du diagnostic ${args.action}: ${(error as Error).message}`);
   }
 }
 
@@ -185,6 +185,7 @@ async function getInstanceWithRetry(
   maxRetries = 5,
   baseDelayMs = 100
 ) {
+  const { RooSyncService } = await getLazyModule();
   let lastError: unknown;
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
@@ -199,9 +200,8 @@ async function getInstanceWithRetry(
       await new Promise(resolve => setTimeout(resolve, delay));
     }
   }
-  throw new RooSyncServiceError(
-    `Failed to create RooSyncService instance after ${maxRetries} retries`,
-    'INSTANCE_CREATION_FAILED'
+  throw new Error(
+    `Failed to create RooSyncService instance after ${maxRetries} retries`
   );
 }
 
@@ -213,6 +213,7 @@ async function handleDebugAction(
   args: DiagnoseArgs,
   timestamp: string
 ): Promise<DiagnoseResult> {
+  const { RooSyncService } = await getLazyModule();
   await RooSyncService.resetInstance();
 
   const service = await getInstanceWithRetry({ enabled: false });
@@ -254,6 +255,7 @@ async function handleResetAction(
     };
   }
 
+  const { RooSyncService, getRooSyncService } = await getLazyModule();
   await RooSyncService.resetInstance();
 
   if (args.clearCache) {


### PR DESCRIPTION
## Summary
- Convert static import of `lazy-roosync.js` to dynamic import in `diagnose.ts`
- Only `debug` and `reset` actions load `RooSyncService` — `test`, `env`, and `health` remain dependency-free
- Replace `RooSyncServiceError` with plain `Error` in catch paths (no longer needed from static import)

## Problem
`roosync_diagnose` with `action: "test"` hangs indefinitely on myia-web1 because the static import of `lazy-roosync.js` at line 11 triggers `RooSyncService` initialization. When GDrive or Qdrant is slow/unavailable, the dynamic `import()` in the registry never resolves.

The `test` action itself is trivial (returns a static object) but the module-level import blocks the entire tool.

## Test plan
- [x] Build passes
- [x] 8970/8970 tests pass (CI config)
- [x] Existing diagnose tests updated for `Error` instead of `RooSyncServiceError`
- [ ] Manual verification: `roosync_diagnose(action: "test")` returns instantly on web1

🤖 Generated with [Claude Code](https://claude.com/claude-code)