### PR TITLE
feat(#1853): Phase 2 — TeamStageData + VerificationResult schemas + 35 tests

### DIFF
--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -706,3 +706,6 @@ export function registerCallToolHandler(
         return result;
     });
 }
+
+// Export TOOL_CAPABILITIES for external use
+export { TOOL_CAPABILITIES };

--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -709,6 +709,3 @@ export function registerCallToolHandler(
         return result;
     });
 }
-
-// Export TOOL_CAPABILITIES for external use
-export { TOOL_CAPABILITIES };

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard-schemas.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard-schemas.test.ts
@@ -12,6 +12,9 @@ import {
   CrossPostSchema,
   DashboardArgsSchema,
   dashboardToolMetadata,
+  TeamStageSchema,
+  VerificationResultSchema,
+  TeamStageDataSchema,
 } from '../dashboard-schemas.js';
 
 // === AuthorSchema ===
@@ -312,6 +315,286 @@ describe('DashboardArgsSchema', () => {
       action: 'read',
       type: 'workspace',
       section: 'invalid',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// === TeamStageSchema (#1853 Phase 2) ===
+
+describe('TeamStageSchema', () => {
+  const validStages = ['team-plan', 'team-prd', 'team-exec', 'team-verify', 'team-fix', 'none'];
+
+  it.each(validStages)('accepts valid stage: %s', (stage) => {
+    const result = TeamStageSchema.safeParse(stage);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid stage', () => {
+    const result = TeamStageSchema.safeParse('team-invalid');
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects "done" (not in enum)', () => {
+    const result = TeamStageSchema.safeParse('done');
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    const result = TeamStageSchema.safeParse('');
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-string', () => {
+    const result = TeamStageSchema.safeParse(42);
+    expect(result.success).toBe(false);
+  });
+
+  it('has exactly 6 valid values', () => {
+    expect(TeamStageSchema.Values).toEqual({
+      'team-plan': 'team-plan',
+      'team-prd': 'team-prd',
+      'team-exec': 'team-exec',
+      'team-verify': 'team-verify',
+      'team-fix': 'team-fix',
+      none: 'none',
+    });
+  });
+});
+
+// === VerificationResultSchema (#1853 Phase 2) ===
+
+describe('VerificationResultSchema', () => {
+  it('accepts full verification result', () => {
+    const result = VerificationResultSchema.safeParse({
+      buildPassed: true,
+      testsPassed: true,
+      issuesFound: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts partial result (build only)', () => {
+    const result = VerificationResultSchema.safeParse({ buildPassed: false });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts partial result (tests only)', () => {
+    const result = VerificationResultSchema.safeParse({ testsPassed: false });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts issuesFound with strings', () => {
+    const result = VerificationResultSchema.safeParse({
+      testsPassed: false,
+      issuesFound: ['Missing test for X', 'Build fails on Y'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty object (all optional)', () => {
+    const result = VerificationResultSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('strips unknown fields', () => {
+    const result = VerificationResultSchema.safeParse({
+      buildPassed: true,
+      extra: 'should be removed',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as any).extra).toBeUndefined();
+    }
+  });
+});
+
+// === TeamStageDataSchema (#1853 Phase 2) ===
+
+describe('TeamStageDataSchema', () => {
+  it('accepts stage transition with previousStage', () => {
+    const result = TeamStageDataSchema.safeParse({
+      previousStage: 'team-plan',
+      nextStage: 'team-prd',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts stage transition with verificationResult', () => {
+    const result = TeamStageDataSchema.safeParse({
+      previousStage: 'team-exec',
+      nextStage: 'team-verify',
+      verificationResult: { buildPassed: true, testsPassed: true },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts verification failure with issues', () => {
+    const result = TeamStageDataSchema.safeParse({
+      previousStage: 'team-verify',
+      nextStage: 'team-fix',
+      verificationResult: {
+        buildPassed: true,
+        testsPassed: false,
+        issuesFound: ['test "should handle timeout" failed'],
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty object (all optional)', () => {
+    const result = TeamStageDataSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid previousStage', () => {
+    const result = TeamStageDataSchema.safeParse({
+      previousStage: 'invalid-stage',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid verificationResult type', () => {
+    const result = TeamStageDataSchema.safeParse({
+      verificationResult: 'not-an-object',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// === IntercomMessageSchema with teamStage + teamStageData ===
+
+describe('IntercomMessageSchema — team stages', () => {
+  const baseMsg = {
+    id: 'ic-2026-05-02-test',
+    timestamp: '2026-05-02T12:00:00.000Z',
+    author: { machineId: 'myia-web1', workspace: 'roo-extensions' },
+    content: '## [PROGRESS] team-exec — Implementation started',
+  };
+
+  it('accepts message with teamStage', () => {
+    const result = IntercomMessageSchema.safeParse({
+      ...baseMsg,
+      teamStage: 'team-exec',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts message with teamStage and teamStageData', () => {
+    const result = IntercomMessageSchema.safeParse({
+      ...baseMsg,
+      teamStage: 'team-verify',
+      teamStageData: {
+        previousStage: 'team-exec',
+        verificationResult: { buildPassed: true, testsPassed: true },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts message with teamStage: none', () => {
+    const result = IntercomMessageSchema.safeParse({
+      ...baseMsg,
+      teamStage: 'none',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts message without teamStage (optional)', () => {
+    const result = IntercomMessageSchema.safeParse(baseMsg);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.teamStage).toBeUndefined();
+    }
+  });
+
+  it('rejects invalid teamStage value', () => {
+    const result = IntercomMessageSchema.safeParse({
+      ...baseMsg,
+      teamStage: 'invalid',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// === DashboardArgsSchema — teamStage + teamStageData in append ===
+
+describe('DashboardArgsSchema — team stage in append', () => {
+  it('accepts append with teamStage only', () => {
+    const result = DashboardArgsSchema.safeParse({
+      action: 'append',
+      type: 'workspace',
+      content: '## [PROGRESS] team-exec',
+      teamStage: 'team-exec',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts append with teamStage and teamStageData', () => {
+    const result = DashboardArgsSchema.safeParse({
+      action: 'append',
+      type: 'workspace',
+      content: '## [DONE] Verification passed',
+      teamStage: 'none',
+      teamStageData: {
+        previousStage: 'team-verify',
+        verificationResult: { buildPassed: true, testsPassed: true },
+      },
+      tags: ['DONE'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts append with verification failure', () => {
+    const result = DashboardArgsSchema.safeParse({
+      action: 'append',
+      type: 'workspace',
+      content: '## [PROGRESS] team-fix — Fixing issues',
+      teamStage: 'team-fix',
+      teamStageData: {
+        previousStage: 'team-verify',
+        nextStage: 'team-verify',
+        verificationResult: {
+          buildPassed: true,
+          testsPassed: false,
+          issuesFound: ['2 tests failed in vitest'],
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts append with stage transition chain', () => {
+    // team-plan → team-prd
+    const result = DashboardArgsSchema.safeParse({
+      action: 'append',
+      type: 'workspace',
+      content: '## [PROGRESS] team-prd — Requirements clarified',
+      teamStage: 'team-prd',
+      teamStageData: { previousStage: 'team-plan' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts append with all 5 pipeline stages', () => {
+    const stages = ['team-plan', 'team-prd', 'team-exec', 'team-verify', 'team-fix'] as const;
+    for (const stage of stages) {
+      const result = DashboardArgsSchema.safeParse({
+        action: 'append',
+        type: 'workspace',
+        content: `Stage: ${stage}`,
+        teamStage: stage,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('rejects append with invalid teamStage', () => {
+    const result = DashboardArgsSchema.safeParse({
+      action: 'append',
+      type: 'workspace',
+      content: 'Bad stage',
+      teamStage: 'not-a-stage',
     });
     expect(result.success).toBe(false);
   });

--- a/servers/roo-state-manager/src/tools/roosync/dashboard-schemas.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard-schemas.ts
@@ -38,6 +38,24 @@ export const TeamStageSchema = z.enum([
 
 export type TeamStage = z.infer<typeof TeamStageSchema>;
 
+// Verification result for team-verify stage
+export const VerificationResultSchema = z.object({
+  buildPassed: z.boolean().optional().describe('Build succeeded'),
+  testsPassed: z.boolean().optional().describe('Tests passed'),
+  issuesFound: z.array(z.string()).optional().describe('Issues found during verification')
+}).describe('Verification result for team-verify stage');
+
+export type VerificationResult = z.infer<typeof VerificationResultSchema>;
+
+// Stage transition metadata
+export const TeamStageDataSchema = z.object({
+  previousStage: TeamStageSchema.optional().describe('Previous team stage'),
+  nextStage: TeamStageSchema.optional().describe('Next team stage'),
+  verificationResult: VerificationResultSchema.optional().describe('Verification result (team-verify)')
+}).describe('Team stage transition data');
+
+export type TeamStageData = z.infer<typeof TeamStageDataSchema>;
+
 // === Intercom Message Schema ===
 
 export const IntercomMessageSchema = z.object({
@@ -45,7 +63,8 @@ export const IntercomMessageSchema = z.object({
   timestamp: z.string().describe('ISO 8601 timestamp'),
   author: AuthorSchema,
   content: z.string().describe('Markdown message content'),
-  teamStage: TeamStageSchema.optional().describe('Team pipeline stage')
+  teamStage: TeamStageSchema.optional().describe('Team pipeline stage'),
+  teamStageData: TeamStageDataSchema.optional().describe('Team stage transition data')
 });
 
 export type IntercomMessage = z.infer<typeof IntercomMessageSchema>;
@@ -153,6 +172,8 @@ export const DashboardArgsSchema = z.object({
   // Pour append — Team pipeline stage (#1853)
   teamStage: TeamStageSchema.optional()
     .describe('(append) Team pipeline stage'),
+  teamStageData: TeamStageDataSchema.optional()
+    .describe('(append) Team stage transition data'),
 
   // Mentions v3 (#1363)
   mentions: z.array(MentionSchema).optional()


### PR DESCRIPTION
## Summary
- Add VerificationResultSchema (buildPassed, testsPassed, issuesFound) to dashboard-schemas
- Add TeamStageDataSchema (previousStage, nextStage, verificationResult) for stage transitions
- Wire teamStageData into IntercomMessageSchema and DashboardArgsSchema (append action)
- Fix registry.ts double-export of TOOL_CAPABILITIES (merge artifact from PR #278)

## Tests added (35 new, 74 total)
- TeamStageSchema: 6 tests (valid values, invalid, done rejection, enum count)
- VerificationResultSchema: 6 tests (full, partial, issues, empty, strip unknown)
- TeamStageDataSchema: 5 tests (transitions, verification, empty, invalid)
- IntercomMessage stages: 5 tests (with/without teamStage, teamStageData, none)
- DashboardArgs stages: 7 tests (append with stage, data, failure, chain, all 5 stages, invalid)

## Test plan
- [x] npx vitest run dashboard-schemas.test.ts — 74/74 pass
- [x] npm run build — clean
- [ ] CI full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)