### PR TITLE
feat(#1935): Cluster B dashboard fusion — refresh/update sub-actions

### DIFF
--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -592,23 +592,28 @@ export function registerCallToolHandler(
                }
                break;
            }
-           // NOUVEAU: Outil de refresh dashboard (T3.17)
+           // #1935 Cluster B: Backward-compat redirect → roosync_dashboard(action: "refresh")
            case 'roosync_refresh_dashboard': {
                try {
-                   const m = await import('./roosync/refresh-dashboard.js');
-                   const roosyncResult = await m.roosyncRefreshDashboard(args as any);
-                   result = { content: [{ type: 'text', text: JSON.stringify(roosyncResult, null, 2) }] };
+                   const m = await import('./roosync/dashboard.js');
+                   const dashboardResult = await m.roosyncDashboard({ ...args, action: 'refresh' } as any);
+                   result = { content: [{ type: 'text', text: JSON.stringify(dashboardResult, null, 2) }] };
                } catch (error) {
                    result = { content: [{ type: 'text', text: `Error: ${(error as Error).message}` }], isError: true };
                }
                break;
            }
-           // #546: Dashboard hiérarchique
+           // #1935 Cluster B: Backward-compat redirect → roosync_dashboard(action: "update")
            case 'roosync_update_dashboard': {
                try {
-                   const m = await import('./roosync/update-dashboard.js');
-                   const roosyncResult = await m.roosyncUpdateDashboard(args as any);
-                   result = { content: [{ type: 'text', text: JSON.stringify(roosyncResult, null, 2) }] };
+                   const m = await import('./roosync/dashboard.js');
+                   const updateArgs = { ...args, action: 'update' };
+                   // Map old 'machine' param to machineId
+                   if ((args as any).machine && !(args as any).machineId) {
+                       (updateArgs as any).machineId = (args as any).machine;
+                   }
+                   const dashboardResult = await m.roosyncDashboard(updateArgs as any);
+                   result = { content: [{ type: 'text', text: JSON.stringify(dashboardResult, null, 2) }] };
                } catch (error) {
                    result = { content: [{ type: 'text', text: `Error: ${(error as Error).message}` }], isError: true };
                }

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard-cluster-b.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard-cluster-b.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for #1935 Cluster B: refresh/update sub-actions in roosync_dashboard
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { roosyncDashboard } from '../dashboard.js';
+
+// Mock refresh-dashboard module
+const mockRefreshDashboard = vi.fn();
+vi.mock('../refresh-dashboard.js', () => ({
+  roosyncRefreshDashboard: (...args: any[]) => mockRefreshDashboard(...args),
+  RefreshDashboardArgsSchema: {},
+  RefreshDashboardResultSchema: {},
+  refreshDashboardToolMetadata: { name: 'roosync_refresh_dashboard' }
+}));
+
+// Mock update-dashboard module
+const mockUpdateDashboard = vi.fn();
+vi.mock('../update-dashboard.js', () => ({
+  roosyncUpdateDashboard: (...args: any[]) => mockUpdateDashboard(...args),
+  UpdateDashboardArgsSchema: {},
+  UpdateDashboardResultSchema: {},
+  updateDashboardToolMetadata: { name: 'roosync_update_dashboard' }
+}));
+
+// Mock OpenAI for condensation
+vi.mock('@/services/openai', () => ({
+  getChatOpenAIClient: () => { throw new Error('No chat API key configured'); },
+  resetChatOpenAIClient: vi.fn(),
+  getLLMModelId: () => 'test-model',
+}));
+
+// Mock heartbeat-activity
+vi.mock('../heartbeat-activity.js', () => ({
+  recordRooSyncActivityAsync: vi.fn(),
+}));
+
+describe('roosync_dashboard Cluster B (#1935)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ROOSYNC_SHARED_PATH = '/tmp/test-shared';
+    process.env.ROOSYNC_MACHINE_ID = 'test-machine';
+    process.env.ROOSYNC_WORKSPACE_ID = 'test-workspace';
+  });
+
+  describe('action: refresh', () => {
+    it('should delegate to roosyncRefreshDashboard', async () => {
+      mockRefreshDashboard.mockResolvedValue({
+        success: true,
+        dashboardPath: '/tmp/dashboard.md',
+        timestamp: '2026-05-03',
+        baseline: 'myia-ai-01',
+        machines: [
+          { id: 'myia-ai-01', status: '✅ OK', diffs: '0' }
+        ],
+        metrics: { totalMachines: 1, machinesWithInventory: 1, machinesWithoutInventory: 0 }
+      });
+
+      const result = await roosyncDashboard({
+        action: 'refresh',
+        baseline: 'myia-ai-01'
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe('refresh');
+      expect(mockRefreshDashboard).toHaveBeenCalledWith({
+        baseline: 'myia-ai-01',
+        outputDir: undefined
+      });
+    });
+
+    it('should pass outputDir when provided', async () => {
+      mockRefreshDashboard.mockResolvedValue({
+        success: true,
+        dashboardPath: '/custom/dir/dashboard.md',
+        timestamp: '2026-05-03',
+        baseline: 'myia-ai-01',
+        machines: [],
+        metrics: { totalMachines: 0, machinesWithInventory: 0, machinesWithoutInventory: 0 }
+      });
+
+      const result = await roosyncDashboard({
+        action: 'refresh',
+        baseline: 'myia-po-2026',
+        outputDir: '/custom/dir'
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockRefreshDashboard).toHaveBeenCalledWith({
+        baseline: 'myia-po-2026',
+        outputDir: '/custom/dir'
+      });
+    });
+
+    it('should handle refresh failure gracefully', async () => {
+      mockRefreshDashboard.mockRejectedValue(new Error('PowerShell not found'));
+
+      await expect(roosyncDashboard({ action: 'refresh' })).rejects.toThrow('PowerShell not found');
+    });
+  });
+
+  describe('action: update', () => {
+    it('should delegate to roosyncUpdateDashboard', async () => {
+      mockUpdateDashboard.mockResolvedValue({
+        success: true,
+        dashboardPath: '/tmp/DASHBOARD.md',
+        section: 'machine',
+        mode: 'replace',
+        timestamp: '2026-05-03T20:00:00Z'
+      });
+
+      const result = await roosyncDashboard({
+        action: 'update',
+        section: 'machine',
+        content: '## Status\nAll good',
+        machineId: 'test-machine',
+        workspace: 'roo-extensions',
+        mode: 'replace'
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe('update');
+      expect(mockUpdateDashboard).toHaveBeenCalledWith({
+        section: 'machine',
+        content: '## Status\nAll good',
+        machine: 'test-machine',
+        workspace: 'roo-extensions',
+        mode: 'replace'
+      });
+    });
+
+    it('should reject missing section', async () => {
+      await expect(roosyncDashboard({
+        action: 'update',
+        content: 'test'
+      })).rejects.toThrow('section');
+    });
+
+    it('should reject invalid section values', async () => {
+      await expect(roosyncDashboard({
+        action: 'update',
+        section: 'status',
+        content: 'test'
+      })).rejects.toThrow('section');
+    });
+
+    it('should reject missing content', async () => {
+      await expect(roosyncDashboard({
+        action: 'update',
+        section: 'global'
+      })).rejects.toThrow('content');
+    });
+
+    it('should handle all valid sections', async () => {
+      const sections = ['machine', 'global', 'intercom', 'decisions', 'metrics'] as const;
+      mockUpdateDashboard.mockResolvedValue({
+        success: true,
+        dashboardPath: '/tmp/DASHBOARD.md',
+        section: 'global',
+        mode: 'replace',
+        timestamp: '2026-05-03T20:00:00Z'
+      });
+
+      for (const section of sections) {
+        const result = await roosyncDashboard({
+          action: 'update',
+          section,
+          content: `Content for ${section}`
+        });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it('should map machineId to machine param', async () => {
+      mockUpdateDashboard.mockResolvedValue({
+        success: true,
+        dashboardPath: '/tmp/DASHBOARD.md',
+        section: 'machine',
+        mode: 'replace',
+        timestamp: '2026-05-03T20:00:00Z'
+      });
+
+      await roosyncDashboard({
+        action: 'update',
+        section: 'machine',
+        content: 'test',
+        machineId: 'myia-po-2026'
+      });
+
+      expect(mockUpdateDashboard).toHaveBeenCalledWith(
+        expect.objectContaining({ machine: 'myia-po-2026' })
+      );
+    });
+  });
+});

--- a/servers/roo-state-manager/src/tools/roosync/dashboard-schemas.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard-schemas.ts
@@ -133,11 +133,11 @@ export interface DashboardFrontmatter {
 // === Dashboard Args Schema (unified for all actions) ===
 
 export const DashboardArgsSchema = z.object({
-  action: z.enum(['read', 'write', 'append', 'condense', 'list', 'delete', 'read_archive', 'read_overview'])
+  action: z.enum(['read', 'write', 'append', 'condense', 'list', 'delete', 'read_archive', 'read_overview', 'refresh', 'update'])
     .describe('Action to perform'),
 
   type: z.enum(['global', 'machine', 'workspace']).optional()
-    .describe('Dashboard type (required except list/read_overview)'),
+    .describe('Dashboard type (required except list/read_overview/refresh/update)'),
 
   machineId: z.string().optional()
     .describe('Machine ID (default: local)'),
@@ -145,9 +145,9 @@ export const DashboardArgsSchema = z.object({
   workspace: z.string().optional()
     .describe('Workspace (default: current)'),
 
-  // Pour read
-  section: z.enum(['status', 'intercom', 'all']).optional()
-    .describe('Section to read (default: all)'),
+  // Pour read/update — section semantics depend on action
+  section: z.enum(['status', 'intercom', 'all', 'machine', 'global', 'decisions', 'metrics']).optional()
+    .describe('Section to read (status/intercom/all) or update (machine/global/intercom/decisions/metrics)'),
   intercomLimit: z.number().optional()
     .describe('Max messages to return (default: all)'),
   mentionsOnly: z.boolean().optional()
@@ -157,7 +157,7 @@ export const DashboardArgsSchema = z.object({
 
   // Pour write/append
   content: z.string().optional()
-    .describe('Markdown for write (replaces status) or append (new message)'),
+    .describe('Markdown for write (replaces status), append (new message), or update (section content)'),
   author: AuthorSchema.optional()
     .describe('Author (write/append)'),
   createIfNotExists: z.boolean().optional()
@@ -189,7 +189,17 @@ export const DashboardArgsSchema = z.object({
 
   // Pour read_archive
   archiveFile: z.string().optional()
-    .describe('(read_archive) Archive filename (omit to list)')
+    .describe('(read_archive) Archive filename (omit to list)'),
+
+  // Pour refresh (#1935 Cluster B)
+  baseline: z.string().optional()
+    .describe('(refresh) Baseline machine (default: myia-ai-01)'),
+  outputDir: z.string().optional()
+    .describe('(refresh) Output directory (default: $ROOSYNC_SHARED_PATH/dashboards)'),
+
+  // Pour update (#1935 Cluster B)
+  mode: z.enum(['replace', 'append', 'prepend']).optional()
+    .describe('(update) Update mode: replace, append, prepend (default: replace)')
 }).passthrough();
 
 export type DashboardArgs = z.infer<typeof DashboardArgsSchema> & Record<string, any>;
@@ -200,6 +210,6 @@ export type DashboardArgs = z.infer<typeof DashboardArgsSchema> & Record<string,
 
 export const dashboardToolMetadata = {
   name: 'roosync_dashboard',
-  description: 'Shared dashboards (global/machine/workspace). Actions: read, write, append, condense, list, delete, read_archive, read_overview. Team stages supported.',
+  description: 'Shared dashboards (global/machine/workspace). Actions: read, write, append, condense, list, delete, read_archive, read_overview, refresh, update. Team stages supported.',
   inputSchema: zodToJsonSchema(DashboardArgsSchema as any, { target: 'openApi3' })
 };

--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -1563,6 +1563,14 @@ export async function roosyncDashboard(rawArgs: unknown): Promise<DashboardResul
     return handleReadOverview(resolvedMachineId, resolvedWorkspace, args, requestEcho);
   }
 
+  // #1935 Cluster B: refresh/update actions delegate to legacy tools
+  if (args.action === 'refresh') {
+    return handleRefresh(args, requestEcho);
+  }
+  if (args.action === 'update') {
+    return handleUpdate(args, requestEcho);
+  }
+
   if (!args.type) {
     throw new Error('type est requis pour action=' + args.action);
   }
@@ -1762,16 +1770,18 @@ async function handleRead(
   }
 
   const section = args.section ?? 'all';
+  // #1935: section now includes update-specific values — narrow to read-safe values
+  const readSection = (section === 'status' || section === 'intercom' || section === 'all') ? section : 'all';
   // intercomLimit is kept as an optional safety net but defaults to returning ALL messages.
   // The dashboard should stay under 50KB thanks to size-based condensation,
   // so agents always see the full picture without needing to paginate.
   const intercomLimit = args.intercomLimit;
   let data: Partial<Dashboard> = {};
 
-  if (section === 'status' || section === 'all') {
+  if (readSection === 'status' || readSection === 'all') {
     data.status = dashboard.status;
   }
-  if (section === 'intercom' || section === 'all') {
+  if (readSection === 'intercom' || readSection === 'all') {
     let messages = intercomLimit
       ? dashboard.intercom.messages.slice(-intercomLimit)
       : dashboard.intercom.messages;
@@ -1789,7 +1799,7 @@ async function handleRead(
       messages
     };
   }
-  if (section === 'all') {
+  if (readSection === 'all') {
     data = {
       type: dashboard.type,
       key: dashboard.key,
@@ -1812,7 +1822,7 @@ async function handleRead(
 
   // #1832: markdown format (default) — return human-readable markdown instead of JSON envelope
   if (args.format !== 'json') {
-    jsonResult.markdownContent = buildMarkdownOutput(dashboard, section, data.intercom?.messages);
+    jsonResult.markdownContent = buildMarkdownOutput(dashboard, readSection, data.intercom?.messages);
   }
 
   return jsonResult;
@@ -2609,4 +2619,59 @@ async function handleReadArchive(key: string, args: DashboardArgs, requestEcho: 
     }
     throw error;
   }
+}
+
+// === #1935 Cluster B: refresh/update handlers ===
+
+async function handleRefresh(
+  args: DashboardArgs,
+  requestEcho: DashboardRequestEcho
+): Promise<DashboardResult> {
+  const { roosyncRefreshDashboard } = await import('./refresh-dashboard.js');
+  const result = await roosyncRefreshDashboard({
+    baseline: args.baseline,
+    outputDir: args.outputDir
+  });
+  return {
+    success: result.success,
+    action: 'refresh',
+    key: 'mcp-inventory',
+    type: 'inventory',
+    request: requestEcho,
+    data: result as unknown as Partial<Dashboard>,
+    message: result.success
+      ? `Dashboard MCP rafraîchi: ${result.metrics.totalMachines} machines`
+      : `Erreur rafraîchissement: ${(result as any).message ?? 'unknown'}`
+  };
+}
+
+async function handleUpdate(
+  args: DashboardArgs,
+  requestEcho: DashboardRequestEcho
+): Promise<DashboardResult> {
+  if (!args.section || !['machine', 'global', 'intercom', 'decisions', 'metrics'].includes(args.section)) {
+    throw new Error('section (machine/global/intercom/decisions/metrics) est requis pour action=update');
+  }
+  if (!args.content) {
+    throw new Error('content est requis pour action=update');
+  }
+  const { roosyncUpdateDashboard } = await import('./update-dashboard.js');
+  const result = await roosyncUpdateDashboard({
+    section: args.section as 'machine' | 'global' | 'intercom' | 'decisions' | 'metrics',
+    content: args.content,
+    machine: args.machineId,
+    workspace: args.workspace,
+    mode: args.mode
+  });
+  return {
+    success: result.success,
+    action: 'update',
+    key: 'hierarchical',
+    type: 'hierarchical',
+    request: requestEcho,
+    data: result as unknown as Partial<Dashboard>,
+    message: result.success
+      ? `Section '${result.section}' mise à jour (${result.mode})`
+      : `Erreur mise à jour: ${result.dashboardPath ?? 'unknown'}`
+  };
 }

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -502,7 +502,7 @@ export const roosyncDiagnoseDefinition = {
 
 export const roosyncRefreshDashboardDefinition = {
     name: 'roosync_refresh_dashboard',
-    description: 'Rafraîchit le dashboard MCP en exécutant le script generate-mcp-dashboard.ps1',
+    description: '[DEPRECATED #1935] Use roosync_dashboard(action: "refresh") instead. Rafraîchit le dashboard MCP en exécutant le script generate-mcp-dashboard.ps1',
     inputSchema: {
         type: 'object',
         properties: {
@@ -515,7 +515,7 @@ export const roosyncRefreshDashboardDefinition = {
 
 export const roosyncUpdateDashboardDefinition = {
     name: 'roosync_update_dashboard',
-    description: 'Met à jour une section du dashboard hiérarchique RooSync sur GDrive (#546)',
+    description: '[DEPRECATED #1935] Use roosync_dashboard(action: "update") instead. Met à jour une section du dashboard hiérarchique RooSync sur GDrive (#546)',
     inputSchema: {
         type: 'object',
         properties: {


### PR DESCRIPTION
## Summary
- Fuse `roosync_refresh_dashboard` + `roosync_update_dashboard` into `roosync_dashboard(action: "refresh" | "update")`
- Extend `DashboardArgsSchema.action` enum with `refresh` and `update`
- Add `handleRefresh` + `handleUpdate` handlers via dynamic imports (no circular deps)
- Backward-compat redirects in registry.ts for old tool names
- Deprecated notices on old tool definitions (30-day grace period)

## Test plan
- [x] 9 new unit tests (refresh delegation, update validation, section mapping)
- [x] Build: `npm run build` — clean (0 TS errors)
- [x] CI tests: 9110/9110 passed (0 failures)
- [ ] Manual: `roosync_dashboard(action: "refresh")` produces same result as `roosync_refresh_dashboard`
- [ ] Manual: `roosync_dashboard(action: "update", section: "machine", content: "...")` produces same result as `roosync_update_dashboard`

## Token savings
~251 tokens when deprecated tools are removed from `tools/list` after 30-day grace period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)