### PR TITLE
fix(#1843): cleanup LOW audit findings — dead stubs, debug log, hardcoded PS version

### DIFF
--- a/servers/roo-state-manager/src/services/roosync/ConfigComparator.ts
+++ b/servers/roo-state-manager/src/services/roosync/ConfigComparator.ts
@@ -189,8 +189,6 @@ export class ConfigComparator {
         allMachines.add(this.config.machineId);
       }
 
-      console.log('[DEBUG] listDiffs - allMachines trouvées:', Array.from(allMachines));
-
       const allDiffs: Array<{
         type: string;
         path: string;

--- a/servers/roo-state-manager/src/services/roosync/InventoryService.ts
+++ b/servers/roo-state-manager/src/services/roosync/InventoryService.ts
@@ -87,8 +87,8 @@ export class InventoryService {
     slashCommands: [], // Not implemented in script
     terminalCommands: { allowed: [], restricted: [] }, // Not implemented in script
     rooModes: await this.collectRooModes(),
-    sdddSpecs: await this.collectSdddSpecs(),
-    scripts: await this.collectScripts(),
+    sdddSpecs: [], // #1843 LOW #9: stubs inlined (never collected, bloats inventory)
+    scripts: { categories: {}, all: [] },
     tools: {}, // Skipped in script
     systemInfo: {
       os: `${os.type()} ${os.release()}`,
@@ -220,39 +220,14 @@ private async collectMcpServers(): Promise<McpServerInfo[]> {
     }
   }
 
-  /**
-   * SIMPLIFICATION "Écuries d'Augias" : Ne plus collecter les specs SDDD
-   * Ces fichiers ne sont pas utiles pour la comparaison des configurations
-   * et gonflent inutilement l'inventaire.
-   */
-  private async collectSdddSpecs(): Promise<any[]> {
-     // Retourner un tableau vide pour alléger l'inventaire
-     return [];
-  }
-
-  /**
-   * SIMPLIFICATION "Écuries d'Augias" : Ne plus collecter les scripts PowerShell
-   * Ces fichiers ne sont pas utiles pour la comparaison des configurations
-   * et gonflent l'inventaire de 70+ KB à cause de la récursion.
-   */
-  private async collectScripts(): Promise<{ categories: { [key: string]: ScriptInfo[] }; all: ScriptInfo[] }> {
-      // Retourner un objet vide pour alléger l'inventaire
-      return {
-          categories: {},
-          all: []
-      };
-  }
 
   private async getPowershellVersion(): Promise<string> {
-      // In a real environment, we might execute 'pwsh -v' or '$PSVersionTable'
-      // For now, returning a placeholder or executing a simple command if possible
-      // Since we don't have direct command execution easily available in this service context without external dependencies
-      // We will try to use the PowerShellExecutor if available or return default.
       try {
-           // Placeholder: assuming PWSH 7 for this environment as per system info
-           return "7.x";
+          const { execSync } = await import('child_process');
+          const output = execSync('pwsh -NoProfile -Command "$PSVersionTable.PSVersion.ToString()"', { timeout: 5000 }).toString().trim();
+          return output || 'Unknown';
       } catch {
-          return "Unknown";
+          return 'Unknown';
       }
   }
 

--- a/servers/roo-state-manager/src/services/roosync/__tests__/InventoryService.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/InventoryService.test.ts
@@ -170,7 +170,7 @@ describe('InventoryService', () => {
         os: 'Windows_NT 10.0.19045',
         hostname: 'test-machine',
         username: 'test-user',
-        powershellVersion: '7.x',
+        powershellVersion: expect.any(String),
       });
     });
 


### PR DESCRIPTION
## Summary
- Clean up 3 LOW findings from #1843 roosync/ service audit
- Remove dead stub methods, implement actual PS version detection, remove debug logging

## Changes
| Finding | File | Action | LOC |
|---------|------|--------|-----|
| LOW #9 | InventoryService.ts | Remove `collectSdddSpecs()` + `collectScripts()` stubs, inline empty values | -27 |
| LOW #10 | InventoryService.ts | Replace hardcoded `"7.x"` with `execSync('pwsh -NoProfile ...')` | +5/-10 |
| LOW #11 | ConfigComparator.ts | Remove `[DEBUG] listDiffs` console.log | -2 |

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 9554 passed, 0 failed
- [x] InventoryService.test.ts updated (powershellVersion: expect.any(String))

🤖 Generated with [Claude Code](https://claude.com/claude-code)