### PR TITLE
test(fix): get-status.test.ts — partial fs mock to preserve existsSync/mkdirSync

### DIFF
--- a/servers/roo-state-manager/tests/unit/tools/roosync/get-status.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/get-status.test.ts
@@ -56,11 +56,17 @@ vi.mock('../../../../src/utils/tool-call-metrics.js', () => ({
     getToolUsageSnapshot: mockGetToolUsageSnapshot,
 }));
 
-vi.mock('fs', () => ({
-    readdirSync: mockReaddirSync,
-    statSync: mockStatSync,
-    readFileSync: mockReadFileSync,
-}));
+// Partial mock — preserve existsSync/mkdirSync etc. for Logger.ensureLogDirectory()
+// when this test runs in suite ordering that instantiates loggers after the mock.
+vi.mock('fs', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('fs')>();
+    return {
+        ...actual,
+        readdirSync: mockReaddirSync,
+        statSync: mockStatSync,
+        readFileSync: mockReadFileSync,
+    };
+});
 
 function setupMocks(overrides: Record<string, any> = {}) {
     const heartbeatState = overrides.heartbeatState || {


### PR DESCRIPTION
## Summary

Fix CI failure exposed by parent bundle pointer-bump #1981 (cycle 29 W7 merge tour).

## Root cause

\`tests/unit/tools/roosync/get-status.test.ts\` (added in #304) had a complete \`vi.mock('fs')\` exposing only \`readdirSync\`, \`statSync\`, \`readFileSync\`.

When test suite ordering causes \`Logger\` to be instantiated AFTER this mock takes effect (e.g., \`createLogger()\` in \`get-status.ts\` module side-effects), \`Logger.ensureLogDirectory()\` calls \`existsSync()\` which is undefined → suite fails.

Individual PR CI for #304 passed because of test ordering luck. Bundle merge #1981 exposed the latent bug.

## Fix

Convert the \`fs\` mock to a partial mock via \`vi.importActual\` (vitest-recommended pattern). Preserves all real \`fs\` exports while overriding only the 3 mocked methods.

\`\`\`ts
vi.mock('fs', async (importOriginal) => {
    const actual = await importOriginal<typeof import('fs')>();
    return {
        ...actual,
        readdirSync: mockReaddirSync,
        statSync: mockStatSync,
        readFileSync: mockReadFileSync,
    };
});
\`\`\`

## Test plan

- [ ] CI green on this PR
- [ ] After merge, parent #1981 CI re-run will pass build-and-test (20+22)

## Urgency

⚡ Blocks parent bundle pointer-bump #1981 (cycle 29 W7 merge tour). Coordinator merge tour blocked until this fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)