### PR TITLE
feat(#1836): pre-claim enforcement tool — roosync_claim

### DIFF
--- a/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
@@ -39,10 +39,11 @@ import {
     roosyncManageDefinition,
     roosyncCleanupMessagesDefinition,
     roosyncAttachmentsDefinition,
-    roosyncDashboardDefinition
+    roosyncDashboardDefinition,
+    roosyncClaimDefinition
 } from '../tool-definitions.js';
 
-const EXPECTED_TOOL_COUNT = 33;
+const EXPECTED_TOOL_COUNT = 34;
 
 // Order MUST mirror allToolDefinitions in tool-definitions.ts.
 // heartbeat sits right after getStatus (not after machines) — see source.
@@ -80,7 +81,8 @@ const allDefinitions = [
     roosyncManageDefinition,
     roosyncCleanupMessagesDefinition,
     roosyncAttachmentsDefinition,
-    roosyncDashboardDefinition
+    roosyncDashboardDefinition,
+    roosyncClaimDefinition
 ];
 
 describe('tool-definitions.ts — Schema Validation', () => {

--- a/servers/roo-state-manager/src/tools/claims/__tests__/claim.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/claims/__tests__/claim.tool.test.ts
@@ -1,0 +1,468 @@
+/**
+ * Tests for claim.tool.ts — Pre-claim enforcement (#1836)
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+
+const { mockGetSharedStatePath } = vi.hoisted(() => ({
+	mockGetSharedStatePath: vi.fn()
+}));
+
+const { mockGetLocalMachineId } = vi.hoisted(() => ({
+	mockGetLocalMachineId: vi.fn()
+}));
+
+vi.mock('../../../utils/shared-state-path.js', () => ({
+	getSharedStatePath: mockGetSharedStatePath
+}));
+
+vi.mock('../../../utils/message-helpers.js', () => ({
+	getLocalMachineId: mockGetLocalMachineId
+}));
+
+vi.mock('../../../utils/logger.js', () => ({
+	createLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+	Logger: class {}
+}));
+
+vi.mock('../../roosync/heartbeat-activity.js', () => ({
+	recordRooSyncActivityAsync: vi.fn()
+}));
+
+import { handleClaimTool, ClaimToolArgsSchema } from '../claim.tool.js';
+
+describe('claim.tool', () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claim-test-'));
+		mockGetSharedStatePath.mockReturnValue(tmpDir);
+		mockGetLocalMachineId.mockReturnValue('test-machine');
+		vi.clearAllMocks();
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+	});
+
+	// ============================================================
+	// Schema validation
+	// ============================================================
+
+	describe('schema', () => {
+		test('requires action', () => {
+			const result = ClaimToolArgsSchema.safeParse({});
+			expect(result.success).toBe(false);
+		});
+
+		test('claim requires issue_number and eta_minutes', () => {
+			const result = ClaimToolArgsSchema.safeParse({ action: 'claim' });
+			expect(result.success).toBe(false);
+		});
+
+		test('valid claim args pass', () => {
+			const result = ClaimToolArgsSchema.safeParse({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30
+			});
+			expect(result.success).toBe(true);
+		});
+
+		test('check requires issue_number', () => {
+			const result = ClaimToolArgsSchema.safeParse({ action: 'check' });
+			expect(result.success).toBe(false);
+		});
+
+		test('release requires claim_id or issue_number', () => {
+			const result = ClaimToolArgsSchema.safeParse({ action: 'release' });
+			expect(result.success).toBe(false);
+		});
+
+		test('extend requires claim_id or issue_number and additional_minutes', () => {
+			const result = ClaimToolArgsSchema.safeParse({ action: 'extend' });
+			expect(result.success).toBe(false);
+		});
+
+		test('list requires no extra params', () => {
+			const result = ClaimToolArgsSchema.safeParse({ action: 'list' });
+			expect(result.success).toBe(true);
+		});
+	});
+
+	// ============================================================
+	// Claim action
+	// ============================================================
+
+	describe('claim', () => {
+		test('creates a claim successfully', async () => {
+			const result = await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30
+			});
+
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.status).toBe('claimed');
+			expect(data.issue_number).toBe('1836');
+			expect(data.claim_id).toMatch(/^claim-/);
+			expect(result.isError).toBeFalsy();
+
+			// Verify file was written
+			const claimsPath = path.join(tmpDir, 'claims', 'active-claims.json');
+			const file = JSON.parse(await fs.readFile(claimsPath, 'utf-8'));
+			expect(file.claims).toHaveLength(1);
+			expect(file.claims[0].issue_number).toBe('1836');
+			expect(file.claims[0].status).toBe('active');
+		});
+
+		test('conflicts on double-claim', async () => {
+			await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30
+			});
+
+			const result = await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 60,
+				agent: 'other-machine'
+			});
+
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.status).toBe('conflict');
+			expect(data.claim.claimed_by).toBe('test-machine');
+			expect(result.isError).toBe(true);
+		});
+
+		test('uses provided agent name', async () => {
+			const result = await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30,
+				agent: 'custom-agent'
+			});
+
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.claim_id).toContain('custom-agent');
+		});
+
+		test('stores branch if provided', async () => {
+			await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30,
+				branch: 'wt/1836-claim-api'
+			});
+
+			const claimsPath = path.join(tmpDir, 'claims', 'active-claims.json');
+			const file = JSON.parse(await fs.readFile(claimsPath, 'utf-8'));
+			expect(file.claims[0].branch).toBe('wt/1836-claim-api');
+		});
+
+		test('sets expiry to eta_minutes * 1.5', async () => {
+			const before = Date.now();
+			await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30
+			});
+
+			const claimsPath = path.join(tmpDir, 'claims', 'active-claims.json');
+			const file = JSON.parse(await fs.readFile(claimsPath, 'utf-8'));
+			const expiresAt = new Date(file.claims[0].expires_at).getTime();
+			const startedAt = new Date(file.claims[0].started_at).getTime();
+			const diffMinutes = (expiresAt - startedAt) / 60000;
+			expect(diffMinutes).toBe(45); // 30 * 1.5
+		});
+	});
+
+	// ============================================================
+	// Check action
+	// ============================================================
+
+	describe('check', () => {
+		test('returns available when not claimed', async () => {
+			const result = await handleClaimTool({
+				action: 'check',
+				issue_number: '1836'
+			});
+
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.status).toBe('available');
+			expect(data.issue_number).toBe('1836');
+		});
+
+		test('returns claimed when active claim exists', async () => {
+			await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30
+			});
+
+			const result = await handleClaimTool({
+				action: 'check',
+				issue_number: '1836'
+			});
+
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.status).toBe('claimed');
+			expect(data.claim.claimed_by).toBe('test-machine');
+			expect(data.claim.started_ago_minutes).toBeGreaterThanOrEqual(0);
+		});
+	});
+
+	// ============================================================
+	// Release action
+	// ============================================================
+
+	describe('release', () => {
+		test('releases by claim_id', async () => {
+			const claimResult = await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30
+			});
+			const claimId = JSON.parse(claimResult.content[0].text as string).claim_id;
+
+			const result = await handleClaimTool({
+				action: 'release',
+				claim_id: claimId
+			});
+
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.status).toBe('released');
+			expect(data.issue_number).toBe('1836');
+		});
+
+		test('releases by issue_number', async () => {
+			await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30
+			});
+
+			const result = await handleClaimTool({
+				action: 'release',
+				issue_number: '1836'
+			});
+
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.status).toBe('released');
+		});
+
+		test('returns not_found for unknown claim_id', async () => {
+			const result = await handleClaimTool({
+				action: 'release',
+				claim_id: 'claim-nonexistent'
+			});
+
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.status).toBe('not_found');
+		});
+
+		test('allows re-claim after release', async () => {
+			await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30
+			});
+			await handleClaimTool({
+				action: 'release',
+				issue_number: '1836'
+			});
+
+			const result = await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 60
+			});
+
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.status).toBe('claimed');
+		});
+	});
+
+	// ============================================================
+	// Extend action
+	// ============================================================
+
+	describe('extend', () => {
+		test('extends a claim by additional_minutes', async () => {
+			await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30
+			});
+
+			const result = await handleClaimTool({
+				action: 'extend',
+				issue_number: '1836',
+				additional_minutes: 20
+			});
+
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.status).toBe('extended');
+			expect(data.total_eta_minutes).toBe(50);
+		});
+
+		test('updates expires_at when extending', async () => {
+			await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30
+			});
+
+			const claimsPath = path.join(tmpDir, 'claims', 'active-claims.json');
+			const before = JSON.parse(await fs.readFile(claimsPath, 'utf-8'));
+			const oldExpiry = new Date(before.claims[0].expires_at);
+
+			await handleClaimTool({
+				action: 'extend',
+				issue_number: '1836',
+				additional_minutes: 15
+			});
+
+			const after = JSON.parse(await fs.readFile(claimsPath, 'utf-8'));
+			const newExpiry = new Date(after.claims[0].expires_at);
+			expect(newExpiry.getTime()).toBeGreaterThan(oldExpiry.getTime());
+		});
+
+		test('returns not_found for non-active claim', async () => {
+			const result = await handleClaimTool({
+				action: 'extend',
+				issue_number: '9999',
+				additional_minutes: 10
+			});
+
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.status).toBe('not_found');
+		});
+	});
+
+	// ============================================================
+	// List action
+	// ============================================================
+
+	describe('list', () => {
+		test('returns empty when no claims', async () => {
+			const result = await handleClaimTool({
+				action: 'list'
+			});
+
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.status).toBe('ok');
+			expect(data.count).toBe(0);
+			expect(data.claims).toEqual([]);
+		});
+
+		test('lists active claims', async () => {
+			await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30
+			});
+			await handleClaimTool({
+				action: 'claim',
+				issue_number: '1837',
+				eta_minutes: 45,
+				agent: 'other-machine'
+			});
+
+			const result = await handleClaimTool({ action: 'list' });
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.count).toBe(2);
+			expect(data.claims[0].issue_number).toBe('1836');
+			expect(data.claims[1].issue_number).toBe('1837');
+		});
+
+		test('excludes released claims from list', async () => {
+			await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30
+			});
+			await handleClaimTool({
+				action: 'claim',
+				issue_number: '1837',
+				eta_minutes: 45
+			});
+			await handleClaimTool({
+				action: 'release',
+				issue_number: '1836'
+			});
+
+			const result = await handleClaimTool({ action: 'list' });
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.count).toBe(1);
+			expect(data.claims[0].issue_number).toBe('1837');
+		});
+	});
+
+	// ============================================================
+	// Auto-expiry
+	// ============================================================
+
+	describe('auto-expiry', () => {
+		test('expired claims are marked on read', async () => {
+			await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30
+			});
+
+			// Manually expire the claim
+			const claimsPath = path.join(tmpDir, 'claims', 'active-claims.json');
+			const file = JSON.parse(await fs.readFile(claimsPath, 'utf-8'));
+			file.claims[0].expires_at = new Date(Date.now() - 10000).toISOString();
+			await fs.writeFile(claimsPath, JSON.stringify(file, null, 2));
+
+			const result = await handleClaimTool({ action: 'list' });
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.count).toBe(0);
+		});
+
+		test('expired claim allows re-claim', async () => {
+			await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 30
+			});
+
+			// Manually expire
+			const claimsPath = path.join(tmpDir, 'claims', 'active-claims.json');
+			const file = JSON.parse(await fs.readFile(claimsPath, 'utf-8'));
+			file.claims[0].expires_at = new Date(Date.now() - 10000).toISOString();
+			await fs.writeFile(claimsPath, JSON.stringify(file, null, 2));
+
+			const result = await handleClaimTool({
+				action: 'claim',
+				issue_number: '1836',
+				eta_minutes: 60
+			});
+
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.status).toBe('claimed');
+		});
+	});
+
+	// ============================================================
+	// Error handling
+	// ============================================================
+
+	describe('error handling', () => {
+		test('returns error for unknown action', async () => {
+			const result = await handleClaimTool({
+				action: 'unknown' as any
+			});
+
+			const data = JSON.parse(result.content[0].text as string);
+			expect(data.status).toBe('error');
+			expect(data.message).toContain('Unknown action');
+		});
+	});
+});

--- a/servers/roo-state-manager/src/tools/claims/claim.tool.ts
+++ b/servers/roo-state-manager/src/tools/claims/claim.tool.ts
@@ -1,0 +1,377 @@
+/**
+ * MCP tool: roosync_claim
+ *
+ * Pre-claim enforcement — prevents concurrent agent collisions.
+ * Actions: claim, release, extend, list, check.
+ *
+ * Claims are stored in {sharedPath}/claims/active-claims.json.
+ * Auto-expire after eta_minutes * 1.5.
+ *
+ * @module tools/claims
+ * @version 1.0.0
+ * @issue #1836
+ */
+
+import { z } from 'zod';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { createLogger, type Logger } from '../../utils/logger.js';
+import { getLocalMachineId } from '../../utils/message-helpers.js';
+import { getSharedStatePath } from '../../utils/shared-state-path.js';
+import { recordRooSyncActivityAsync } from '../roosync/heartbeat-activity.js';
+
+const logger: Logger = createLogger('ClaimTool');
+
+// ============================================================
+// Types
+// ============================================================
+
+interface Claim {
+	id: string;
+	issue_number: string;
+	agent: string;
+	workspace: string;
+	started_at: string;
+	eta_minutes: number;
+	expires_at: string;
+	status: 'active' | 'released' | 'expired';
+	branch?: string;
+	pr_url?: string;
+}
+
+interface ClaimsFile {
+	claims: Claim[];
+	last_updated: string;
+}
+
+// ============================================================
+// Schema
+// ============================================================
+
+export const ClaimToolArgsSchema = z.object({
+	action: z.enum(['claim', 'release', 'extend', 'list', 'check']).describe(
+		'Action: "claim" (reserve issue), "release" (free claim), "extend" (prolong), "list" (active claims), "check" (verify issue status)'
+	),
+	issue_number: z.string().describe(
+		'Issue number (e.g., "1836"). Required for claim/check/release/extend.'
+	).optional(),
+	agent: z.string().describe(
+		'Agent identifier (machine ID). Defaults to local machine.'
+	).optional(),
+	eta_minutes: z.number().describe(
+		'Estimated time in minutes. Required for claim, optional for extend.'
+	).optional(),
+	branch: z.string().describe(
+		'Git branch name for the claim (optional).'
+	).optional(),
+	claim_id: z.string().describe(
+		'Claim ID. Required for release/extend.'
+	).optional(),
+	additional_minutes: z.number().describe(
+		'Additional minutes for extend action.'
+	).optional(),
+}).superRefine((data, ctx) => {
+	if ((data.action === 'claim' || data.action === 'check') && !data.issue_number) {
+		ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'issue_number is required for claim and check actions', path: ['issue_number'] });
+	}
+	if ((data.action === 'release' || data.action === 'extend') && !data.claim_id && !data.issue_number) {
+		ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'claim_id or issue_number is required for release/extend actions', path: ['claim_id'] });
+	}
+	if (data.action === 'claim' && !data.eta_minutes) {
+		ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'eta_minutes is required for claim action', path: ['eta_minutes'] });
+	}
+	if (data.action === 'extend' && !data.additional_minutes) {
+		ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'additional_minutes is required for extend action', path: ['additional_minutes'] });
+	}
+});
+
+export type ClaimToolArgs = z.infer<typeof ClaimToolArgsSchema>;
+
+// ============================================================
+// Storage
+// ============================================================
+
+function getClaimsFilePath(): string {
+	const sharedPath = getSharedStatePath();
+	return path.join(sharedPath, 'claims', 'active-claims.json');
+}
+
+async function readClaims(): Promise<ClaimsFile> {
+	const filePath = getClaimsFilePath();
+	try {
+		const raw = await fs.readFile(filePath, 'utf-8');
+		return JSON.parse(raw);
+	} catch {
+		return { claims: [], last_updated: new Date().toISOString() };
+	}
+}
+
+async function writeClaims(data: ClaimsFile): Promise<void> {
+	const filePath = getClaimsFilePath();
+	const dir = path.dirname(filePath);
+	await fs.mkdir(dir, { recursive: true });
+	data.last_updated = new Date().toISOString();
+	await fs.writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+function expireOldClaims(claims: Claim[]): Claim[] {
+	const now = new Date();
+	return claims.map(c => {
+		if (c.status === 'active' && new Date(c.expires_at) < now) {
+			return { ...c, status: 'expired' as const };
+		}
+		return c;
+	});
+}
+
+function generateClaimId(agent: string): string {
+	const now = new Date();
+	const ts = now.toISOString().replace(/[-:T]/g, '').slice(0, 15);
+	return `claim-${ts}-${agent}`;
+}
+
+// ============================================================
+// Handlers
+// ============================================================
+
+async function handleClaim(args: ClaimToolArgs): Promise<string> {
+	const agent = args.agent || getLocalMachineId();
+	const issueNumber = args.issue_number!;
+	const etaMinutes = args.eta_minutes!;
+
+	let data = await readClaims();
+	data.claims = expireOldClaims(data.claims);
+
+	// Check for existing active claim
+	const existing = data.claims.find(
+		c => c.issue_number === issueNumber && c.status === 'active'
+	);
+
+	if (existing) {
+		const startedAgo = Math.round((Date.now() - new Date(existing.started_at).getTime()) / 60000);
+		return JSON.stringify({
+			status: 'conflict',
+			message: `Issue #${issueNumber} is already claimed`,
+			claim: {
+				claimed_by: existing.agent,
+				claim_id: existing.id,
+				started_at: existing.started_at,
+				eta_minutes: existing.eta_minutes,
+				started_ago_minutes: startedAgo,
+				expires_at: existing.expires_at,
+				branch: existing.branch,
+			},
+			action: 'STOP — do not work on this issue. Contact coordinator for arbitration.',
+		});
+	}
+
+	// Create new claim
+	const now = new Date();
+	const expiresAt = new Date(now.getTime() + etaMinutes * 1.5 * 60000);
+	const claim: Claim = {
+		id: generateClaimId(agent),
+		issue_number: issueNumber,
+		agent,
+		workspace: process.env.ROOSYNC_MACHINE_ID || 'unknown',
+		started_at: now.toISOString(),
+		eta_minutes: etaMinutes,
+		expires_at: expiresAt.toISOString(),
+		status: 'active',
+		branch: args.branch,
+	};
+
+	data.claims.push(claim);
+	await writeClaims(data);
+
+	recordRooSyncActivityAsync('claim_created');
+
+	logger.info(`Claim created: ${claim.id} for #${issueNumber} by ${agent}`);
+	return JSON.stringify({
+		status: 'claimed',
+		claim_id: claim.id,
+		issue_number: issueNumber,
+		expires_at: claim.expires_at,
+		message: `Issue #${issueNumber} claimed by ${agent}. Post [CLAIMED] to dashboard with this claim_id.`,
+	});
+}
+
+async function handleRelease(args: ClaimToolArgs): Promise<string> {
+	let data = await readClaims();
+	data.claims = expireOldClaims(data.claims);
+
+	const claim = data.claims.find(c => {
+		if (args.claim_id) return c.id === args.claim_id;
+		if (args.issue_number) return c.issue_number === args.issue_number && c.status === 'active';
+		return false;
+	});
+
+	if (!claim) {
+		return JSON.stringify({
+			status: 'not_found',
+			message: args.claim_id
+				? `Claim ${args.claim_id} not found`
+				: `No active claim for issue #${args.issue_number}`,
+		});
+	}
+
+	claim.status = 'released';
+	await writeClaims(data);
+
+	logger.info(`Claim released: ${claim.id} for #${claim.issue_number}`);
+	return JSON.stringify({
+		status: 'released',
+		claim_id: claim.id,
+		issue_number: claim.issue_number,
+		message: `Claim released for issue #${claim.issue_number}`,
+	});
+}
+
+async function handleExtend(args: ClaimToolArgs): Promise<string> {
+	const additionalMinutes = args.additional_minutes!;
+
+	let data = await readClaims();
+	data.claims = expireOldClaims(data.claims);
+
+	const claim = data.claims.find(c => {
+		if (args.claim_id) return c.id === args.claim_id && c.status === 'active';
+		if (args.issue_number) return c.issue_number === args.issue_number && c.status === 'active';
+		return false;
+	});
+
+	if (!claim) {
+		return JSON.stringify({
+			status: 'not_found',
+			message: args.claim_id
+				? `Active claim ${args.claim_id} not found`
+				: `No active claim for issue #${args.issue_number}`,
+		});
+	}
+
+	const newExpiry = new Date(new Date(claim.expires_at).getTime() + additionalMinutes * 60000);
+	claim.expires_at = newExpiry.toISOString();
+	claim.eta_minutes += additionalMinutes;
+
+	await writeClaims(data);
+
+	logger.info(`Claim extended: ${claim.id}, +${additionalMinutes}min`);
+	return JSON.stringify({
+		status: 'extended',
+		claim_id: claim.id,
+		issue_number: claim.issue_number,
+		new_expires_at: claim.expires_at,
+		total_eta_minutes: claim.eta_minutes,
+		message: `Claim extended by ${additionalMinutes} minutes`,
+	});
+}
+
+async function handleList(args: ClaimToolArgs): Promise<string> {
+	let data = await readClaims();
+	data.claims = expireOldClaims(data.claims);
+
+	// Persist expiry updates
+	await writeClaims(data);
+
+	const activeClaims = data.claims.filter(c => c.status === 'active');
+
+	if (activeClaims.length === 0) {
+		return JSON.stringify({
+			status: 'ok',
+			count: 0,
+			claims: [],
+			message: 'No active claims',
+		});
+	}
+
+	return JSON.stringify({
+		status: 'ok',
+		count: activeClaims.length,
+		claims: activeClaims.map(c => ({
+			claim_id: c.id,
+			issue_number: c.issue_number,
+			agent: c.agent,
+			started_at: c.started_at,
+			eta_minutes: c.eta_minutes,
+			expires_at: c.expires_at,
+			branch: c.branch,
+		})),
+	});
+}
+
+async function handleCheck(args: ClaimToolArgs): Promise<string> {
+	const issueNumber = args.issue_number!;
+
+	let data = await readClaims();
+	data.claims = expireOldClaims(data.claims);
+
+	const claim = data.claims.find(
+		c => c.issue_number === issueNumber && c.status === 'active'
+	);
+
+	if (!claim) {
+		return JSON.stringify({
+			status: 'available',
+			issue_number: issueNumber,
+			message: `Issue #${issueNumber} is not claimed`,
+		});
+	}
+
+	const startedAgo = Math.round((Date.now() - new Date(claim.started_at).getTime()) / 60000);
+	return JSON.stringify({
+		status: 'claimed',
+		issue_number: issueNumber,
+		claim: {
+			claimed_by: claim.agent,
+			claim_id: claim.id,
+			started_at: claim.started_at,
+			started_ago_minutes: startedAgo,
+			eta_minutes: claim.eta_minutes,
+			expires_at: claim.expires_at,
+			branch: claim.branch,
+		},
+	});
+}
+
+// ============================================================
+// Main handler
+// ============================================================
+
+export async function handleClaimTool(args: ClaimToolArgs): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+	try {
+		let result: string;
+
+		switch (args.action) {
+			case 'claim':
+				result = await handleClaim(args);
+				break;
+			case 'release':
+				result = await handleRelease(args);
+				break;
+			case 'extend':
+				result = await handleExtend(args);
+				break;
+			case 'list':
+				result = await handleList(args);
+				break;
+			case 'check':
+				result = await handleCheck(args);
+				break;
+			default:
+				result = JSON.stringify({ status: 'error', message: `Unknown action: ${args.action}` });
+		}
+
+		// Conflict (double-claim) returns isError so agents can detect it
+		const parsed = JSON.parse(result);
+		const isError = parsed.status === 'conflict';
+
+		return {
+			content: [{ type: 'text' as const, text: result }],
+			...(isError ? { isError: true } : {}),
+		};
+	} catch (error: any) {
+		logger.error(`Claim tool error: ${error.message}`);
+		return {
+			content: [{ type: 'text' as const, text: JSON.stringify({ status: 'error', message: error.message }) }],
+			isError: true,
+		};
+	}
+}

