### PR TITLE
fix(#1410): resolve 3 friction items in roo-state-manager

### DIFF
--- a/servers/roo-state-manager/src/services/GranularDiffDetector.ts
+++ b/servers/roo-state-manager/src/services/GranularDiffDetector.ts
@@ -447,66 +447,99 @@ export class GranularDiffDetector {
         targetMap.get(identity).push({ index: i, value: target[i] });
       }
 
-      // Détecter les ajouts
+      // #1410: Collect additions and removals by identity, then cross-match
+      // by discriminant name (name/id/title/key) to detect false positives
+      // where the same logical item appears as both "added" and "removed"
+      // because createIdentity() includes all key-value pairs.
+      const additions: Array<{ index: number; value: any; name: string | null }> = [];
+      const removals: Array<{ index: number; value: any; name: string | null }> = [];
+
       for (const [identity, targetItems] of targetMap) {
         if (!sourceMap.has(identity)) {
           for (const item of targetItems) {
-            const itemName = this.extractItemName(item.value);
-            const elementPath = itemName
-              ? `${currentPath}.${itemName}`
-              : `${currentPath}[${item.index}]`;
-            const description = itemName
-              ? `Élément ajouté: '${itemName}'`
-              : `Élément ajouté à l'index ${item.index}`;
-            diffs.push(this.createDiffResult(
-              elementPath,
-              'added',
-              'INFO',
-              'array',
-              description,
-              undefined,
-              item.value,
-              undefined,
-              undefined,
-              JSON.stringify({ arrayIndex: item.index.toString() })
-            ));
+            additions.push({ index: item.index, value: item.value, name: this.extractItemName(item.value) });
           }
         }
       }
 
-      // Détecter les suppressions
       for (const [identity, sourceItems] of sourceMap) {
         if (!targetMap.has(identity)) {
           for (const item of sourceItems) {
-            const itemName = this.extractItemName(item.value);
-            const elementPath = itemName
-              ? `${currentPath}.${itemName}`
-              : `${currentPath}[${item.index}]`;
-            const description = itemName
-              ? `Élément supprimé: '${itemName}'`
-              : `Élément supprimé à l'index ${item.index}`;
-            diffs.push(this.createDiffResult(
-              elementPath,
-              'removed',
-              'WARNING',
-              'array',
-              description,
-              item.value,
-              undefined,
-              undefined,
-              undefined,
-              JSON.stringify({ arrayIndex: item.index.toString() })
-            ));
+            removals.push({ index: item.index, value: item.value, name: this.extractItemName(item.value) });
           }
         }
       }
 
-      // Détecter les déplacements et modifications
+      // Cross-match additions and removals by discriminant name
+      const matchedRemovalIndices = new Set<number>();
+      for (const addition of additions) {
+        if (addition.name === null) continue;
+        const removalIdx = removals.findIndex(
+          (r, ri) => !matchedRemovalIndices.has(ri) && r.name === addition.name
+        );
+        if (removalIdx !== -1) {
+          matchedRemovalIndices.add(removalIdx);
+          const removal = removals[removalIdx];
+          const elementPath = `${currentPath}.${addition.name}`;
+          diffs.push(this.createDiffResult(
+            elementPath,
+            'modified',
+            'WARNING',
+            'array',
+            `Élément modifié: '${addition.name}'`,
+            removal.value,
+            addition.value,
+            undefined,
+            undefined,
+            undefined
+          ));
+        }
+      }
+
+      // Unmatched additions are genuine new items
+      for (let ai = 0; ai < additions.length; ai++) {
+        const addition = additions[ai];
+        // Skip if this addition was matched by name to a removal
+        if (addition.name !== null) {
+          const wasMatched = removals.some(
+            (r, ri) => matchedRemovalIndices.has(ri) && r.name === addition.name
+          );
+          if (wasMatched) continue;
+        }
+        const elementPath = addition.name
+          ? `${currentPath}.${addition.name}`
+          : `${currentPath}[${addition.index}]`;
+        const description = addition.name
+          ? `Élément ajouté: '${addition.name}'`
+          : `Élément ajouté à l'index ${addition.index}`;
+        diffs.push(this.createDiffResult(
+          elementPath, 'added', 'INFO', 'array', description,
+          undefined, addition.value, undefined, undefined,
+          JSON.stringify({ arrayIndex: addition.index.toString() })
+        ));
+      }
+
+      // Unmatched removals are genuine deletions
+      for (let ri = 0; ri < removals.length; ri++) {
+        if (matchedRemovalIndices.has(ri)) continue;
+        const removal = removals[ri];
+        const elementPath = removal.name
+          ? `${currentPath}.${removal.name}`
+          : `${currentPath}[${removal.index}]`;
+        const description = removal.name
+          ? `Élément supprimé: '${removal.name}'`
+          : `Élément supprimé à l'index ${removal.index}`;
+        diffs.push(this.createDiffResult(
+          elementPath, 'removed', 'WARNING', 'array', description,
+          removal.value, undefined, undefined, undefined,
+          JSON.stringify({ arrayIndex: removal.index.toString() })
+        ));
+      }
+
+      // Détecter les déplacements et modifications (identical identity, different count)
       for (const [identity, sourceItems] of sourceMap) {
         if (targetMap.has(identity)) {
           const targetItems = targetMap.get(identity);
-          
-          // Si le nombre d'occurrences est différent
           if (sourceItems.length !== targetItems.length) {
             const elementPath = `${currentPath}[${sourceItems[0].index}]`;
             diffs.push(this.createDiffResult(

--- a/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
+++ b/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
@@ -504,7 +504,7 @@ export const listConversationsTool = {
         inputSchema: {
             type: 'object',
             properties: {
-                limit: { type: 'number', description: 'Alias for per_page (backward compat). Clamped to [10, 100].' },
+                limit: { type: 'number', description: 'Hard cap on total results. When only limit is provided (no per_page), it sets page size with no minimum floor. Cap: 100.' },
                 page: { type: 'number', description: 'Page number (1-based). Default: 1.' },
                 per_page: { type: 'number', description: 'Results per page. Default: 10 (keeps output <50KB so Claude Code displays inline). Min: 10. Max: 100 (opt-in large pages — above ~50KB the host redirects output to a file).' },
                 sortBy: { type: 'string', enum: ['lastActivity', 'messageCount', 'totalSize'] },

--- a/servers/roo-state-manager/src/tools/roosync/manage.ts
+++ b/servers/roo-state-manager/src/tools/roosync/manage.ts
@@ -308,17 +308,30 @@ async function cleanupMessages(
   logger.info('🧹 Starting cleanup operation');
   const machineId = getLocalMachineId();
   const results: string[] = [];
+  const allFailedIds: string[] = [];
 
   // 0a. Cleanup expired auto-destruct messages (#629)
-  const expiredCount = await messageManager.cleanupExpiredMessages();
-  if (expiredCount > 0) {
-    results.push(`- 💀 Messages auto-destruct expirés détruits : **${expiredCount}**`);
+  try {
+    const expiredCount = await messageManager.cleanupExpiredMessages();
+    if (expiredCount > 0) {
+      results.push(`- 💀 Messages auto-destruct expirés détruits : **${expiredCount}**`);
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    results.push(`- 💀 Auto-destruct cleanup échoué : ${msg}`);
+    logger.error('Auto-destruct cleanup failed', error);
   }
 
   // 0b. Send expiry reminders for approaching TTL (#629)
-  const remindersCount = await messageManager.sendExpiryReminders();
-  if (remindersCount > 0) {
-    results.push(`- ⏰ Rappels d'expiration envoyés : **${remindersCount}**`);
+  try {
+    const remindersCount = await messageManager.sendExpiryReminders();
+    if (remindersCount > 0) {
+      results.push(`- ⏰ Rappels d'expiration envoyés : **${remindersCount}**`);
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    results.push(`- ⏰ Envoi rappels échoué : ${msg}`);
+    logger.error('Expiry reminders failed', error);
   }
 
   // 1. Mark test messages as read
@@ -328,6 +341,10 @@ async function cleanupMessages(
   );
   if (testResult.processed > 0) {
     results.push(`- 🧪 Messages de test marqués lus : **${testResult.processed}**`);
+  }
+  if (testResult.failed_ids.length > 0) {
+    results.push(`- ⚠️ Échecs test mark_read : ${testResult.failed_ids.length} (${testResult.failed_ids.slice(0, 5).join(', ')}${testResult.failed_ids.length > 5 ? '…' : ''})`);
+    allFailedIds.push(...testResult.failed_ids);
   }
 
   // 2. Archive old read messages (>30 days)
@@ -340,6 +357,10 @@ async function cleanupMessages(
   if (oldReadResult.processed > 0) {
     results.push(`- 📦 Messages lus >30j archivés : **${oldReadResult.processed}**`);
   }
+  if (oldReadResult.failed_ids.length > 0) {
+    results.push(`- ⚠️ Échecs archive >30j : ${oldReadResult.failed_ids.length} (${oldReadResult.failed_ids.slice(0, 5).join(', ')}${oldReadResult.failed_ids.length > 5 ? '…' : ''})`);
+    allFailedIds.push(...oldReadResult.failed_ids);
+  }
 
   // 3. Mark old LOW priority messages as read (>7 days)
   const sevenDaysAgo = new Date();
@@ -351,15 +372,23 @@ async function cleanupMessages(
   if (oldLowResult.processed > 0) {
     results.push(`- 📭 Messages LOW >7j marqués lus : **${oldLowResult.processed}**`);
   }
+  if (oldLowResult.failed_ids.length > 0) {
+    results.push(`- ⚠️ Échecs LOW mark_read : ${oldLowResult.failed_ids.length} (${oldLowResult.failed_ids.slice(0, 5).join(', ')}${oldLowResult.failed_ids.length > 5 ? '…' : ''})`);
+    allFailedIds.push(...oldLowResult.failed_ids);
+  }
 
   // 4. Get current stats
   const stats = await messageManager.getInboxStats(machineId);
+
+  const errorSection = allFailedIds.length > 0
+    ? `\n\n### Échecs (${allFailedIds.length} messages)\n${allFailedIds.slice(0, 10).map(id => `- \`${id}\``).join('\n')}${allFailedIds.length > 10 ? `\n… et ${allFailedIds.length - 10} autres` : ''}`
+    : '';
 
   return `🧹 **Cleanup terminé**
 
 ---
 
-${results.length > 0 ? `### Actions effectuées\n${results.join('\n')}` : '### Aucune action nécessaire\nTous les messages sont déjà dans un état propre.'}
+${results.length > 0 ? `### Actions effectuées\n${results.join('\n')}` : '### Aucune action nécessaire\nTous les messages sont déjà dans un état propre.'}${errorSection}
 
 ### État de la boîte après cleanup
 

--- a/servers/roo-state-manager/tests/unit/tools/roosync/manage.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/manage.test.ts
@@ -180,7 +180,7 @@ describe('roosync_manage', () => {
     describe('action=bulk_mark_read', () => {
         it('calls bulk operation with filters', async () => {
             mockBulkOperation.mockResolvedValue({
-                operation: 'mark_read', matched: 3, processed: 3, errors: 0, message_ids: ['a', 'b', 'c'],
+                operation: 'mark_read', matched: 3, processed: 3, errors: 0, message_ids: ['a', 'b', 'c'], failed_ids: [],
             });
             const result = await roosyncManage({
                 action: 'bulk_mark_read', from: 'test-machine', priority: 'LOW',
@@ -194,7 +194,7 @@ describe('roosync_manage', () => {
 
         it('handles zero matches', async () => {
             mockBulkOperation.mockResolvedValue({
-                operation: 'mark_read', matched: 0, processed: 0, errors: 0, message_ids: [],
+                operation: 'mark_read', matched: 0, processed: 0, errors: 0, message_ids: [], failed_ids: [],
             });
             const result = await roosyncManage({ action: 'bulk_mark_read' });
             expect(result.content[0].text).toContain('0');
@@ -204,7 +204,7 @@ describe('roosync_manage', () => {
     describe('action=bulk_archive', () => {
         it('calls bulk operation with archive operation', async () => {
             mockBulkOperation.mockResolvedValue({
-                operation: 'archive', matched: 5, processed: 5, errors: 0, message_ids: ['x1', 'x2', 'x3', 'x4', 'x5'],
+                operation: 'archive', matched: 5, processed: 5, errors: 0, message_ids: ['x1', 'x2', 'x3', 'x4', 'x5'], failed_ids: [],
             });
             const result = await roosyncManage({
                 action: 'bulk_archive', before_date: '2026-04-01T00:00:00Z',
@@ -222,7 +222,7 @@ describe('roosync_manage', () => {
             mockCleanupExpiredMessages.mockResolvedValue(2);
             mockSendExpiryReminders.mockResolvedValue(1);
             mockBulkOperation.mockResolvedValue({
-                operation: 'mark_read', matched: 3, processed: 3, errors: 0, message_ids: [],
+                operation: 'mark_read', matched: 3, processed: 3, errors: 0, message_ids: [], failed_ids: [],
             });
             mockGetInboxStats.mockResolvedValue({
                 total: 10, unread: 2, read: 8,
@@ -238,7 +238,7 @@ describe('roosync_manage', () => {
 
         it('handles empty cleanup', async () => {
             mockBulkOperation.mockResolvedValue({
-                operation: 'mark_read', matched: 0, processed: 0, errors: 0, message_ids: [],
+                operation: 'mark_read', matched: 0, processed: 0, errors: 0, message_ids: [], failed_ids: [],
             });
             mockGetInboxStats.mockResolvedValue({
                 total: 0, unread: 0, read: 0,


### PR DESCRIPTION
## Summary

- **GranularDiffDetector false positives**: Fix identity-mode array comparison emitting spurious "added"+"removed" pairs when the same logical item (matched by name/id/title/key discriminant) has different values. Now correctly emits a single "modified" diff.
- **conversation_browser limit description**: Schema claimed "Clamped to [10, 100]" but `limit` has no minimum floor (only `per_page` does). Updated description to match actual behavior.
- **cleanup_messages error reporting**: Each bulk operation now reports `failed_ids` when individual messages fail. `cleanupExpiredMessages`/`sendExpiryReminders` wrapped in try/catch so one failure doesn't abort the rest.

## Test plan
- [x] Build: `npm run build` clean
- [x] CI config: 9554/9554 tests pass (`vitest.config.ci.ts`)
- [x] `GranularDiffDetector.test.ts`: all existing tests pass with new dedup logic
- [x] `manage.test.ts`: 20/20 pass (added `failed_ids: []` to all mock results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)