### PR TITLE
test: coverage extension for shared-state-path + cache-manager

### DIFF
--- a/servers/roo-state-manager/src/utils/__tests__/cache-manager-disk.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/cache-manager-disk.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Disk persistence coverage for cache-manager.ts
+ * Targets: persistEntry, removeFromDisk, saveToDisk (private methods)
+ * Lines 551-571 in cache-manager.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { CacheManager } from '../cache-manager.js';
+import { promises as fs } from 'fs';
+
+vi.mock('../../services/ConfigDiffService.js', () => ({
+	ConfigDiffService: class MockConfigDiffService {
+		compare() { return { summary: { added: 0, modified: 0, deleted: 0 } }; }
+	}
+}));
+
+describe('CacheManager — Disk Persistence', () => {
+	const tmpDir = `/tmp/cache-test-${Date.now()}`;
+	let cm: CacheManager;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(async () => {
+		if (cm) await cm.close();
+		vi.useRealTimers();
+		// Cleanup temp dir
+		try { await fs.rm(tmpDir, { recursive: true }); } catch {}
+	});
+
+	it('persists entries to disk when persistToDisk is true', async () => {
+		cm = new CacheManager({
+			persistToDisk: true,
+			cacheDir: tmpDir,
+			maxSize: 1024 * 1024,
+			maxAge: 60000,
+			cleanupInterval: 10000
+		});
+
+		await cm.set('test-key', { data: 'hello' });
+		await cm.set('another-key', 'world');
+
+		// saveToDisk should have written files
+		const files = await fs.readdir(tmpDir);
+		expect(files.length).toBeGreaterThanOrEqual(1);
+		expect(files.some(f => f.includes('test-key'))).toBe(true);
+	});
+
+	it('persists entry as JSON with metadata', async () => {
+		cm = new CacheManager({
+			persistToDisk: true,
+			cacheDir: tmpDir,
+			maxSize: 1024 * 1024,
+			maxAge: 60000,
+			cleanupInterval: 10000
+		});
+
+		await cm.set('key1', 'value1');
+
+		const files = await fs.readdir(tmpDir);
+		expect(files).toContain('key1.json');
+
+		const entry = JSON.parse(await fs.readFile(`${tmpDir}/key1.json`, 'utf-8'));
+		expect(entry.data).toBe('value1');
+		expect(entry.version).toBe('1.0.0');
+		expect(entry).toHaveProperty('timestamp');
+	});
+
+	it('removes entry from disk on invalidation', async () => {
+		cm = new CacheManager({
+			persistToDisk: true,
+			cacheDir: tmpDir,
+			maxSize: 1024 * 1024,
+			maxAge: 60000,
+			cleanupInterval: 10000
+		});
+
+		await cm.set('to-remove', 'data', ['dep1']);
+
+		const filesBefore = await fs.readdir(tmpDir);
+		expect(filesBefore.some(f => f.includes('to-remove'))).toBe(true);
+
+		await cm.invalidateByDependency('dep1');
+
+		const filesAfter = await fs.readdir(tmpDir);
+		expect(filesAfter.some(f => f.includes('to-remove'))).toBe(false);
+	});
+
+	it('handles special characters in keys for disk file names', async () => {
+		cm = new CacheManager({
+			persistToDisk: true,
+			cacheDir: tmpDir,
+			maxSize: 1024 * 1024,
+			maxAge: 60000,
+			cleanupInterval: 10000
+		});
+
+		await cm.set('key:with:colons/and/slashes', 'data');
+
+		const files = await fs.readdir(tmpDir);
+		// Special chars replaced with _
+		const entryFile = files.find(f => f.includes('key_with_colons'));
+		expect(entryFile).toBeDefined();
+	});
+
+	it('does not persist when persistToDisk is false (default)', async () => {
+		cm = new CacheManager({
+			persistToDisk: false,
+			cacheDir: tmpDir,
+			maxSize: 1024 * 1024,
+			maxAge: 60000,
+			cleanupInterval: 10000
+		});
+
+		await cm.set('no-persist', 'data');
+
+		// cacheDir may not even exist since nothing was written
+		try {
+			const files = await fs.readdir(tmpDir);
+			expect(files.some(f => f.includes('no-persist'))).toBe(false);
+		} catch {
+			// Dir doesn't exist = correct behavior
+		}
+	});
+
+	it('gracefully handles write errors in persistEntry', async () => {
+		const readOnlyDir = '/nonexistent/path/that/cannot/be/created';
+		cm = new CacheManager({
+			persistToDisk: true,
+			cacheDir: readOnlyDir,
+			maxSize: 1024 * 1024,
+			maxAge: 60000,
+			cleanupInterval: 10000
+		});
+
+		// Should not throw even if disk write fails
+		await expect(cm.set('fail-key', 'data')).resolves.toBeUndefined();
+	});
+
+	it('gracefully handles unlink errors in removeFromDisk', async () => {
+		cm = new CacheManager({
+			persistToDisk: true,
+			cacheDir: tmpDir,
+			maxSize: 1024 * 1024,
+			maxAge: 60000,
+			cleanupInterval: 10000
+		});
+
+		await cm.set('will-delete', 'data', ['dep-delete']);
+
+		// Manually remove the file so unlink fails
+		const files = await fs.readdir(tmpDir);
+		for (const f of files) {
+			if (f.includes('will-delete')) {
+				await fs.unlink(`${tmpDir}/${f}`);
+			}
+		}
+
+		// Should not throw even if file already gone
+		await expect(cm.invalidateByDependency('dep-delete')).resolves.toBe(1);
+	});
+});