--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -662,6 +662,16 @@ export function registerCallToolHandler(
                }
                break;
            }
+          // #1836: Pre-claim enforcement — prevents concurrent agent collisions
+          case 'roosync_claim': {
+              try {
+                  const m = await import('./claims/claim.tool.js');
+                  result = await m.handleClaimTool(args as any);
+              } catch (error) {
+                  result = { content: [{ type: 'text', text: `Error: ${(error as Error).message}` }], isError: true };
+              }
+              break;
+          }
            default:
                throw new GenericError(`Tool not found: ${name}`, GenericErrorCode.INVALID_ARGUMENT);
        }

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -656,6 +656,27 @@ export const roosyncAttachmentsDefinition = {
 export const roosyncDashboardDefinition = dashboardToolMetadata;
 
 // ============================================================
+// roosync_claim (#1836)
+// ============================================================
+export const roosyncClaimDefinition = {
+    name: 'roosync_claim',
+    description: 'Pre-claim enforcement — prevents concurrent agent collisions. Actions: "claim" (reserve an issue — fails if already claimed), "release" (free a claim), "extend" (prolong ETA), "list" (show active claims), "check" (verify if issue is available). Claims auto-expire after eta * 1.5 minutes.',
+    inputSchema: {
+        type: 'object',
+        properties: {
+            action: { type: 'string', enum: ['claim', 'release', 'extend', 'list', 'check'], description: 'Action: "claim" (reserve issue), "release" (free claim), "extend" (prolong), "list" (active claims), "check" (verify issue status)' },
+            issue_number: { type: 'string', description: 'Issue number (e.g., "1836"). Required for claim/check. Optional for release/extend.' },
+            agent: { type: 'string', description: 'Agent identifier (machine ID). Defaults to local machine.' },
+            eta_minutes: { type: 'number', description: 'Estimated time in minutes. Required for claim action.' },
+            branch: { type: 'string', description: 'Git branch name for the claim (optional).' },
+            claim_id: { type: 'string', description: 'Claim ID. Required for release/extend (or use issue_number).' },
+            additional_minutes: { type: 'number', description: 'Additional minutes for extend action.' }
+        },
+        required: ['action']
+    }
+};
+
+// ============================================================
 // allToolDefinitions — the complete ordered list for ListTools
 // This mirrors the order in the current registerListToolsHandler.
 // ============================================================
@@ -699,5 +720,7 @@ export const allToolDefinitions = [
     roosyncManageDefinition,
     roosyncCleanupMessagesDefinition,
     roosyncAttachmentsDefinition,
-    roosyncDashboardDefinition
+    roosyncDashboardDefinition,
+    // #1836: Pre-claim enforcement
+    roosyncClaimDefinition
 ];

--- a/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
@@ -233,10 +233,11 @@ describe('#1863 Fusion A3: cleanup → manage redirect', () => {
 // Cross-cutting: Definition count and deprecation markers
 // ============================================================
 describe('#1863 Cross-cutting: tool count and deprecation markers', () => {
-  it('allToolDefinitions should still contain all 33 tools (3 deprecated but kept)', () => {
+  it('allToolDefinitions should still contain all 34 tools (3 deprecated but kept)', () => {
     // Before fusions: 33 tools in allToolDefinitions (heartbeat removed in #1609)
-    // After fusions: still 33 (deprecated tools kept for backward compat, not removed from list)
-    expect(allToolDefinitions.length).toBe(33);
+    // After fusions: still 33 + roosync_claim (#1836) = 34
+    // (deprecated tools kept for backward compat, not removed from list)
+    expect(allToolDefinitions.length).toBe(34);
   });
 
   it('deprecated definitions should have DEPRECATED in description', () => {


### PR DESCRIPTION
## Summary
- New MCP tool `roosync_claim` preventing concurrent agent collisions on GitHub issues
- 5 actions: claim, release, extend, list, check
- Claims stored in `{sharedPath}/claims/active-claims.json` with auto-expiry (eta * 1.5)
- Double-claim returns `isError: true` so agents can detect conflicts
- 27 tests covering all actions, schema validation, auto-expiry, and error handling
- Tool count: 33 → 34

## Files changed
- `src/tools/claims/claim.tool.ts` — Tool implementation (5 handlers, Zod schema, JSON file storage)
- `src/tools/claims/__tests__/claim.tool.test.ts` — 27 tests
- `src/tools/tool-definitions.ts` — Static tool definition + allToolDefinitions array
- `src/tools/registry.ts` — TOOL_CAPABILITIES + switch case with dynamic import
- `src/tools/__tests__/tool-definitions.test.ts` — Count 33→34
- `tests/unit/tools/roosync/fusions-1863.test.ts` — Count 33→34

## Test plan
- [x] Build passes (`npm run build`)
- [x] CI test suite passes (9257 tests, 466 files)
- [x] 27 new claim tool tests pass
- [x] Tool count assertions updated to 34

🤖 Generated with [Claude Code](https://claude.com/claude-code)