### PR TITLE
test: McpValidationConstants + export_data coverage (+40 tests)

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/McpValidationConstants.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/McpValidationConstants.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for McpValidationConstants — #1656 Phase A3
+ *
+ * Coverage: validateMcpConfig() with valid/invalid configs for Claude and Roo agents.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  validateMcpConfig,
+  RETIRED_MCP_NAMES,
+  CLAUDE_CRITICAL_MCPS,
+  ROO_CRITICAL_MCPS,
+  WINCLI_CANONICAL,
+  type McpServerEntry,
+} from '../McpValidationConstants.js';
+
+describe('McpValidationConstants', () => {
+  describe('exports', () => {
+    it('RETIRED_MCP_NAMES should list desktop-commander, github-projects-mcp, quickfiles', () => {
+      expect(RETIRED_MCP_NAMES).toContain('desktop-commander');
+      expect(RETIRED_MCP_NAMES).toContain('github-projects-mcp');
+      expect(RETIRED_MCP_NAMES).toContain('quickfiles');
+    });
+
+    it('CLAUDE_CRITICAL_MCPS should require roo-state-manager', () => {
+      expect(CLAUDE_CRITICAL_MCPS).toContain('roo-state-manager');
+    });
+
+    it('ROO_CRITICAL_MCPS should require win-cli and roo-state-manager', () => {
+      expect(ROO_CRITICAL_MCPS).toContain('win-cli');
+      expect(ROO_CRITICAL_MCPS).toContain('roo-state-manager');
+    });
+
+    it('WINCLI_CANONICAL should define node command with local fork pattern', () => {
+      expect(WINCLI_CANONICAL.command).toBe('node');
+      expect(WINCLI_CANONICAL.argsPattern.test('mcps/external/win-cli/server/dist/index.js')).toBe(true);
+      expect(WINCLI_CANONICAL.argsPattern.test('mcps\\external\\win-cli\\server\\dist\\index.js')).toBe(true);
+    });
+
+    it('WINCLI_CANONICAL should forbid @simonb97 and @anthropic packages', () => {
+      expect(WINCLI_CANONICAL.forbiddenPatterns.length).toBeGreaterThanOrEqual(2);
+      expect(WINCLI_CANONICAL.forbiddenPatterns[0].test('@simonb97/server-win-cli')).toBe(true);
+    });
+  });
+
+  describe('validateMcpConfig — Claude agent', () => {
+    it('should pass for valid Claude config', () => {
+      const servers: Record<string, McpServerEntry> = {
+        'roo-state-manager': { command: 'node', transportType: 'stdio' },
+        playwright: { command: 'npx', args: ['@anthropic/playwright'] },
+      };
+
+      const result = validateMcpConfig(servers, 'claude');
+      expect(result.passed).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+
+    it('should fail when roo-state-manager is missing', () => {
+      const servers: Record<string, McpServerEntry> = {
+        playwright: { command: 'npx', args: ['@anthropic/playwright'] },
+      };
+
+      const result = validateMcpConfig(servers, 'claude');
+      expect(result.passed).toBe(false);
+      expect(result.violations).toContain("CRITICAL MCP 'roo-state-manager' missing");
+      expect(result.checks.criticalMissing).toContain('roo-state-manager');
+    });
+
+    it('should fail when roo-state-manager is disabled', () => {
+      const servers: Record<string, McpServerEntry> = {
+        'roo-state-manager': { command: 'node', disabled: true },
+      };
+
+      const result = validateMcpConfig(servers, 'claude');
+      expect(result.passed).toBe(false);
+      expect(result.violations).toContain("CRITICAL MCP 'roo-state-manager' is disabled");
+    });
+
+    it('should fail when retired MCP is present', () => {
+      const servers: Record<string, McpServerEntry> = {
+        'roo-state-manager': { command: 'node' },
+        'desktop-commander': { command: 'npx', args: ['desktop-commander'] },
+      };
+
+      const result = validateMcpConfig(servers, 'claude');
+      expect(result.passed).toBe(false);
+      expect(result.violations[0]).toContain("RETIRED MCP 'desktop-commander'");
+      expect(result.checks.retired).toContain('desktop-commander');
+    });
+
+    it('should not check win-cli for Claude agent', () => {
+      const servers: Record<string, McpServerEntry> = {
+        'roo-state-manager': { command: 'node' },
+      };
+
+      const result = validateMcpConfig(servers, 'claude');
+      expect(result.checks.winCliDrift).toHaveLength(0);
+    });
+  });
+
+  describe('validateMcpConfig — Roo agent', () => {
+    const validRooServers: Record<string, McpServerEntry> = {
+      'roo-state-manager': { command: 'node', transportType: 'stdio' },
+      'win-cli': {
+        command: 'node',
+        args: ['mcps/external/win-cli/server/dist/index.js'],
+        transportType: 'stdio',
+      },
+    };
+
+    it('should pass for valid Roo config', () => {
+      const result = validateMcpConfig(validRooServers, 'roo');
+      expect(result.passed).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+
+    it('should fail when win-cli is missing', () => {
+      const servers: Record<string, McpServerEntry> = {
+        'roo-state-manager': { command: 'node' },
+      };
+
+      const result = validateMcpConfig(servers, 'roo');
+      expect(result.passed).toBe(false);
+      expect(result.checks.winCliDrift).toContain('win-cli missing from Roo mcpServers');
+    });
+
+    it('should fail when win-cli has wrong command', () => {
+      const servers: { [k: string]: McpServerEntry } = {
+        'roo-state-manager': { command: 'node' },
+        'win-cli': {
+          command: 'npx',
+          args: ['mcps/external/win-cli/server/dist/index.js'],
+        },
+      };
+
+      const result = validateMcpConfig(servers, 'roo');
+      expect(result.passed).toBe(false);
+      expect(result.violations).toContain("Roo win-cli drift: command='npx'");
+    });
+
+    it('should fail when win-cli args point to npm package', () => {
+      const servers: Record<string, McpServerEntry> = {
+        'roo-state-manager': { command: 'node' },
+        'win-cli': {
+          command: 'node',
+          args: ['@simonb97/server-win-cli'],
+        },
+      };
+
+      const result = validateMcpConfig(servers, 'roo');
+      expect(result.passed).toBe(false);
+      expect(result.checks.winCliDrift.some(d => d.includes('BROKEN npm reference'))).toBe(true);
+    });
+
+    it('should fail when win-cli args do not match local fork pattern', () => {
+      const servers: Record<string, McpServerEntry> = {
+        'roo-state-manager': { command: 'node' },
+        'win-cli': {
+          command: 'node',
+          args: ['/some/other/path/index.js'],
+        },
+      };
+
+      const result = validateMcpConfig(servers, 'roo');
+      expect(result.passed).toBe(false);
+      expect(result.checks.winCliDrift.some(d => d.includes('does not point to local fork'))).toBe(true);
+    });
+
+    it('should fail when win-cli is disabled', () => {
+      const servers: Record<string, McpServerEntry> = {
+        'roo-state-manager': { command: 'node' },
+        'win-cli': {
+          command: 'node',
+          args: ['mcps/external/win-cli/server/dist/index.js'],
+          disabled: true,
+        },
+      };
+
+      const result = validateMcpConfig(servers, 'roo');
+      expect(result.passed).toBe(false);
+      expect(result.checks.winCliDrift).toContain('win-cli is disabled');
+    });
+
+    it('should report multiple violations simultaneously', () => {
+      const servers: Record<string, McpServerEntry> = {
+        'desktop-commander': { command: 'npx' },
+        'win-cli': { command: 'python' },
+      };
+
+      const result = validateMcpConfig(servers, 'roo');
+      expect(result.passed).toBe(false);
+      expect(result.violations.length).toBeGreaterThanOrEqual(3);
+      expect(result.checks.retired).toContain('desktop-commander');
+      expect(result.checks.criticalMissing).toContain('roo-state-manager');
+      expect(result.checks.winCliDrift.length).toBeGreaterThan(0);
+    });
+
+    it('should handle empty server config', () => {
+      const result = validateMcpConfig({}, 'roo');
+      expect(result.passed).toBe(false);
+      expect(result.checks.criticalMissing).toContain('roo-state-manager');
+      expect(result.checks.criticalMissing).toContain('win-cli');
+    });
+  });
+});

--- a/servers/roo-state-manager/tests/unit/tools/export/export-data.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/export/export-data.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for export_data tool — schema and validation
+ *
+ * Tests the tool definition, schema, and handleExportData validation logic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { exportDataTool } from '../../../../src/tools/export/export-data.js';
+import { handleExportData } from '../../../../src/tools/export/export-data.js';
+
+describe('export_data tool definition', () => {
+  it('should have correct name', () => {
+    expect(exportDataTool.name).toBe('export_data');
+  });
+
+  it('should require target and format', () => {
+    const schema = exportDataTool.inputSchema as any;
+    expect(schema.required).toContain('target');
+    expect(schema.required).toContain('format');
+  });
+
+  it('should support xml, json, csv formats', () => {
+    const schema = exportDataTool.inputSchema as any;
+    const formatEnum = schema.properties.format.enum;
+    expect(formatEnum).toContain('xml');
+    expect(formatEnum).toContain('json');
+    expect(formatEnum).toContain('csv');
+  });
+
+  it('should support task, conversation, project targets', () => {
+    const schema = exportDataTool.inputSchema as any;
+    const targetEnum = schema.properties.target.enum;
+    expect(targetEnum).toContain('task');
+    expect(targetEnum).toContain('conversation');
+    expect(targetEnum).toContain('project');
+  });
+
+  it('should have jsonVariant with light and full options', () => {
+    const schema = exportDataTool.inputSchema as any;
+    expect(schema.properties.jsonVariant.enum).toContain('light');
+    expect(schema.properties.jsonVariant.enum).toContain('full');
+  });
+
+  it('should have csvVariant with conversations, messages, tools options', () => {
+    const schema = exportDataTool.inputSchema as any;
+    expect(schema.properties.csvVariant.enum).toContain('conversations');
+    expect(schema.properties.csvVariant.enum).toContain('messages');
+    expect(schema.properties.csvVariant.enum).toContain('tools');
+  });
+
+  it('should have optional filePath parameter', () => {
+    const schema = exportDataTool.inputSchema as any;
+    expect(schema.properties.filePath).toBeDefined();
+    expect(schema.properties.filePath.type).toBe('string');
+  });
+
+  it('should have optional truncationChars parameter', () => {
+    const schema = exportDataTool.inputSchema as any;
+    expect(schema.properties.truncationChars).toBeDefined();
+    expect(schema.properties.truncationChars.type).toBe('number');
+  });
+});
+
+describe('handleExportData — validation', () => {
+  const emptyCache = new Map();
+  const noopEnsureFresh = async () => {};
+  const noopGetSkeleton = async () => null;
+
+  // Create a minimal mock for XmlExporterService
+  const mockXmlExporter = {} as any;
+
+  it('should return error when target is missing', async () => {
+    const result = await handleExportData(
+      { format: 'xml' } as any,
+      emptyCache, mockXmlExporter, noopEnsureFresh, noopGetSkeleton
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain('target');
+  });
+
+  it('should return error when format is missing', async () => {
+    const result = await handleExportData(
+      { target: 'task' } as any,
+      emptyCache, mockXmlExporter, noopEnsureFresh, noopGetSkeleton
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain('format');
+  });
+
+  it('should return error for unsupported target/format combination', async () => {
+    const result = await handleExportData(
+      { target: 'task', format: 'json' } as any,
+      emptyCache, mockXmlExporter, noopEnsureFresh, noopGetSkeleton
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain('non support');
+  });
+
+  it('should return error when taskId missing for target=task', async () => {
+    const result = await handleExportData(
+      { target: 'task', format: 'xml' } as any,
+      emptyCache, mockXmlExporter, noopEnsureFresh, noopGetSkeleton
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain('taskId');
+  });
+
+  it('should return error when projectPath missing for target=project', async () => {
+    const result = await handleExportData(
+      { target: 'project', format: 'xml' } as any,
+      emptyCache, mockXmlExporter, noopEnsureFresh, noopGetSkeleton
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain('projectPath');
+  });
+
+  it('should return error for task+json combination', async () => {
+    const result = await handleExportData(
+      { target: 'task', format: 'csv' } as any,
+      emptyCache, mockXmlExporter, noopEnsureFresh, noopGetSkeleton
+    );
+    expect(result.isError).toBe(true);
+  });
+
+  it('should return error for project+json combination', async () => {
+    const result = await handleExportData(
+      { target: 'project', format: 'json' } as any,
+      emptyCache, mockXmlExporter, noopEnsureFresh, noopGetSkeleton
+    );
+    expect(result.isError).toBe(true);
+  });
+
+  it('should return error when conversationId missing for conversation+xml', async () => {
+    const result = await handleExportData(
+      { target: 'conversation', format: 'xml' } as any,
+      emptyCache, mockXmlExporter, noopEnsureFresh, noopGetSkeleton
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain('conversationId');
+  });
+
+  it('should return error when taskId missing for conversation+json', async () => {
+    const result = await handleExportData(
+      { target: 'conversation', format: 'json' } as any,
+      emptyCache, mockXmlExporter, noopEnsureFresh, noopGetSkeleton
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain('taskId');
+  });
+
+  it('should return error when taskId missing for conversation+csv', async () => {
+    const result = await handleExportData(
+      { target: 'conversation', format: 'csv' } as any,
+      emptyCache, mockXmlExporter, noopEnsureFresh, noopGetSkeleton
+    );
+    expect(result.isError).toBe(true);
+  });
+
+  it('should return error for task not found', async () => {
+    const result = await handleExportData(
+      { target: 'task', format: 'xml', taskId: 'nonexistent-task' } as any,
+      emptyCache, mockXmlExporter, noopEnsureFresh, noopGetSkeleton
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain('non trouv');
+  });
+
+  it('should return error for conversation root not found', async () => {
+    const result = await handleExportData(
+      { target: 'conversation', format: 'xml', conversationId: 'nonexistent-conv' } as any,
+      emptyCache, mockXmlExporter, noopEnsureFresh, noopGetSkeleton
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain('non trouv');
+  });
+
+  it('should reject path traversal in filePath for json export', async () => {
+    const getSkeleton = async () => ({ metadata: {}, messages: [] } as any);
+    const result = await handleExportData(
+      { target: 'conversation', format: 'json', taskId: 'task-1', filePath: '../../../etc/passwd' } as any,
+      emptyCache, mockXmlExporter, noopEnsureFresh, getSkeleton
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain('Unsafe');
+  });
+
+  it('should reject too long filePath for csv export', async () => {
+    const longPath = 'a'.repeat(300);
+    const getSkeleton = async () => ({ metadata: {}, messages: [] } as any);
+    const result = await handleExportData(
+      { target: 'conversation', format: 'csv', taskId: 'task-1', filePath: longPath } as any,
+      emptyCache, mockXmlExporter, noopEnsureFresh, getSkeleton
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as any).text).toContain('too long');
+  });
+});


### PR DESCRIPTION
## Summary
- Add 18 unit tests for `McpValidationConstants` (Claude/Roo config validation, retired MCP detection, win-cli drift)
- Add 22 unit tests for `export_data` tool (schema validation, target/format combos, security checks)

## Test plan
- [x] All 9199 tests pass (CI config)
- [x] No build errors
- [x] Path traversal security validation covered
- [x] Invalid target/format combinations covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)