--- a/servers/roo-state-manager/src/utils/__tests__/shared-state-path-coverage.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/shared-state-path-coverage.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Coverage extension for shared-state-path.ts
+ * Targets: tryGetSharedStatePath, isSharedPathAccessible, .env edge cases
+ */
+
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('shared-state-path coverage extension', () => {
+	const originalEnv = process.env.ROOSYNC_SHARED_PATH;
+
+	beforeEach(() => {
+		delete process.env.ROOSYNC_SHARED_PATH;
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		if (originalEnv !== undefined) {
+			process.env.ROOSYNC_SHARED_PATH = originalEnv;
+		} else {
+			delete process.env.ROOSYNC_SHARED_PATH;
+		}
+		vi.restoreAllMocks();
+	});
+
+	describe('tryGetSharedStatePath', () => {
+		test('returns path when env var is set', async () => {
+			process.env.ROOSYNC_SHARED_PATH = '/try/path';
+			const { tryGetSharedStatePath } = await import('../shared-state-path.js');
+			expect(tryGetSharedStatePath()).toBe('/try/path');
+		});
+
+		test('returns null when no path available', async () => {
+			vi.doMock('fs', async () => {
+				const actual = await vi.importActual('fs');
+				return { ...actual, existsSync: () => false };
+			});
+			const { tryGetSharedStatePath } = await import('../shared-state-path.js');
+			expect(tryGetSharedStatePath()).toBeNull();
+		});
+	});
+
+	describe('isSharedPathAccessible', () => {
+		test('returns true when path exists on disk', async () => {
+			process.env.ROOSYNC_SHARED_PATH = '/accessible/path';
+			vi.doMock('fs', async () => {
+				const actual = await vi.importActual('fs');
+				return { ...actual, existsSync: (p: string) => p === '/accessible/path' };
+			});
+			const { isSharedPathAccessible } = await import('../shared-state-path.js');
+			expect(isSharedPathAccessible()).toBe(true);
+		});
+
+		test('returns false when path is not on disk', async () => {
+			process.env.ROOSYNC_SHARED_PATH = '/missing/path';
+			vi.doMock('fs', async () => {
+				const actual = await vi.importActual('fs');
+				return { ...actual, existsSync: () => false };
+			});
+			const { isSharedPathAccessible } = await import('../shared-state-path.js');
+			expect(isSharedPathAccessible()).toBe(false);
+		});
+
+		test('returns false when no path configured', async () => {
+			vi.doMock('fs', async () => {
+				const actual = await vi.importActual('fs');
+				return { ...actual, existsSync: () => false };
+			});
+			const { isSharedPathAccessible } = await import('../shared-state-path.js');
+			expect(isSharedPathAccessible()).toBe(false);
+		});
+	});
+
+	describe('.env edge cases', () => {
+		test('handles quoted values in .env file', async () => {
+			vi.doMock('fs', async () => {
+				const actual = await vi.importActual('fs');
+				return {
+					...actual,
+					existsSync: () => true,
+					readFileSync: () => 'ROOSYNC_SHARED_PATH="/quoted/path"\n',
+				};
+			});
+			const { getSharedStatePath } = await import('../shared-state-path.js');
+			expect(getSharedStatePath()).toBe('/quoted/path');
+		});
+
+		test('handles single-quoted values in .env file', async () => {
+			vi.doMock('fs', async () => {
+				const actual = await vi.importActual('fs');
+				return {
+					...actual,
+					existsSync: () => true,
+					readFileSync: () => "ROOSYNC_SHARED_PATH='/single/quoted'\n",
+				};
+			});
+			const { getSharedStatePath } = await import('../shared-state-path.js');
+			expect(getSharedStatePath()).toBe('/single/quoted');
+		});
+
+		test('skips comment lines in .env file', async () => {
+			vi.doMock('fs', async () => {
+				const actual = await vi.importActual('fs');
+				return {
+					...actual,
+					existsSync: () => true,
+					readFileSync: () => '# This is a comment\nROOSYNC_SHARED_PATH=/after/comment\n',
+				};
+			});
+			const { getSharedStatePath } = await import('../shared-state-path.js');
+			expect(getSharedStatePath()).toBe('/after/comment');
+		});
+
+		test('skips empty lines in .env file', async () => {
+			vi.doMock('fs', async () => {
+				const actual = await vi.importActual('fs');
+				return {
+					...actual,
+					existsSync: () => true,
+					readFileSync: () => '\n\nROOSYNC_SHARED_PATH=/after/blanks\n\n',
+				};
+			});
+			const { getSharedStatePath } = await import('../shared-state-path.js');
+			expect(getSharedStatePath()).toBe('/after/blanks');
+		});
+
+		test('returns null when .env key has empty value', async () => {
+			vi.doMock('fs', async () => {
+				const actual = await vi.importActual('fs');
+				return {
+					...actual,
+					existsSync: () => true,
+					readFileSync: () => 'ROOSYNC_SHARED_PATH=\n',
+				};
+			});
+			const { getSharedStatePath } = await import('../shared-state-path.js');
+			expect(() => getSharedStatePath()).toThrow('ROOSYNC_SHARED_PATH');
+		});
+
+		test('skips lines without equals sign', async () => {
+			vi.doMock('fs', async () => {
+				const actual = await vi.importActual('fs');
+				return {
+					...actual,
+					existsSync: () => true,
+					readFileSync: () => 'NOEQUALSSIGN\nROOSYNC_SHARED_PATH=/valid\n',
+				};
+			});
+			const { getSharedStatePath } = await import('../shared-state-path.js');
+			expect(getSharedStatePath()).toBe('/valid');
+		});
+
+		test('skips non-matching keys', async () => {
+			vi.doMock('fs', async () => {
+				const actual = await vi.importActual('fs');
+				return {
+					...actual,
+					existsSync: () => true,
+					readFileSync: () => 'OTHER_KEY=/other\nROOSYNC_SHARED_PATH=/correct\n',
+				};
+			});
+			const { getSharedStatePath } = await import('../shared-state-path.js');
+			expect(getSharedStatePath()).toBe('/correct');
+		});
+
+		test('handles readFileSync throwing gracefully', async () => {
+			vi.doMock('fs', async () => {
+				const actual = await vi.importActual('fs');
+				return {
+					...actual,
+					existsSync: () => true,
+					readFileSync: () => { throw new Error('permission denied'); },
+				};
+			});
+			const { getSharedStatePath } = await import('../shared-state-path.js');
+			expect(() => getSharedStatePath()).toThrow('ROOSYNC_SHARED_PATH');
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Add 13 tests for `shared-state-path.ts` covering `tryGetSharedStatePath()`, `isSharedPathAccessible()`, and `.env` edge cases (quotes, comments, empty values, read errors, non-matching keys)
- Add 7 tests for `cache-manager.ts` covering disk persistence (`persistEntry`, `removeFromDisk`, special chars, write errors)
- Previous coverage: `shared-state-path.ts` 64.91%, `cache-manager.ts` 75.63%

## Test plan
- [x] `npx vitest run` — 20/20 new tests pass
- [x] `npx vitest run --config vitest.config.ci.ts` — 9121/9121 pass, 0 failures
- [x] `npm run build` — clean

## Dispatch
Cycle 27 Mandat 3 (coverage extension) for myia-po-2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)