### PR TITLE
fix(#1985): Block Claude Code session automatic background indexing

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/background-services.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/background-services.test.ts
@@ -759,7 +759,7 @@ describe('background-services', () => {
       expect(state.indexingDecisionService.markIndexingSuccess).toHaveBeenCalledWith(skeleton);
     });
 
-    it('should call TaskIndexer.indexTask with correct source for claude-code', async () => {
+    it('should skip claude-code sessions (#1985 sanctuary protection)', async () => {
       const state = createMockState();
       const skeleton = createMockSkeleton('task-001');
       skeleton.metadata = {
@@ -784,7 +784,8 @@ describe('background-services', () => {
 
       await indexTaskInQdrant('task-001', state);
 
-      expect(mockIndexTask).toHaveBeenCalledWith('task-001', 'claude-code');
+      // #1985: Claude Code sessions must NOT be indexed via background path
+      expect(mockIndexTask).not.toHaveBeenCalled();
     });
 
     it('should update metrics on success', async () => {

--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -821,6 +821,16 @@ export async function indexTaskInQdrant(taskId: string, state: ServerState): Pro
 
         // #604: Determine source from skeleton metadata
         const source: 'roo' | 'claude-code' = skeleton.metadata?.dataSource === 'claude' ? 'claude-code' : 'roo';
+
+        // #1985: Claude Code sessions are sanctuary — skip automatic background indexing.
+        // Manual indexing via roosync_indexing(action: "index") is still allowed.
+        // Root cause: Claude Code sessions get new UUIDs on resume/compact, causing
+        // 3-4x duplicate vectors (49% of Qdrant storage = duplicates).
+        if (source === 'claude-code') {
+            console.log(`[SKIP] Task ${taskId}: Claude Code session — automatic indexing blocked (#1985 sanctuary protection)`);
+            return;
+        }
+
         const taskIndexer = new TaskIndexer();
         await taskIndexer.indexTask(taskId, source);
 


### PR DESCRIPTION
## Summary

- Add guard in `indexTaskInQdrant()` to skip automatic background indexing when `source='claude-code'`
- Prevents Claude Code sessions from being indexed 3-4x under different UUIDs on resume/compact
- Manual indexing via `roosync_indexing(action: "index")` remains available for explicit requests

## Root Cause

Claude Code sessions get new UUIDs when resuming or compacting conversations. The background indexer treated each new UUID as a new task, creating duplicate vectors. At the time of #1985, 49% of Qdrant vectors (~300GB) were duplicates.

## Fix

Mirror the existing sanctuary protection on the archive action: block automatic background indexing of Claude Code sessions while keeping manual indexing available.

## Test Plan
- [x] Build passes (`npm run build`)
- [x] All 9554 CI tests pass (`npx vitest run --config vitest.config.ci.ts`)
- [x] Updated existing test to verify claude-code sessions are skipped
- [ ] Verify no new Claude Code sessions are auto-indexed after deploy
- [ ] Run duplicate cleanup on Qdrant (separate task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)