### PR TITLE
feat(#1918): HeartbeatService capability-aware — graceful GDrive degradation

### DIFF
--- a/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
+++ b/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
@@ -14,6 +14,7 @@
 import { promises as fs, existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync, unlinkSync, statSync, renameSync as fsRenameSync } from 'fs';
 import { join } from 'path';
 import { createLogger } from '../../utils/logger.js';
+import { getServerCapabilities } from '../../utils/server-capabilities.js';
 
 const logger = createLogger('HeartbeatService');
 
@@ -216,6 +217,14 @@ export class HeartbeatService {
   }
 
   /**
+   * #1918: Check if shared path (GDrive) is accessible for disk I/O.
+   * When degraded, heartbeat data stays in-memory only.
+   */
+  private isDiskAvailable(): boolean {
+    return getServerCapabilities().isAvailable('sharedPath');
+  }
+
+  /**
    * Returns the file path for a machine's heartbeat file
    */
   private getMachineFilePath(machineId: string): string {
@@ -390,6 +399,11 @@ export class HeartbeatService {
    * Reload all per-machine files from disk (useful before checkHeartbeats)
    */
   public reloadFromDisk(): void {
+    if (!this.isDiskAvailable()) {
+      // #1918: GDrive offline — keep in-memory state, skip disk reads
+      this.updateMachineStatus();
+      return;
+    }
     this.state.heartbeats.clear();
     if (existsSync(this.heartbeatsDir)) {
       this.loadFromPerMachineFiles();
@@ -401,6 +415,10 @@ export class HeartbeatService {
    * Save a single machine's heartbeat data to its own file
    */
   private async saveMachineHeartbeat(machineId: string): Promise<void> {
+    if (!this.isDiskAvailable()) {
+      // #1918: GDrive offline — keep heartbeat in-memory only
+      return;
+    }
     try {
       await fs.mkdir(this.heartbeatsDir, { recursive: true });
 
@@ -418,6 +436,7 @@ export class HeartbeatService {
    * Delete a machine's heartbeat file
    */
   private async removeMachineFile(machineId: string): Promise<void> {
+    if (!this.isDiskAvailable()) return;
     try {
       const filePath = this.getMachineFilePath(machineId);
       if (existsSync(filePath)) {
@@ -432,6 +451,7 @@ export class HeartbeatService {
    * Sauvegarde l'état de TOUTES les machines (used at stop/config update)
    */
   private async saveState(): Promise<void> {
+    if (!this.isDiskAvailable()) return;
     try {
       await fs.mkdir(this.heartbeatsDir, { recursive: true });
 

--- a/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService-degraded.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService-degraded.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for HeartbeatService graceful degradation (#1918)
+ *
+ * Verifies that HeartbeatService continues operating in-memory
+ * when sharedPath (GDrive) is degraded, without attempting disk I/O.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { join } from 'path';
+import { mkdtemp, rm, mkdir, readFile, readdir } from 'fs/promises';
+import { tmpdir } from 'os';
+import { HeartbeatService, HeartbeatConfig } from '../../../../src/services/roosync/HeartbeatService.js';
+import { getServerCapabilities } from '../../../../src/utils/server-capabilities.js';
+
+describe('HeartbeatService - Graceful Degradation (#1918)', () => {
+  let tempDir: string;
+  let sharedPath: string;
+  let heartbeatService: HeartbeatService;
+  let caps: ReturnType<typeof getServerCapabilities>;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'heartbeat-degraded-'));
+    sharedPath = join(tempDir, 'shared');
+    await mkdir(sharedPath, { recursive: true });
+
+    caps = getServerCapabilities();
+    caps.reset();
+
+    const config: HeartbeatConfig = {
+      heartbeatInterval: 30000,
+      offlineTimeout: 120000,
+      missedHeartbeatThreshold: 4,
+      autoSyncEnabled: false,
+      autoSyncInterval: 60000,
+      persistenceInterval: 100,
+    };
+
+    heartbeatService = new HeartbeatService(sharedPath, config);
+  });
+
+  afterEach(async () => {
+    await heartbeatService.stopHeartbeatService();
+    caps.reset();
+
+    try {
+      await rm(tempDir, { recursive: true, force: true });
+    } catch (error: any) {
+      if (error.code !== 'ENOTEMPTY' && error.code !== 'EPERM' && error.code !== 'EBUSY') {
+        console.warn('Cleanup failed:', error.message);
+      }
+    }
+    vi.restoreAllMocks();
+  });
+
+  describe('registerHeartbeat in degraded mode', () => {
+    it('tracks heartbeat in-memory when sharedPath is degraded', async () => {
+      caps.markDegraded('sharedPath', 'GDrive offline');
+
+      await heartbeatService.registerHeartbeat('test-machine');
+
+      const data = heartbeatService.getHeartbeatData('test-machine');
+      expect(data).toBeDefined();
+      expect(data?.status).toBe('online');
+      expect(data?.machineId).toBe('test-machine');
+    });
+
+    it('does not write files to disk when degraded', async () => {
+      caps.markDegraded('sharedPath', 'GDrive offline');
+
+      await heartbeatService.registerHeartbeat('no-disk-machine');
+
+      const heartbeatsDir = join(sharedPath, 'heartbeats');
+      let files: string[] = [];
+      try {
+        files = await readdir(heartbeatsDir);
+      } catch {
+        // Directory may not exist — that's fine
+      }
+      expect(files).toHaveLength(0);
+    });
+
+    it('resumes disk writes after recovery', async () => {
+      caps.markDegraded('sharedPath', 'GDrive offline');
+
+      await heartbeatService.registerHeartbeat('recovery-machine');
+      expect(heartbeatService.getHeartbeatData('recovery-machine')?.status).toBe('online');
+
+      // Recover GDrive
+      caps.recover('sharedPath');
+
+      // Wait for persistenceInterval to elapse (100ms in test config)
+      await new Promise(resolve => setTimeout(resolve, 150));
+
+      // Register again — should now write to disk
+      await heartbeatService.registerHeartbeat('recovery-machine');
+
+      const heartbeatsDir = join(sharedPath, 'heartbeats');
+      const files = await readdir(heartbeatsDir);
+      expect(files.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('reloadFromDisk in degraded mode', () => {
+    it('preserves in-memory state when degraded instead of clearing', async () => {
+      // First register a machine normally
+      await heartbeatService.registerHeartbeat('existing-machine');
+      expect(heartbeatService.getHeartbeatData('existing-machine')?.status).toBe('online');
+
+      // Degrade
+      caps.markDegraded('sharedPath', 'GDrive offline');
+
+      // Register another machine (in-memory only)
+      await heartbeatService.registerHeartbeat('degraded-machine');
+
+      // reloadFromDisk should NOT clear in-memory state when degraded
+      heartbeatService.reloadFromDisk();
+
+      // existing-machine may be lost (clear happens before the guard)
+      // but degraded-machine should still be there
+      const data = heartbeatService.getHeartbeatData('degraded-machine');
+      expect(data).toBeDefined();
+    });
+  });
+
+  describe('saveState in degraded mode', () => {
+    it('skips saving when sharedPath is degraded', async () => {
+      caps.markDegraded('sharedPath', 'GDrive offline');
+
+      await heartbeatService.registerHeartbeat('unsaved-machine');
+
+      // Force save via stopHeartbeatService (calls saveState internally)
+      await heartbeatService.stopHeartbeatService();
+
+      const heartbeatsDir = join(sharedPath, 'heartbeats');
+      let files: string[] = [];
+      try {
+        files = await readdir(heartbeatsDir);
+      } catch {
+        // OK
+      }
+      expect(files).toHaveLength(0);
+    });
+  });
+
+  describe('mixed degradation cycle', () => {
+    it('handles full degrade → operate → recover cycle', async () => {
+      // Step 1: Normal operation — write to disk
+      await heartbeatService.registerHeartbeat('cycle-machine');
+      const onlineMachines = heartbeatService.getOnlineMachines();
+      expect(onlineMachines).toContain('cycle-machine');
+
+      // Step 2: Degrade — operations continue in-memory
+      caps.markDegraded('sharedPath', 'GDrive offline');
+
+      await heartbeatService.registerHeartbeat('degraded-only-machine');
+      expect(heartbeatService.getHeartbeatData('degraded-only-machine')).toBeDefined();
+
+      // Step 3: Recover — disk writes resume
+      caps.recover('sharedPath');
+
+      await heartbeatService.registerHeartbeat('recovered-machine');
+      expect(heartbeatService.getHeartbeatData('recovered-machine')?.status).toBe('online');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- HeartbeatService now checks `getServerCapabilities().isAvailable('sharedPath')` before all disk I/O operations
- When GDrive disconnects (sharedPath degraded), heartbeat data stays in-memory only — no failed I/O attempts, no noisy error logs
- Automatically resumes disk writes when GDrive reconnects and capability recovers

## Changes

| File | Change |
|------|--------|
| `HeartbeatService.ts` | Added `isDiskAvailable()` check before `reloadFromDisk`, `saveMachineHeartbeat`, `removeMachineFile`, `saveState` |
| `HeartbeatService-degraded.test.ts` | +6 unit tests: in-memory tracking, no disk writes when degraded, recovery, full cycle |

## Test plan

- [x] 6 new unit tests pass (HeartbeatService-degraded.test.ts)
- [x] TypeScript build clean
- [ ] Full CI test suite passing (vitest.config.ci.ts)

## Context

Part of #1918 (MCP graceful degradation for GDrive disconnect on myia-web1). Previous PRs already implemented:
- `server-capabilities.ts` — runtime degradation tracking
- `shared-state-path.ts` — `tryGetSharedStatePath()` + `isSharedPathAccessible()`
- `index.ts` — uncaughtException/unhandledRejection I/O error classification + GDrive health check
- `registry.ts` — capability guard before tool execution

This PR closes the last gap: HeartbeatService was the only component still attempting disk I/O during degradation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)