### PR TITLE
refactor(#1841): consolidate tools 31→25 (-19%)

### DIFF
--- a/servers/roo-state-manager/docs/mcp-best-practices.md
+++ b/servers/roo-state-manager/docs/mcp-best-practices.md
@@ -1,0 +1,104 @@
+# MCP Debugging Guide — Roo Framework
+
+**Source:** Former `get_mcp_best_practices` tool, converted to static reference.
+**Based on:** SDDD stabilization sessions for 3 critical MCPs.
+
+---
+
+## Proven Debugging Patterns
+
+### 1. Progressive Isolation
+Reduce code progressively until you isolate the exact problem.
+Minimal version → progressive additions → identify blocking point.
+Example: 60s timeout even with immediate `return {}` = infrastructure problem.
+
+### 2. Exception Wrapping
+Try/catch with graceful fallback and detailed diagnostics.
+Prevents complete MCP crashes.
+
+### 3. Environment Diagnostic First
+Always diagnose the environment before looking for logic bugs.
+Tools: `read_vscode_logs`, `roosync_mcp_management(action: "manage", subAction: "read")`.
+
+---
+
+## Systematic Debugging Workflow
+
+```bash
+# 1. Initial diagnostic
+roosync_mcp_management(action: "manage", subAction: "read")
+
+# 2. Force reload after modification
+roosync_mcp_management(action: "touch")
+
+# 3. Progressive isolation if problem persists
+# Minimal version → progressive additions → identify blocking point
+
+# 4. Diagnostic logs
+read_vscode_logs(filter: "error", lines: 50)
+```
+
+---
+
+## Urgent Debugging Checklist
+
+When an MCP stops responding:
+
+- [ ] Force reload: `roosync_mcp_management(action: "touch")`
+- [ ] Test connectivity with a simple tool call
+- [ ] Check logs: `read_vscode_logs`
+- [ ] Progressive isolation if timeout persists
+
+---
+
+## Common Errors
+
+### TypeScript/Node.js
+- **ENOENT errors:** Hardcoded incorrect paths
+- **Module resolution:** Build not reflected, needs rebuild + restart
+
+### Python
+- **Import timeouts:** Heavy imports blocking MCP context
+- **Subprocess conda:** Recurring 60s timeout pattern
+
+### MCP Infrastructure
+- **Persistent cache:** Modified code invisible without force reload
+- **Timeout -32001:** Standard MCP error signature
+
+---
+
+## Essential MCP Configuration
+
+### `watchPaths` — The Pillar of Hot-Reload
+Declares files/directories whose change should trigger automatic MCP restart.
+Example: `"watchPaths": ["d:/roo-extensions/mcps/internal/servers/roo-state-manager/build/index.js"]`
+Without this, the MCP runs stale code after modifications.
+
+### `cwd` — Stable Relative Paths
+Defines the working directory for the MCP.
+Example: `"options": { "cwd": "d:/roo-extensions/mcps/internal/servers/roo-state-manager" }`
+Essential for MCPs using relative paths for files (logs, templates, etc.).
+
+---
+
+## Essential roo-state-manager Tools
+
+| Tool | Primary Usage | When to Use |
+|------|---------------|-------------|
+| `roosync_mcp_management(action: "touch")` | Force reload all MCPs | After each code modification |
+| `roosync_mcp_management(action: "rebuild")` | Build TypeScript + restart | Modified TypeScript MCPs |
+| `read_vscode_logs` | System error diagnostics | Advanced debugging |
+| `roosync_mcp_management(action: "manage")` | Configuration verification | Setup and diagnostic |
+
+---
+
+## Grounding for External Agents
+
+Complete procedure for debugging a defective MCP:
+
+1. Identify the MCP via `roosync_mcp_management(action: "manage", subAction: "read")`
+2. Check logs via `read_vscode_logs`
+3. Test minimal with Progressive Isolation
+4. Force reload via `roosync_mcp_management(action: "touch")`
+5. Rebuild if TypeScript via `roosync_mcp_management(action: "rebuild")`
+6. Validate the fix with functional tests

--- a/servers/roo-state-manager/src/tools/__tests__/registry.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/registry.test.ts
@@ -130,18 +130,8 @@ describe('registry.ts - Tool Registration', () => {
             expect(toolNames).toContain('export_data');
         });
 
-        it('should include export_config tool', async () => {
-            const mockServer = {
-                setRequestHandler: vi.fn()
-            } as any;
-
-            registerListToolsHandler(mockServer);
-
-            const handler = mockServer.setRequestHandler.mock.calls[0][1];
-            const result = await handler();
-            const toolNames = result.tools.map((t: any) => t.name);
-            expect(toolNames).toContain('export_config');
-        });
+        // [REMOVED #291] export_config test removed — tool removed from allToolDefinitions (ListTools)
+        // Backward compat redirect preserved in registry.ts for CallTool
 
         it('should have tools count greater than 20', async () => {
             const mockServer = {

--- a/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
@@ -1,6 +1,10 @@
 /**
- * Tests for tool-definitions.ts — static schema validation for all 30 tool definitions.
+ * Tests for tool-definitions.ts — static schema validation for all 24 tool definitions.
  * Ensures structural integrity, naming conventions, and schema correctness.
+ * #1863: 3 deprecated definitions (decision_info, machines, cleanup_messages) removed from tools/list.
+ * #1922: 3 more deprecated removed (same as #1863 Pass 4).
+ * #1841: 6 more definitions removed from allToolDefinitions (best practices, export_config, view_task_details,
+ *        get_raw_conversation, refresh_dashboard, update_dashboard). Handlers preserved via registry.ts redirects.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -40,7 +44,7 @@ import {
     roosyncDashboardDefinition
 } from '../tool-definitions.js';
 
-const EXPECTED_TOOL_COUNT = 30;
+const EXPECTED_TOOL_COUNT = 24;
 
 // Order MUST mirror allToolDefinitions in tool-definitions.ts.
 const allDefinitions = [
@@ -50,11 +54,11 @@ const allDefinitions = [
     roosyncIndexingDefinition,
     codebaseSearchDefinition,
     readVscodeLogsDefinition,
-    getMcpBestPracticesDefinition,
+    // [REMOVED #291] getMcpBestPracticesDefinition — removed from allToolDefinitions
     exportDataDefinition,
-    exportConfigDefinition,
-    viewTaskDetailsDefinition,
-    getRawConversationDefinition,
+    // [REMOVED #291] exportConfigDefinition — removed from allToolDefinitions
+    // [REMOVED #291] viewTaskDetailsDefinition — removed from allToolDefinitions
+    // [REMOVED #291] getRawConversationDefinition — removed from allToolDefinitions
     analyzeRooSyncProblemsDefinition,
     roosyncInitDefinition,
     roosyncGetStatusDefinition,
@@ -68,8 +72,8 @@ const allDefinitions = [
     roosyncMcpManagementDefinition,
     roosyncStorageManagementDefinition,
     roosyncDiagnoseDefinition,
-    roosyncRefreshDashboardDefinition,
-    roosyncUpdateDashboardDefinition,
+    // [REMOVED #291] roosyncRefreshDashboardDefinition — removed from allToolDefinitions
+    // [REMOVED #291] roosyncUpdateDashboardDefinition — removed from allToolDefinitions
     roosyncSendDefinition,
     roosyncReadDefinition,
     roosyncManageDefinition,
@@ -80,7 +84,7 @@ const allDefinitions = [
 describe('tool-definitions.ts — Schema Validation', () => {
 
     describe('allToolDefinitions array', () => {
-        it('should have exactly 34 tool definitions', () => {
+        it('should have exactly 24 tool definitions', () => {
             expect(allToolDefinitions).toHaveLength(EXPECTED_TOOL_COUNT);
         });
 
@@ -354,7 +358,8 @@ describe('tool-definitions.ts — Schema Validation', () => {
             // #1609: roosyncHeartbeatDefinition removed
             // #1863: roosyncMachinesDefinition removed
             roosyncMcpManagementDefinition, roosyncStorageManagementDefinition,
-            roosyncDiagnoseDefinition, roosyncRefreshDashboardDefinition, roosyncUpdateDashboardDefinition
+            roosyncDiagnoseDefinition
+            // [REMOVED #291] roosyncRefreshDashboardDefinition, roosyncUpdateDashboardDefinition
         ];
 
         it.each(strictTools.map(d => [d.name, d]))(

--- a/servers/roo-state-manager/src/tools/__tests__/tool-discoverability.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-discoverability.test.ts
@@ -128,10 +128,10 @@ describe('Category 1: ListTools → CallTool Consistency', () => {
         expect(missingHandlers).toEqual([]);
     });
 
-    it('ListTools should expose a reasonable number of tools (30-50 range)', async () => {
+    it('ListTools should expose a reasonable number of tools (20-50 range)', async () => {
         const toolNames = await getListToolsNames();
-        // Currently ~35 tools. This guards against accidental mass removal or explosion
-        expect(toolNames.length).toBeGreaterThanOrEqual(30);
+        // Currently 24 tools. This guards against accidental mass removal or explosion
+        expect(toolNames.length).toBeGreaterThanOrEqual(20);
         expect(toolNames.length).toBeLessThanOrEqual(50);
     });
 
@@ -286,10 +286,7 @@ describe('Category 3: Consolidated Tool Action Completeness', () => {
             field: 'target',
             actions: ['task', 'conversation', 'project'],
         },
-        'export_config': {
-            field: 'action',
-            actions: ['get', 'set', 'reset'],
-        },
+        // [REMOVED #291] export_config removed from allToolDefinitions — backward compat via registry.ts redirect
         'roosync_decision': {
             field: 'action',
             actions: ['approve', 'reject', 'apply', 'rollback', 'info'],
@@ -409,8 +406,8 @@ describe('Category 4: Essential Tools for Agent Workflows', () => {
         // Navigation & Discovery
         'conversation_browser',  // list/tree/current/view/summarize
         'roosync_search',        // find tasks by content
-        'view_task_details',     // inspect task details
-        'get_raw_conversation',  // raw conversation data
+        // [REMOVED #291] view_task_details removed from allToolDefinitions — backward compat via registry.ts redirect
+        // [REMOVED #291] get_raw_conversation removed from allToolDefinitions — backward compat via registry.ts redirect
 
         // Communication
         'roosync_send',          // send messages
@@ -491,12 +488,12 @@ describe('Category 5: Description Discoverability', () => {
         'roosync_baseline': ['baseline'],                // "baselines RooSync"
         'roosync_indexing': ['index'],                   // "index sémantique"
         'export_data': ['export'],                       // "exporter des données"
-        'export_config': ['export', 'config'],           // "paramètres de configuration des exports"
+        // [REMOVED #291] export_config removed from allToolDefinitions
         'task_export': ['export', 'tâche'],              // "exporter/diagnostiquer les tâches"
         // B4: maintenance removed from ListTools — covered by roosync_storage_management(action: 'maintenance')
         // B4: storage_info removed from ListTools — covered by roosync_storage_management(action: 'storage')
         'codebase_search': ['recherche', 'code'],        // "Recherche sémantique dans le code"
-        'view_task_details': ['détails', 'tâche'],        // "Affiche les détails techniques complets... pour une tâche spécifique"
+        // [REMOVED #291] view_task_details removed from allToolDefinitions
     };
 
     it('tool descriptions contain discoverable keywords', async () => {

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -622,12 +622,12 @@ export const allToolDefinitions = [
     // #452 Phase 2: codebase_search
     codebaseSearchDefinition,
     readVscodeLogsDefinition,
-    getMcpBestPracticesDefinition,
+    // [REMOVED #1841] getMcpBestPracticesDefinition — converted to static doc: docs/mcp-best-practices.md, redirect in registry.ts
     // CONS-10: Export
     exportDataDefinition,
-    exportConfigDefinition,
-    viewTaskDetailsDefinition,
-    getRawConversationDefinition,
+    // [REMOVED #1841] exportConfigDefinition — rarely used, config accessible via export_data settings, redirect in registry.ts
+    // [REMOVED #1841] viewTaskDetailsDefinition — conversation_browser(action: "view", detail_level: "Full") provides equivalent, redirect in registry.ts
+    // [REMOVED #1841] getRawConversationDefinition — export_data(format: "json", target: "task") provides equivalent, redirect in registry.ts
     // WP4: Diagnostic
     analyzeRooSyncProblemsDefinition,
     // RooSync tools (20) — same order as roosyncTools array in roosync/index.ts
@@ -643,8 +643,8 @@ export const allToolDefinitions = [
     roosyncMcpManagementDefinition,
     roosyncStorageManagementDefinition,
     roosyncDiagnoseDefinition,
-    roosyncRefreshDashboardDefinition,
-    roosyncUpdateDashboardDefinition,
+    // [REMOVED #1935 Cluster B] roosyncRefreshDashboardDefinition — fused into roosync_dashboard(action: "refresh"), redirect in registry.ts
+    // [REMOVED #1935 Cluster B] roosyncUpdateDashboardDefinition — fused into roosync_dashboard(action: "update"), redirect in registry.ts
     roosyncSendDefinition,
     roosyncReadDefinition,
     roosyncManageDefinition,

--- a/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
@@ -189,9 +189,13 @@ describe('#1863 Fusion A3: cleanup → manage redirect', () => {
 // ============================================================
 // Cross-cutting: Definition count and deprecation removal verification
 // ============================================================
-describe('#1863 Cross-cutting: tool count after deprecated removal', () => {
-  it('allToolDefinitions should contain 30 tools (3 deprecated removed in #1922 Pass 4)', () => {
-    expect(allToolDefinitions.length).toBe(30);
+describe('#1863 Cross-cutting: tool count and deprecation markers', () => {
+  it('allToolDefinitions should contain 24 tools (3 deprecated #1863 + 6 low-usage #1841 removed)', () => {
+    // Before: 33 tools (33 + roosync_claim #1836) → #1922 Pass 4 removed 3 deprecated → 30
+    // #1841 removed 6 low-usage: get_mcp_best_practices, export_config, view_task_details,
+    //   get_raw_conversation, refresh_dashboard, update_dashboard → 24
+    // Backward compat redirect handlers in registry.ts are preserved
+    expect(allToolDefinitions.length).toBe(24);
   });
 
   it('deprecated tools should NOT be in allToolDefinitions', () => {


### PR DESCRIPTION
## Summary
- Remove 6 low-usage tool definitions from `allToolDefinitions` (ListTools): `get_mcp_best_practices`, `export_config`, `view_task_details`, `get_raw_conversation`, `roosync_refresh_dashboard`, `roosync_update_dashboard`
- Convert `get_mcp_best_practices` static content to `docs/mcp-best-practices.md`
- Preserve backward compatibility: all handlers remain in `registry.ts` as redirects

## Tool count: 31 → 25 (-19%)

| Removed Tool | Reason | Replacement |
|-------------|--------|-------------|
| `get_mcp_best_practices` | Static doc, not dynamic tool | `docs/mcp-best-practices.md` |
| `export_config` | Rarely used | Redirect preserved in registry.ts |
| `view_task_details` | Redundant with conversation_browser | `conversation_browser(action: "view", detail_level: "Full")` |
| `get_raw_conversation` | Redundant with export_data | `export_data(format: "json", target: "task")` |
| `roosync_refresh_dashboard` | Deprecated #1935 | `roosync_dashboard(action: "refresh")` |
| `roosync_update_dashboard` | Deprecated #1935 | `roosync_dashboard(action: "update")` |

## Test plan
- [x] Build passes (`npm run build`)
- [x] CI tests: 9159/9159 passed (0 failures)
- [x] Backward compat: removed tools still callable via registry.ts redirects
- [x] Updated 4 test files for new tool count

🤖 Generated with [Claude Code](https://claude.com/claude-code)