### PR TITLE
fix(test): get-status fs mock missing existsSync+mkdirSync

### DIFF
--- a/servers/roo-state-manager/tests/unit/tools/roosync/get-status.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/get-status.test.ts
@@ -22,6 +22,8 @@ const {
     mockReaddirSync,
     mockStatSync,
     mockReadFileSync,
+    mockExistsSync,
+    mockMkdirSync,
 } = vi.hoisted(() => ({
     mockGetRooSyncService: vi.fn(),
     mockGetMessageManager: vi.fn(),
@@ -30,6 +32,8 @@ const {
     mockReaddirSync: vi.fn(),
     mockStatSync: vi.fn(),
     mockReadFileSync: vi.fn(),
+    mockExistsSync: vi.fn().mockReturnValue(true),
+    mockMkdirSync: vi.fn(),
 }));
 
 vi.mock('../../../../src/services/lazy-roosync.js', () => ({
@@ -60,6 +64,8 @@ vi.mock('fs', () => ({
     readdirSync: mockReaddirSync,
     statSync: mockStatSync,
     readFileSync: mockReadFileSync,
+    existsSync: mockExistsSync,
+    mkdirSync: mockMkdirSync,
 }));
 
 function setupMocks(overrides: Record<string, any> = {}) {


### PR DESCRIPTION
## Summary
- Add `existsSync` and `mkdirSync` to the `fs` mock in `get-status.test.ts`
- Regression from PR #293 which added `createLogger('GetStatus')` — the logger constructor calls `existsSync` to ensure log directory exists

## Test plan
- [x] `npx vitest run tests/unit/tools/roosync/get-status.test.ts` — 23/23 pass
- [x] `npx vitest run --config vitest.config.ci.ts` — 9557/9557 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)