### PR TITLE
fix(#1356): move inbox check to background interval — zero I/O on hot path

### DIFF
--- a/servers/roo-state-manager/src/notifications/ToolUsageInterceptor.ts
+++ b/servers/roo-state-manager/src/notifications/ToolUsageInterceptor.ts
@@ -1,15 +1,18 @@
 /**
  * Intercepteur pour capturer l'usage de tous les outils MCP
- * 
+ *
  * Pattern: Middleware/Decorator
  * Responsabilités:
  * 1. Refresher le cache de conversations (via scanDiskForNewTasks)
- * 2. Vérifier la boîte de réception RooSync pour nouveaux messages
+ * 2. Vérifier la boîte de réception RooSync (background interval, never on hot path)
  * 3. Émettre un événement de notification si pertinent
  * 4. Exécuter l'outil original sans blocage
- * 
+ *
+ * FIX #1356: Inbox check moved entirely to background interval (60s).
+ * Previous fire-and-forget still saturated GDrive FUSE I/O on the event loop.
+ *
  * @module ToolUsageInterceptor
- * @version 1.0.0
+ * @version 2.0.0
  */
 
 import { NotificationService, NotificationEvent } from './NotificationService.js';
@@ -18,32 +21,36 @@ import { scanDiskForNewTasks } from '../tools/task/disk-scanner.js';
 import { SkeletonHeader } from '../types/conversation.js';
 import { getLocalWorkspaceId } from '../utils/message-helpers.js';
 
+/** Background inbox check interval (ms) */
+const BACKGROUND_CHECK_INTERVAL_MS = 60_000;
+/** Initial delay before first background check (ms) */
+const BACKGROUND_CHECK_INITIAL_DELAY_MS = 5_000;
+
 /**
  * Configuration de l'intercepteur
  */
 export interface InterceptorConfig {
   /** Activer le système d'interception */
   enabled?: boolean;
-  
+
   /** ID de la machine courante (pour filtrer les messages inbox) */
   machineId: string;
-  
+
   /** Activer la vérification de l'inbox RooSync */
   checkInbox: boolean;
-  
+
   /** Activer le refresh du cache de conversations */
   refreshCache: boolean;
-  
+
   /** Priorité minimale pour déclencher une notification */
   minPriority?: 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT';
 }
 
 /**
  * Intercepteur d'usage d'outils MCP
- * 
- * Wrapper autour de l'exécution de tous les outils MCP pour déclencher
- * des actions automatiques (indexation, vérification inbox) et émettre
- * des notifications si pertinent.
+ *
+ * FIX #1356 v2: Inbox check runs on a background interval (every 60s).
+ * interceptToolCall is completely I/O-free for inbox — no GDrive reads on the hot path.
  */
 export class ToolUsageInterceptor {
   private notificationService: NotificationService;
@@ -51,16 +58,10 @@ export class ToolUsageInterceptor {
   private conversationCache: Map<string, SkeletonHeader>;
   private config: InterceptorConfig;
 
-  // FIX #1356: prevent pile-up of background inbox scans when tool calls
-  // arrive faster than the GDrive scan completes. One at a time is enough.
+  private backgroundCheckInterval: ReturnType<typeof setInterval> | null = null;
   private inboxCheckInFlight = false;
-  
-  /**
-   * Constructeur de l'intercepteur
-   * @param notificationService Service de notifications
-   * @param messageManager Gestionnaire de messagerie RooSync
-   * @param config Configuration de l'intercepteur
-   */
+  private notifiedMessageIds: Set<string> = new Set();
+
   constructor(
     notificationService: NotificationService,
     messageManager: MessageManager,
@@ -71,31 +72,23 @@ export class ToolUsageInterceptor {
     this.messageManager = messageManager;
     this.conversationCache = conversationCache;
     this.config = config;
-    
+
     console.error('🔧 [ToolUsageInterceptor] Initialized with config:', {
       machineId: config.machineId,
       checkInbox: config.checkInbox,
       refreshCache: config.refreshCache,
       minPriority: config.minPriority
     });
+
+    if (config.checkInbox) {
+      this.startBackgroundCheck();
+    }
   }
-  
+
   /**
    * Intercepter l'exécution d'un outil MCP
-   * 
-   * Process:
-   * 1. Logger l'usage de l'outil
-   * 2. Refresher le cache de conversations (asynchrone, non-bloquant)
-   * 3. Vérifier la boîte de réception RooSync
-   * 4. Émettre notification si nouveaux messages pertinents
-   * 5. Exécuter l'outil original
-   * 
-   * ⚠️ IMPORTANT: Ne JAMAIS bloquer l'exécution de l'outil si une erreur survient
-   * 
-   * @param toolName Nom de l'outil appelé
-   * @param args Arguments passés à l'outil
-   * @param execute Fonction d'exécution de l'outil original
-   * @returns Résultat de l'exécution de l'outil
+   *
+   * Zero I/O for inbox check — the background interval handles it.
    */
   async interceptToolCall<T>(
     toolName: string,
@@ -103,39 +96,17 @@ export class ToolUsageInterceptor {
     execute: () => Promise<T>
   ): Promise<T> {
     console.error(`🔍 [ToolUsageInterceptor] Intercepting tool: ${toolName}`);
-    
-    // 1. Refresher le cache de conversations (non-bloquant)
+
+    // 1. Refresh conversation cache (non-blocking, fire-and-forget)
     if (this.config.refreshCache) {
       this.refreshConversationCache().catch(error => {
         console.error('⚠️ [ToolUsageInterceptor] Error refreshing cache:', error);
-        // Ne pas bloquer l'exécution de l'outil
       });
     }
-    
-    // 2. Vérifier la boîte de réception RooSync (FIRE-AND-FORGET)
-    // FIX #1356: The previous `Promise.race(3s)` did NOT fire under heavy GDrive I/O
-    // because the event-loop timer was starved by libuv threadpool saturation
-    // (1345+ sequential fs.readFile calls on FUSE-mounted GDrive).
-    // Solution: never await the inbox check. Let it run in the background.
-    // Any notifications will still be emitted, just asynchronously after the tool returns.
-    if (this.config.checkInbox && !this.inboxCheckInFlight) {
-      this.inboxCheckInFlight = true;
-      this.checkForNewMessages()
-        .then(async (newMessages) => {
-          if (newMessages.length > 0) {
-            console.error(`📬 [ToolUsageInterceptor] Found ${newMessages.length} new messages`);
-            await this.notifyNewMessages(newMessages, toolName);
-          }
-        })
-        .catch(error => {
-          console.error('⚠️ [ToolUsageInterceptor] Error checking inbox:', error);
-        })
-        .finally(() => {
-          this.inboxCheckInFlight = false;
-        });
-    }
-    
-    // 4. Exécuter l'outil original
+
+    // 2. Inbox check is done by background interval — zero I/O on hot path.
+
+    // 3. Execute the tool
     console.error(`▶️ [ToolUsageInterceptor] Executing tool: ${toolName}`);
     return await execute();
   }
@@ -162,23 +133,38 @@ export class ToolUsageInterceptor {
   }
   
   /**
-   * Vérifier la présence de nouveaux messages dans l'inbox
-   * @returns Liste des nouveaux messages (status: unread)
+   * Start the background inbox check interval.
+   * FIX #1356 v2: Completely removes inbox I/O from the tool execution hot path.
    * @private
    */
-  private async checkForNewMessages(): Promise<Message[]> {
-    console.error(`📬 [ToolUsageInterceptor] Checking inbox for: ${this.config.machineId}`);
-    
+  private startBackgroundCheck(): void {
+    // First check after a short delay (let MCP initialize first)
+    setTimeout(() => this.backgroundInboxCheck(), BACKGROUND_CHECK_INITIAL_DELAY_MS);
+
+    this.backgroundCheckInterval = setInterval(
+      () => this.backgroundInboxCheck(),
+      BACKGROUND_CHECK_INTERVAL_MS
+    );
+
+    console.error(`📬 [ToolUsageInterceptor] Background inbox check started (interval: ${BACKGROUND_CHECK_INTERVAL_MS}ms)`);
+  }
+
+  /**
+   * Background inbox check — runs on interval, never blocks tool execution.
+   * @private
+   */
+  private async backgroundInboxCheck(): Promise<void> {
+    if (this.inboxCheckInFlight) return;
+    this.inboxCheckInFlight = true;
+
     try {
-      // Utiliser readInbox avec filtre 'unread'
       const unreadItems = await this.messageManager.readInbox(
         this.config.machineId,
         'unread',
         undefined,
         getLocalWorkspaceId()
       );
-      
-      // Récupérer les messages complets
+
       const messages: Message[] = [];
       for (const item of unreadItems) {
         const msg = await this.messageManager.getMessage(item.id);
@@ -186,12 +172,33 @@ export class ToolUsageInterceptor {
           messages.push(msg);
         }
       }
-      
-      return messages;
+
+      // Only notify about messages we haven't already notified about
+      const newToNotify = messages.filter(m => !this.notifiedMessageIds.has(m.id));
+
+      if (newToNotify.length > 0) {
+        for (const m of newToNotify) {
+          this.notifiedMessageIds.add(m.id);
+        }
+        console.error(`📬 [ToolUsageInterceptor] Background check: ${newToNotify.length} new unread messages`);
+        await this.notifyNewMessages(newToNotify, 'background-check');
+      }
     } catch (error) {
-      console.error('❌ [ToolUsageInterceptor] Error checking messages:', error);
-      return [];
+      console.error('⚠️ [ToolUsageInterceptor] Background inbox check failed:', error);
+    } finally {
+      this.inboxCheckInFlight = false;
     }
+  }
+
+  /**
+   * Stop the background interval and clean up.
+   */
+  dispose(): void {
+    if (this.backgroundCheckInterval) {
+      clearInterval(this.backgroundCheckInterval);
+      this.backgroundCheckInterval = null;
+    }
+    this.notifiedMessageIds.clear();
   }
   
   /**
@@ -274,8 +281,15 @@ export class ToolUsageInterceptor {
    * @param config Nouvelle configuration (partielle)
    */
   updateConfig(config: Partial<InterceptorConfig>): void {
+    const wasChecking = this.config.checkInbox;
     this.config = { ...this.config, ...config };
     console.error('⚙️ [ToolUsageInterceptor] Config updated:', this.config);
+
+    if (!wasChecking && this.config.checkInbox) {
+      this.startBackgroundCheck();
+    } else if (wasChecking && !this.config.checkInbox) {
+      this.dispose();
+    }
   }
   
   /**

--- a/servers/roo-state-manager/src/notifications/__tests__/ToolUsageInterceptor.test.ts
+++ b/servers/roo-state-manager/src/notifications/__tests__/ToolUsageInterceptor.test.ts
@@ -1,22 +1,21 @@
 /**
- * Tests unitaires pour ToolUsageInterceptor
+ * Tests unitaires pour ToolUsageInterceptor v2
  *
- * Couvre :
- * - interceptToolCall : exécution de l'outil sans bloquer
- * - interceptToolCall : avec refreshCache=true (non-bloquant)
- * - interceptToolCall : avec checkInbox=true + messages non lus → notification
- * - interceptToolCall : avec checkInbox=true + aucun message
- * - interceptToolCall : erreur dans execute → propagée
- * - calculateHighestPriority (via notifyNewMessages)
- * - meetsPriorityThreshold (via notifyNewMessages)
- * - updateConfig
- * - getStats
+ * FIX #1356 v2: Inbox check moved to background interval.
+ * Tests verify:
+ * - interceptToolCall is zero-I/O for inbox (no readInbox call)
+ * - Background interval triggers inbox checks
+ * - dispose() cleans up interval
+ * - updateConfig toggles background check
+ * - Notification emission via background path
+ * - Cache refresh still works (non-blocking)
+ * - Error resilience
  *
  * @module notifications/__tests__/ToolUsageInterceptor.test
- * @version 1.0.0 (#492)
+ * @version 2.0.0
  */
 
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ─────────────────── mocks (vi.hoisted pour éviter TDZ) ───────────────────
 
@@ -28,12 +27,23 @@ vi.mock('../../tools/task/disk-scanner.js', () => ({
   scanDiskForNewTasks: (...args: any[]) => mockScanDiskForNewTasks(...args),
 }));
 
+vi.mock('../../utils/message-helpers.js', () => ({
+  getLocalWorkspaceId: () => 'test-workspace',
+}));
+
 import { ToolUsageInterceptor } from '../ToolUsageInterceptor.js';
 import { NotificationService } from '../NotificationService.js';
 import type { InterceptorConfig } from '../ToolUsageInterceptor.js';
 import type { ConversationSkeleton } from '../../types/conversation.js';
 
 // ─────────────────── helpers ───────────────────
+
+/** Flush microtask queue (needed with vi.useFakeTimers for async chains) */
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
 
 function makeConfig(overrides: Partial<InterceptorConfig> = {}): InterceptorConfig {
   return {
@@ -76,9 +86,14 @@ let conversationCache: Map<string, ConversationSkeleton>;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.useFakeTimers();
   notificationService = new NotificationService();
   conversationCache = new Map();
   mockScanDiskForNewTasks.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 // ─────────────────── tests ───────────────────
@@ -98,6 +113,7 @@ describe('ToolUsageInterceptor', () => {
         conversationCache,
         config
       );
+      interceptor.dispose();
 
       const stats = interceptor.getStats();
       expect(stats.config.machineId).toBe('my-machine');
@@ -111,6 +127,7 @@ describe('ToolUsageInterceptor', () => {
         conversationCache,
         makeConfig({ checkInbox: true })
       );
+      interceptor.dispose();
       expect(interceptor.getStats().isActive).toBe(true);
     });
 
@@ -160,11 +177,57 @@ describe('ToolUsageInterceptor', () => {
         conversationCache,
         makeConfig({ checkInbox: true, refreshCache: true })
       );
+      interceptor.dispose();
 
       interceptor.updateConfig({ machineId: 'new-machine' });
 
       expect(interceptor.getStats().config.checkInbox).toBe(true);
       expect(interceptor.getStats().config.refreshCache).toBe(true);
+      interceptor.dispose();
+    });
+
+    test('enables background check when checkInbox toggled on', async () => {
+      const msgManager = makeMockMessageManager();
+      const interceptor = new ToolUsageInterceptor(
+        notificationService,
+        msgManager as any,
+        conversationCache,
+        makeConfig({ checkInbox: false })
+      );
+
+      // No inbox check initially
+      await interceptor.interceptToolCall('tool', {}, async () => 'ok');
+      expect(msgManager.readInbox).not.toHaveBeenCalled();
+
+      // Toggle on
+      interceptor.updateConfig({ checkInbox: true });
+
+      // Trigger the initial delay (5s)
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(msgManager.readInbox).toHaveBeenCalledTimes(1);
+
+      interceptor.dispose();
+    });
+
+    test('disposes background check when checkInbox toggled off', async () => {
+      const msgManager = makeMockMessageManager();
+      const interceptor = new ToolUsageInterceptor(
+        notificationService,
+        msgManager as any,
+        conversationCache,
+        makeConfig({ checkInbox: true })
+      );
+
+      // Trigger initial check
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(msgManager.readInbox).toHaveBeenCalledTimes(1);
+
+      // Toggle off
+      interceptor.updateConfig({ checkInbox: false });
+
+      // Advance past interval — should NOT trigger another check
+      await vi.advanceTimersByTimeAsync(70_000);
+      expect(msgManager.readInbox).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -186,7 +249,7 @@ describe('ToolUsageInterceptor', () => {
       expect(result).toBe('expected-result');
     });
 
-    test('propage l\'erreur de la fonction execute', async () => {
+    test("propage l'erreur de la fonction execute", async () => {
       const interceptor = new ToolUsageInterceptor(
         notificationService,
         makeMockMessageManager() as any,
@@ -217,6 +280,31 @@ describe('ToolUsageInterceptor', () => {
   });
 
   // ============================================================
+  // FIX #1356 v2: interceptToolCall does NOT call readInbox
+  // ============================================================
+
+  describe('interceptToolCall - zero I/O for inbox', () => {
+    test('readInbox is NOT called during interceptToolCall', async () => {
+      const msgManager = makeMockMessageManager();
+      const interceptor = new ToolUsageInterceptor(
+        notificationService,
+        msgManager as any,
+        conversationCache,
+        makeConfig({ checkInbox: true })
+      );
+
+      await interceptor.interceptToolCall('tool', {}, async () => 'ok');
+      await interceptor.interceptToolCall('tool2', {}, async () => 'ok2');
+      await interceptor.interceptToolCall('tool3', {}, async () => 'ok3');
+
+      // Tool calls should NOT trigger readInbox
+      expect(msgManager.readInbox).not.toHaveBeenCalled();
+
+      interceptor.dispose();
+    });
+  });
+
+  // ============================================================
   // interceptToolCall - refreshCache=true
   // ============================================================
 
@@ -231,8 +319,7 @@ describe('ToolUsageInterceptor', () => {
 
       await interceptor.interceptToolCall('tool', {}, async () => 'ok');
 
-      // Attendre micro-tick pour que la promesse non-bloquante s'exécute
-      await new Promise(r => setTimeout(r, 10));
+      await vi.advanceTimersByTimeAsync(10);
       expect(mockScanDiskForNewTasks).toHaveBeenCalled();
     });
 
@@ -245,18 +332,17 @@ describe('ToolUsageInterceptor', () => {
         makeConfig({ refreshCache: true })
       );
 
-      // Should not throw
       const result = await interceptor.interceptToolCall('tool', {}, async () => 'ok');
       expect(result).toBe('ok');
     });
   });
 
   // ============================================================
-  // interceptToolCall - checkInbox=true
+  // Background inbox check
   // ============================================================
 
-  describe('interceptToolCall - checkInbox=true', () => {
-    test('lit la boîte de réception', async () => {
+  describe('background inbox check', () => {
+    test('first check fires after initial delay', async () => {
       const msgManager = makeMockMessageManager([]);
       const interceptor = new ToolUsageInterceptor(
         notificationService,
@@ -265,29 +351,49 @@ describe('ToolUsageInterceptor', () => {
         makeConfig({ checkInbox: true })
       );
 
-      await interceptor.interceptToolCall('tool', {}, async () => 'ok');
+      // Before delay
+      expect(msgManager.readInbox).not.toHaveBeenCalled();
 
-      expect(msgManager.readInbox).toHaveBeenCalled();
+      // After initial delay (5s)
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(msgManager.readInbox).toHaveBeenCalledTimes(1);
+
+      interceptor.dispose();
     });
 
-    test('sans nouveaux messages : ne notifie pas', async () => {
-      const notifySpy = vi.spyOn(notificationService, 'notify');
+    test('subsequent checks fire at interval', async () => {
+      const msgManager = makeMockMessageManager([]);
       const interceptor = new ToolUsageInterceptor(
         notificationService,
-        makeMockMessageManager([]) as any,
+        msgManager as any,
         conversationCache,
         makeConfig({ checkInbox: true })
       );
 
-      await interceptor.interceptToolCall('tool', {}, async () => 'ok');
+      // Initial delay
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(msgManager.readInbox).toHaveBeenCalledTimes(1);
 
-      expect(notifySpy).not.toHaveBeenCalled();
+      // First interval
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(msgManager.readInbox).toHaveBeenCalledTimes(2);
+
+      // Second interval
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(msgManager.readInbox).toHaveBeenCalledTimes(3);
+
+      interceptor.dispose();
     });
 
     test('avec nouveaux messages : émet une notification', async () => {
       const msg = makeMessage({ id: 'msg-1', priority: 'HIGH' });
       const msgManager = makeMockMessageManager([{ id: 'msg-1' }], { 'msg-1': msg });
       const notifySpy = vi.spyOn(notificationService, 'notify').mockResolvedValue(undefined);
+
+      notificationService.loadFilterRules([{
+        id: 'allow-all', eventType: 'new_message', condition: {},
+        action: 'allow', notifyUser: false,
+      }]);
 
       const interceptor = new ToolUsageInterceptor(
         notificationService,
@@ -296,43 +402,23 @@ describe('ToolUsageInterceptor', () => {
         makeConfig({ checkInbox: true, minPriority: 'LOW' })
       );
 
-      // Load a permissive filter rule
-      notificationService.loadFilterRules([{
-        id: 'allow-all',
-        eventType: 'new_message',
-        condition: {},
-        action: 'allow',
-        notifyUser: false,
-      }]);
+      // Trigger initial delay + let async chain resolve
+      await vi.advanceTimersByTimeAsync(6_000);
+      // Allow the promise chain (readInbox → getMessage → notifyNewMessages) to settle
+      await flushMicrotasks();
+      // Flush remaining microtasks
+      await vi.advanceTimersByTimeAsync(0);
 
-      await interceptor.interceptToolCall('tool', {}, async () => 'ok');
-
-      // FIX #1356: inbox check is fire-and-forget; wait for background notification
-      await vi.waitFor(() => expect(notifySpy).toHaveBeenCalledWith(
+      expect(notifySpy).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'new_message' })
-      ));
-    });
-
-    test('message en dessous du seuil minPriority : pas de notification', async () => {
-      const msg = makeMessage({ id: 'msg-low', priority: 'LOW' });
-      const msgManager = makeMockMessageManager([{ id: 'msg-low' }], { 'msg-low': msg });
-      const notifySpy = vi.spyOn(notificationService, 'notify');
-
-      const interceptor = new ToolUsageInterceptor(
-        notificationService,
-        msgManager as any,
-        conversationCache,
-        makeConfig({ checkInbox: true, minPriority: 'HIGH' })
       );
 
-      await interceptor.interceptToolCall('tool', {}, async () => 'ok');
-
-      expect(notifySpy).not.toHaveBeenCalled();
+      interceptor.dispose();
     });
 
-    test('erreur readInbox ne bloque pas l\'outil', async () => {
-      const msgManager = makeMockMessageManager();
-      msgManager.readInbox.mockRejectedValue(new Error('Inbox unavailable'));
+    test('sans nouveaux messages : ne notifie pas', async () => {
+      const msgManager = makeMockMessageManager([]);
+      const notifySpy = vi.spyOn(notificationService, 'notify');
 
       const interceptor = new ToolUsageInterceptor(
         notificationService,
@@ -341,14 +427,106 @@ describe('ToolUsageInterceptor', () => {
         makeConfig({ checkInbox: true })
       );
 
-      const result = await interceptor.interceptToolCall('tool', {}, async () => 'safe');
+      await vi.advanceTimersByTimeAsync(6_000);
 
-      expect(result).toBe('safe');
+      expect(notifySpy).not.toHaveBeenCalled();
+
+      interceptor.dispose();
+    });
+
+    test('déduit les messages déjà notifiés', async () => {
+      const msg = makeMessage({ id: 'msg-1', priority: 'HIGH' });
+      const msgManager = makeMockMessageManager([{ id: 'msg-1' }], { 'msg-1': msg });
+      const notifySpy = vi.spyOn(notificationService, 'notify').mockResolvedValue(undefined);
+
+      notificationService.loadFilterRules([{
+        id: 'allow-all', eventType: 'new_message', condition: {},
+        action: 'allow', notifyUser: false,
+      }]);
+
+      const interceptor = new ToolUsageInterceptor(
+        notificationService,
+        msgManager as any,
+        conversationCache,
+        makeConfig({ checkInbox: true, minPriority: 'LOW' })
+      );
+
+      // First check — notifies
+      await vi.advanceTimersByTimeAsync(6_000);
+      await flushMicrotasks();
+      expect(notifySpy).toHaveBeenCalledTimes(1);
+
+      // Second check — same message, should NOT notify again
+      notifySpy.mockClear();
+      await vi.advanceTimersByTimeAsync(60_000);
+      await flushMicrotasks();
+      expect(notifySpy).not.toHaveBeenCalled();
+
+      interceptor.dispose();
+    });
+
+    test('erreur readInbox ne crash pas le background check', async () => {
+      const msgManager = makeMockMessageManager();
+      msgManager.readInbox.mockRejectedValue(new Error('GDrive down'));
+
+      const interceptor = new ToolUsageInterceptor(
+        notificationService,
+        msgManager as any,
+        conversationCache,
+        makeConfig({ checkInbox: true })
+      );
+
+      // Should not throw
+      await vi.advanceTimersByTimeAsync(6_000);
+
+      // Subsequent interval should still fire (resilient)
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(msgManager.readInbox).toHaveBeenCalledTimes(2);
+
+      interceptor.dispose();
     });
   });
 
   // ============================================================
-  // refreshCache - cache integration (regression: scan results were discarded)
+  // dispose
+  // ============================================================
+
+  describe('dispose', () => {
+    test('stops background interval', async () => {
+      const msgManager = makeMockMessageManager([]);
+      const interceptor = new ToolUsageInterceptor(
+        notificationService,
+        msgManager as any,
+        conversationCache,
+        makeConfig({ checkInbox: true })
+      );
+
+      // Trigger initial check
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(msgManager.readInbox).toHaveBeenCalledTimes(1);
+
+      interceptor.dispose();
+
+      // Advance past interval — should NOT trigger another check
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(msgManager.readInbox).toHaveBeenCalledTimes(1);
+    });
+
+    test('safe to call dispose when no interval active', () => {
+      const interceptor = new ToolUsageInterceptor(
+        notificationService,
+        makeMockMessageManager() as any,
+        conversationCache,
+        makeConfig({ checkInbox: false })
+      );
+
+      // Should not throw
+      interceptor.dispose();
+    });
+  });
+
+  // ============================================================
+  // refreshCache - cache integration
   // ============================================================
 
   describe('interceptToolCall - refreshCache integrates new tasks into cache', () => {
@@ -378,11 +556,8 @@ describe('ToolUsageInterceptor', () => {
       );
 
       await interceptor.interceptToolCall('tool', {}, async () => 'ok');
+      await vi.advanceTimersByTimeAsync(50);
 
-      // Wait for the non-blocking cache refresh to complete
-      await new Promise(r => setTimeout(r, 50));
-
-      // The cache should now contain the discovered task
       expect(conversationCache.has('discovered-task-123')).toBe(true);
       expect(conversationCache.get('discovered-task-123')?.taskId).toBe('discovered-task-123');
     });
@@ -410,16 +585,15 @@ describe('ToolUsageInterceptor', () => {
       );
 
       await interceptor.interceptToolCall('tool', {}, async () => 'ok');
-      await new Promise(r => setTimeout(r, 50));
+      await vi.advanceTimersByTimeAsync(50);
 
-      // Existing task should still be there
       expect(conversationCache.has('existing-task')).toBe(true);
       expect(conversationCache.size).toBe(1);
     });
   });
 
   // ============================================================
-  // calculateHighestPriority (indirect via notifyNewMessages)
+  // Priority handling (via background check)
   // ============================================================
 
   describe('priorité maximale des messages', () => {
@@ -444,12 +618,35 @@ describe('ToolUsageInterceptor', () => {
         makeConfig({ checkInbox: true, minPriority: 'LOW' })
       );
 
-      await interceptor.interceptToolCall('tool', {}, async () => 'ok');
+      // Trigger background check
+      await vi.advanceTimersByTimeAsync(6_000);
+      await flushMicrotasks();
 
-      // FIX #1356: inbox check is fire-and-forget; wait for background notification
-      await vi.waitFor(() => expect(notifySpy).toHaveBeenCalledWith(
+      expect(notifySpy).toHaveBeenCalledWith(
         expect.objectContaining({ priority: 'URGENT' })
-      ));
+      );
+
+      interceptor.dispose();
+    });
+
+    test('message en dessous du seuil minPriority : pas de notification', async () => {
+      const msg = makeMessage({ id: 'msg-low', priority: 'LOW' });
+      const msgManager = makeMockMessageManager([{ id: 'msg-low' }], { 'msg-low': msg });
+      const notifySpy = vi.spyOn(notificationService, 'notify');
+
+      const interceptor = new ToolUsageInterceptor(
+        notificationService,
+        msgManager as any,
+        conversationCache,
+        makeConfig({ checkInbox: true, minPriority: 'HIGH' })
+      );
+
+      await vi.advanceTimersByTimeAsync(6_000);
+      await flushMicrotasks();
+
+      expect(notifySpy).not.toHaveBeenCalled();
+
+      interceptor.dispose();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Move inbox check from `interceptToolCall` hot path to a background `setInterval` (60s)
- Tool calls are now **zero-I/O** for inbox — no `readInbox` call during execution
- Dedup tracking prevents re-notifying about already-seen messages
- `dispose()` cleans up interval; `updateConfig()` toggles dynamically

## Problem
`ToolUsageInterceptor.beforeTool()` called `checkForNewMessages()` → `MessageManager.readInbox()` → `ensureInboxCache()` on **every** tool call. On ai-01 with 1345+ inbox files on GDrive FUSE mount, this caused 50s+ blocks (or never returning). Even the previous fire-and-forget approach saturated libuv threadpool I/O.

## Test plan
- [x] Build passes (`npm run build` — clean)
- [x] CI tests pass (9561/9561 — `vitest.config.ci.ts`)
- [x] 26 unit tests for ToolUsageInterceptor (all pass)
- [x] New tests: zero-I/O verification, background interval, dispose, config toggle, dedup
- [ ] Manual: deploy to ai-01, verify tool calls no longer block with large inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>