### PR TITLE
fix(#1928): tools/list reliability — event loop yield + cache location

### DIFF
--- a/servers/roo-state-manager/mcp-wrapper.cjs
+++ b/servers/roo-state-manager/mcp-wrapper.cjs
@@ -36,7 +36,9 @@ if (envResult.error) {
 const serverPath = path.join(__dirname, 'build', 'index.js');
 
 // --- Persisted tools/list cache ---
-const CACHE_FILE = path.join(os.tmpdir(), '.mcp-roo-state-tools-cache.json');
+// Use build/ directory (NOT os.tmpdir()) — Windows Disk Cleanup clears %TEMP%,
+// which invalidates the cache multiple times per day, causing the "0 tools" bug.
+const CACHE_FILE = path.join(__dirname, 'build', '.tools-cache.json');
 
 function logDebug(message) {
     if (process.env.ROO_DEBUG_LOGS) {

--- a/servers/roo-state-manager/src/index.ts
+++ b/servers/roo-state-manager/src/index.ts
@@ -186,10 +186,14 @@ class RooStateManagerServer {
                 });
         };
 
-        // Primary path: wait for MCP handshake to complete
+        // Primary path: wait for MCP handshake to complete.
+        // Use setImmediate to yield to the event loop — the client sends
+        // tools/list right after initialized, and if we start the heavy
+        // init (dynamic import → synchronous ESM graph evaluation) here,
+        // it blocks the event loop and tools/list never gets answered.
         this.server.oninitialized = () => {
-            logger.info("[#1817] MCP handshake complete, starting heavy initialization");
-            startInit();
+            logger.info("[#1817] MCP handshake complete, scheduling heavy initialization after event loop yield");
+            setImmediate(startInit);
         };
 
         // Fallback: if client doesn't send initialized notification within 5s, start anyway


### PR DESCRIPTION
## Summary

Fixes the recurring "MCP starts with 0 tools" bug that happens multiple times per day, especially on the CoursIA workspace.

### Root Cause

Two interacting issues:

1. **Event loop blocking**: `oninitialized` callback starts heavy initialization (`await import()` → synchronous ESM graph evaluation) immediately, blocking the event loop. If `tools/list` arrives while the event loop is blocked, it never gets answered.

2. **Cache eviction**: The persisted tools cache was stored in `os.tmpdir()` (`%TEMP%`), which Windows Disk Cleanup clears periodically. After eviction, the next cold start must rely on the server answering `tools/list` directly — which fails if issue #1 triggers.

### Fix

- **Server** (`index.ts`): `setImmediate(startInit)` instead of `startInit()` in `oninitialized`. Yields to the event loop so `tools/list` can be processed before heavy init starts.

- **Wrapper** (`mcp-wrapper.cjs`): Move cache from `%TEMP%` to `build/.tools-cache.json`. Survives Windows cleanup, provides instant `<1ms` tools/list response from cache regardless of server state.

### Test Results

- 444 test files, 9034 assertions — all pass (0 failures)
- Manual handshake tests verified:
  - No cache + no delay → 34 tools ✓
  - No cache + delays → server handles via setImmediate ✓
  - Cache present + delays → instant from cache ✓

## Test plan

- [x] `npm run build` succeeds
- [x] `npx vitest run --config vitest.config.ci.ts` — 444/444 pass
- [x] Manual handshake test: `initialize → initialized → tools/list` returns 34 tools
- [x] Cache persists in `build/.tools-cache.json` after server start
- [ ] Verify on CoursIA workspace after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)