### PR TITLE
fix: export TOOL_CAPABILITIES for test access

### DIFF
--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -706,3 +706,6 @@ export function registerCallToolHandler(
         return result;
     });
 }
+
+// Export TOOL_CAPABILITIES for tests
+export { TOOL_CAPABILITIES };


### PR DESCRIPTION
## Summary
- Add export statement for TOOL_CAPABILITIES constant in registry.ts
- Resolves 3 failing tests that were trying to import this constant
- All 34 registry tests now pass with both regular and CI configurations

## Test plan
✅ Regular tests: `npx vitest run --config vitest.config.ts` - 34 passed
✅ CI tests: `npx vitest run --config vitest.config.ci.ts` - 34 passed

## Evidence
- **PR created**: wt/registry-test-fixes-completed
- **Commit**: ce11f111
- **Tests**: 34/34 passing (86.38s regular, 89.84s CI)
- **Build**: ✅ clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)