### PR TITLE
fix(#1608): sizeWarning for sessions >10MB in conversation_browser list

### DIFF
--- a/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
+++ b/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
@@ -311,6 +311,10 @@ function toConversationSummary(node: SkeletonNode, _depth = 0): Record<string, u
         meta.totalSize = node.metadata.totalSize;
         const sizeHuman = formatBytes(node.metadata.totalSize);
         if (sizeHuman) meta.sizeHuman = sizeHuman;
+        // #1608 R2: Warn agents about large sessions that can saturate GLM context
+        if (node.metadata.totalSize > 10_000_000) { // >10 MB
+            summary.sizeWarning = `Session is ${sizeHuman} — use smart_truncation: true with max_output_length: 50000 when viewing`;
+        }
     }
     if (node.metadata.mode) meta.mode = node.metadata.mode;
     if (node.metadata.workspace) {


### PR DESCRIPTION
## Summary
- Add `sizeWarning` field in `conversation_browser(list)` output when session exceeds 10MB
- Visual cue for agents to use `smart_truncation: true` with `max_output_length: 50000` when viewing large sessions

## Context
Issue #1608: Meta-analyst context explosions caused by agents viewing massive sessions (500MB CoursIA) that saturate GLM context in 1 call. `smart_truncation` is ON by default since #1244, but agents need explicit warnings about dangerously large sessions.

## Test plan
- [x] Build: clean
- [x] CI tests: 9162/9162 pass (0 failures)
- [ ] Verify `sizeWarning` appears in list output for sessions >10MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)