### PR TITLE
fix(#834): fire-and-forget disk scan prevents list timeouts

### DIFF
--- a/servers/roo-state-manager/src/tools/conversation/__tests__/conversation-browser.smoke.test.ts
+++ b/servers/roo-state-manager/src/tools/conversation/__tests__/conversation-browser.smoke.test.ts
@@ -130,13 +130,16 @@ describe('SMOKE: conversation_browser', () => {
       { role: 'assistant', content: 'Assistant response' }
     ], 'c:/dev/roo-extensions');
 
-    // Step 2: Initial call to get baseline (should list 1 conversation)
+    const cache = new Map();
+
+    // Step 2: Initial call triggers fire-and-forget disk scan
+    // First call may return empty since scan is async
     const result1 = await handleConversationBrowser(
       {
         action: 'list',
         limit: 10
       },
-      new Map(),
+      cache,
       async () => {},
       'roo-extensions',
       async (id) => null
@@ -145,12 +148,25 @@ describe('SMOKE: conversation_browser', () => {
     expect(result1.content).toBeDefined();
     expect(result1.content[0].type).toBe('text');
 
-    // Verify initial result contains conversations (at least the one we created)
-    const result1Text = result1.content[0].text;
-    // The result should be valid JSON with a conversations array
-    const result1Json = JSON.parse(result1Text);
-    expect(result1Json.conversations).toBeDefined();
-    expect(result1Json.conversations.length).toBeGreaterThan(0);
+    // Wait for fire-and-forget scan to discover and cache the conversation
+    await vi.waitFor(() => expect(cache.size).toBeGreaterThan(0), { timeout: 5000 });
+
+    // Step 2b: Second call now has the conversation in cache
+    const result1b = await handleConversationBrowser(
+      {
+        action: 'list',
+        limit: 10
+      },
+      cache,
+      async () => {},
+      'roo-extensions',
+      async (id) => null
+    );
+
+    const result1bText = result1b.content[0].text;
+    const result1bJson = JSON.parse(result1bText);
+    expect(result1bJson.conversations).toBeDefined();
+    expect(result1bJson.conversations.length).toBeGreaterThan(0);
 
     // Step 3: Add more conversations
     const task2Id = 'smoke-test-task-2';
@@ -168,24 +184,41 @@ describe('SMOKE: conversation_browser', () => {
     invalidateDiskScanCache();
 
     // Step 4: Second call to list (should detect new conversations)
+    // Note: Use the same cache so fire-and-forget from step 2 populated it
+    invalidateDiskScanCache();
     const result2 = await handleConversationBrowser(
       {
         action: 'list',
         limit: 10
       },
-      new Map(),
+      cache,
+      async () => {},
+      'roo-extensions',
+      async (id) => null
+    );
+
+    // Wait for fire-and-forget scan to discover new conversations
+    await vi.waitFor(() => expect(cache.size).toBeGreaterThan(1), { timeout: 5000 });
+
+    // Call again to get updated results
+    const result2b = await handleConversationBrowser(
+      {
+        action: 'list',
+        limit: 10
+      },
+      cache,
       async () => {},
       'roo-extensions',
       async (id) => null
     );
 
     // Step 5: Verify that result2 reflects the state change (fresh list, not stale)
-    expect(result2.content[0].type).toBe('text');
-    const result2Text = result2.content[0].text;
+    expect(result2b.content[0].type).toBe('text');
+    const result2Text = result2b.content[0].text;
     const result2Json = JSON.parse(result2Text);
 
     // Should have more conversations than initial result
-    expect(result2Json.conversations.length).toBeGreaterThan(result1Json.conversations.length);
+    expect(result2Json.conversations.length).toBeGreaterThan(result1bJson.conversations.length);
 
     // This validates that the list is computed fresh from filesystem,
     // not from stale cached data

--- a/servers/roo-state-manager/src/tools/conversation/__tests__/list-conversations-performance.test.ts
+++ b/servers/roo-state-manager/src/tools/conversation/__tests__/list-conversations-performance.test.ts
@@ -179,27 +179,30 @@ describe('list_conversations performance & caching', () => {
       expect(mockScanDiskForNewTasks).toHaveBeenCalledTimes(5);
     });
 
-    test('scan results are integrated regardless of cache state', async () => {
+    test('scan results are integrated on subsequent call (fire-and-forget)', async () => {
       const cache = makeCache(makeConversation('base-task'));
 
-      // First call: scan returns task-A
+      // First call: scan returns task-A (fire-and-forget — won't be in this response)
       mockScanDiskForNewTasks.mockResolvedValueOnce([makeConversation('task-A')]);
       const result1 = await listConversationsTool.handler({}, cache);
       const _response1 = JSON.parse((result1.content[0] as any).text);
       const parsed1 = _response1.conversations ?? _response1;
-      expect(parsed1.map((t: any) => t.taskId)).toContain('task-A');
+      // Only base-task is in cache at response time (scan is async)
+      expect(parsed1.map((t: any) => t.taskId)).toContain('base-task');
 
-      // Second call: scan returns task-B (simulating cache expiration in scanner)
+      // Wait for fire-and-forget scan to complete and update cache
+      await vi.waitFor(() => expect(cache.has('task-A')).toBe(true));
+
+      // Second call: now task-A is in cache from the previous scan
+      // scan returns task-B (simulating cache expiration in scanner)
       mockScanDiskForNewTasks.mockResolvedValueOnce([makeConversation('task-B')]);
       const result2 = await listConversationsTool.handler({}, cache);
       const _response2 = JSON.parse((result2.content[0] as any).text);
       const parsed2 = _response2.conversations ?? _response2;
 
-      // Both task-A (from cache map) and task-B (from scan) should appear
       const taskIds2 = parsed2.map((t: any) => t.taskId);
       expect(taskIds2).toContain('base-task');
       expect(taskIds2).toContain('task-A');
-      expect(taskIds2).toContain('task-B');
     });
   });
 

--- a/servers/roo-state-manager/src/tools/conversation/__tests__/list-conversations.test.ts
+++ b/servers/roo-state-manager/src/tools/conversation/__tests__/list-conversations.test.ts
@@ -503,14 +503,23 @@ describe('listConversationsTool.handler', () => {
 
       mockScanDiskForNewTasks.mockResolvedValue([newTask]);
 
+      // First call triggers fire-and-forget scan — new task won't be in response yet
       const result = await listConversationsTool.handler({}, cache);
       const _response = JSON.parse((result.content[0] as any).text);
       const parsed = _response.conversations ?? _response;
 
-      // Should contain both the existing and the newly discovered task
+      // Existing task is always present (from cache)
       const taskIds = parsed.map((t: any) => t.taskId);
       expect(taskIds).toContain('existing-task');
-      expect(taskIds).toContain('new-disk-task');
+
+      // Wait for fire-and-forget scan to integrate new task into cache
+      await vi.waitFor(() => expect(cache.has('new-disk-task')).toBe(true));
+
+      // Second call now sees the new task in cache
+      const result2 = await listConversationsTool.handler({}, cache);
+      const _response2 = JSON.parse((result2.content[0] as any).text);
+      const parsed2 = _response2.conversations ?? _response2;
+      expect(parsed2.map((t: any) => t.taskId)).toContain('new-disk-task');
     });
 
     test('new task is added to the cache map (side effect)', async () => {

--- a/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
+++ b/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
@@ -586,23 +586,18 @@ export const listConversationsTool = {
 
         // Include Roo conversations (default behavior)
         if (includeRoo) {
-            // FIX: Scan disk for new tasks not yet in cache before listing
-            // Without this, tasks created after MCP startup are invisible to list
-            // PERF: Timeout wrapper (3s) prevents disk scan from blocking list responses
-            // when filesystem is slow or contended by background VectorIndexer I/O
-            try {
-                const scanPromise = scanDiskForNewTasks(conversationCache);
-                const timeoutPromise = new Promise<ConversationSkeleton[]>((_, reject) =>
-                    setTimeout(() => reject(new Error('Disk scan timeout (3s)')), 3000)
-                );
-                const newTasks = await Promise.race([scanPromise, timeoutPromise]);
+            // #834 PERF: Fire-and-forget disk scan — never block list responses.
+            // Previous blocking approach (3s timeout race) caused timeouts on ai-01
+            // with 7250+ task directories. Now: scan runs in background, updates
+            // cache for the NEXT call. Trade-off: new tasks may take up to
+            // DISK_SCAN_CACHE_TTL (5 min) to appear — acceptable for interactive use.
+            scanDiskForNewTasks(conversationCache).then(newTasks => {
                 for (const task of newTasks) {
                     conversationCache.set(task.taskId, task);
                 }
-                // Discovery count logged only in debug mode (#832)
-            } catch (scanError) {
-                console.warn('⚠️ list_conversations: Disk scan failed or timed out, using cache only:', scanError instanceof Error ? scanError.message : scanError);
-            }
+            }).catch(err => {
+                console.warn('Background disk scan failed:', err instanceof Error ? err.message : err);
+            });
 
             allSkeletons = Array.from(conversationCache.values()).filter(skeleton =>
                 skeleton.metadata


### PR DESCRIPTION
## Summary
- Convert `scanDiskForNewTasks` in `list_conversations` from blocking (3s timeout race) to fire-and-forget
- Eliminates `conversation_browser` `list` timeouts on ai-01 (7250+ task directories)
- Tests updated to use `vi.waitFor()` for async cache population

## Changes
- `list-conversations.tool.ts`: Remove `Promise.race` blocking pattern; scan runs as `.then()` fire-and-forget
- 3 test files updated to account for async scan behavior

## Trade-off
New tasks may take up to `DISK_SCAN_CACHE_TTL` (5 min) to appear in list results. Acceptable for interactive use — `ToolUsageInterceptor` also refreshes cache every 60s.

## Validation
- Build: clean
- CI tests: 9562/9562 pass (476 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)