### PR TITLE
perf(tools): trim tool descriptions -11% tokens, remove 3 deprecated defs (#1922 Phase 2)

### DIFF
--- a/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
@@ -1,6 +1,7 @@
 /**
- * Tests for tool-definitions.ts — static schema validation for all 34 tool definitions.
+ * Tests for tool-definitions.ts — static schema validation for all 31 tool definitions.
  * Ensures structural integrity, naming conventions, and schema correctness.
+ * #1863: 3 deprecated definitions (decision_info, machines, cleanup_messages) removed from tools/list.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -23,11 +24,11 @@ import {
     roosyncCompareConfigDefinition,
     roosyncListDiffsDefinition,
     roosyncDecisionDefinition,
-    roosyncDecisionInfoDefinition,
+    // [REMOVED #1863] roosyncDecisionInfoDefinition — fused into roosync_decision(action: "info")
     roosyncBaselineDefinition,
     roosyncConfigDefinition,
     roosyncInventoryDefinition,
-    roosyncMachinesDefinition,
+    // [REMOVED #1863] roosyncMachinesDefinition — fused into roosync_inventory(type: "machines")
     // #1609: roosyncHeartbeatDefinition removed — auto-heartbeat on any tool call
     roosyncMcpManagementDefinition,
     roosyncStorageManagementDefinition,
@@ -37,16 +38,16 @@ import {
     roosyncSendDefinition,
     roosyncReadDefinition,
     roosyncManageDefinition,
-    roosyncCleanupMessagesDefinition,
+    // [REMOVED #1863] roosyncCleanupMessagesDefinition — fused into roosync_manage(action: "bulk_*")
     roosyncAttachmentsDefinition,
     roosyncDashboardDefinition,
     roosyncClaimDefinition
 } from '../tool-definitions.js';
 
-const EXPECTED_TOOL_COUNT = 34;
+const EXPECTED_TOOL_COUNT = 31;
 
 // Order MUST mirror allToolDefinitions in tool-definitions.ts.
-// heartbeat sits right after getStatus (not after machines) — see source.
+// #1863: 3 deprecated definitions removed from allToolDefinitions
 const allDefinitions = [
     conversationBrowserDefinition,
     taskExportDefinition,
@@ -65,11 +66,11 @@ const allDefinitions = [
     roosyncCompareConfigDefinition,
     roosyncListDiffsDefinition,
     roosyncDecisionDefinition,
-    roosyncDecisionInfoDefinition,
+    // [REMOVED #1863] roosyncDecisionInfoDefinition
     roosyncBaselineDefinition,
     roosyncConfigDefinition,
     roosyncInventoryDefinition,
-    roosyncMachinesDefinition,
+    // [REMOVED #1863] roosyncMachinesDefinition
     // #1609: roosyncHeartbeatDefinition removed — auto-heartbeat on any tool call
     roosyncMcpManagementDefinition,
     roosyncStorageManagementDefinition,
@@ -79,7 +80,7 @@ const allDefinitions = [
     roosyncSendDefinition,
     roosyncReadDefinition,
     roosyncManageDefinition,
-    roosyncCleanupMessagesDefinition,
+    // [REMOVED #1863] roosyncCleanupMessagesDefinition
     roosyncAttachmentsDefinition,
     roosyncDashboardDefinition,
     roosyncClaimDefinition
@@ -88,7 +89,7 @@ const allDefinitions = [
 describe('tool-definitions.ts — Schema Validation', () => {
 
     describe('allToolDefinitions array', () => {
-        it('should have exactly 34 tool definitions', () => {
+        it('should have exactly 31 tool definitions', () => {
             expect(allToolDefinitions).toHaveLength(EXPECTED_TOOL_COUNT);
         });
 
@@ -290,9 +291,8 @@ describe('tool-definitions.ts — Schema Validation', () => {
             expect(actions).toContain('maintenance');
         });
 
-        it('roosync_cleanup_messages should require operation', () => {
-            expect(roosyncCleanupMessagesDefinition.inputSchema.required).toContain('operation');
-        });
+        // #1863: roosync_cleanup_messages test removed — definition removed from tools/list
+        // Backward compat redirect preserved in registry.ts
 
         it('roosync_compare_config should support full granularity', () => {
             const granularity = (roosyncCompareConfigDefinition.inputSchema.properties.granularity as Record<string, unknown>).enum as string[];
@@ -314,9 +314,8 @@ describe('tool-definitions.ts — Schema Validation', () => {
             expect(roosyncDecisionDefinition.inputSchema.required).toContain('decisionId');
         });
 
-        it('roosync_decision_info should require decisionId', () => {
-            expect(roosyncDecisionInfoDefinition.inputSchema.required).toContain('decisionId');
-        });
+        // #1863: roosync_decision_info test removed — definition removed from tools/list
+        // Use roosync_decision(action: "info") instead
 
         it('roosync_attachments should require action', () => {
             expect(roosyncAttachmentsDefinition.inputSchema.required).toContain('action');
@@ -326,9 +325,8 @@ describe('tool-definitions.ts — Schema Validation', () => {
             expect(roosyncInventoryDefinition.inputSchema.required).toContain('type');
         });
 
-        it('roosync_machines should require status', () => {
-            expect(roosyncMachinesDefinition.inputSchema.required).toContain('status');
-        });
+        // #1863: roosync_machines test removed — definition removed from tools/list
+        // Use roosync_inventory(type: "machines") instead
 
         it('export_config should require action', () => {
             expect(exportConfigDefinition.inputSchema.required).toContain('action');
@@ -370,7 +368,8 @@ describe('tool-definitions.ts — Schema Validation', () => {
         const strictTools = [
             roosyncInitDefinition, roosyncGetStatusDefinition, roosyncCompareConfigDefinition,
             roosyncListDiffsDefinition, roosyncBaselineDefinition, roosyncConfigDefinition,
-            roosyncInventoryDefinition, roosyncMachinesDefinition,
+            roosyncInventoryDefinition,
+            // #1863: roosyncMachinesDefinition removed from tools/list
             // #1609: roosyncHeartbeatDefinition removed
             roosyncMcpManagementDefinition, roosyncStorageManagementDefinition,
             roosyncDiagnoseDefinition, roosyncRefreshDashboardDefinition, roosyncUpdateDashboardDefinition

--- a/servers/roo-state-manager/src/tools/__tests__/tool-discoverability.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-discoverability.test.ts
@@ -479,7 +479,7 @@ describe('Category 5: Description Discoverability', () => {
         // Keywords matched case-insensitively against description text
         // Descriptions are mostly in French, so use French keywords where applicable
         'conversation_browser': ['conversation'],
-        'roosync_search': ['recherche', 'tâche'],       // "Outil unifié de recherche dans les tâches Roo"
+        'roosync_search': ['search', 'task'],            // "Search Roo tasks (semantic, text, diagnostic)"
         'roosync_send': ['message'],                     // "Envoyer un message structuré"
         'roosync_read': ['réception', 'message'],        // "Lire la boîte de réception des messages"
         'roosync_config': ['config'],                    // "Gestion de configuration RooSync"

--- a/servers/roo-state-manager/src/tools/conversation/conversation-browser.ts
+++ b/servers/roo-state-manager/src/tools/conversation/conversation-browser.ts
@@ -171,132 +171,132 @@ export interface ConversationBrowserArgs {
  */
 export const conversationBrowserTool: Tool = {
     name: 'conversation_browser',
-    description: 'Outil consolide pour naviguer, visualiser et resumer les conversations Roo et Claude Code (cross-machine via archives GDrive). Actions: "list" (decouvrir les conversations avec filtres), "tree" (arbre parent-enfant), "current" (tache active du workspace), "view" (zoom contenu d\'une conversation, supporte la pagination message-level), "summarize" (resume/synthese), "rebuild" (reconstruire le cache multi-tier roo+claude+archive). Pattern de zoom: list -> view(detail_level=skeleton) -> view(messageStart/messageEnd) -> summarize. Toujours commencer par "list" pour decouvrir les IDs.',
+    description: 'Navigate Roo/Claude conversations (cross-machine via GDrive). Actions: list, tree, current, view, summarize, rebuild. Zoom pattern: list -> view(skeleton) -> view(messageStart/messageEnd) -> summarize. Always "list" first to discover IDs.',
     inputSchema: {
         type: 'object',
         properties: {
             action: {
                 type: 'string',
                 enum: ['list', 'tree', 'current', 'view', 'summarize', 'rebuild'],
-                description: 'Action a effectuer. "list" = decouvrir les conversations (filtres workspace, machineId, startDate/endDate, contentPattern, source). "view" = inspecter une tache (detail_level=skeleton/summary/full, messageStart/messageEnd pour pagination). "summarize" = trace/cluster/synthesis. "tree" = arbre parent-enfant. "rebuild" = reconstruire le cache multi-tier (sources=[roo,claude,archive]).'
+                description: 'Action. list=discover (filters: workspace, machineId, dates, contentPattern, source). view=inspect task (detail_level, messageStart/messageEnd). summarize=trace/cluster/synthesis. tree=parent-child tree. rebuild=cache (sources=[roo,claude,archive]).'
             },
             // --- Arguments list ---
             limit: {
                 type: 'number',
-                description: '[list] Nombre maximum de conversations à retourner (défaut: toutes).'
+                description: '[list] Max conversations to return.'
             },
             sortBy: {
                 type: 'string',
                 enum: ['lastActivity', 'messageCount', 'totalSize'],
-                description: '[list] Critère de tri.',
+                description: '[list] Sort criterion.',
                 default: 'lastActivity'
             },
             sortOrder: {
                 type: 'string',
                 enum: ['asc', 'desc'],
-                description: '[list] Ordre de tri.',
+                description: '[list] Sort order.',
                 default: 'desc'
             },
             pendingSubtaskOnly: {
                 type: 'boolean',
-                description: '[list] Ne retourner que les tâches avec sous-tâche en attente.'
+                description: '[list] Only return tasks with pending subtasks.'
             },
             contentPattern: {
                 type: 'string',
-                description: '[list] Filtre les tâches contenant ce texte dans leurs messages.'
+                description: '[list] Filter tasks containing this text.'
             },
             // --- Arguments tree ---
             conversation_id: {
                 type: 'string',
-                description: '[tree] ID de la conversation pour l\'arbre des tâches.'
+                description: '[tree] Conversation ID for task tree.'
             },
             max_depth: {
                 type: 'number',
-                description: '[tree] Profondeur maximale de l\'arbre.'
+                description: '[tree] Max tree depth.'
             },
             include_siblings: {
                 type: 'boolean',
-                description: '[tree] Inclure les tâches sœurs.',
+                description: '[tree] Include sibling tasks.',
                 default: true
             },
             output_format: {
                 type: 'string',
                 enum: ['json', 'markdown', 'ascii-tree', 'hierarchical'],
-                description: '[tree] Format de sortie.',
+                description: '[tree] Output format.',
                 default: 'json'
             },
             current_task_id: {
                 type: 'string',
-                description: '[tree/view] ID de la tâche en cours pour marquage.'
+                description: '[tree/view] Current task ID for marking.'
             },
             truncate_instruction: {
                 type: 'number',
-                description: '[tree] Longueur max de l\'instruction (défaut: 80).',
+                description: '[tree] Max instruction length (default: 80).',
                 default: 80
             },
             show_metadata: {
                 type: 'boolean',
-                description: '[tree] Afficher les métadonnées détaillées.',
+                description: '[tree] Show detailed metadata.',
                 default: false
             },
             // --- Arguments current ---
             workspace: {
                 type: 'string',
-                description: '[current/view] Chemin du workspace (détection auto si omis).'
+                description: '[current/view] Workspace path (auto-detected if omitted).'
             },
             workspacePathMatch: {
                 type: 'string',
                 enum: ['exact', 'normalized', 'substring'],
-                description: '[list] #1244 Couche 2.2 — Strategie de matching du workspace. "exact": comparaison stricte (apres normalisation forward-slash). "normalized" (defaut): match par basename, tolere les variations de chemin parent (`d:/dev/CoursIA` == `d:/CoursIA`) — strategie cross-machine la plus robuste. "substring": test includes lowercase, le plus tolerant.',
+                description: '[list] Workspace matching strategy. exact=strict, normalized(default)=basename match cross-machine, substring=includes match.',
                 default: 'normalized'
             },
             startDate: {
                 type: 'string',
-                description: '[list] #1244 Couche 2.1 — Date debut (ISO 8601 ou YYYY-MM-DD). Filtre les taches dont lastActivity >= startDate. Combinable avec endDate. Exemple: "2026-04-07".'
+                description: '[list] Start date filter (ISO 8601 or YYYY-MM-DD).'
             },
             endDate: {
                 type: 'string',
-                description: '[list] #1244 Couche 2.1 — Date fin (ISO 8601 ou YYYY-MM-DD). Filtre les taches dont lastActivity <= endDate (inclusif jusqu\'a fin de journee). Exemple: "2026-04-08".'
+                description: '[list] End date filter (ISO 8601 or YYYY-MM-DD, inclusive).'
             },
             machineId: {
                 type: 'string',
-                description: '[list] #1244 Couche 2.1 — Filtre par identifiant machine (cross-machine). Permet d\'isoler les conversations d\'une machine specifique parmi les archives chargees depuis GDrive. Exemple: "myia-po-2025".'
+                description: '[list] Filter by machine ID (cross-machine).'
             },
             // --- Arguments view ---
             task_id: {
                 type: 'string',
-                description: '[view/summarize] ID de la tâche à inspecter. Decouvrir les IDs via action="list" en premier. Pour les sessions Claude Code, le prefixe peut etre "claude-" ; les taches Roo et les archives utilisent l\'UUID brut.'
+                description: '[view/summarize] Task ID to inspect. Use "list" first to discover IDs.'
             },
             view_mode: {
                 type: 'string',
                 enum: ['single', 'chain', 'cluster'],
-                description: '[view] Mode d\'affichage. "single" = une tache, "chain" (defaut) = remonte la chaine parent, "cluster" = arbre enfants.',
+                description: '[view] Display mode. single=one task, chain(default)=parent chain, cluster=child tree.',
                 default: 'chain'
             },
             detail_level: {
                 type: 'string',
                 enum: ['skeleton', 'summary', 'full'],
-                description: '[view] Niveau de detail (zoom progressif). "skeleton" (defaut, ~15k chars) = vue overview ; "summary" (~50k) = contenu principal condense ; "full" (~150k) = sequence complete avec tous les outils. Combiner avec messageStart/messageEnd pour pagination message-level.',
+                description: '[view] Detail level. skeleton(default)=overview, summary=condensed, full=complete. Use messageStart/messageEnd for pagination.',
                 default: 'skeleton'
             },
             truncate: {
                 type: 'number',
-                description: '[view] Lignes à conserver au début/fin (0 = défaut intelligent).',
+                description: '[view] Lines to keep at head/tail (0=auto).',
                 default: 0
             },
             max_output_length: {
                 type: 'number',
-                description: '[view] Limite max de caractères en sortie. Un hard cap final est applique pour garantir le respect de cette limite quel que soit le mode de troncature.',
+                description: '[view] Max output chars (hard cap enforced).',
                 default: 300000
             },
             smart_truncation: {
                 type: 'boolean',
-                description: '[view] #1244 Couche 2.5 — Algorithme de troncature intelligente (gradient temporel + priorisation par type, preserve debut/fin de conversation). Active PAR DEFAUT depuis #1244. Passer false uniquement pour debug ou comparaison avec le legacy path.',
+                description: '[view] Smart truncation (gradient + type prioritization). Default: true.',
                 default: true
             },
             smart_truncation_config: {
                 type: 'object',
-                description: '[view] Configuration avancée pour la troncature intelligente.',
+                description: '[view] Smart truncation config.',
                 properties: {
                     gradientStrength: { type: 'number' },
                     minPreservationRate: { type: 'number' },
@@ -305,155 +305,155 @@ export const conversationBrowserTool: Tool = {
             },
             messageStart: {
                 type: 'number',
-                description: '[view] #1244 Couche 2.6 — Index 0-based du premier message a inclure (inclusif). Permet la pagination message-level sur les longues conversations. Defaut: 0 (debut). Pour paginer, re-appeler view avec messageStart = messageEnd precedent.'
+                description: '[view] 0-based start index (inclusive) for message-level pagination.'
             },
             messageEnd: {
                 type: 'number',
-                description: '[view] #1244 Couche 2.6 — Index 0-based du dernier message a inclure (exclusif). Si > total, est clampe a total. Defaut: jusqu\'a la fin. La reponse inclut messageRange: {start, end, total} et truncated: bool pour faciliter la navigation.'
+                description: '[view] 0-based end index (exclusive). Clamped to total. Response includes messageRange for navigation.'
             },
             output_file: {
                 type: 'string',
-                description: '[view] Chemin pour sauvegarder l\'arbre dans un fichier.'
+                description: '[view] File path to save output.'
             },
             // --- Arguments summarize ---
             summarize_type: {
                 type: 'string',
                 enum: ['trace', 'cluster', 'synthesis'],
-                description: '[summarize] Type de résumé (requis si action=summarize). "trace" = statistiques et timeline. "cluster" = grappes parent-enfant. "synthesis" = pipeline LLM avec analyse sémantique et profils d\'acteurs.'
+                description: '[summarize] Summary type (required). trace=stats+timeline, cluster=parent-child groups, synthesis=LLM analysis.'
             },
             taskId: {
                 type: 'string',
-                description: '[summarize] ID de la tâche (ou tâche racine pour cluster).'
+                description: '[summarize] Task ID (or root task for cluster).'
             },
             source: {
                 type: 'string',
                 enum: ['roo', 'claude', 'all'],
-                description: '[list/summarize] Source des conversations: "roo" (défaut, Roo Code), "claude" (Claude Code sessions), "all" (les deux).',
+                description: '[list/summarize] Conversation source: roo, claude, or all.',
                 default: 'roo'
             },
             filePath: {
                 type: 'string',
-                description: '[summarize] Chemin pour sauvegarder le fichier.'
+                description: '[summarize] Save output to this file.'
             },
             summarize_output_format: {
                 type: 'string',
                 enum: ['markdown', 'html', 'json'],
-                description: '[summarize] Format de sortie.',
+                description: '[summarize] Output format.',
                 default: 'markdown'
             },
             detailLevel: {
                 type: 'string',
                 enum: ['Full', 'NoTools', 'NoResults', 'Messages', 'Summary', 'UserOnly'],
-                description: '[summarize] Niveau de détail du résumé.',
+                description: '[summarize] Detail level.',
                 default: 'Full'
             },
             truncationChars: {
                 type: 'number',
-                description: '[summarize] Chars max avant troncature (0 = pas de troncature).',
+                description: '[summarize] Max chars before truncation (0=no limit).',
                 default: 0
             },
             compactStats: {
                 type: 'boolean',
-                description: '[summarize] Format compact pour les statistiques.',
+                description: '[summarize] Compact stats format.',
                 default: false
             },
             includeCss: {
                 type: 'boolean',
-                description: '[summarize] Inclure le CSS embarqué.',
+                description: '[summarize] Include embedded CSS.',
                 default: true
             },
             generateToc: {
                 type: 'boolean',
-                description: '[summarize] Générer la table des matières.',
+                description: '[summarize] Generate table of contents.',
                 default: true
             },
             startIndex: {
                 type: 'number',
-                description: '[summarize] Index de début (1-based).'
+                description: '[summarize] Start index (1-based).'
             },
             endIndex: {
                 type: 'number',
-                description: '[summarize] Index de fin (1-based).'
+                description: '[summarize] End index (1-based).'
             },
             childTaskIds: {
                 type: 'array',
                 items: { type: 'string' },
-                description: '[summarize/cluster] IDs des tâches enfantes.'
+                description: '[summarize/cluster] Child task IDs.'
             },
             clusterMode: {
                 type: 'string',
                 enum: ['aggregated', 'detailed', 'comparative'],
-                description: '[summarize/cluster] Mode de clustering.',
+                description: '[summarize/cluster] Clustering mode.',
                 default: 'aggregated'
             },
             includeClusterStats: {
                 type: 'boolean',
-                description: '[summarize/cluster] Inclure les statistiques de grappe.',
+                description: '[summarize/cluster] Include cluster stats.',
                 default: true
             },
             crossTaskAnalysis: {
                 type: 'boolean',
-                description: '[summarize/cluster] Activer l\'analyse cross-task.',
+                description: '[summarize/cluster] Enable cross-task analysis.',
                 default: false
             },
             maxClusterDepth: {
                 type: 'number',
-                description: '[summarize/cluster] Profondeur max de grappe.',
+                description: '[summarize/cluster] Max cluster depth.',
                 default: 10
             },
             clusterSortBy: {
                 type: 'string',
                 enum: ['chronological', 'size', 'activity', 'alphabetical'],
-                description: '[summarize/cluster] Critère de tri.',
+                description: '[summarize/cluster] Sort criterion.',
                 default: 'chronological'
             },
             includeClusterTimeline: {
                 type: 'boolean',
-                description: '[summarize/cluster] Inclure la timeline.',
+                description: '[summarize/cluster] Include timeline.',
                 default: false
             },
             clusterTruncationChars: {
                 type: 'number',
-                description: '[summarize/cluster] Troncature spécifique aux grappes.',
+                description: '[summarize/cluster] Cluster-specific truncation chars.',
                 default: 0
             },
             showTaskRelationships: {
                 type: 'boolean',
-                description: '[summarize/cluster] Montrer les relations entre tâches.',
+                description: '[summarize/cluster] Show inter-task relationships.',
                 default: true
             },
             // --- Arguments synthesis ---
             synthesis_output_format: {
                 type: 'string',
                 enum: ['json', 'markdown'],
-                description: '[summarize/synthesis] Format de sortie pour la synthèse LLM. "json" retourne l\'analyse complète, "markdown" retourne la section narrative.',
+                description: '[summarize/synthesis] LLM output format. json=full analysis, markdown=narrative section.',
                 default: 'json'
             },
             // --- Arguments rebuild ---
             force_rebuild: {
                 type: 'boolean',
-                description: '[rebuild] Si true, reconstruit TOUS les squelettes (lent). Si false/omis, ne reconstruit que les manquants/obsolètes.',
+                description: '[rebuild] Rebuild all skeletons (slow). If false, only missing/stale ones.',
                 default: false
             },
             task_ids: {
                 type: 'array',
                 items: { type: 'string' },
-                description: '[rebuild] Liste optionnelle d\'IDs de tâches spécifiques à reconstruire.'
+                description: '[rebuild] Specific task IDs to rebuild.'
             },
             sources: {
                 type: 'array',
                 items: { type: 'string', enum: ['roo', 'claude', 'archive'] },
-                description: '[rebuild] #1244 Couche 1.4 — Sources de squelettes a charger. Defaut: ["roo"]. "claude" inclut les sessions Claude Code locales (Tier 2). "archive" inclut les archives cross-machine GDrive (Tier 3, requiert ROOSYNC_SHARED_PATH).'
+                description: '[rebuild] Skeleton sources. Default: ["roo"]. "claude"=local Claude sessions, "archive"=cross-machine GDrive.'
             },
             reindex: {
                 type: 'boolean',
-                description: '[rebuild] #1244 Couche 1.4 — Si true, force l\'enqueue Qdrant pour tous les squelettes construits/charges (tous tiers).',
+                description: '[rebuild] Force Qdrant reindex for all built/loaded skeletons.',
                 default: false
             },
             // #1752 Bug #3: Expose GDrive archive support in inputSchema
             includeArchives: {
                 type: 'boolean',
-                description: '[list] #1752 — Inclure les archives cross-machine depuis GDrive (Tier 3). Quand true, conversation_browser list charge les squelettes archives d\'autres machines via TaskArchiver. Defaut: false (seules les conversations locales sont retournees). Requiert ROOSYNC_SHARED_PATH configure.',
+                description: '[list] Include cross-machine GDrive archives (Tier 3). Requires ROOSYNC_SHARED_PATH.',
                 default: false
             }
         },

--- a/servers/roo-state-manager/src/tools/export/export-data.ts
+++ b/servers/roo-state-manager/src/tools/export/export-data.ts
@@ -81,93 +81,81 @@ export interface ExportDataArgs {
  */
 export const exportDataTool: Tool = {
     name: 'export_data',
-    description: `Outil consolidé pour exporter des données au format XML, JSON ou CSV.
-
-Cibles supportées:
-- task: Export d'une tâche individuelle (XML uniquement)
-- conversation: Export d'une conversation complète (tous formats)
-- project: Export d'un projet entier (XML uniquement)
-
-Formats supportés:
-- xml: Format XML structuré
-- json: Format JSON avec variantes light/full
-- csv: Format CSV avec variantes conversations/messages/tools
-
-CONS-10: Remplace export_tasks_xml, export_conversation_xml, export_project_xml, export_conversation_json, export_conversation_csv`,
+    description: 'Export data as XML, JSON or CSV. Targets: task (XML), conversation (all formats), project (XML). JSON variants: light/full. CSV variants: conversations/messages/tools.',
     inputSchema: {
         type: 'object',
         properties: {
             target: {
                 type: 'string',
                 enum: ['task', 'conversation', 'project'],
-                description: 'Cible de l\'export: task, conversation, ou project'
+                description: 'Export target: task, conversation, or project'
             },
             format: {
                 type: 'string',
                 enum: ['xml', 'json', 'csv'],
-                description: 'Format de sortie: xml, json, ou csv'
+                description: 'Output format: xml, json, or csv'
             },
             taskId: {
                 type: 'string',
-                description: 'ID de la tâche (requis pour target=task, ou conversation avec json/csv)'
+                description: 'Task ID (required for target=task, or conversation with json/csv)'
             },
             conversationId: {
                 type: 'string',
-                description: 'ID de la conversation racine (requis pour target=conversation avec xml)'
+                description: 'Root conversation ID (required for target=conversation with xml)'
             },
             projectPath: {
                 type: 'string',
-                description: 'Chemin du projet (requis pour target=project)'
+                description: 'Project path (required for target=project)'
             },
             filePath: {
                 type: 'string',
-                description: 'Chemin de sortie pour le fichier. Si non fourni, retourne le contenu.'
+                description: 'Output file path. If omitted, returns content inline.'
             },
             // Options XML
             includeContent: {
                 type: 'boolean',
-                description: 'Inclure le contenu complet des messages (XML, défaut: false)'
+                description: 'Include full message content (XML, default: false)'
             },
             prettyPrint: {
                 type: 'boolean',
-                description: 'Indenter pour lisibilité (XML, défaut: true)'
+                description: 'Indent for readability (XML, default: true)'
             },
             maxDepth: {
                 type: 'integer',
-                description: 'Profondeur max de l\'arbre de tâches (XML conversation)'
+                description: 'Max tree depth (XML conversation)'
             },
             startDate: {
                 type: 'string',
-                description: 'Date de début ISO 8601 pour filtrer (XML project)'
+                description: 'ISO 8601 start date filter (XML project)'
             },
             endDate: {
                 type: 'string',
-                description: 'Date de fin ISO 8601 pour filtrer (XML project)'
+                description: 'ISO 8601 end date filter (XML project)'
             },
             // Options JSON
             jsonVariant: {
                 type: 'string',
                 enum: ['light', 'full'],
-                description: 'Variante JSON: light (squelette) ou full (détail complet)'
+                description: 'JSON variant: light (skeleton) or full (complete)'
             },
             // Options CSV
             csvVariant: {
                 type: 'string',
                 enum: ['conversations', 'messages', 'tools'],
-                description: 'Variante CSV: conversations, messages, ou tools'
+                description: 'CSV variant: conversations, messages, or tools'
             },
             // Options communes
             truncationChars: {
                 type: 'number',
-                description: 'Max caractères avant troncature (0 = pas de troncature)'
+                description: 'Max chars before truncation (0 = no truncation)'
             },
             startIndex: {
                 type: 'number',
-                description: 'Index de début (1-based) pour plage de messages'
+                description: 'Start index (1-based) for message range'
             },
             endIndex: {
                 type: 'number',
-                description: 'Index de fin (1-based) pour plage de messages'
+                description: 'End index (1-based) for message range'
             }
         },
         required: ['target', 'format']

--- a/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
@@ -92,109 +92,109 @@ export interface RooSyncIndexingArgs {
  */
 export const roosyncIndexingTool: Tool = {
     name: 'roosync_indexing',
-    description: "Outil unifié de gestion de l'index sémantique, du cache et de l'archivage (indexation, reset, rebuild, diagnostic, archive Roo/Claude Code, cleanup orphelins #1821)",
+    description: 'Manage semantic index, cache, and archiving (index, reset, rebuild, diagnose, archive, status, cleanup, garbage_scan, cleanup_orphans)',
     inputSchema: {
         type: 'object',
         properties: {
             action: {
                 type: 'string',
                 enum: ['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'cleanup', 'garbage_scan', 'cleanup_orphans'],
-                description: "Action: 'index' (indexer une tâche dans Qdrant), 'reset' (réinitialiser la collection Qdrant), 'rebuild' (reconstruire l'index SQLite VS Code), 'diagnose' (diagnostic complet de l'index), 'archive' (archiver une tâche Roo ou les sessions Claude Code sur GDrive), 'status' (état du background indexer et métriques), 'cleanup' (supprimer les vecteurs plus anciens qu'un âge donné #1658), 'garbage_scan' (détecter/nettoyer les tâches garbage #1786), 'cleanup_orphans' (détecter/supprimer les vecteurs Qdrant dont les fichiers source n'existent plus #1821)"
+                description: 'Action: index (Qdrant), reset (collection), rebuild (SQLite index), diagnose (health check), archive (GDrive), status (metrics), cleanup (old vectors), garbage_scan (detect junk), cleanup_orphans (remove orphaned vectors)'
             },
             task_id: {
                 type: 'string',
-                description: 'ID de la tâche à indexer (requis pour action=index)'
+                description: 'Task ID to index (required for action=index)'
             },
             confirm: {
                 type: 'boolean',
-                description: 'Confirmation obligatoire pour action=reset',
+                description: 'Required confirmation for action=reset',
                 default: false
             },
             workspace_filter: {
                 type: 'string',
-                description: 'Filtre optionnel par workspace (pour action=rebuild)'
+                description: 'Workspace filter (for rebuild)'
             },
             max_tasks: {
                 type: 'number',
-                description: 'Nombre maximum de tâches à traiter (pour action=rebuild, 0 = toutes)',
+                description: 'Max tasks to process (for rebuild, 0 = all)',
                 default: 0
             },
             dry_run: {
                 type: 'boolean',
-                description: 'Mode simulation sans modification (pour action=rebuild)',
+                description: 'Simulation mode (for rebuild, garbage_scan, cleanup_orphans)',
                 default: false
             },
             machine_id: {
                 type: 'string',
-                description: 'Filtre par machine (pour action=archive, liste les archives de cette machine uniquement)'
+                description: 'Machine filter (for archive, list archives for this machine)'
             },
             claude_code_sessions: {
                 type: 'boolean',
-                description: 'Archiver les sessions Claude Code (pour action=archive) - DÉSACTIVÉ: sessions sanctuarisées #1621',
+                description: 'Archive Claude Code sessions (BLOCKED - sessions are sanctuary).',
                 default: false
             },
             max_sessions: {
                 type: 'number',
-                description: 'Nombre max de sessions Claude Code à archiver (pour action=archive avec claude_code_sessions=true, 0 = toutes)',
+                description: 'Max Claude Code sessions to archive (0 = all).',
                 default: 0
             },
             source: {
                 type: 'string',
                 enum: ['roo', 'claude-code'],
-                description: "#604: Source de la conversation (pour action=index). 'roo' = tâche Roo standard, 'claude-code' = session Claude Code JSONL. Par défaut: 'roo'"
+                description: 'Conversation source for action=index. "roo" (default) or "claude-code".'
             },
             max_age_days: {
                 type: 'number',
-                description: "#1658: Pour action=cleanup. Âge maximum en jours des vecteurs à conserver. Les vecteurs dont le timestamp est antérieur à (now - max_age_days) seront supprimés. Défaut: 90.",
+                description: 'For cleanup. Max age in days of vectors to keep (default: 90).',
                 default: 90
             },
             workspace_name_filter: {
                 type: 'string',
-                description: "#1658: Pour action=cleanup. Filtre optionnel par workspace_name pour limiter le cleanup à un workspace spécifique."
+                description: 'For cleanup. Optional workspace_name filter.'
             },
             deep: {
                 type: 'boolean',
-                description: "#1244: Pour action=diagnose. Active le diagnostic approfondi (scroll d'un échantillon, distribution source/workspace_name, field coverage, payload samples). Permet de détecter les bugs d'indexation (champs manquants, dimension mismatch).",
+                description: 'For diagnose. Enable deep diagnostic (scroll sample, source/workspace distribution, field coverage).',
                 default: false
             },
             sample_size: {
                 type: 'number',
-                description: "#1244: Pour action=diagnose avec deep=true. Taille de l'échantillon Qdrant à scroll. Défaut 1000, max 5000.",
+                description: 'For diagnose with deep=true. Qdrant scroll sample size. Default 1000, max 5000.',
                 default: 1000
             },
             top_n_workspaces: {
                 type: 'number',
-                description: "#1244: Pour action=diagnose avec deep=true. Nombre de top workspace_name à reporter dans la distribution. Défaut 20, max 100.",
+                description: 'For diagnose with deep=true. Top workspace_name count to report. Default 20, max 100.',
                 default: 20
             },
             garbage_category: {
                 type: 'string',
                 enum: ['death_spiral', 'duplicate', 'low_value', 'all'],
-                description: "#1786: Pour action=garbage_scan. Catégorie de garbage à détecter. 'death_spiral' (erreurs en boucle), 'duplicate' (sessions dupliquées), 'low_value' (taux d'erreur élevé, quasi-zéro output assistant), 'all' (toutes). Défaut: all"
+                description: 'For garbage_scan. Category: death_spiral, duplicate, low_value, all. Default: all'
             },
             min_messages: {
                 type: 'number',
-                description: "#1786: Pour action=garbage_scan. Nombre minimum de messages pour qu'une tâche soit scannée. Défaut: 10.",
+                description: 'For garbage_scan. Min messages for a task to be scanned. Default: 10.',
                 default: 10
             },
             max_results: {
                 type: 'number',
-                description: "#1786: Pour action=garbage_scan. Nombre maximum de résultats retournés. Défaut: 100.",
+                description: 'For garbage_scan. Max results returned. Default: 100.',
                 default: 100
             },
             remove_skeletons: {
                 type: 'boolean',
-                description: "#1786: Pour action=garbage_scan avec dry_run=false. Supprimer les fichiers skeleton garbage. Défaut: true.",
+                description: 'For garbage_scan with dry_run=false. Delete garbage skeleton files. Default: true.',
                 default: true
             },
             remove_vectors: {
                 type: 'boolean',
-                description: "#1786: Pour action=garbage_scan avec dry_run=false. Supprimer les vecteurs Qdrant garbage. Défaut: true.",
+                description: 'For garbage_scan with dry_run=false. Delete garbage Qdrant vectors. Default: true.',
                 default: true
             },
             confirm_orphan_cleanup: {
                 type: 'boolean',
-                description: "#1821: Pour action=cleanup_orphans avec dry_run=false. Confirmation obligatoire pour la suppression des vecteurs orphelins. Défaut: false.",
+                description: 'For cleanup_orphans with dry_run=false. Required confirmation. Default: false.',
                 default: false
             }
         },

--- a/servers/roo-state-manager/src/tools/roosync/config.ts
+++ b/servers/roo-state-manager/src/tools/roosync/config.ts
@@ -14,14 +14,14 @@ export type ClaudeCodeScope = 'user' | 'project' | 'settings';
  */
 export const ConfigArgsSchema = z.object({
   // Action requise
-  action: z.enum(['collect', 'publish', 'apply', 'apply_profile']).describe('Action à effectuer: collect (collecte config locale), publish (publication vers GDrive), apply (application depuis GDrive), apply_profile (appliquer un profil de modèle)'),
+  action: z.enum(['collect', 'publish', 'apply', 'apply_profile']).describe('Action: collect, publish, apply, or apply_profile'),
 
   // Paramètres communs
-  machineId: z.string().optional().describe('ID de la machine (optionnel, utilise ROOSYNC_MACHINE_ID par défaut)'),
-  dryRun: z.boolean().optional().describe('Si true, simule l\'opération sans modifier les fichiers. Défaut: false'),
+  machineId: z.string().optional().describe('Machine ID (default: ROOSYNC_MACHINE_ID)'),
+  dryRun: z.boolean().optional().describe('Simulate without modifying files (default: false)'),
 
   // Scope Claude Code (#601)
-  scope: z.enum(['user', 'project', 'settings']).optional().describe('Scope Claude Code pour les configs MCP: user (~/.claude.json), project (.mcp.json), settings (~/.claude/settings.json). Défaut: user'),
+  scope: z.enum(['user', 'project', 'settings']).optional().describe('Claude Code config scope: user (~/.claude.json), project (.mcp.json), settings (~/.claude/settings.json). Default: user'),
 
   // Pour collect et apply
   targets: z.array(z.string()).optional().refine(
@@ -41,19 +41,19 @@ export const ConfigArgsSchema = z.object({
     {
       message: "Target invalide. Valeurs acceptées: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, ou mcp:<nomServeur>"
     }
-  ).describe('Liste des cibles à collecter/appliquer (modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, ou mcp:<nomServeur>). Défaut: ["modes", "mcp"]'),
+  ).describe('Targets: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, mcp:<server>. Default: ["modes", "mcp"]'),
 
   // Pour publish (requiert collect préalable OU packagePath)
-  packagePath: z.string().optional().describe('Chemin du package créé par collect. Si omis avec action=publish et targets fourni, fait collect+publish atomique'),
-  version: z.string().optional().describe('Version de la configuration (ex: "2.3.0"). Requis pour action=publish'),
-  description: z.string().optional().describe('Description des changements. Requis pour action=publish'),
+  packagePath: z.string().optional().describe('Package path from collect. If omitted with publish+targets, does collect+publish atomically'),
+  version: z.string().optional().describe('Config version (e.g., "2.3.0"). Required for publish'),
+  description: z.string().optional().describe('Change description. Required for publish'),
 
   // Pour apply
-  backup: z.boolean().optional().describe('Créer un backup local avant application (défaut: true). Pour action=apply et apply_profile'),
+  backup: z.boolean().optional().describe('Create local backup before apply (default: true). For apply and apply_profile'),
 
   // Pour apply_profile (#498 Phase 2)
-  profileName: z.string().optional().describe('Nom du profil à appliquer (requis pour action=apply_profile). Ex: "Production (Qwen 3.5 local + GLM-5 cloud)"'),
-  sourceMachineId: z.string().optional().describe('ID de la machine source pour charger model-configs.json depuis sa config publiée (optionnel, défaut: fichier local)')
+  profileName: z.string().optional().describe('Profile name (required for apply_profile). E.g. "Production (Qwen 3.5 + GLM-5)"'),
+  sourceMachineId: z.string().optional().describe('Source machine ID for model-configs.json (default: local file)')
 }).refine(
   (data) => {
     // Validation spécifique par action
@@ -303,56 +303,56 @@ export async function roosyncConfig(args: ConfigArgs) {
  */
 export const configToolMetadata = {
   name: 'roosync_config',
-  description: 'Gestion de configuration RooSync. Actions : collect (collecte locale), publish (publication GDrive), apply (application depuis GDrive), apply_profile (appliquer un profil de modèle). Cibles : modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, mcp:<nomServeur>. Stocke par machineId. Issue #601: Support scope Claude Code (user/project/settings).',
+  description: 'RooSync config management. Actions: collect (local), publish (to GDrive), apply (from GDrive), apply_profile (model profile). Targets: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, mcp:<server>.',
   inputSchema: {
     type: 'object' as const,
     properties: {
       action: {
         type: 'string',
         enum: ['collect', 'publish', 'apply', 'apply_profile'],
-        description: 'Action à effectuer: collect (collecte config locale), publish (publication vers GDrive), apply (application depuis GDrive), apply_profile (appliquer un profil de modèle)'
+        description: 'Action: collect, publish, apply, or apply_profile'
       },
       machineId: {
         type: 'string',
-        description: 'ID de la machine (optionnel, utilise ROOSYNC_MACHINE_ID par défaut)'
+        description: 'Machine ID (default: ROOSYNC_MACHINE_ID)'
       },
       dryRun: {
         type: 'boolean',
-        description: 'Si true, simule l\'opération sans modifier les fichiers. Défaut: false'
+        description: 'Simulate without modifying files (default: false)'
       },
       scope: {
         type: 'string',
         enum: ['user', 'project', 'settings'],
-        description: 'Scope Claude Code pour les configs MCP: user (~/.claude.json global), project (.mcp.json projet), settings (~/.claude/settings.json env/hooks). Défaut: user. Issue #601.'
+        description: 'Claude Code config scope: user (~/.claude.json), project (.mcp.json), settings (~/.claude/settings.json). Default: user.'
       },
       targets: {
         type: 'array',
         items: { type: 'string' },
-        description: 'Liste des cibles à collecter/appliquer (modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, ou mcp:<nomServeur>). Défaut: ["modes", "mcp"]'
+        description: 'Targets: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, mcp:<server>. Default: ["modes", "mcp"]'
       },
       packagePath: {
         type: 'string',
-        description: 'Chemin du package créé par collect. Pour action=publish uniquement. Si omis avec targets fourni, fait collect+publish atomique'
+        description: 'Package path from collect. For publish. If omitted with targets, does collect+publish atomically.'
       },
       version: {
         type: 'string',
-        description: 'Version de la configuration (ex: "2.3.0"). Requis pour action=publish. Pour action=apply, défaut: "latest"'
+        description: 'Config version. Required for publish. For apply, default: "latest".'
       },
       description: {
         type: 'string',
-        description: 'Description des changements. Requis pour action=publish'
+        description: 'Change description. Required for publish.'
       },
       backup: {
         type: 'boolean',
-        description: 'Créer un backup local avant application (défaut: true). Pour action=apply et apply_profile'
+        description: 'Create local backup before apply (default: true). For apply and apply_profile.'
       },
       profileName: {
         type: 'string',
-        description: 'Nom du profil à appliquer (requis pour action=apply_profile). Ex: "Production (Qwen 3.5 local + GLM-5 cloud)"'
+        description: 'Profile name (required for apply_profile). E.g. "Production (Qwen 3.5 + GLM-5)"'
       },
       sourceMachineId: {
         type: 'string',
-        description: 'ID de la machine source pour charger model-configs.json depuis sa config publiée (optionnel, défaut: fichier local)'
+        description: 'Source machine ID for model-configs.json (default: local file)'
       }
     },
     required: ['action'],

--- a/servers/roo-state-manager/src/tools/roosync/dashboard-schemas.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard-schemas.ts
@@ -16,9 +16,9 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 // === Author Schema ===
 
 export const AuthorSchema = z.object({
-  machineId: z.string().describe('ID de la machine'),
+  machineId: z.string().describe('Machine ID'),
   workspace: z.string().describe('Workspace ID'),
-  worktree: z.string().optional().describe('Worktree path (si applicable)')
+  worktree: z.string().optional().describe('Worktree path')
 });
 
 export type Author = z.infer<typeof AuthorSchema>;
@@ -34,18 +34,18 @@ export const TeamStageSchema = z.enum([
   'team-verify',  // Verify the solution (build + tests)
   'team-fix',     // Fix any issues found in verification (loops until verify passes)
   'none'          // No team stage (simple tasks)
-]).describe('Team pipeline stage for complex task execution');
+]).describe('Team pipeline stage');
 
 export type TeamStage = z.infer<typeof TeamStageSchema>;
 
 // === Intercom Message Schema ===
 
 export const IntercomMessageSchema = z.object({
-  id: z.string().describe('ID unique du message (ic-{timestamp})'),
+  id: z.string().describe('Unique message ID'),
   timestamp: z.string().describe('ISO 8601 timestamp'),
   author: AuthorSchema,
-  content: z.string().describe('Contenu markdown du message'),
-  teamStage: TeamStageSchema.optional().describe('Team pipeline stage (optionnel)')
+  content: z.string().describe('Markdown message content'),
+  teamStage: TeamStageSchema.optional().describe('Team pipeline stage')
 });
 
 export type IntercomMessage = z.infer<typeof IntercomMessageSchema>;
@@ -54,7 +54,7 @@ export type IntercomMessage = z.infer<typeof IntercomMessageSchema>;
 // userId = { machineId, workspace } tuple. Exactly one of userId/messageId (XOR).
 
 export const UserIdSchema = z.object({
-  machineId: z.string().describe('ID de la machine'),
+  machineId: z.string().describe('Machine ID'),
   workspace: z.string().describe('Workspace ID')
 });
 
@@ -62,11 +62,11 @@ export type UserId = z.infer<typeof UserIdSchema>;
 
 export const MentionSchema = z.object({
   userId: UserIdSchema.optional()
-    .describe('userId explicite à mentionner (exclusif avec messageId)'),
+    .describe('User to mention (exclusive with messageId)'),
   messageId: z.string().optional()
-    .describe('ID de message à référencer (format: machineId:workspace:ic-...). Résout en userId = auteur du message référencé.'),
+    .describe('Message ID to reference (resolves to author)'),
   note: z.string().optional()
-    .describe('Note optionnelle expliquant la raison de la mention')
+    .describe('Optional note')
 }).refine(
   (m) => (m.userId !== undefined) !== (m.messageId !== undefined),
   { message: 'mention: exactement un de userId ou messageId doit être fourni' }
@@ -76,11 +76,11 @@ export type Mention = z.infer<typeof MentionSchema>;
 
 export const CrossPostSchema = z.object({
   type: z.enum(['global', 'machine', 'workspace'])
-    .describe('Type de dashboard cible'),
+    .describe('Target dashboard type'),
   machineId: z.string().optional()
-    .describe('machineId cible (pour type=machine)'),
+    .describe('Target machineId'),
   workspace: z.string().optional()
-    .describe('workspace cible (pour type=workspace)')
+    .describe('Target workspace')
 });
 
 export type CrossPost = z.infer<typeof CrossPostSchema>;
@@ -115,60 +115,60 @@ export interface DashboardFrontmatter {
 
 export const DashboardArgsSchema = z.object({
   action: z.enum(['read', 'write', 'append', 'condense', 'list', 'delete', 'read_archive', 'read_overview'])
-    .describe('Action : read, write, append, condense, list (tous dashboards), delete (supprimer), read_archive (lire archives), read_overview (vue concaténée des 3 niveaux)'),
+    .describe('Action to perform'),
 
   type: z.enum(['global', 'machine', 'workspace']).optional()
-    .describe('Type de dashboard (requis sauf pour action=list)'),
+    .describe('Dashboard type (required except list/read_overview)'),
 
   machineId: z.string().optional()
-    .describe('ID machine (défaut: machine locale). Utilisé pour type machine'),
+    .describe('Machine ID (default: local)'),
 
   workspace: z.string().optional()
-    .describe('Workspace (défaut: workspace courant). Utilisé pour type workspace'),
+    .describe('Workspace (default: current)'),
 
   // Pour read
   section: z.enum(['status', 'intercom', 'all']).optional()
-    .describe('Section à lire (défaut: all)'),
+    .describe('Section to read (default: all)'),
   intercomLimit: z.number().optional()
-    .describe('Nombre max de messages intercom retournés (défaut: tous). Le dashboard est auto-condensé, donc tous les messages sont normalement visibles.'),
+    .describe('Max messages to return (default: all)'),
   mentionsOnly: z.boolean().optional()
-    .describe('(read) Ne retourner que les messages mentionnant la machine/agent courant (défaut: false)'),
+    .describe('(read) Only messages mentioning local machine/agent'),
   format: z.enum(['markdown', 'json']).optional()
-    .describe('(read/read_overview) Format de retour : "markdown" (défaut, raw markdown lisible), "json" (envelope JSON structuré)'),
+    .describe('(read/read_overview) Output format: markdown (default) or json'),
 
   // Pour write/append
   content: z.string().optional()
-    .describe('Contenu markdown pour write (remplace status.markdown) ou append (nouveau message)'),
+    .describe('Markdown for write (replaces status) or append (new message)'),
   author: AuthorSchema.optional()
-    .describe('Auteur de la modification (requis pour write/append)'),
+    .describe('Author (write/append)'),
   createIfNotExists: z.boolean().optional()
-    .describe('Créer le dashboard s\'il n\'existe pas (défaut: true)'),
+    .describe('Create if missing (default: true)'),
   messageId: z.string().optional()
-    .describe('(append) ID optionnel pour le message. Si absent, généré automatiquement.'),
+    .describe('(append) Custom message ID'),
 
   // Pour append — tags
   tags: z.array(z.string()).optional()
-    .describe('(append) Tags pour le message intercom (ex: ["INFO", "WARN", "ERROR"])'),
+    .describe('(append) Message tags'),
 
   // Pour append — Team pipeline stage (#1853)
   teamStage: TeamStageSchema.optional()
-    .describe('(append) Team pipeline stage actuel (ex: "team-plan", "team-exec", "team-verify"). Pour tâches complexes (>3 fichiers ou >50 LOC).'),
+    .describe('(append) Team pipeline stage'),
 
   // Mentions v3 (#1363)
   mentions: z.array(MentionSchema).optional()
-    .describe('(append) Mentions structurées. Chaque entrée = userId XOR messageId. Notifie les destinataires via RooSync.'),
+    .describe('(append) Mentions (userId XOR messageId)'),
 
   // Cross-post v3 (#1363)
   crossPost: z.array(CrossPostSchema).optional()
-    .describe('(append) Cross-post le même message vers d\'autres dashboards (sans notification RooSync).'),
+    .describe('(append) Cross-post to other dashboards'),
 
   // Pour condense
   keepMessages: z.number().optional()
-    .describe('Nombre de messages à conserver lors de la condensation (défaut: 10)'),
+    .describe('Messages to keep (default: 10)'),
 
   // Pour read_archive
   archiveFile: z.string().optional()
-    .describe('(read_archive) Nom du fichier archive à lire. Si absent, liste les archives disponibles.')
+    .describe('(read_archive) Archive filename (omit to list)')
 }).passthrough();
 
 export type DashboardArgs = z.infer<typeof DashboardArgsSchema> & Record<string, any>;
@@ -179,6 +179,6 @@ export type DashboardArgs = z.infer<typeof DashboardArgsSchema> & Record<string,
 
 export const dashboardToolMetadata = {
   name: 'roosync_dashboard',
-  description: 'Dashboards markdown partagés cross-machine. 3 types : global, machine, workspace. Actions : read, write (status diff), append (message intercom), condense, list (tous dashboards), delete, read_archive, read_overview (vue concaténée des 3 niveaux en 1 appel). Supporte Team pipeline stages (#1853) : team-plan, team-prd, team-exec, team-verify, team-fix.',
+  description: 'Shared dashboards (global/machine/workspace). Actions: read, write, append, condense, list, delete, read_archive, read_overview. Team stages supported.',
   inputSchema: zodToJsonSchema(DashboardArgsSchema as any, { target: 'openApi3' })
 };

--- a/servers/roo-state-manager/src/tools/roosync/index.ts
+++ b/servers/roo-state-manager/src/tools/roosync/index.ts
@@ -56,17 +56,8 @@ export type {
   RooSyncDecisionResult
 } from './decision.js';
 
-export {
-  roosyncDecisionInfo,
-  RooSyncDecisionInfoArgsSchema,
-  RooSyncDecisionInfoResultSchema,
-  roosyncDecisionInfoToolMetadata
-} from './decision-info.js';
-
-export type {
-  RooSyncDecisionInfoArgs,
-  RooSyncDecisionInfoResult
-} from './decision-info.js';
+// [REMOVED #1863] Deprecated roosync_decision_info exports — fused into roosync_decision(action: "info")
+// Source file decision-info.ts retained for: decision.ts imports + registry.ts redirect + tests
 
 export {
   roosyncInit,
@@ -143,9 +134,8 @@ export { roosyncRead, readToolMetadata } from './read.js';
 export { roosyncSend, sendToolMetadata } from './send.js';
 export { roosyncManage, manageToolMetadata } from './manage.js';
 
-// #613 ISS-1: Outil de cleanup en masse des messages RooSync
-export { cleanupMessages, cleanupToolMetadata } from './cleanup.js';
-export type { CleanupMessagesArgs } from './cleanup.js';
+// [REMOVED #1863] Deprecated cleanup_messages exports — fused into roosync_manage(action: "bulk_*")
+// Source file cleanup.ts retained for: registry.ts redirect + tests
 
 // #674: Outils de gestion des pièces jointes (legacy — backward compat)
 export {
@@ -170,8 +160,8 @@ export {
 
 // CONS-6: Outils consolidés Inventory (4→2)
 export { inventoryTool, inventoryToolMetadata } from './inventory.js';
-export { roosyncMachines, machinesToolMetadata } from './machines.js';
-// [DEPRECATED] Legacy inventory tool - utiliser inventoryTool à la place
+// [REMOVED #1863] Deprecated roosync_machines exports — fused into roosync_inventory(type: "machines")
+// Source file machines.ts retained for: registry.ts redirect + tests
 
 // #519: Legacy heartbeat tools retirés (7 outils) - utiliser roosync_heartbeat consolidé
 // Modules conservés pour les tests unitaires existants mais non exportés publiquement
@@ -212,14 +202,14 @@ import { compareConfigToolMetadata } from './compare-config.js';
 import { listDiffsToolMetadata } from './list-diffs.js';
 // CONS-5: Legacy decision imports replaced by consolidated
 import { roosyncDecisionToolMetadata } from './decision.js';
-import { roosyncDecisionInfoToolMetadata } from './decision-info.js';
+// [REMOVED #1863] roosyncDecisionInfoToolMetadata import — not used in any array
 import { initToolMetadata } from './roosync_init.js';
 import { baselineToolMetadata } from './baseline.js';
 import { diagnoseToolMetadata } from './diagnose.js';
 import { configToolMetadata } from './config.js'; // CONS-3
 // Import des métadonnées des outils consolidés Inventory (CONS-6)
 import { inventoryToolMetadata } from './inventory.js';
-import { machinesToolMetadata } from './machines.js';
+// [REMOVED #1863] machinesToolMetadata import — not used in any array
 
 // CLEANUP-1: Imports deprecated heartbeat retirés (register, get-offline, get-warning, get-state, start, stop, check)
 // Les modules existent toujours pour backward compat dans registry.ts CallTool handlers
@@ -246,8 +236,7 @@ import { sendToolMetadata } from './send.js';
 import { readToolMetadata } from './read.js';
 import { manageToolMetadata } from './manage.js';
 
-// #613 ISS-1: Import des métadonnées de l'outil cleanup
-import { cleanupToolMetadata } from './cleanup.js';
+// [REMOVED #1863] cleanupToolMetadata import — not used in any array
 
 // #674: Import des métadonnées des outils d'attachments (legacy)
 import {
@@ -303,11 +292,8 @@ export type {
 
 /**
  * Liste de tous les outils RooSync pour enregistrement MCP
+ * Version 3.18 : 19 outils (#1863: 3 deprecated definitions removed from tools/list — decision_info, machines, cleanup_messages)
  * Version 3.17 : 22 outils (CONS-7: 3 outils attachments → 1 roosync_attachments)
- * Version 3.16 : 24 outils (#675: roosync_dashboard ajouté + #674: 3 attachments)
- * Version 3.15 : 20 outils (#613 ISS-1: roosync_cleanup_messages ajouté)
- * Version 3.14 : 19 outils (#546: roosync_update_dashboard ajouté)
- * Version 3.13 : 18 outils (#533: roosync_sync_event retiré - jamais utilisé en production)
  *
  * - Configuration: init, compare-config, roosync_config (CONS-3), baseline (CONS-4)
  * - Services: inventory (CONS-6), machines (CONS-6)

--- a/servers/roo-state-manager/src/tools/roosync/send.ts
+++ b/servers/roo-state-manager/src/tools/roosync/send.ts
@@ -460,83 +460,83 @@ Le **contenu original** est préservé dans \`metadata.original_content\` pour t
  */
 export const sendToolMetadata = {
   name: 'roosync_send',
-  description: 'Envoyer un message structuré, répondre à un message existant, ou amender un message envoyé via RooSync',
+  description: 'Send, reply to, or amend a RooSync inter-machine message',
   inputSchema: {
     type: 'object',
     properties: {
       action: {
         type: 'string',
         enum: ['send', 'reply', 'amend'],
-        description: 'Action à effectuer : send (nouveau message), reply (répondre), amend (modifier)'
+        description: 'Action: send, reply, or amend'
       },
       to: {
         type: 'string',
-        description: 'Destinataire : machine (ex: myia-ai-01) ou machine:workspace (ex: myia-ai-01:roo-extensions). Requis pour action=send'
+        description: 'Recipient: machine or machine:workspace. Required for send.'
       },
       subject: {
         type: 'string',
-        description: 'Sujet du message. Requis pour action=send'
+        description: 'Message subject. Required for send.'
       },
       body: {
         type: 'string',
-        description: 'Corps du message (markdown supporté). Requis pour action=send et reply'
+        description: 'Message body (markdown). Required for send/reply.'
       },
       priority: {
         type: 'string',
         enum: ['LOW', 'MEDIUM', 'HIGH', 'URGENT'],
-        description: 'Priorité du message (défaut: MEDIUM)'
+        description: 'Priority (default: MEDIUM)'
       },
       tags: {
         type: 'array',
         items: { type: 'string' },
-        description: 'Tags optionnels pour catégoriser le message'
+        description: 'Optional tags'
       },
       thread_id: {
         type: 'string',
-        description: 'ID du thread pour regrouper les messages'
+        description: 'Thread ID for grouping'
       },
       reply_to: {
         type: 'string',
-        description: 'ID du message auquel on répond (pour action=send)'
+        description: 'Message ID being replied to (for send)'
       },
       message_id: {
         type: 'string',
-        description: 'ID du message (requis pour action=reply et amend)'
+        description: 'Message ID (required for reply/amend)'
       },
       new_content: {
         type: 'string',
-        description: 'Nouveau contenu du message (requis pour action=amend)'
+        description: 'New content (required for amend)'
       },
       reason: {
         type: 'string',
-        description: 'Raison de l\'amendement (optionnel, pour action=amend)'
+        description: 'Amend reason (optional)'
       },
       auto_destruct: {
         type: 'boolean',
-        description: 'Activer l\'auto-destruction du message après lecture (#629). Défaut: false'
+        description: 'Auto-destruct after read (default: false)'
       },
       destruct_after_read_by: {
         type: 'array',
         items: { type: 'string' },
-        description: 'Liste des machines qui doivent lire avant destruction (optionnel). Si vide, détruit après lecture par le destinataire'
+        description: 'Machines that must read before destruction.'
       },
       destruct_after: {
         type: 'string',
-        description: 'Durée TTL avant destruction (ex: "30m", "2h", "1d"). Le message est détruit après ce délai même sans lecture'
+        description: 'TTL before destruction (e.g., "30m", "2h", "1d").'
       },
       attachments: {
         type: 'array',
-        description: 'Pièces jointes à envoyer avec le message (#674)',
+        description: 'File attachments',
         items: {
           type: 'object',
           properties: {
             path: {
               type: 'string',
-              description: 'Chemin local du fichier à attacher'
+              description: 'Local file path'
             },
             filename: {
               type: 'string',
-              description: 'Nom du fichier (optionnel, défaut: basename du path)'
+              description: 'Filename (default: basename)'
             }
           },
           required: ['path']

--- a/servers/roo-state-manager/src/tools/search/roosync-search.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/roosync-search.tool.ts
@@ -72,69 +72,69 @@ export interface RooSyncSearchArgs {
  */
 export const roosyncSearchTool: Tool = {
     name: 'roosync_search',
-    description: "Outil unifié de recherche dans les tâches Roo (sémantique, textuelle, diagnostic de l'index)",
+    description: 'Search Roo tasks (semantic vector search, text search, or index diagnostic)',
     inputSchema: {
         type: 'object',
         properties: {
             action: {
                 type: 'string',
                 enum: ['semantic', 'text', 'diagnose'],
-                description: "Action: 'semantic' (recherche vectorielle Qdrant avec fallback automatique), 'text' (recherche textuelle directe dans le cache), 'diagnose' (diagnostic de l'index sémantique)"
+                description: 'Action: semantic (Qdrant vector search), text (cache search), diagnose (index health)'
             },
             search_query: {
                 type: 'string',
-                description: 'La requête de recherche (requis pour semantic et text)'
+                description: 'Search query (required for semantic/text)'
             },
             conversation_id: {
                 type: 'string',
-                description: 'ID de la conversation à fouiller (filtre optionnel pour semantic)'
+                description: 'Conversation ID filter (optional)'
             },
             max_results: {
                 type: 'number',
-                description: 'Nombre maximum de résultats à retourner'
+                description: 'Max results to return'
             },
             workspace: {
                 type: 'string',
-                description: 'Filtre par nom de workspace (ex: "roo-extensions"). Auto-défaut: workspace courant du MCP. Pour une recherche globale cross-workspace, passer workspace: "*" ou workspace: "all".'
+                description: 'Workspace filter. Default: MCP workspace. "*" or "all" = global.'
             },
             source: {
                 type: 'string',
                 enum: ['roo', 'claude-code'],
-                description: '#604: Filtre par source de conversation (tâches Roo ou sessions Claude Code)'
+                description: 'Filter by source (Roo or Claude Code)'
             },
             chunk_type: {
                 type: 'string',
                 enum: ['message_exchange', 'tool_interaction'],
-                description: '#636: Filter by chunk type (messages vs tool calls)'
+                description: 'Filter by chunk type (messages vs tool calls)'
             },
             role: {
                 type: 'string',
                 enum: ['user', 'assistant'],
-                description: '#636: Filter by message role'
+                description: 'Filter by message role'
             },
             tool_name: {
                 type: 'string',
-                description: '#636: Filter by tool name (e.g., "write_to_file", "roosync_send")'
+                description: 'Filter by tool name'
             },
             has_errors: {
                 type: 'boolean',
-                description: '#636: Filter chunks that contain error patterns'
+                description: 'Filter chunks with error patterns'
             },
             model: {
                 type: 'string',
-                description: '#636: Filter by LLM model (e.g., "opus", "sonnet", "glm-5")'
+                description: 'Filter by LLM model'
             },
             start_date: {
                 type: 'string',
-                description: '#636 P2: Filter results after this date (ISO 8601 or YYYY-MM-DD, e.g., "2026-03-01")'
+                description: 'Filter after date (ISO 8601)'
             },
             end_date: {
                 type: 'string',
-                description: '#636 P2: Filter results before this date (ISO 8601 or YYYY-MM-DD, e.g., "2026-03-11")'
+                description: 'Filter before date (ISO 8601)'
             },
             exclude_tool_results: {
                 type: 'boolean',
-                description: '#636 P3: Exclude tool_interaction chunks, returning only message_exchange chunks (conversation messages)'
+                description: 'Exclude tool_interaction chunks'
             }
         },
         required: ['action']

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -102,24 +102,24 @@ export const taskExportDefinition = {
 // ============================================================
 export const roosyncSearchDefinition = {
     name: 'roosync_search',
-    description: "Outil unifié de recherche dans les tâches Roo (sémantique, textuelle, diagnostic de l'index)",
+    description: 'Search Roo tasks (semantic vector search, text search, or index diagnostic)',
     inputSchema: {
         type: 'object',
         properties: {
-            action: { type: 'string', enum: ['semantic', 'text', 'diagnose'], description: "Action: 'semantic' (recherche vectorielle Qdrant avec fallback automatique), 'text' (recherche textuelle directe dans le cache), 'diagnose' (diagnostic de l'index sémantique)" },
-            search_query: { type: 'string', description: 'La requête de recherche (requis pour semantic et text)' },
-            conversation_id: { type: 'string', description: 'ID de la conversation à fouiller (filtre optionnel pour semantic)' },
-            max_results: { type: 'number', description: 'Nombre maximum de résultats à retourner' },
-            workspace: { type: 'string', description: 'Filtre par nom de workspace (ex: "roo-extensions"). Auto-défaut: workspace courant du MCP. Pour une recherche globale cross-workspace, passer workspace: "*" ou workspace: "all".' },
-            source: { type: 'string', enum: ['roo', 'claude-code'], description: '#604: Filtre par source de conversation (tâches Roo ou sessions Claude Code)' },
-            chunk_type: { type: 'string', enum: ['message_exchange', 'tool_interaction'], description: '#636: Filter by chunk type (messages vs tool calls)' },
-            role: { type: 'string', enum: ['user', 'assistant'], description: '#636: Filter by message role' },
-            tool_name: { type: 'string', description: '#636: Filter by tool name (e.g., "write_to_file", "roosync_send")' },
-            has_errors: { type: 'boolean', description: '#636: Filter chunks that contain error patterns' },
-            model: { type: 'string', description: '#636: Filter by LLM model (e.g., "opus", "sonnet", "glm-5")' },
-            start_date: { type: 'string', description: '#636 P2: Filter results after this date (ISO 8601 or YYYY-MM-DD, e.g., "2026-03-01")' },
-            end_date: { type: 'string', description: '#636 P2: Filter results before this date (ISO 8601 or YYYY-MM-DD, e.g., "2026-03-11")' },
-            exclude_tool_results: { type: 'boolean', description: '#636 P3: Exclude tool_interaction chunks, returning only message_exchange chunks (conversation messages)' }
+            action: { type: 'string', enum: ['semantic', 'text', 'diagnose'], description: 'Action: semantic (Qdrant vector search), text (cache search), diagnose (index health)' },
+            search_query: { type: 'string', description: 'Search query (required for semantic/text)' },
+            conversation_id: { type: 'string', description: 'Conversation ID filter (optional)' },
+            max_results: { type: 'number', description: 'Max results to return' },
+            workspace: { type: 'string', description: 'Workspace filter. Default: MCP workspace. "*" or "all" = global.' },
+            source: { type: 'string', enum: ['roo', 'claude-code'], description: 'Filter by source (Roo or Claude Code)' },
+            chunk_type: { type: 'string', enum: ['message_exchange', 'tool_interaction'], description: 'Filter by chunk type (messages vs tool calls)' },
+            role: { type: 'string', enum: ['user', 'assistant'], description: 'Filter by message role' },
+            tool_name: { type: 'string', description: 'Filter by tool name' },
+            has_errors: { type: 'boolean', description: 'Filter chunks with error patterns' },
+            model: { type: 'string', description: 'Filter by LLM model' },
+            start_date: { type: 'string', description: 'Filter after date (ISO 8601)' },
+            end_date: { type: 'string', description: 'Filter before date (ISO 8601)' },
+            exclude_tool_results: { type: 'boolean', description: 'Exclude tool_interaction chunks' }
         },
         required: ['action']
     }
@@ -130,20 +130,20 @@ export const roosyncSearchDefinition = {
 // ============================================================
 export const roosyncIndexingDefinition = {
     name: 'roosync_indexing',
-    description: "Outil unifié de gestion de l'index sémantique, du cache et de l'archivage (indexation, reset, rebuild, diagnostic, archive Roo/Claude Code)",
+    description: 'Manage semantic index and archiving (index, reset, rebuild, diagnose, archive, status, cleanup, garbage_scan, cleanup_orphans)',
     inputSchema: {
         type: 'object',
         properties: {
-            action: { type: 'string', enum: ['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status'], description: "Action: 'index' (indexer une tâche dans Qdrant), 'reset' (réinitialiser la collection Qdrant), 'rebuild' (reconstruire l'index SQLite VS Code), 'diagnose' (diagnostic complet de l'index), 'archive' (archiver une tâche Roo ou les sessions Claude Code sur GDrive), 'status' (état du background indexer et métriques)" },
-            task_id: { type: 'string', description: 'ID de la tâche à indexer (requis pour action=index)' },
-            confirm: { type: 'boolean', description: 'Confirmation obligatoire pour action=reset', default: false },
-            workspace_filter: { type: 'string', description: 'Filtre optionnel par workspace (pour action=rebuild)' },
-            max_tasks: { type: 'number', description: 'Nombre maximum de tâches à traiter (pour action=rebuild, 0 = toutes)', default: 0 },
-            dry_run: { type: 'boolean', description: 'Mode simulation sans modification (pour action=rebuild)', default: false },
-            machine_id: { type: 'string', description: 'Filtre par machine (pour action=archive, liste les archives de cette machine uniquement)' },
-            claude_code_sessions: { type: 'boolean', description: 'Archiver les sessions Claude Code (pour action=archive)', default: false },
-            max_sessions: { type: 'number', description: 'Nombre max de sessions Claude Code à archiver (pour action=archive avec claude_code_sessions=true, 0 = toutes)', default: 0 },
-            source: { type: 'string', enum: ['roo', 'claude-code'], description: "#604: Source de la conversation (pour action=index). 'roo' = tâche Roo standard, 'claude-code' = session Claude Code JSONL. Par défaut: 'roo'" }
+            action: { type: 'string', enum: ['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'cleanup', 'garbage_scan', 'cleanup_orphans'], description: 'Action to perform' },
+            task_id: { type: 'string', description: 'Task ID (required for index)' },
+            confirm: { type: 'boolean', description: 'Confirmation for reset', default: false },
+            workspace_filter: { type: 'string', description: 'Workspace filter (rebuild)' },
+            max_tasks: { type: 'number', description: 'Max tasks (rebuild, 0=all)', default: 0 },
+            dry_run: { type: 'boolean', description: 'Simulation mode', default: false },
+            machine_id: { type: 'string', description: 'Machine filter (archive)' },
+            claude_code_sessions: { type: 'boolean', description: 'BLOCKED - sessions are sanctuary.', default: false },
+            max_sessions: { type: 'number', description: 'Max sessions (0=all)', default: 0 },
+            source: { type: 'string', enum: ['roo', 'claude-code'], description: 'Source for index. Default: "roo".' }
         },
         required: ['action']
     }
@@ -203,26 +203,26 @@ export const getMcpBestPracticesDefinition = {
 // ============================================================
 export const exportDataDefinition = {
     name: 'export_data',
-    description: `Outil consolidé pour exporter des données au format XML, JSON ou CSV.\n\nCibles supportées:\n- task: Export d'une tâche individuelle (XML uniquement)\n- conversation: Export d'une conversation complète (tous formats)\n- project: Export d'un projet entier (XML uniquement)\n\nFormats supportés:\n- xml: Format XML structuré\n- json: Format JSON avec variantes light/full\n- csv: Format CSV avec variantes conversations/messages/tools\n\nCONS-10: Remplace export_tasks_xml, export_conversation_xml, export_project_xml, export_conversation_json, export_conversation_csv`,
+    description: 'Export data as XML, JSON or CSV. Targets: task (XML), conversation (all formats), project (XML). JSON variants: light/full. CSV variants: conversations/messages/tools.',
     inputSchema: {
         type: 'object',
         properties: {
-            target: { type: 'string', enum: ['task', 'conversation', 'project'], description: "Cible de l'export: task, conversation, ou project" },
-            format: { type: 'string', enum: ['xml', 'json', 'csv'], description: 'Format de sortie: xml, json, ou csv' },
-            taskId: { type: 'string', description: 'ID de la tâche (requis pour target=task, ou conversation avec json/csv)' },
-            conversationId: { type: 'string', description: 'ID de la conversation racine (requis pour target=conversation avec xml)' },
-            projectPath: { type: 'string', description: 'Chemin du projet (requis pour target=project)' },
-            filePath: { type: 'string', description: 'Chemin de sortie pour le fichier. Si non fourni, retourne le contenu.' },
-            includeContent: { type: 'boolean', description: 'Inclure le contenu complet des messages (XML, défaut: false)' },
-            prettyPrint: { type: 'boolean', description: 'Indenter pour lisibilité (XML, défaut: true)' },
-            maxDepth: { type: 'integer', description: "Profondeur max de l'arbre de tâches (XML conversation)" },
-            startDate: { type: 'string', description: 'Date de début ISO 8601 pour filtrer (XML project)' },
-            endDate: { type: 'string', description: 'Date de fin ISO 8601 pour filtrer (XML project)' },
-            jsonVariant: { type: 'string', enum: ['light', 'full'], description: 'Variante JSON: light (squelette) ou full (détail complet)' },
-            csvVariant: { type: 'string', enum: ['conversations', 'messages', 'tools'], description: 'Variante CSV: conversations, messages, ou tools' },
-            truncationChars: { type: 'number', description: 'Max caractères avant troncature (0 = pas de troncature)' },
-            startIndex: { type: 'number', description: 'Index de début (1-based) pour plage de messages' },
-            endIndex: { type: 'number', description: 'Index de fin (1-based) pour plage de messages' }
+            target: { type: 'string', enum: ['task', 'conversation', 'project'], description: 'Export target: task, conversation, or project' },
+            format: { type: 'string', enum: ['xml', 'json', 'csv'], description: 'Output format: xml, json, or csv' },
+            taskId: { type: 'string', description: 'Task ID (required for target=task, or conversation with json/csv)' },
+            conversationId: { type: 'string', description: 'Root conversation ID (required for target=conversation with xml)' },
+            projectPath: { type: 'string', description: 'Project path (required for target=project)' },
+            filePath: { type: 'string', description: 'Output file path. If omitted, returns content inline.' },
+            includeContent: { type: 'boolean', description: 'Include full message content (XML, default: false)' },
+            prettyPrint: { type: 'boolean', description: 'Indent for readability (XML, default: true)' },
+            maxDepth: { type: 'integer', description: 'Max tree depth (XML conversation)' },
+            startDate: { type: 'string', description: 'ISO 8601 start date filter (XML project)' },
+            endDate: { type: 'string', description: 'ISO 8601 end date filter (XML project)' },
+            jsonVariant: { type: 'string', enum: ['light', 'full'], description: 'JSON variant: light (skeleton) or full (complete)' },
+            csvVariant: { type: 'string', enum: ['conversations', 'messages', 'tools'], description: 'CSV variant: conversations, messages, or tools' },
+            truncationChars: { type: 'number', description: 'Max chars before truncation (0 = no truncation)' },
+            startIndex: { type: 'number', description: 'Start index (1-based) for message range' },
+            endIndex: { type: 'number', description: 'End index (1-based) for message range' }
         },
         required: ['target', 'format']
     }
@@ -292,7 +292,7 @@ export const analyzeRooSyncProblemsDefinition = {
 };
 
 // ============================================================
-// RooSync tools — static metadata objects (22 tools in roosyncTools array)
+// RooSync tools — static metadata objects (22 tools → 19 after removing 3 deprecated definitions #1863)
 // ============================================================
 
 export const roosyncInitDefinition = {
@@ -371,20 +371,8 @@ export const roosyncDecisionDefinition = {
     }
 };
 
-// DEPRECATED #1863: Fused into roosync_decision(action: "info"). Kept for backward-compat redirect.
-export const roosyncDecisionInfoDefinition = {
-    name: 'roosync_decision_info',
-    description: "[DEPRECATED] Use roosync_decision(action: \"info\"). Consulte les détails d'une décision RooSync (read-only)",
-    inputSchema: {
-        type: 'object',
-        properties: {
-            decisionId: { type: 'string', description: 'ID de la décision à consulter' },
-            includeHistory: { type: 'boolean', description: "Inclure l'historique complet des actions (défaut: true)", default: true },
-            includeLogs: { type: 'boolean', description: "Inclure les logs d'exécution (défaut: true)", default: true }
-        },
-        required: ['decisionId']
-    }
-};
+// [REMOVED #1863] roosyncDecisionInfoDefinition — fused into roosync_decision(action: "info")
+// CallTool redirect in registry.ts preserved for backward compat.
 
 export const roosyncBaselineDefinition = {
     name: 'roosync_baseline',
@@ -412,21 +400,21 @@ export const roosyncBaselineDefinition = {
 
 export const roosyncConfigDefinition = {
     name: 'roosync_config',
-    description: 'Gestion de configuration RooSync. Actions : collect (collecte locale), publish (publication GDrive), apply (application depuis GDrive), apply_profile (appliquer un profil de modèle). Cibles : modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, mcp:<nomServeur>. Stocke par machineId.',
+    description: 'RooSync config management. Actions: collect (local), publish (to GDrive), apply (from GDrive), apply_profile (model profile). Targets: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, mcp:<server>.',
     inputSchema: {
         type: 'object',
         properties: {
-            action: { type: 'string', enum: ['collect', 'publish', 'apply', 'apply_profile'], description: 'Action à effectuer: collect (collecte config locale), publish (publication vers GDrive), apply (application depuis GDrive), apply_profile (appliquer un profil de modèle)' },
-            machineId: { type: 'string', description: 'ID de la machine (optionnel, utilise ROOSYNC_MACHINE_ID par défaut)' },
-            dryRun: { type: 'boolean', description: "Si true, simule l'opération sans modifier les fichiers. Défaut: false" },
-            scope: { type: 'string', enum: ['user', 'project', 'settings'], description: 'Scope Claude Code pour les configs MCP: user (~/.claude.json global), project (.mcp.json projet), settings (~/.claude/settings.json env/hooks). Défaut: user.' },
-            targets: { type: 'array', items: { type: 'string' }, description: 'Liste des cibles à collecter/appliquer (modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, ou mcp:<nomServeur>). Défaut: ["modes", "mcp"]' },
-            packagePath: { type: 'string', description: "Chemin du package créé par collect. Pour action=publish uniquement. Si omis avec targets fourni, fait collect+publish atomique" },
-            version: { type: 'string', description: 'Version de la configuration (ex: "2.3.0"). Requis pour action=publish. Pour action=apply, défaut: "latest"' },
-            description: { type: 'string', description: 'Description des changements. Requis pour action=publish' },
-            backup: { type: 'boolean', description: 'Créer un backup local avant application (défaut: true). Pour action=apply et apply_profile' },
-            profileName: { type: 'string', description: 'Nom du profil à appliquer (requis pour action=apply_profile). Ex: "Production (Qwen 3.5 local + GLM-5 cloud)"' },
-            sourceMachineId: { type: 'string', description: 'ID de la machine source pour charger model-configs.json depuis sa config publiée (optionnel, défaut: fichier local)' }
+            action: { type: 'string', enum: ['collect', 'publish', 'apply', 'apply_profile'], description: 'Action: collect, publish, apply, or apply_profile' },
+            machineId: { type: 'string', description: 'Machine ID (default: ROOSYNC_MACHINE_ID)' },
+            dryRun: { type: 'boolean', description: 'Simulate without modifying files (default: false)' },
+            scope: { type: 'string', enum: ['user', 'project', 'settings'], description: 'Claude Code config scope: user (~/.claude.json), project (.mcp.json), settings (~/.claude/settings.json). Default: user.' },
+            targets: { type: 'array', items: { type: 'string' }, description: 'Targets: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, mcp:<server>. Default: ["modes", "mcp"]' },
+            packagePath: { type: 'string', description: 'Package path from collect. For publish. If omitted with targets, does collect+publish atomically.' },
+            version: { type: 'string', description: 'Config version. Required for publish. For apply, default: "latest".' },
+            description: { type: 'string', description: 'Change description. Required for publish.' },
+            backup: { type: 'boolean', description: 'Create local backup before apply (default: true). For apply and apply_profile.' },
+            profileName: { type: 'string', description: 'Profile name (required for apply_profile). E.g. "Production (Qwen 3.5 + GLM-5)"' },
+            sourceMachineId: { type: 'string', description: 'Source machine ID for model-configs.json (default: local file)' }
         },
         required: ['action'],
         additionalProperties: false
@@ -450,20 +438,8 @@ export const roosyncInventoryDefinition = {
     }
 };
 
-// DEPRECATED #1863: Fused into roosync_inventory(type: "machines"). Kept for backward-compat redirect.
-export const roosyncMachinesDefinition = {
-    name: 'roosync_machines',
-    description: '[DEPRECATED] Use roosync_inventory(type: "machines"). Récupération des machines offline et/ou en avertissement.',
-    inputSchema: {
-        type: 'object',
-        properties: {
-            status: { type: 'string', enum: ['offline', 'warning', 'all'], description: 'Statut des machines à récupérer' },
-            includeDetails: { type: 'boolean', description: 'Inclure les détails complets de chaque machine (défaut: false)' }
-        },
-        required: ['status'],
-        additionalProperties: false
-    }
-};
+// [REMOVED #1863] roosyncMachinesDefinition — fused into roosync_inventory(type: "machines")
+// CallTool redirect in registry.ts preserved for backward compat.
 
 // #1609: roosync_heartbeat retiré — auto-heartbeat now triggered on any tool call
 export const roosyncMcpManagementDefinition = {
@@ -556,25 +532,25 @@ export const roosyncUpdateDashboardDefinition = {
 
 export const roosyncSendDefinition = {
     name: 'roosync_send',
-    description: 'Envoyer un message structuré, répondre à un message existant, ou amender un message envoyé via RooSync',
+    description: 'Send, reply to, or amend a RooSync inter-machine message',
     inputSchema: {
         type: 'object',
         properties: {
-            action: { type: 'string', enum: ['send', 'reply', 'amend'], description: 'Action à effectuer : send (nouveau message), reply (répondre), amend (modifier)' },
-            to: { type: 'string', description: 'Destinataire : machine (ex: myia-ai-01) ou machine:workspace (ex: myia-ai-01:roo-extensions). Requis pour action=send' },
-            subject: { type: 'string', description: 'Sujet du message. Requis pour action=send' },
-            body: { type: 'string', description: 'Corps du message (markdown supporté). Requis pour action=send et reply' },
-            priority: { type: 'string', enum: ['LOW', 'MEDIUM', 'HIGH', 'URGENT'], description: 'Priorité du message (défaut: MEDIUM)' },
-            tags: { type: 'array', items: { type: 'string' }, description: 'Tags optionnels pour catégoriser le message' },
-            thread_id: { type: 'string', description: 'ID du thread pour regrouper les messages' },
-            reply_to: { type: 'string', description: "ID du message auquel on répond (pour action=send)" },
-            message_id: { type: 'string', description: 'ID du message (requis pour action=reply et amend)' },
-            new_content: { type: 'string', description: 'Nouveau contenu du message (requis pour action=amend)' },
-            reason: { type: 'string', description: "Raison de l'amendement (optionnel, pour action=amend)" },
-            auto_destruct: { type: 'boolean', description: "Activer l'auto-destruction du message après lecture (#629). Défaut: false" },
-            destruct_after_read_by: { type: 'array', items: { type: 'string' }, description: 'Liste des machines qui doivent lire avant destruction (optionnel).' },
-            destruct_after: { type: 'string', description: 'Durée TTL avant destruction (ex: "30m", "2h", "1d").' },
-            attachments: { type: 'array', description: 'Pièces jointes à envoyer avec le message (#674)', items: { type: 'object', properties: { path: { type: 'string', description: 'Chemin local du fichier à attacher' }, filename: { type: 'string', description: 'Nom du fichier (optionnel, défaut: basename du path)' } } } }
+            action: { type: 'string', enum: ['send', 'reply', 'amend'], description: 'Action: send, reply, or amend' },
+            to: { type: 'string', description: 'Recipient: machine or machine:workspace. Required for send.' },
+            subject: { type: 'string', description: 'Message subject. Required for send.' },
+            body: { type: 'string', description: 'Message body (markdown). Required for send/reply.' },
+            priority: { type: 'string', enum: ['LOW', 'MEDIUM', 'HIGH', 'URGENT'], description: 'Priority (default: MEDIUM)' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Optional tags' },
+            thread_id: { type: 'string', description: 'Thread ID for grouping' },
+            reply_to: { type: 'string', description: 'Message ID being replied to (for send)' },
+            message_id: { type: 'string', description: 'Message ID (required for reply/amend)' },
+            new_content: { type: 'string', description: 'New content (required for amend)' },
+            reason: { type: 'string', description: 'Amend reason (optional)' },
+            auto_destruct: { type: 'boolean', description: 'Auto-destruct after read (default: false)' },
+            destruct_after_read_by: { type: 'array', items: { type: 'string' }, description: 'Machines that must read before destruction.' },
+            destruct_after: { type: 'string', description: 'TTL before destruction (e.g., "30m", "2h", "1d").' },
+            attachments: { type: 'array', description: 'File attachments', items: { type: 'object', properties: { path: { type: 'string', description: 'Local file path' }, filename: { type: 'string', description: 'Filename (default: basename)' } } } }
         }
     }
 };
@@ -617,25 +593,8 @@ export const roosyncManageDefinition = {
     }
 };
 
-// DEPRECATED #1863: Fused into roosync_manage(action: "bulk_mark_read"/"bulk_archive"). Kept for backward-compat redirect.
-export const roosyncCleanupMessagesDefinition = {
-    name: 'roosync_cleanup_messages',
-    description: '[DEPRECATED] Use roosync_manage(action: "bulk_mark_read"/"bulk_archive"). Effectue des opérations de cleanup en masse sur les messages RooSync.',
-    inputSchema: {
-        type: 'object',
-        properties: {
-            operation: { type: 'string', enum: ['mark_read', 'archive'], description: "Opération à effectuer : mark_read (marquer comme lu) ou archive (archiver)" },
-            from: { type: 'string', description: 'Filtre par expéditeur (substring match). Ex: "test-machine" pour ignorer les messages de test' },
-            priority: { type: 'string', enum: ['LOW', 'MEDIUM', 'HIGH', 'URGENT'], description: 'Filtre par priorité. Ex: "LOW" pour marquer automatiquement les messages LOW' },
-            before_date: { type: 'string', description: 'Filtre par date (messages antérieurs à cette date). Format ISO-8601: "2026-02-01T00:00:00Z"' },
-            subject_contains: { type: 'string', description: 'Filtre par sujet (substring, case-insensitive)' },
-            tag: { type: 'string', description: 'Filtre par tag' },
-            status: { type: 'string', enum: ['unread', 'read'], description: 'Ne traiter que les messages avec ce statut' },
-            verbose: { type: 'boolean', description: 'Afficher les IDs des messages traités (défaut: true)' }
-        },
-        required: ['operation']
-    }
-};
+// [REMOVED #1863] roosyncCleanupMessagesDefinition — fused into roosync_manage(action: "bulk_mark_read"/"bulk_archive")
+// CallTool redirect in registry.ts preserved for backward compat.
 
 export const roosyncAttachmentsDefinition = {
     name: 'roosync_attachments',
@@ -704,11 +663,11 @@ export const allToolDefinitions = [
     roosyncCompareConfigDefinition,
     roosyncListDiffsDefinition,
     roosyncDecisionDefinition,
-    roosyncDecisionInfoDefinition,
+    // [REMOVED #1863] roosyncDecisionInfoDefinition — not listed in tools/list, redirect in registry.ts
     roosyncBaselineDefinition,
     roosyncConfigDefinition,
     roosyncInventoryDefinition,
-    roosyncMachinesDefinition,
+    // [REMOVED #1863] roosyncMachinesDefinition — not listed in tools/list, redirect in registry.ts
     // #1609: roosyncHeartbeatDefinition retiré — auto-heartbeat on any tool call
     roosyncMcpManagementDefinition,
     roosyncStorageManagementDefinition,
@@ -718,7 +677,7 @@ export const allToolDefinitions = [
     roosyncSendDefinition,
     roosyncReadDefinition,
     roosyncManageDefinition,
-    roosyncCleanupMessagesDefinition,
+    // [REMOVED #1863] roosyncCleanupMessagesDefinition — not listed in tools/list, redirect in registry.ts
     roosyncAttachmentsDefinition,
     roosyncDashboardDefinition,
     // #1836: Pre-claim enforcement

--- a/servers/roo-state-manager/tests/unit/tools/roosync/config.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/config.test.ts
@@ -338,8 +338,8 @@ describe('roosync_config - Metadata', () => {
     const metadata = module.configToolMetadata;
 
     expect(metadata.name).toBe('roosync_config');
-    expect(metadata.description).toContain('Gestion');
-    expect(metadata.description).toContain('configuration RooSync');
+    expect(metadata.description).toContain('config');
+    expect(metadata.description).toContain('RooSync');
     expect(metadata.inputSchema).toBeDefined();
     expect(metadata.inputSchema.type).toBe('object');
     expect(metadata.inputSchema.properties).toHaveProperty('action');
@@ -366,9 +366,9 @@ describe('roosync_config - Metadata', () => {
     const module = await import('../../../../src/tools/roosync/config.js');
     const metadata = module.configToolMetadata;
 
-    // Test simplifié après cleanup #443 - description compacte sans détails techniques
-    expect(metadata.description).toContain('collecte');
-    expect(metadata.description).toContain('publication');
+    // Test simplifié après #1922 Phase 2 - English descriptions
+    expect(metadata.description).toContain('collect');
+    expect(metadata.description).toContain('publish');
   });
 
   it('devrait avoir enum correct pour action', async () => {

--- a/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
@@ -8,7 +8,7 @@
  *
  * Scenarios per fusion:
  *   1. Canonical call — new API path works
- *   2. Redirected call — old tool name still works via backward-compat
+ *   2. Redirected call — deprecated tools REMOVED from tools/list
  *   3. Error case — invalid input handled correctly
  */
 
@@ -18,10 +18,7 @@ import { InventoryArgsSchema } from '../../../../src/tools/roosync/inventory.js'
 import {
   allToolDefinitions,
   roosyncDecisionDefinition,
-  roosyncInventoryDefinition,
-  roosyncDecisionInfoDefinition,
-  roosyncMachinesDefinition,
-  roosyncCleanupMessagesDefinition
+  roosyncInventoryDefinition
 } from '../../../../src/tools/tool-definitions.js';
 
 // ============================================================
@@ -66,10 +63,10 @@ describe('#1863 Fusion A1: decision_info → decision(action: "info")', () => {
     });
   });
 
-  describe('Scenario 2: Redirected call — backward-compat definition exists', () => {
-    it('should have roosync_decision_info in allToolDefinitions for backward compat', () => {
+  describe('Scenario 2: Deprecated tool removed from tools/list', () => {
+    it('should NOT have roosync_decision_info in allToolDefinitions', () => {
       const names = allToolDefinitions.map(d => d.name);
-      expect(names).toContain('roosync_decision_info');
+      expect(names).not.toContain('roosync_decision_info');
     });
 
     it('should have "info" in decision definition action enum', () => {
@@ -154,10 +151,10 @@ describe('#1863 Fusion A2: machines → inventory(type: "machines")', () => {
     });
   });
 
-  describe('Scenario 2: Redirected call — backward-compat definition exists', () => {
-    it('should have roosync_machines in allToolDefinitions for backward compat', () => {
+  describe('Scenario 2: Deprecated tool removed from tools/list', () => {
+    it('should NOT have roosync_machines in allToolDefinitions', () => {
       const names = allToolDefinitions.map(d => d.name);
-      expect(names).toContain('roosync_machines');
+      expect(names).not.toContain('roosync_machines');
     });
 
     it('should have "machines" in inventory definition type enum', () => {
@@ -200,31 +197,28 @@ describe('#1863 Fusion A3: cleanup → manage redirect', () => {
     });
   });
 
-  describe('Scenario 2: Redirected call — backward-compat definition exists', () => {
-    it('should have roosync_cleanup_messages in allToolDefinitions for backward compat', () => {
+  describe('Scenario 2: Deprecated tool removed from tools/list', () => {
+    it('should NOT have roosync_cleanup_messages in allToolDefinitions', () => {
       const names = allToolDefinitions.map(d => d.name);
-      expect(names).toContain('roosync_cleanup_messages');
-    });
-
-    it('cleanup definition should be marked as deprecated in description', () => {
-      expect(roosyncCleanupMessagesDefinition.description).toContain('DEPRECATED');
-    });
-
-    it('cleanup definition should reference manage in description', () => {
-      expect(roosyncCleanupMessagesDefinition.description).toContain('roosync_manage');
+      expect(names).not.toContain('roosync_cleanup_messages');
     });
   });
 
-  describe('Scenario 3: Error case — redirect mapping validation', () => {
-    it('should have operation enum with mark_read and archive in cleanup definition', () => {
-      const opEnum = (roosyncCleanupMessagesDefinition.inputSchema as any).properties.operation.enum;
-      expect(opEnum).toContain('mark_read');
-      expect(opEnum).toContain('archive');
+  describe('Scenario 3: Canonical manage tool covers cleanup use cases', () => {
+    it('should have bulk_mark_read and bulk_archive in manage definition', () => {
+      const manageDef = allToolDefinitions.find(d => d.name === 'roosync_manage')!;
+      const actionEnum = (manageDef.inputSchema as any).properties.action.enum;
+      expect(actionEnum).toContain('bulk_mark_read');
+      expect(actionEnum).toContain('bulk_archive');
     });
 
-    it('should require operation in cleanup definition', () => {
-      const required = (roosyncCleanupMessagesDefinition.inputSchema as any).required;
-      expect(required).toContain('operation');
+    it('manage definition should have filter properties for bulk operations', () => {
+      const manageDef = allToolDefinitions.find(d => d.name === 'roosync_manage')!;
+      const props = (manageDef.inputSchema as any).properties;
+      expect(props).toHaveProperty('from');
+      expect(props).toHaveProperty('before_date');
+      expect(props).toHaveProperty('subject_contains');
+      expect(props).toHaveProperty('tag');
     });
   });
 });
@@ -233,21 +227,22 @@ describe('#1863 Fusion A3: cleanup → manage redirect', () => {
 // Cross-cutting: Definition count and deprecation markers
 // ============================================================
 describe('#1863 Cross-cutting: tool count and deprecation markers', () => {
-  it('allToolDefinitions should still contain all 34 tools (3 deprecated but kept)', () => {
-    // Before fusions: 33 tools in allToolDefinitions (heartbeat removed in #1609)
-    // After fusions: still 33 + roosync_claim (#1836) = 34
-    // (deprecated tools kept for backward compat, not removed from list)
-    expect(allToolDefinitions.length).toBe(34);
-  });
-
-  it('deprecated definitions should have DEPRECATED in description', () => {
-    expect(roosyncDecisionInfoDefinition.description).toContain('DEPRECATED');
-    expect(roosyncMachinesDefinition.description).toContain('DEPRECATED');
-    expect(roosyncCleanupMessagesDefinition.description).toContain('DEPRECATED');
+  it('allToolDefinitions should contain 31 tools (3 deprecated definitions removed from tools/list)', () => {
+    // Before: 34 tools (33 + roosync_claim #1836)
+    // After removing 3 deprecated tool definitions: 31
+    // Backward compat redirect handlers in registry.ts are preserved
+    expect(allToolDefinitions.length).toBe(31);
   });
 
   it('canonical tools should not be deprecated', () => {
     expect(roosyncDecisionDefinition.description).not.toContain('DEPRECATED');
     expect(roosyncInventoryDefinition.description).not.toContain('DEPRECATED');
+  });
+
+  it('deprecated tool names should NOT appear in tools/list', () => {
+    const names = allToolDefinitions.map(d => d.name);
+    expect(names).not.toContain('roosync_decision_info');
+    expect(names).not.toContain('roosync_machines');
+    expect(names).not.toContain('roosync_cleanup_messages');
   });
 });


### PR DESCRIPTION
## Summary
- Remove 3 deprecated tool definitions from `tools/list` response (decision_info, machines, cleanup_messages) — backward-compat CallTool redirects preserved
- Trim descriptions for 7 largest tools: conversation_browser, roosync_dashboard, roosync_search, roosync_config, export_data, roosync_send, roosync_indexing
- French verbose → concise English descriptions
- Remove issue references from description strings

## Token Impact
| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Tool definitions (chars) | 45,268 | 40,173 | **-11.3%** |
| Estimated tokens | ~11,317 | ~10,043 | **-1,274** |
| Tool count | 33 | 31 | -2 (deprecated removed) |

### Per-tool trimming
| Tool | Before | After | % Saved |
|------|--------|-------|---------|
| conversation_browser | 6,743 | desc -31% | — |
| roosync_dashboard | 4,424 | 3,150 | -28.8% |
| roosync_search | 2,142 | 1,508 | -29.6% |
| roosync_config | 2,341 | 1,837 | -21.5% |
| export_data | 2,430 | 1,909 | -21.4% |
| roosync_send | 2,105 | 1,660 | -21.1% |
| roosync_indexing | 1,876 | 1,177 | -37.3% |

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 444 files, 9,016 tests passed
- [x] Updated discoverability and config tests for English descriptions
- [x] Backward-compat redirect handlers in registry.ts preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)