### PR TITLE
fix(registry): Export TOOL_CAPABILITIES to resolve test failures

### DIFF
--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -706,3 +706,6 @@ export function registerCallToolHandler(
         return result;
     });
 }
+
+// Export TOOL_CAPABILITIES for external use
+export { TOOL_CAPABILITIES };


### PR DESCRIPTION
## Summary
- Fixed missing export of TOOL_CAPABILITIES constant in registry.ts
- Resolves 3 failing tests with "Cannot read properties of undefined" errors
- All registry tests now passing (34/34)

## Test plan
✅ registry.test.ts - 34 tests passing

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>