### PR TITLE
fix(#1411): Update obsolete tool names in get_mcp_best_practices

### DIFF
--- a/servers/roo-state-manager/src/services/ExportConfigManager.ts
+++ b/servers/roo-state-manager/src/services/ExportConfigManager.ts
@@ -32,25 +32,8 @@ const DEFAULT_CONFIG: ExportConfig = {
         includeContent: false,
         compression: 'none'
     },
-    templates: {
-        jira_export: {
-            format: 'simplified',
-            fields: ['taskId', 'title', 'user_messages_only']
-        },
-        full_export: {
-            format: 'complete',
-            fields: ['taskId', 'title', 'metadata', 'sequence']
-        }
-    },
-    filters: {
-        last_week: {
-            startDate: 'now-7d',
-            endDate: 'now'
-        },
-        debug_tasks: {
-            mode: 'debug-complex'
-        }
-    }
+    templates: {},
+    filters: {}
 };
 
 /**

--- a/servers/roo-state-manager/src/services/__tests__/ExportConfigManager.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/ExportConfigManager.test.ts
@@ -56,6 +56,12 @@ const MOCK_CONFIG_PATH = '/mock/home/.vscode/xml_export_config.json';
 
 const DEFAULT_CONFIG_SNAPSHOT = {
   defaults: { prettyPrint: true, includeContent: false, compression: 'none' },
+  templates: {},
+  filters: {},
+};
+
+const TEST_CONFIG_WITH_PRESETS = {
+  defaults: { prettyPrint: true, includeContent: false, compression: 'none' },
   templates: {
     jira_export: { format: 'simplified', fields: ['taskId', 'title', 'user_messages_only'] },
     full_export: { format: 'complete', fields: ['taskId', 'title', 'metadata', 'sequence'] },
@@ -131,7 +137,7 @@ describe('ExportConfigManager', () => {
     test('fusionne le fichier avec les valeurs par défaut manquantes', async () => {
       const partialConfig = {
         defaults: { prettyPrint: false, includeContent: true, compression: 'none' as const },
-        // templates et filters absents → doivent être fusionnés avec les défauts
+        // templates et filters absents → doivent être fusionnés avec les défauts (vides)
       };
       mockAccess.mockResolvedValue(undefined);
       mockReadFile.mockResolvedValue(JSON.stringify(partialConfig));
@@ -139,9 +145,9 @@ describe('ExportConfigManager', () => {
       const manager = makeManager();
       const config = await manager.getConfig();
 
-      // Les templates par défaut doivent être présents
-      expect(config.templates).toHaveProperty('jira_export');
-      expect(config.templates).toHaveProperty('full_export');
+      // Les sections templates/filters sont fusionnées (vides par défaut)
+      expect(config.templates).toBeDefined();
+      expect(config.filters).toBeDefined();
     });
 
     test('nettoie le BOM UTF-8 si présent', async () => {
@@ -223,8 +229,6 @@ describe('ExportConfigManager', () => {
 
       const config = await manager.getConfig();
       expect(config.templates).toHaveProperty('my_template');
-      // Les templates par défaut sont préservés
-      expect(config.templates).toHaveProperty('jira_export');
     });
 
     test('appelle writeFile lors de updateConfig', async () => {
@@ -317,7 +321,7 @@ describe('ExportConfigManager', () => {
 
     test('removeTemplate supprime un template existant et retourne true', async () => {
       mockAccess.mockResolvedValue(undefined);
-      mockReadFile.mockResolvedValue(JSON.stringify(DEFAULT_CONFIG_SNAPSHOT));
+      mockReadFile.mockResolvedValue(JSON.stringify(TEST_CONFIG_WITH_PRESETS));
 
       const manager = makeManager();
       await manager.getConfig();
@@ -366,7 +370,7 @@ describe('ExportConfigManager', () => {
 
     test('removeFilter supprime un filtre existant et retourne true', async () => {
       mockAccess.mockResolvedValue(undefined);
-      mockReadFile.mockResolvedValue(JSON.stringify(DEFAULT_CONFIG_SNAPSHOT));
+      mockReadFile.mockResolvedValue(JSON.stringify(TEST_CONFIG_WITH_PRESETS));
 
       const manager = makeManager();
       await manager.getConfig();

--- a/servers/roo-state-manager/src/tools/__tests__/get-mcp-best-practices.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/get-mcp-best-practices.test.ts
@@ -121,8 +121,8 @@ describe('get_mcp_best_practices', () => {
       const result = await getMcpBestPractices.handler();
       const text = result.content[0].text as string;
 
-      expect(text).toContain('touch_mcp_settings');
-      expect(text).toContain('rebuild_and_restart_mcp');
+      expect(text).toContain('roosync_mcp_management touch');
+      expect(text).toContain('roosync_mcp_management rebuild');
       expect(text).toContain('read_vscode_logs');
     });
 
@@ -271,7 +271,7 @@ describe('get_mcp_best_practices', () => {
       expect(text).toContain('🚀 Commandes de développement');
       expect(text).toContain('npm install');
       expect(text).toContain('npm run build');
-      expect(text).toContain('use_mcp_tool roo-state-manager rebuild_and_restart_mcp');
+      expect(text).toContain('use_mcp_tool roo-state-manager roosync_mcp_management {"action": "rebuild"');
     });
   });
 });

--- a/servers/roo-state-manager/src/tools/get_mcp_best_practices.ts
+++ b/servers/roo-state-manager/src/tools/get_mcp_best_practices.ts
@@ -177,16 +177,16 @@ export const getMcpBestPractices = {
             
             combinedContent += `### 🩺 4. Pattern "Environment Diagnostic First"\n`;
             combinedContent += `**Approche:** Toujours diagnostiquer l'environnement avant de chercher des bugs de logique\n`;
-            combinedContent += `**Outils:** system_info, read_vscode_logs, manage_mcp_settings\n\n`;
+            combinedContent += `**Outils:** system_info, read_vscode_logs, roosync_mcp_management\n\n`;
             
             // === SECTION 2: WORKFLOW SYSTÉMATIQUE ===
             combinedContent += `## ⚡ WORKFLOW DE DÉBOGAGE SYSTÉMATIQUE\n\n`;
             combinedContent += `\`\`\`bash\n`;
             combinedContent += `# 1. Diagnostic initial\n`;
-            combinedContent += `use_mcp_tool roo-state-manager manage_mcp_settings {"action": "read"}\n`;
+            combinedContent += `use_mcp_tool roo-state-manager roosync_mcp_management {"action": "manage", "subAction": "read"}\n`;
             combinedContent += `use_mcp_tool [mcp-name] system_info {}\n\n`;
             combinedContent += `# 2. Force reload après modification\n`;
-            combinedContent += `use_mcp_tool roo-state-manager touch_mcp_settings {}\n\n`;
+            combinedContent += `use_mcp_tool roo-state-manager roosync_mcp_management {"action": "touch"}\n\n`;
             combinedContent += `# 3. Progressive isolation si problème persiste\n`;
             combinedContent += `# Version minimale → ajout progressif → identification blocage\n\n`;
             combinedContent += `# 4. Logs diagnostic\n`;
@@ -196,7 +196,7 @@ export const getMcpBestPractices = {
             // === SECTION 3: CHECKLIST URGENTE ===
             combinedContent += `## 🚨 CHECKLIST DE DÉBOGAGE URGENT\n\n`;
             combinedContent += `**Quand un MCP ne répond plus:**\n\n`;
-            combinedContent += `- [ ] **Force reload:** \`touch_mcp_settings\`\n`;
+            combinedContent += `- [ ] **Force reload:** \`roosync_mcp_management touch\`\n`;
             combinedContent += `- [ ] **Test connectivité:** outil simple (system_info)\n`;
             combinedContent += `- [ ] **Logs diagnostic:** \`read_vscode_logs\`\n`;
             combinedContent += `- [ ] **Progressive isolation** si timeout persiste\n\n`;
@@ -205,7 +205,7 @@ export const getMcpBestPractices = {
             combinedContent += `## 🐛 ERREURS COMMUNES DOCUMENTÉES\n\n`;
             combinedContent += `### TypeScript/Node.js:\n`;
             combinedContent += `- **ENOENT errors:** Chemins hardcodés incorrects (ex: get-mcp-dev-docs.ts)\n`;
-            combinedContent += `- **Module resolution:** Build non-reflété nécessitant rebuild_and_restart_mcp\n\n`;
+            combinedContent += `- **Module resolution:** Build non-reflété nécessitant roosync_mcp_management rebuild\n\n`;
             combinedContent += `### Python:\n`;
             combinedContent += `- **Import timeouts:** Imports lourds (papermill) bloquants en contexte MCP\n`;
             combinedContent += `- **Subprocess conda:** Pattern récurrent de timeout 60s\n\n`;
@@ -230,7 +230,7 @@ export const getMcpBestPractices = {
             combinedContent += `## 💡 BONNES PRATIQUES VALIDÉES\n\n`;
             combinedContent += `### ✅ Toujours faire:\n`;
             combinedContent += `- Test avec outils de diagnostic d'abord\n`;
-            combinedContent += `- \`touch_mcp_settings\` après chaque modification\n`;
+            combinedContent += `- \`roosync_mcp_management touch\` après chaque modification\n`;
             combinedContent += `- Progressive isolation des problèmes complexes\n`;
             combinedContent += `- Exception wrapping avec fallback gracieux\n\n`;
             combinedContent += `### ❌ Éviter absolument:\n`;
@@ -242,10 +242,10 @@ export const getMcpBestPractices = {
             combinedContent += `## 🔄 OUTILS ROO-STATE-MANAGER ESSENTIELS\n\n`;
             combinedContent += `| Outil | Usage Principal | Quand l'utiliser |\n`;
             combinedContent += `|-------|----------------|------------------|\n`;
-            combinedContent += `| \`touch_mcp_settings\` | Force reload tous MCPs | Après chaque modif code |\n`;
-            combinedContent += `| \`rebuild_and_restart_mcp\` | Build TypeScript + restart | MCPs TypeScript modifiés |\n`;
+            combinedContent += `| \`roosync_mcp_management touch\` | Force reload tous MCPs | Après chaque modif code |\n`;
+            combinedContent += `| \`roosync_mcp_management rebuild\` | Build TypeScript + restart | MCPs TypeScript modifiés |\n`;
             combinedContent += `| \`read_vscode_logs\` | Diagnostic erreurs système | Debugging avancé |\n`;
-            combinedContent += `| \`manage_mcp_settings\` | Vérification configuration | Setup et diagnostic |\n\n`;
+            combinedContent += `| \`roosync_mcp_management manage\` | Vérification configuration | Setup et diagnostic |\n\n`;
 
             // === SECTION 7: CONFIGURATION MCP ===
             const mcpSettings = await getMcpConfiguration();
@@ -293,8 +293,8 @@ export const getMcpBestPractices = {
                         combinedContent += `npm run build  # Build\n`;
                         combinedContent += `npm test  # Tests si disponibles\n\n`;
                         combinedContent += `# Workflow Roo debug\n`;
-                        combinedContent += `use_mcp_tool roo-state-manager rebuild_and_restart_mcp {"mcp_name": "${args.mcp_name}"}\n`;
-                        combinedContent += `use_mcp_tool roo-state-manager touch_mcp_settings {}\n`;
+                        combinedContent += `use_mcp_tool roo-state-manager roosync_mcp_management {"action": "rebuild", "mcp_name": "${args.mcp_name}"}\n`;
+                        combinedContent += `use_mcp_tool roo-state-manager roosync_mcp_management {"action": "touch"}\n`;
                         combinedContent += `\`\`\`\n\n`;
                     } else {
                         combinedContent += `⚠️ **Impossible de déterminer le chemin pour ce MCP.**\n\n`;
@@ -310,12 +310,12 @@ export const getMcpBestPractices = {
             // === SECTION 9: GROUNDING AGENTS EXTERNES ===
             combinedContent += `## 🎯 GROUNDING POUR AGENTS EXTERNES\n\n`;
             combinedContent += `**Procédure complète pour debugger un MCP défectueux:**\n\n`;
-            combinedContent += `1. **Identifier le MCP** via \`manage_mcp_settings read\`\n`;
-            combinedContent += `2. **Analyser sa structure** via \`get_mcp_dev_docs --mcp_name=<nom>\`\n`;
+            combinedContent += `1. **Identifier le MCP** via \`roosync_mcp_management manage read\`\n`;
+            combinedContent += `2. **Analyser sa structure** via \`get_mcp_best_practices --mcp_name=<nom>\`\n`;
             combinedContent += `3. **Vérifier les logs** via \`read_vscode_logs\`\n`;
             combinedContent += `4. **Test minimal** avec Progressive Isolation\n`;
-            combinedContent += `5. **Force reload** via \`touch_mcp_settings\`\n`;
-            combinedContent += `6. **Rebuild si TypeScript** via \`rebuild_and_restart_mcp\`\n`;
+            combinedContent += `5. **Force reload** via \`roosync_mcp_management touch\`\n`;
+            combinedContent += `6. **Rebuild si TypeScript** via \`roosync_mcp_management rebuild\`\n`;
             combinedContent += `7. **Valider la correction** avec tests fonctionnels\n\n`;
 
             combinedContent += `---\n\n`;

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/inventory.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/inventory.test.ts
@@ -312,4 +312,57 @@ describe('inventoryTool', () => {
       expect(result.metrics.executionTime).toBeGreaterThanOrEqual(0);
     });
   });
+
+  // ============================================================
+  // Tests for summary mode (#1411)
+  // ============================================================
+
+  describe('summary mode', () => {
+    test('should return markdown summary for type=all with summary=true', async () => {
+      const result = await inventoryTool.execute(
+        { type: 'all', summary: true },
+        mockExecutionContext
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data.summary).toBeDefined();
+      expect(result.data.summary).toContain('Inventory Summary');
+      expect(result.data.summary).toContain('Machine:');
+      expect(result.data.summary).toContain('Cluster status:');
+      expect(result.data.summary).toContain('Online');
+      expect(result.data.summary).toContain('Offline');
+    });
+
+    test('should not return full JSON when summary=true', async () => {
+      const result = await inventoryTool.execute(
+        { type: 'all', summary: true },
+        mockExecutionContext
+      );
+
+      expect(result.data.machineInventory).toBeUndefined();
+      expect(result.data.heartbeatState).toBeUndefined();
+    });
+
+    test('should return full JSON when summary=false (default)', async () => {
+      const result = await inventoryTool.execute(
+        { type: 'all', summary: false },
+        mockExecutionContext
+      );
+
+      expect(result.data.machineInventory).toBeDefined();
+      expect(result.data.heartbeatState).toBeDefined();
+      expect(result.data.summary).toBeUndefined();
+    });
+
+    test('should return summary for type=machine', async () => {
+      const result = await inventoryTool.execute(
+        { type: 'machine', summary: true },
+        mockExecutionContext
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data.summary).toContain('Machine:');
+      expect(result.data.summary).toContain('MCPs:');
+    });
+  });
 });

--- a/servers/roo-state-manager/src/tools/roosync/inventory.ts
+++ b/servers/roo-state-manager/src/tools/roosync/inventory.ts
@@ -27,7 +27,9 @@ export const InventoryArgsSchema = z.object({
   status: z.enum(['offline', 'warning', 'all']).optional()
     .describe('Filtrer par statut machines (type="machines": offline, warning, all)'),
   includeDetails: z.boolean().optional()
-    .describe('Inclure les détails complets des machines (type="machines", défaut: false)')
+    .describe('Inclure les détails complets des machines (type="machines", défaut: false)'),
+  summary: z.boolean().optional()
+    .describe('Retourner un résumé compact (markdown) au lieu du JSON complet (défaut: false)')
 });
 
 export type InventoryArgs = z.infer<typeof InventoryArgsSchema>;
@@ -124,7 +126,7 @@ export const inventoryTool: UnifiedToolContract = {
   execute: async (input: z.infer<typeof InventoryArgsSchema>, context: any): Promise<ToolResult<any>> => {
     const startTime = Date.now();
     try {
-      const { type, machineId, includeHeartbeats = true } = input;
+      const { type, machineId, includeHeartbeats = true, summary = false } = input;
       const retrievedAt = new Date().toISOString();
 
       const result: any = {
@@ -132,10 +134,18 @@ export const inventoryTool: UnifiedToolContract = {
         retrievedAt
       };
 
+      // Collect data
+      let machineInventory: any = null;
+      let heartbeatState: any = null;
+      let machinesData: any = null;
+
       // Récupérer l'inventaire machine si demandé
       if (type === 'machine' || type === 'all') {
         const inventoryService = InventoryService.getInstance();
-        result.machineInventory = await inventoryService.getMachineInventory(machineId);
+        machineInventory = await inventoryService.getMachineInventory(machineId);
+        if (!summary) {
+          result.machineInventory = machineInventory;
+        }
       }
 
       // Récupérer l'état heartbeat si demandé
@@ -144,7 +154,7 @@ export const inventoryTool: UnifiedToolContract = {
         const heartbeatService = rooSyncService.getHeartbeatService();
         const state = heartbeatService.getState();
 
-        result.heartbeatState = {
+        heartbeatState = {
           onlineMachines: state.onlineMachines,
           offlineMachines: state.offlineMachines,
           warningMachines: state.warningMachines,
@@ -152,6 +162,9 @@ export const inventoryTool: UnifiedToolContract = {
           heartbeats: includeHeartbeats ? Object.fromEntries(state.heartbeats) : undefined,
           retrievedAt
         };
+        if (!summary) {
+          result.heartbeatState = heartbeatState;
+        }
       }
 
       // [FUSION A2 #1863] type="machines" — fused from roosync_machines
@@ -160,6 +173,8 @@ export const inventoryTool: UnifiedToolContract = {
         const heartbeatService = rooSyncService.getHeartbeatService();
         const machinesStatus = input.status || 'all';
         const wantDetails = input.includeDetails || false;
+
+        machinesData = { offlineMachines: [], offlineCount: 0, warningMachines: [], warningCount: 0 };
 
         if (machinesStatus === 'offline' || machinesStatus === 'all') {
           const offlineMachines = heartbeatService.getOfflineMachines();
@@ -171,11 +186,11 @@ export const inventoryTool: UnifiedToolContract = {
                 detailed.push({ machineId: data.machineId, lastHeartbeat: data.lastHeartbeat, offlineSince: data.offlineSince, missedHeartbeats: data.missedHeartbeats, metadata: data.metadata });
               }
             }
-            result.offlineMachines = detailed;
-            result.offlineCount = detailed.length;
+            machinesData.offlineMachines = detailed;
+            machinesData.offlineCount = detailed.length;
           } else {
-            result.offlineMachines = offlineMachines;
-            result.offlineCount = offlineMachines.length;
+            machinesData.offlineMachines = offlineMachines;
+            machinesData.offlineCount = offlineMachines.length;
           }
         }
 
@@ -189,13 +204,55 @@ export const inventoryTool: UnifiedToolContract = {
                 detailed.push({ machineId: data.machineId, lastHeartbeat: data.lastHeartbeat, missedHeartbeats: data.missedHeartbeats, metadata: data.metadata });
               }
             }
-            result.warningMachines = detailed;
-            result.warningCount = detailed.length;
+            machinesData.warningMachines = detailed;
+            machinesData.warningCount = detailed.length;
           } else {
-            result.warningMachines = warningMachines;
-            result.warningCount = warningMachines.length;
+            machinesData.warningMachines = warningMachines;
+            machinesData.warningCount = warningMachines.length;
           }
         }
+        if (!summary) {
+          Object.assign(result, machinesData);
+        }
+      }
+
+      // Summary mode: return compact markdown instead of full JSON
+      if (summary) {
+        const lines: string[] = [`**Inventory Summary** (${retrievedAt})`, ''];
+
+        if (machineInventory) {
+          const inv = machineInventory as any;
+          lines.push(`**Machine:** ${inv.systemInfo?.hostname || machineId || 'unknown'}`);
+          lines.push(`- OS: ${inv.systemInfo?.os || 'N/A'}`);
+          const mcpCount = inv.mcpServers ? Object.keys(inv.mcpServers).length : 0;
+          lines.push(`- MCPs: ${mcpCount} servers`);
+          const modes = inv.rooModes?.modes ? Object.keys(inv.rooModes.modes).length : 0;
+          lines.push(`- Roo modes: ${modes}`);
+          lines.push('');
+        }
+
+        if (heartbeatState) {
+          const hs = heartbeatState;
+          lines.push(`**Cluster status:** ${hs.statistics.totalMachines} machines`);
+          lines.push(`- Online (${hs.onlineMachines.length}): ${hs.onlineMachines.join(', ') || 'none'}`);
+          lines.push(`- Offline (${hs.offlineMachines.length}): ${hs.offlineMachines.join(', ') || 'none'}`);
+          lines.push(`- Warning (${hs.warningMachines.length}): ${hs.warningMachines.join(', ') || 'none'}`);
+          lines.push('');
+        }
+
+        if (machinesData) {
+          lines.push(`**Filtered machines:** offline=${machinesData.offlineCount}, warning=${machinesData.warningCount}`);
+          lines.push('');
+        }
+
+        return {
+          success: true,
+          data: { summary: lines.join('\n'), retrievedAt },
+          metrics: {
+            executionTime: Date.now() - startTime,
+            processingLevel: ProcessingLevel.IMMEDIATE
+          }
+        };
       }
 
       return {
@@ -252,6 +309,10 @@ export const inventoryToolMetadata = {
       includeDetails: {
         type: 'boolean',
         description: 'Inclure les détails complets des machines (type="machines", défaut: false)'
+      },
+      summary: {
+        type: 'boolean',
+        description: 'Retourner un résumé compact (markdown) au lieu du JSON complet (défaut: false)'
       }
     },
     required: ['type'],

--- a/servers/roo-state-manager/tests/unit/services/ServiceRegistry.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/ServiceRegistry.test.ts
@@ -316,4 +316,149 @@ describe('ServiceRegistry', () => {
             expect(r.getRegistryMetrics().totalServices).toBe(7);
         });
     });
+
+    describe('MIXED processing level', () => {
+        it('should fallback to background on immediate timeout', async () => {
+            const slowMock = vi.fn().mockImplementation(() =>
+                new Promise(resolve => setTimeout(() => resolve('slow-result'), 6000))
+            );
+            registry.registerService('utility', { slowProcess: slowMock }, 'MIXED' as any);
+
+            const result = await registry.executeServiceMethod('utility', 'slowProcess');
+
+            // Should have completed via background fallback (Promise.race timeout at 5s)
+            // Note: This test would take 6s in real conditions, so we verify the logic flow
+            const metrics = registry.getRegistryMetrics();
+            const utilityMetrics = metrics.serviceBreakdown.find(m => m.serviceName === 'utility');
+            // MIXED increments immediateCallsCount first, then backgroundCallsCount on fallback
+            expect(utilityMetrics!.backgroundCallsCount).toBeGreaterThan(0);
+        }, 15000);
+
+        it('should use immediate result when fast enough', async () => {
+            const fastMock = vi.fn().mockResolvedValue('fast-result');
+            registry.registerService('utility', { fastProcess: fastMock }, 'MIXED' as any);
+
+            const result = await registry.executeServiceMethod('utility', 'fastProcess');
+
+            expect(result).toBe('fast-result');
+            const metrics = registry.getRegistryMetrics();
+            const utilityMetrics = metrics.serviceBreakdown.find(m => m.serviceName === 'utility');
+            expect(utilityMetrics!.immediateCallsCount).toBe(1);
+        });
+    });
+
+    describe('healthCheck degraded status', () => {
+        it('should mark service as degraded when errorRate > 10%', async () => {
+            const mockInstance = { work: vi.fn().mockRejectedValue(new Error('err')) };
+            registry.registerService('display', mockInstance, 'IMMEDIATE' as any);
+
+            // Need callCount > 10 for errorRate calculation to be > 10% with 1 error
+            for (let i = 0; i < 9; i++) {
+                registry.getService('display');
+            }
+            try { await registry.executeServiceMethod('display', 'work'); } catch {}
+
+            const health = await registry.healthCheck();
+            // errorCount=1, callCount=10 → errorRate=10% → should be 'degraded'
+            expect(health.services['display']).toBe('degraded');
+        });
+
+        it('should mark service as degraded when avgTime > 10000ms', async () => {
+            const slowMock = vi.fn().mockImplementation(() =>
+                new Promise(resolve => setTimeout(() => resolve('result'), 11000))
+            );
+            registry.registerService('display', { slowWork: slowMock }, 'IMMEDIATE' as any);
+
+            registry.getService('display');
+            await registry.executeServiceMethod('display', 'slowWork');
+
+            const health = await registry.healthCheck();
+            // avgTime > 10000ms → 'degraded'
+            expect(health.services['display']).toBe('degraded');
+        }, 20000);
+
+        it('should return degraded when >3 services degraded', async () => {
+            // Create 4 services with slow execution (avgTime > 10000ms)
+            const serviceNames = ['display', 'search', 'storage', 'cache'] as const;
+
+            for (const svcName of serviceNames) {
+                const slowMock = vi.fn().mockImplementation(() =>
+                    new Promise(resolve => setTimeout(() => resolve('result'), 11000))
+                );
+                registry.registerService(svcName, { slowWork: slowMock }, 'IMMEDIATE' as any);
+            }
+
+            // Execute slow work on each service
+            for (const svcName of serviceNames) {
+                registry.getService(svcName);
+                await registry.executeServiceMethod(svcName, 'slowWork');
+            }
+
+            const health = await registry.healthCheck();
+            // With 4 degraded services (> 3), status should be 'degraded'
+            expect(health.status).toBe('degraded');
+        }, 60000);
+    });
+
+    describe('Cache Anti-Leak monitoring', () => {
+        it('should not trigger cleanup when memory is below threshold', async () => {
+            const mockCleanup = vi.fn();
+            registry.registerService('cache', { cleanup: mockCleanup }, 'IMMEDIATE' as any);
+
+            // executeServiceMethod calls checkCacheAntiLeak internally
+            await registry.executeServiceMethod('cache', 'someMethod');
+
+            // With normal memory usage (< 200GB threshold), cleanup should not be called
+            expect(mockCleanup).not.toHaveBeenCalled();
+        });
+
+        it('should trigger cleanup when memory exceeds threshold', async () => {
+            // Mock process.memoryUsage to return high memory usage
+            const originalMemoryUsage = process.memoryUsage;
+            process.memoryUsage = vi.fn().mockReturnValue({
+                heapUsed: 220 * 1024 * 1024 * 1024, // 220GB - exceeds 200GB threshold
+                heapTotal: 250 * 1024 * 1024 * 1024,
+                external: 0,
+                rss: 250 * 1024 * 1024 * 1024,
+                arrayBuffers: 0
+            });
+
+            const mockCleanup = vi.fn();
+            registry.registerService('cache', { cleanup: mockCleanup }, 'IMMEDIATE' as any);
+
+            await registry.executeServiceMethod('cache', 'someMethod');
+
+            // Cleanup should be triggered when memory exceeds threshold
+            expect(mockCleanup).toHaveBeenCalled();
+
+            // Restore original process.memoryUsage
+            process.memoryUsage = originalMemoryUsage;
+        });
+    });
+
+    describe('updateSuccessMetrics', () => {
+        it('should calculate average execution time correctly', async () => {
+            const mockInstance = { work: vi.fn().mockResolvedValue('ok') };
+            registry.registerService('display', mockInstance, 'IMMEDIATE' as any);
+
+            // First call
+            registry.getService('display');
+            await registry.executeServiceMethod('display', 'work');
+
+            const metrics1 = registry.getRegistryMetrics();
+            const displayMetrics1 = metrics1.serviceBreakdown.find(m => m.serviceName === 'display');
+            const avgTime1 = displayMetrics1!.averageExecutionTime;
+
+            // Second call
+            registry.getService('display');
+            await registry.executeServiceMethod('display', 'work');
+
+            const metrics2 = registry.getRegistryMetrics();
+            const displayMetrics2 = metrics2.serviceBreakdown.find(m => m.serviceName === 'display');
+            const avgTime2 = displayMetrics2!.averageExecutionTime;
+
+            // Average should be calculated correctly: (avgTime1 * 1 + execTime2) / 2
+            expect(avgTime2).toBeGreaterThanOrEqual(0);
+        });
+    });
 });


### PR DESCRIPTION
## Summary
3 items from #1411 MCP design debt cleanup:

1. **Update obsolete tool names** in `get_mcp_best_practices` — replace pre-consolidation names (`manage_mcp_settings`, `touch_mcp_settings`, `rebuild_and_restart_mcp`, `get_mcp_dev_docs`) with current `roosync_mcp_management` sub-actions
2. **Add summary mode** to `roosync_inventory` — new `summary` boolean parameter returns compact markdown instead of full JSON dump
3. **Remove hardcoded filter presets** from `export_config` defaults — empty templates/filters by default, users add their own via the tool

## Test plan
- [x] `npx vitest run src/tools/__tests__/get-mcp-best-practices.test.ts` — 16/16 pass
- [x] `npx vitest run src/tools/roosync/__tests__/inventory.test.ts` — 18/18 pass (14 + 4 new)
- [x] `npx vitest run src/services/__tests__/ExportConfigManager.test.ts` — 22/22 pass
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)