### PR TITLE
feat(#1953): dashboard-derived status cross-check

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
@@ -41,6 +41,16 @@ vi.mock('../../../services/MessageManager.js', () => ({
   }))
 }));
 
+// #1953: Mock dashboard cross-check to prevent real GDrive file reads in tests
+vi.mock('../../../utils/dashboard-activity.js', () => ({
+  crossCheckWithDashboard: vi.fn((state: any) => ({
+    ...state,
+    overrides: []
+  })),
+  extractMachineActivity: vi.fn(() => new Map()),
+  isRecentlyActive: vi.fn(() => false)
+}));
+
 describe('get-status (Option B)', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -307,10 +307,31 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
 
     // #1365: Filter out orphan test entries (test-machine, persistent-machine, etc.)
     // Only keep machines matching the known pattern: myia-*
-    const filteredOnlineMachines = (heartbeatState?.onlineMachines ?? []).filter(isKnownMachine);
-    const filteredOfflineMachines = (heartbeatState?.offlineMachines ?? []).filter(isKnownMachine);
-    const filteredWarningMachines = (heartbeatState?.warningMachines ?? []).filter(isKnownMachine);
+    let filteredOnlineMachines = (heartbeatState?.onlineMachines ?? []).filter(isKnownMachine);
+    let filteredOfflineMachines = (heartbeatState?.offlineMachines ?? []).filter(isKnownMachine);
+    let filteredWarningMachines = (heartbeatState?.warningMachines ?? []).filter(isKnownMachine);
     const filteredDashboardMachines = machines.filter(m => isKnownMachine(m.id));
+
+    // #1953: Cross-check heartbeat-derived status against dashboard activity.
+    // Dashboard message timestamps are embedded in file content (immune to GDrive
+    // propagation latency on file mod time), preventing false OFFLINE detection.
+    let dashboardOverrides: string[] = [];
+    try {
+      const dashboardsDir = join(getSharedStatePath(), 'dashboards');
+      const workspaceDashboard = join(dashboardsDir, 'workspace-roo-extensions.md');
+      const dashboardContent = readFileSync(workspaceDashboard, 'utf-8');
+      const { crossCheckWithDashboard } = await import('../../utils/dashboard-activity.js');
+      const crossChecked = crossCheckWithDashboard(
+        { onlineMachines: filteredOnlineMachines, offlineMachines: filteredOfflineMachines, warningMachines: filteredWarningMachines },
+        dashboardContent
+      );
+      filteredOnlineMachines = crossChecked.onlineMachines;
+      filteredOfflineMachines = crossChecked.offlineMachines;
+      filteredWarningMachines = crossChecked.warningMachines;
+      dashboardOverrides = crossChecked.overrides;
+    } catch {
+      // Dashboard file may not exist yet — skip cross-check silently
+    }
 
     // #1409: Use machine registry as authoritative source for total count
     const registryMachineIds = service.getKnownMachineIds();
@@ -361,7 +382,8 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
       machines: {
         online: filteredOnlineMachines.length,
         offline: filteredOfflineMachines.length,
-        total: totalMachines
+        total: totalMachines,
+        ...(dashboardOverrides.length > 0 ? { dashboardOverrides } : {})
       },
       inbox: inboxStats,
       decisions: { pending: pendingDecisions },

--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -15,6 +15,9 @@ import { getSharedStatePath } from '../../utils/shared-state-path.js';
 import { getToolUsageSnapshot, type ToolUsageSnapshot } from '../../utils/tool-call-metrics.js';
 import { join } from 'path';
 import { readdirSync, readFileSync, statSync } from 'fs';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('GetStatus');
 
 /**
  * Check if a machine ID is a real production machine (not a test artifact).
@@ -254,7 +257,8 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
           const heartbeatService = service.getHeartbeatService();
           await heartbeatService.checkHeartbeats();
           return heartbeatService.getState();
-        } catch {
+        } catch (err) {
+          logger.warn('Heartbeat check failed', { error: String(err) });
           return { onlineMachines: [] as string[], offlineMachines: [] as string[], warningMachines: [] as string[] };
         }
       })(),
@@ -267,7 +271,8 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
             unread: stats.unread,
             urgent: stats.by_priority?.URGENT ?? 0
           };
-        } catch {
+        } catch (err) {
+          logger.warn('Inbox stats failed', { error: String(err) });
           return { unread: 0, urgent: 0 };
         }
       })(),
@@ -301,8 +306,8 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
           }
         }
       }
-    } catch {
-      // dashboards dir may not exist yet
+    } catch (err) {
+      logger.debug('Dashboards dir not accessible', { error: String(err) });
     }
 
     // #1365: Filter out orphan test entries (test-machine, persistent-machine, etc.)
@@ -329,8 +334,8 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
       filteredOfflineMachines = crossChecked.offlineMachines;
       filteredWarningMachines = crossChecked.warningMachines;
       dashboardOverrides = crossChecked.overrides;
-    } catch {
-      // Dashboard file may not exist yet — skip cross-check silently
+    } catch (err) {
+      logger.debug('Dashboard cross-check skipped', { error: String(err) });
     }
 
     // #1409: Use machine registry as authoritative source for total count
@@ -410,7 +415,8 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
           });
 
           hudData = { activeClaims, activeStages, onlineAgents };
-        } catch {
+        } catch (err) {
+          logger.debug('HUD data unavailable', { error: String(err) });
           hudData = undefined;
         }
         return { hud: hudData };

--- a/servers/roo-state-manager/src/utils/__tests__/dashboard-activity.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/dashboard-activity.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for dashboard-derived machine status utility (#1953)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { extractMachineActivity, isRecentlyActive, crossCheckWithDashboard } from '../dashboard-activity.js';
+
+describe('dashboard-activity', () => {
+	describe('extractMachineActivity', () => {
+		it('should extract machine activity from valid dashboard content', () => {
+			const content = [
+				'### [2026-05-03T20:08:15.436Z] myia-po-2024|roo-extensions',
+				'Some message content',
+				'### [2026-05-03T20:10:00.000Z] myia-po-2023|roo-extensions',
+				'Another message',
+			].join('\n');
+
+			const activity = extractMachineActivity(content);
+			expect(activity.size).toBe(2);
+			expect(activity.get('myia-po-2024')).toBe('2026-05-03T20:08:15.436Z');
+			expect(activity.get('myia-po-2023')).toBe('2026-05-03T20:10:00.000Z');
+		});
+
+		it('should keep the most recent timestamp per machine', () => {
+			const content = [
+				'### [2026-05-03T18:00:00.000Z] myia-po-2024|roo-extensions',
+				'Old message',
+				'### [2026-05-03T20:00:00.000Z] myia-po-2024|roo-extensions',
+				'New message',
+			].join('\n');
+
+			const activity = extractMachineActivity(content);
+			expect(activity.get('myia-po-2024')).toBe('2026-05-03T20:00:00.000Z');
+		});
+
+		it('should ignore non-myia machines', () => {
+			const content = [
+				'### [2026-05-03T20:00:00.000Z] test-machine|roo-extensions',
+				'### [2026-05-03T20:00:00.000Z] some-other|roo-extensions',
+			].join('\n');
+
+			const activity = extractMachineActivity(content);
+			expect(activity.size).toBe(0);
+		});
+
+		it('should return empty map for empty content', () => {
+			expect(extractMachineActivity('').size).toBe(0);
+			expect(extractMachineActivity('no matching content').size).toBe(0);
+		});
+	});
+
+	describe('isRecentlyActive', () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-05-03T20:00:00Z'));
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('should return true for recent timestamp', () => {
+			expect(isRecentlyActive('2026-05-03T19:30:00Z')).toBe(true); // 30 min ago
+		});
+
+		it('should return false for old timestamp with default threshold', () => {
+			expect(isRecentlyActive('2026-05-03T18:00:00Z')).toBe(false); // 2h ago, default 60min
+		});
+
+		it('should respect custom threshold', () => {
+			expect(isRecentlyActive('2026-05-03T18:00:00Z', 3 * 60 * 60 * 1000)).toBe(true); // 2h ago, threshold 3h
+		});
+
+		it('should return false for invalid timestamp', () => {
+			expect(isRecentlyActive('invalid')).toBe(false);
+		});
+	});
+
+	describe('crossCheckWithDashboard', () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-05-03T20:00:00Z'));
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('should override OFFLINE to ONLINE when dashboard shows recent activity', () => {
+			const heartbeatState = {
+				onlineMachines: ['myia-po-2023'],
+				offlineMachines: ['myia-po-2024'],
+				warningMachines: [],
+			};
+			const dashboardContent = '### [2026-05-03T19:30:00Z] myia-po-2024|roo-extensions\nRecent message';
+
+			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
+			expect(result.onlineMachines).toContain('myia-po-2024');
+			expect(result.offlineMachines).not.toContain('myia-po-2024');
+			expect(result.overrides).toContain('myia-po-2024');
+		});
+
+		it('should override WARNING to ONLINE when dashboard shows recent activity', () => {
+			const heartbeatState = {
+				onlineMachines: [],
+				offlineMachines: [],
+				warningMachines: ['myia-web1'],
+			};
+			const dashboardContent = '### [2026-05-03T19:45:00Z] myia-web1|roo-extensions\nRecent message';
+
+			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
+			expect(result.onlineMachines).toContain('myia-web1');
+			expect(result.warningMachines).not.toContain('myia-web1');
+			expect(result.overrides).toContain('myia-web1');
+		});
+
+		it('should NOT override when dashboard activity is too old', () => {
+			const heartbeatState = {
+				onlineMachines: [],
+				offlineMachines: ['myia-po-2025'],
+				warningMachines: [],
+			};
+			const dashboardContent = '### [2026-05-03T10:00:00Z] myia-po-2025|roo-extensions\nOld message';
+
+			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
+			expect(result.offlineMachines).toContain('myia-po-2025');
+			expect(result.overrides).toHaveLength(0);
+		});
+
+		it('should handle multiple overrides', () => {
+			const heartbeatState = {
+				onlineMachines: [],
+				offlineMachines: ['myia-po-2024', 'myia-po-2025'],
+				warningMachines: ['myia-web1'],
+			};
+			const dashboardContent = [
+				'### [2026-05-03T19:50:00Z] myia-po-2024|roo-extensions',
+				'Message 1',
+				'### [2026-05-03T19:55:00Z] myia-po-2025|roo-extensions',
+				'Message 2',
+				'### [2026-05-03T19:40:00Z] myia-web1|roo-extensions',
+				'Message 3',
+			].join('\n');
+
+			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
+			expect(result.onlineMachines).toHaveLength(3);
+			expect(result.overrides).toHaveLength(3);
+		});
+
+		it('should not modify already online machines', () => {
+			const heartbeatState = {
+				onlineMachines: ['myia-ai-01'],
+				offlineMachines: [],
+				warningMachines: [],
+			};
+			const dashboardContent = '### [2026-05-03T19:50:00Z] myia-ai-01|roo-extensions\nMessage';
+
+			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
+			expect(result.overrides).toHaveLength(0);
+			expect(result.onlineMachines).toEqual(['myia-ai-01']);
+		});
+	});
+});

--- a/servers/roo-state-manager/src/utils/dashboard-activity.ts
+++ b/servers/roo-state-manager/src/utils/dashboard-activity.ts
@@ -1,0 +1,122 @@
+/**
+ * Dashboard-derived machine status utility (#1953)
+ *
+ * Parses dashboard message timestamps to determine last-seen time per machine.
+ * Used as a cross-check against heartbeat files to prevent false OFFLINE detection
+ * caused by GDrive propagation latency.
+ *
+ * Dashboard messages embed timestamps INSIDE the content (written by the posting machine),
+ * which are immune to GDrive file modification time delays.
+ *
+ * Message format: ### [2026-05-03T20:08:15.436Z] myia-po-2024|roo-extensions
+ *
+ * @module utils/dashboard-activity
+ * @version 1.0.0
+ */
+
+import { createLogger } from './logger.js';
+
+const logger = createLogger('DashboardActivity');
+
+const DASHBOARD_MSG_PATTERN = /^###\s*\[(\d{4}-\d{2}-\d{2}T[\d:.]+Z)\]\s*(\S+)/gm;
+
+/**
+ * Extract last-seen timestamp per machine from dashboard content.
+ *
+ * @param dashboardContent - Raw dashboard markdown content
+ * @returns Map of machineId → last-seen ISO timestamp
+ */
+export function extractMachineActivity(dashboardContent: string): Map<string, string> {
+	const activity = new Map<string, string>();
+
+	if (!dashboardContent) return activity;
+
+	let match: RegExpExecArray | null;
+	const pattern = new RegExp(DASHBOARD_MSG_PATTERN.source, 'gm');
+
+	while ((match = pattern.exec(dashboardContent)) !== null) {
+		const timestamp = match[1];
+		const authorField = match[2];
+
+		const machineId = authorField.split('|')[0].toLowerCase().trim();
+		if (!machineId.startsWith('myia-')) continue;
+
+		const existing = activity.get(machineId);
+		if (!existing || timestamp > existing) {
+			activity.set(machineId, timestamp);
+		}
+	}
+
+	logger.debug(`Dashboard activity extracted: ${activity.size} machines seen`);
+	return activity;
+}
+
+/**
+ * Determine if a machine should be considered ONLINE based on dashboard activity.
+ *
+ * @param lastSeen - ISO timestamp of last dashboard message from the machine
+ * @param thresholdMs - How far back to consider "recent" (default: 60 min)
+ * @returns true if machine posted within the threshold
+ */
+export function isRecentlyActive(lastSeen: string, thresholdMs: number = 60 * 60 * 1000): boolean {
+	const lastSeenMs = new Date(lastSeen).getTime();
+	if (isNaN(lastSeenMs)) return false;
+	return Date.now() - lastSeenMs < thresholdMs;
+}
+
+/**
+ * Cross-check heartbeat-derived status against dashboard activity.
+ *
+ * For machines marked "offline" or "warning" by heartbeat files,
+ * if dashboard shows recent activity, override the status to "online".
+ *
+ * @param heartbeatState - State from HeartbeatService.checkHeartbeats()
+ * @param dashboardContent - Raw dashboard markdown content
+ * @param thresholdMs - Dashboard activity threshold (default: 60 min)
+ * @returns Updated lists of online/offline/warning machines
+ */
+export function crossCheckWithDashboard(
+	heartbeatState: {
+		onlineMachines: string[];
+		offlineMachines: string[];
+		warningMachines: string[];
+	},
+	dashboardContent: string,
+	thresholdMs: number = 60 * 60 * 1000
+): {
+	onlineMachines: string[];
+	offlineMachines: string[];
+	warningMachines: string[];
+	overrides: string[];
+} {
+	const activity = extractMachineActivity(dashboardContent);
+	const overrides: string[] = [];
+
+	const offlineMachines = [...heartbeatState.offlineMachines];
+	const warningMachines = [...heartbeatState.warningMachines];
+	const onlineMachines = [...heartbeatState.onlineMachines];
+
+	for (let i = offlineMachines.length - 1; i >= 0; i--) {
+		const machineId = offlineMachines[i];
+		const lastSeen = activity.get(machineId);
+		if (lastSeen && isRecentlyActive(lastSeen, thresholdMs)) {
+			offlineMachines.splice(i, 1);
+			onlineMachines.push(machineId);
+			overrides.push(machineId);
+			logger.info(`Dashboard override: ${machineId} OFFLINE→ONLINE (last seen ${lastSeen})`);
+		}
+	}
+
+	for (let i = warningMachines.length - 1; i >= 0; i--) {
+		const machineId = warningMachines[i];
+		const lastSeen = activity.get(machineId);
+		if (lastSeen && isRecentlyActive(lastSeen, thresholdMs)) {
+			warningMachines.splice(i, 1);
+			onlineMachines.push(machineId);
+			overrides.push(machineId);
+			logger.info(`Dashboard override: ${machineId} WARNING→ONLINE (last seen ${lastSeen})`);
+		}
+	}
+
+	return { onlineMachines, offlineMachines, warningMachines, overrides };
+}


### PR DESCRIPTION
## Summary
- New utility `dashboard-activity.ts` extracts machine activity from workspace dashboard message timestamps (immune to GDrive file mod time latency)
- Integrates cross-check in `get-status.ts`: machines marked OFFLINE/WARNING by heartbeat files are overridden to ONLINE if dashboard shows recent activity (<60 min)
- 13 unit tests for the new utility + mock in existing get-status tests

## Root Cause
GDrive propagation latency causes heartbeat files to appear stale to readers, triggering false OFFLINE detection. Dashboard message timestamps are embedded in file **content** (not dependent on file modification time), making them a reliable cross-check.

## Test Plan
- [x] `npm run build` passes
- [x] `npx vitest run --config vitest.config.ci.ts` — 9114 tests pass (0 failures)
- [x] 13 new unit tests for `dashboard-activity.ts`
- [x] Existing 22 `get-status` tests pass with mocked cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)