### PR TITLE
feat(#1867): Phase C — enable Qwen3.6 35B, disable OmniCoder, migrate fast-local agents

### DIFF
--- a/servers/sk-agent/sk_agent_config.py
+++ b/servers/sk-agent/sk_agent_config.py
@@ -44,7 +44,7 @@ class ModelConfig:
     """A model endpoint (shared resource pool)."""
 
     id: str
-    base_url: str = "http://localhost:5001/v1"
+    base_url: str = "https://api.medium.text-generation-webui.myia.io/v1"
     api_key: str = "no-key"
     api_key_env: str = ""
     model_id: str = "default"
@@ -59,7 +59,7 @@ class ModelConfig:
     def from_dict(cls, data: dict) -> ModelConfig:
         return cls(
             id=data.get("id", "unknown"),
-            base_url=data.get("base_url", "http://localhost:5001/v1"),
+            base_url=data.get("base_url", "https://api.medium.text-generation-webui.myia.io/v1"),
             api_key=data.get("api_key", "no-key"),
             api_key_env=data.get("api_key_env", ""),
             model_id=data.get("model_id", data.get("id", "default")),

--- a/servers/sk-agent/sk_agent_config.template.json
+++ b/servers/sk-agent/sk_agent_config.template.json
@@ -69,7 +69,7 @@
     },
     {
       "id": "qwen3.6-35b-a3b",
-      "enabled": false,
+      "enabled": true,
       "base_url": "https://api.medium.text-generation-webui.myia.io/v1",
       "api_key": "YOUR_MEDIUM_API_KEY_HERE",
       "model_id": "qwen3.6-35b-a3b",
@@ -80,7 +80,7 @@
     },
     {
       "id": "qwen3.6-35b-no-thinking",
-      "enabled": false,
+      "enabled": true,
       "base_url": "https://api.medium.text-generation-webui.myia.io/v1",
       "api_key": "YOUR_MEDIUM_API_KEY_HERE",
       "model_id": "qwen3.6-35b-a3b",
@@ -115,7 +115,7 @@
     },
     {
       "id": "owui-omnicoder-9b",
-      "enabled": true,
+      "enabled": false,
       "base_url": "https://open-webui.myia.io/openai",
       "api_key": "YOUR_OWUI_API_KEY_HERE",
       "model_id": "Local.omnicoder-9b",
@@ -167,7 +167,7 @@
       "model_id": "vision-expert",
       "vision": true,
       "thinking": false,
-      "description": "OWUI Expert Vision (wrapper omnicoder-9b).",
+      "description": "OWUI Expert Vision (wrapper qwen3.6-35b-a3b).",
       "context_window": 131072
     }
   ],
@@ -278,17 +278,17 @@
     },
     {
       "id": "fast-local",
-      "description": "Quick local responses via OWUI (~1-5s), no tools, no thinking. Requires OWUI proxy",
-      "model": "owui-glm-4.7-flash-fast",
-      "system_prompt": "You are a fast local assistant via OWUI proxy. Respond concisely and accurately without thinking mode. Always respond in the same language as the user.",
+      "description": "Quick local responses via direct vLLM Qwen3.6 35B no-thinking mode (86 tok/s, 262K ctx). No tools, no thinking overhead",
+      "model": "qwen3.6-35b-no-thinking",
+      "system_prompt": "You are a fast local assistant. Respond concisely and accurately without thinking mode. Always respond in the same language as the user.",
       "mcps": [],
       "memory": { "enabled": false }
     },
     {
       "id": "fast-local-thinking",
-      "description": "Local responses with thinking mode via OWUI GLM-4.7-Flash. Better reasoning, slightly slower",
-      "model": "owui-glm-4.7-flash-thinking",
-      "system_prompt": "You are a local assistant with thinking mode via OWUI proxy. Think step by step before responding, showing your reasoning. Always respond in the same language as the user.",
+      "description": "Local responses with thinking mode via direct vLLM Qwen3.6 35B (86 tok/s, 262K ctx, vision+thinking). Better reasoning, slightly slower",
+      "model": "qwen3.6-35b-a3b",
+      "system_prompt": "You are a local assistant with thinking mode. Think step by step before responding, showing your reasoning. Always respond in the same language as the user.",
       "mcps": [],
       "memory": { "enabled": false }
     },

--- a/servers/sk-agent/test_config.py
+++ b/servers/sk-agent/test_config.py
@@ -474,7 +474,7 @@ class TestDataclasses:
 
     def test_model_config_defaults(self):
         m = ModelConfig(id="test")
-        assert m.base_url == "http://localhost:5001/v1"
+        assert m.base_url == "https://api.medium.text-generation-webui.myia.io/v1"
         assert m.vision is False
         assert m.enabled is True
         assert m.context_window == 32_000


### PR DESCRIPTION
## Summary

Phase C of the sk-agent OmniCoder → Qwen migration (#1867). Rebased cleanly onto current main (supersedes commit `4e805ae9` on `feat/sk-agent-qwen-migration-phase-c` which was conflicting due to stale base).

### Changes (3 files, 26 lines)

| File | Change |
|------|--------|
| `sk_agent_config.py` | Default `base_url` → `api.medium.text-generation-webui.myia.io/v1` |
| `sk_agent_config.template.json` | Enable Qwen3.6 models, disable OmniCoder, migrate fast-local agents |
| `test_config.py` | Update assertion for new default `base_url` |

### Model changes

| Model | Before | After |
|-------|--------|-------|
| `qwen3.6-35b-a3b` | disabled | **enabled** |
| `qwen3.6-35b-no-thinking` | disabled | **enabled** |
| `owui-omnicoder-9b` | enabled | **disabled** |
| `fast-local` agent | `owui-glm-4.7-flash-fast` (dead) | `qwen3.6-35b-no-thinking` |
| `fast-local-thinking` agent | `owui-glm-4.7-flash-thinking` (dead) | `qwen3.6-35b-a3b` |
| `owui-vision-expert` desc | "wrapper omnicoder-9b" | "wrapper qwen3.6-35b-a3b" |

## Test plan

- [x] 51/51 `test_config.py` tests pass (including `test_model_config_defaults`)
- [x] JSON syntax validated
- [ ] Phase D: `list_agents` and `call_agent` functional validation on live endpoint (port 5002)

Refs: #1867

🤖 Generated with [Claude Code](https://claude.com/claude-code)