### PR TITLE
feat(heartbeat): ADR 008 Phase 1 — identity fix + in-memory model (#1953)

### DIFF
--- a/servers/roo-state-manager/src/services/RooSyncService.ts
+++ b/servers/roo-state-manager/src/services/RooSyncService.ts
@@ -10,6 +10,7 @@
 
 import { existsSync, statSync } from 'fs';
 import { join, dirname } from 'path';
+import os from 'os';
 import { loadRooSyncConfig, RooSyncConfig, validateMachineIdUniqueness, registerMachineId } from '../config/roosync-config.js';
 import {
   type RooSyncDecision,
@@ -933,9 +934,11 @@ export class RooSyncService {
 
   /**
    * Enregistre un heartbeat pour la machine courante
+   * #1953 ADR 008: Identity source = os.hostname() (not config.machineId)
    */
   public async registerHeartbeat(metadata?: Record<string, any>): Promise<void> {
-    return this.heartbeatService.registerHeartbeat(this.config.machineId, metadata);
+    const realMachineId = os.hostname().toLowerCase().replace(/[^a-z0-9-]/g, '-');
+    return this.heartbeatService.registerHeartbeat(realMachineId, metadata);
   }
 
   /**

--- a/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
+++ b/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
@@ -75,7 +75,7 @@ export interface HeartbeatData {
   lastHeartbeat: string;
 
   /** Statut de la machine */
-  status: 'online' | 'offline' | 'warning';
+  status: 'online' | 'offline' | 'warning' | 'idle' | 'unknown';
 
   /** Nombre de heartbeats manqués consécutifs */
   missedHeartbeats: number;
@@ -463,6 +463,7 @@ export class HeartbeatService {
 
   /**
    * Enregistre un heartbeat pour une machine
+   * #1953 ADR 008 Phase 1: In-memory only, no GDrive writes.
    */
   public async registerHeartbeat(
     machineId: string,
@@ -470,15 +471,10 @@ export class HeartbeatService {
   ): Promise<void> {
     machineId = machineId.toLowerCase();
     const now = new Date().toISOString();
-    const nowMs = Date.now();
 
     let heartbeatData = this.state.heartbeats.get(machineId);
-    let isNew = false;
-    let statusChanged = false;
 
     if (!heartbeatData) {
-      // Nouvelle machine - toujours écrire sur disque
-      isNew = true;
       heartbeatData = {
         machineId,
         lastHeartbeat: now,
@@ -487,57 +483,27 @@ export class HeartbeatService {
         metadata: {
           firstSeen: now,
           lastUpdated: now,
-          version: '3.1.0'
+          version: '3.2.0'
         }
       };
-
       logger.info(`Nouvelle machine enregistrée: ${machineId}`);
     } else {
-      const previousStatus = heartbeatData.status;
-
-      // Si la machine était offline/warning, logger le retour online
-      if (heartbeatData.offlineSince) {
-        logger.info(`Machine redevenue online: ${machineId}`, {
-          offlineDuration: nowMs - new Date(heartbeatData.offlineSince).getTime()
-        });
-      }
-
-      // Mise à jour heartbeat existant
       heartbeatData.lastHeartbeat = now;
       heartbeatData.status = 'online';
       heartbeatData.missedHeartbeats = 0;
       heartbeatData.offlineSince = undefined;
       heartbeatData.metadata.lastUpdated = now;
-
-      // Détecter si le statut a changé (non-online → online)
-      if (previousStatus !== 'online') {
-        statusChanged = true;
-      }
     }
 
     this.state.heartbeats.set(machineId, heartbeatData);
     this.updateMachineStatus();
-
-    // Fix #607: Dirty-flag write optimization - évite sync GDrive perpétuelle.
-    // N'écrire sur disque que si: nouvelle machine, changement de statut,
-    // ou > persistenceInterval depuis dernière écriture.
-    const lastWrite = this.lastDiskWrite.get(machineId) ?? 0;
-    const timeSinceLastWrite = nowMs - lastWrite;
-    const shouldWrite = isNew || statusChanged || timeSinceLastWrite >= this.config.persistenceInterval;
-
-    if (shouldWrite) {
-      await this.saveMachineHeartbeat(machineId);
-      this.lastDiskWrite.set(machineId, nowMs);
-    }
   }
 
   /**
-   * Vérifie les heartbeats et détecte les machines offline
+   * Vérifie les heartbeats et dérive le statut des machines
+   * #1953 ADR 008 Phase 1: In-memory only, status = ONLINE/IDLE/UNKNOWN (no OFFLINE).
    */
   public async checkHeartbeats(): Promise<HeartbeatCheckResult> {
-    // Reload fresh data from per-machine files
-    this.reloadFromDisk();
-
     const now = Date.now();
     const result: HeartbeatCheckResult = {
       success: true,
@@ -551,50 +517,36 @@ export class HeartbeatService {
       const lastHeartbeatTime = new Date(heartbeatData.lastHeartbeat).getTime();
       const timeSinceLastHeartbeat = now - lastHeartbeatTime;
 
-      // Calculer le nombre de heartbeats manqués
-      const missedHeartbeats = Math.floor(timeSinceLastHeartbeat / this.config.heartbeatInterval);
+      // #1953 ADR 008: ONLINE (<30min), IDLE (30-120min), UNKNOWN (>120min)
+      // No OFFLINE status — true machine failure detected by external tools
+      const ONLINE_THRESHOLD = 30 * 60 * 1000;  // 30 min
+      const IDLE_THRESHOLD = 120 * 60 * 1000;   // 120 min
 
-      // Vérifier d'abord si la machine est en avertissement (avant offline)
-      // Le warning se déclenche à (missedHeartbeatThreshold - 1) * heartbeatInterval
-      const warningThreshold = this.config.heartbeatInterval * (this.config.missedHeartbeatThreshold - 1);
+      const previousStatus = heartbeatData.status;
 
-      if (timeSinceLastHeartbeat > this.config.offlineTimeout) {
-        // Machine offline
-        if (heartbeatData.status !== 'offline') {
-          heartbeatData.status = 'offline';
-          heartbeatData.missedHeartbeats = missedHeartbeats;
-
-          if (!heartbeatData.offlineSince) {
-            heartbeatData.offlineSince = new Date().toISOString();
-          }
-
+      if (timeSinceLastHeartbeat > IDLE_THRESHOLD) {
+        // UNKNOWN — no recent activity, not necessarily down
+        if (previousStatus !== 'unknown') {
+          heartbeatData.status = 'unknown';
           result.newlyOfflineMachines.push(machineId);
-          logger.warn(`Machine détectée offline: ${machineId}`, {
-            timeSinceLastHeartbeat,
-            offlineSince: heartbeatData.offlineSince
-          });
+          logger.info(`Machine status → UNKNOWN: ${machineId}`, { timeSinceLastHeartbeat });
         }
-      } else if (timeSinceLastHeartbeat >= warningThreshold) {
-        // Machine en avertissement (heartbeats manqués mais pas encore offline)
-        if (heartbeatData.status !== 'warning') {
-          heartbeatData.status = 'warning';
-          heartbeatData.missedHeartbeats = missedHeartbeats;
-
+      } else if (timeSinceLastHeartbeat > ONLINE_THRESHOLD) {
+        // IDLE — machine active within last 2h but not in last 30min
+        if (previousStatus !== 'idle' && previousStatus !== 'warning') {
+          heartbeatData.status = 'idle';
+          heartbeatData.missedHeartbeats = 1;
           result.warningMachines.push(machineId);
-          logger.warn(`Machine en avertissement: ${machineId}`, {
-            missedHeartbeats: heartbeatData.missedHeartbeats,
-            timeSinceLastHeartbeat
-          });
+          logger.info(`Machine status → IDLE: ${machineId}`, { timeSinceLastHeartbeat });
         }
       } else {
-        // Machine online
-        if (heartbeatData.status !== 'online') {
+        // ONLINE — active within last 30min
+        if (previousStatus !== 'online') {
           heartbeatData.status = 'online';
           heartbeatData.missedHeartbeats = 0;
           heartbeatData.offlineSince = undefined;
-
           result.newlyOnlineMachines.push(machineId);
-          logger.info(`Machine redevenue online: ${machineId}`);
+          logger.info(`Machine status → ONLINE: ${machineId}`);
         }
       }
 
@@ -603,11 +555,8 @@ export class HeartbeatService {
     }
 
     this.updateMachineStatus();
-    // Status is computed in-memory, not persisted to other machines' files
-
     this.state.statistics.lastHeartbeatCheck = new Date().toISOString();
 
-    // Appeler les callbacks stockés pour les changements de statut
     if (this.onOfflineDetectedCallback) {
       for (const machineId of result.newlyOfflineMachines) {
         this.onOfflineDetectedCallback(machineId);
@@ -637,9 +586,11 @@ export class HeartbeatService {
           onlineMachines.push(machineId);
           break;
         case 'offline':
+        case 'unknown':
           offlineMachines.push(machineId);
           break;
         case 'warning':
+        case 'idle':
           warningMachines.push(machineId);
           break;
       }

--- a/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
@@ -341,17 +341,19 @@ describe('HeartbeatService', () => {
       expect(service.getHeartbeatData('machine-b')!.missedHeartbeats).toBe(0);
     });
 
-    test('writes per-machine file on registration', async () => {
+    test('#1953 ADR 008: registerHeartbeat is in-memory only (no file writes)', async () => {
       const service = new HeartbeatService(TEST_PATH);
 
       await service.registerHeartbeat('machine-y');
 
-      expect(mockMkdir).toHaveBeenCalledWith(HEARTBEATS_DIR, { recursive: true });
-      // Atomic write: writeFile gets .tmp path, then rename to final path
-      const writeFileCalls = mockWriteFile.mock.calls;
-      expect(writeFileCalls.length).toBeGreaterThanOrEqual(1);
-      expect(writeFileCalls[0][0]).toContain(join(HEARTBEATS_DIR, 'machine-y.json'));
-      expect(mockRename).toHaveBeenCalled();
+      // ADR 008 Phase 1: registerHeartbeat is in-memory only
+      expect(mockMkdir).not.toHaveBeenCalled();
+      expect(mockWriteFile).not.toHaveBeenCalled();
+      expect(mockRename).not.toHaveBeenCalled();
+
+      // But machine is registered in memory
+      expect(service.getHeartbeatData('machine-y')).toBeDefined();
+      expect(service.getHeartbeatData('machine-y')!.status).toBe('online');
     });
 
     test('enregistre plusieurs machines indépendamment', async () => {
@@ -373,10 +375,7 @@ describe('HeartbeatService', () => {
       await service.registerHeartbeat('MyIA-AI-01');
 
       expect(service.getHeartbeatData('myia-ai-01')).toBeDefined();
-      // Atomic write: writeFile gets .tmp path
-      const writeFileCalls = mockWriteFile.mock.calls;
-      expect(writeFileCalls.length).toBeGreaterThanOrEqual(1);
-      expect(writeFileCalls[0][0]).toContain(join(HEARTBEATS_DIR, 'myia-ai-01.json'));
+      // ADR 008 Phase 1: in-memory only, no file writes during registration
     });
   });
 
@@ -404,61 +403,45 @@ describe('HeartbeatService', () => {
       expect(result.newlyOnlineMachines).toEqual([]);
     });
 
-    test('détecte une machine offline (lastHeartbeat trop ancien)', async () => {
-      const service = new HeartbeatService(TEST_PATH, {
-        offlineTimeout: 100,      // 100ms
-        heartbeatInterval: 30,
-        missedHeartbeatThreshold: 4,
-      });
+    test('détecte une machine UNKNOWN (lastHeartbeat >120 min) #1953 ADR 008', async () => {
+      const service = new HeartbeatService(TEST_PATH);
 
-      // Set up disk with stale heartbeat
-      const staleData = {
-        ...makeOnlineMachine('slow-machine'),
-        lastHeartbeat: new Date(Date.now() - 200).toISOString(),
-      };
-      setupPerMachineFiles({ 'slow-machine': staleData });
+      // Register machine then make its heartbeat stale (>120 min = UNKNOWN)
+      await service.registerHeartbeat('slow-machine');
+      const hb = service.getHeartbeatData('slow-machine')!;
+      hb.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString(); // 150 min ago
 
       const result = await service.checkHeartbeats();
 
-      expect(result.newlyOfflineMachines).toContain('slow-machine');
+      expect(result.newlyOfflineMachines).toContain('slow-machine'); // UNKNOWN maps to offlineMachines
       expect(service.getOfflineMachines()).toContain('slow-machine');
+      expect(service.getHeartbeatData('slow-machine')!.status).toBe('unknown');
     });
 
-    test('détecte une machine en warning (threshold atteint mais pas offline)', async () => {
-      const service = new HeartbeatService(TEST_PATH, {
-        offlineTimeout: 500,      // offline après 500ms
-        heartbeatInterval: 100,   // intervalle 100ms
-        missedHeartbeatThreshold: 4,  // warning à (4-1)*100 = 300ms
-      });
+    test('détecte une machine IDLE (30-120 min) #1953 ADR 008', async () => {
+      const service = new HeartbeatService(TEST_PATH);
 
-      // 350ms → > warningThreshold (300ms), < offlineTimeout (500ms)
-      const warningData = {
-        ...makeOnlineMachine('warning-machine'),
-        lastHeartbeat: new Date(Date.now() - 350).toISOString(),
-      };
-      setupPerMachineFiles({ 'warning-machine': warningData });
+      // Register machine then make heartbeat 45 min old → IDLE
+      await service.registerHeartbeat('idle-machine');
+      const hb = service.getHeartbeatData('idle-machine')!;
+      hb.lastHeartbeat = new Date(Date.now() - 45 * 60 * 1000).toISOString(); // 45 min ago
 
       const result = await service.checkHeartbeats();
 
-      expect(result.warningMachines).toContain('warning-machine');
-      expect(service.getWarningMachines()).toContain('warning-machine');
+      expect(result.warningMachines).toContain('idle-machine'); // IDLE maps to warningMachines
+      expect(service.getWarningMachines()).toContain('idle-machine');
+      expect(service.getHeartbeatData('idle-machine')!.status).toBe('idle');
     });
 
-    test('machine offline revient online', async () => {
-      const service = new HeartbeatService(TEST_PATH, {
-        offlineTimeout: 100,
-        heartbeatInterval: 30,
-        missedHeartbeatThreshold: 4,
-      });
+    test('machine UNKNOWN revient online after re-registration #1953 ADR 008', async () => {
+      const service = new HeartbeatService(TEST_PATH);
 
-      // Set up stale machine on disk
-      const staleData = {
-        ...makeOnlineMachine('recovering-machine'),
-        lastHeartbeat: new Date(Date.now() - 200).toISOString(),
-      };
-      setupPerMachineFiles({ 'recovering-machine': staleData });
+      // Register machine then make its heartbeat stale (>120 min)
+      await service.registerHeartbeat('recovering-machine');
+      const hb = service.getHeartbeatData('recovering-machine')!;
+      hb.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString(); // 150 min ago
 
-      // First check → detected offline
+      // First check → detected UNKNOWN
       await service.checkHeartbeats();
       expect(service.getOfflineMachines()).toContain('recovering-machine');
 
@@ -468,16 +451,11 @@ describe('HeartbeatService', () => {
       expect(service.getOfflineMachines()).not.toContain('recovering-machine');
     });
 
-    test('machine online stable reste online', async () => {
-      const service = new HeartbeatService(TEST_PATH, {
-        offlineTimeout: 5000,
-        heartbeatInterval: 1000,
-        missedHeartbeatThreshold: 4,
-      });
+    test('machine online stable reste online #1953 ADR 008', async () => {
+      const service = new HeartbeatService(TEST_PATH);
 
-      // Set up recent heartbeat on disk
-      const recentData = makeOnlineMachine('stable-machine');
-      setupPerMachineFiles({ 'stable-machine': recentData });
+      // Register with current timestamp → stays ONLINE
+      await service.registerHeartbeat('stable-machine');
 
       const result = await service.checkHeartbeats();
 

--- a/servers/roo-state-manager/src/tools/roosync/heartbeat-service.ts
+++ b/servers/roo-state-manager/src/tools/roosync/heartbeat-service.ts
@@ -42,7 +42,7 @@ export const RegisterResultSchema = z.object({
     .describe('Identifiant de la machine'),
   timestamp: z.string()
     .describe('Timestamp du heartbeat (ISO 8601)'),
-  status: z.enum(['online', 'offline', 'warning'])
+  status: z.enum(['online', 'offline', 'warning', 'idle', 'unknown'])
     .describe('Statut de la machine apres l\'enregistrement'),
   isNewMachine: z.boolean()
     .describe('Indique si c\'est une nouvelle machine')

--- a/servers/roo-state-manager/src/tools/roosync/heartbeat-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/heartbeat-status.ts
@@ -35,7 +35,7 @@ export const HeartbeatDataSchema = z.object({
     .describe('Identifiant de la machine'),
   lastHeartbeat: z.string()
     .describe('Timestamp du dernier heartbeat (ISO 8601)'),
-  status: z.enum(['online', 'offline', 'warning'])
+  status: z.enum(['online', 'offline', 'warning', 'idle', 'unknown'])
     .describe('Statut de la machine'),
   missedHeartbeats: z.number()
     .describe('Nombre de heartbeats manques consecutifs'),

--- a/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService-degraded.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService-degraded.test.ts
@@ -79,7 +79,7 @@ describe('HeartbeatService - Graceful Degradation (#1918)', () => {
       expect(files).toHaveLength(0);
     });
 
-    it('resumes disk writes after recovery', async () => {
+    it('resumes disk writes after recovery via stopHeartbeatService #1953 ADR 008', async () => {
       caps.markDegraded('sharedPath', 'GDrive offline');
 
       await heartbeatService.registerHeartbeat('recovery-machine');
@@ -88,11 +88,8 @@ describe('HeartbeatService - Graceful Degradation (#1918)', () => {
       // Recover GDrive
       caps.recover('sharedPath');
 
-      // Wait for persistenceInterval to elapse (100ms in test config)
-      await new Promise(resolve => setTimeout(resolve, 150));
-
-      // Register again — should now write to disk
-      await heartbeatService.registerHeartbeat('recovery-machine');
+      // ADR 008 Phase 1: registerHeartbeat is always in-memory, disk writes happen via saveState
+      await heartbeatService.stopHeartbeatService();
 
       const heartbeatsDir = join(sharedPath, 'heartbeats');
       const files = await readdir(heartbeatsDir);

--- a/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
@@ -117,12 +117,12 @@ describe('HeartbeatService - Tests Unitaires', () => {
       const heartbeatPath = join(sharedPath, 'heartbeat.json');
       const state = heartbeatService.getState();
       
-      // Modifier le timestamp pour simuler une machine offline
+      // #1953 ADR 008: UNKNOWN threshold is >120 min (hardcoded in checkHeartbeats)
       const heartbeatData = state.heartbeats.get('machine-1');
       if (heartbeatData) {
-        heartbeatData.lastHeartbeat = new Date(Date.now() - 130000).toISOString(); // Plus de 2 minutes
+        heartbeatData.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString(); // 150 min ago → UNKNOWN
         state.heartbeats.set('machine-1', heartbeatData);
-        
+
         await fs.writeFile(heartbeatPath, JSON.stringify({
           heartbeats: Object.fromEntries(state.heartbeats),
           onlineMachines: state.onlineMachines,
@@ -131,7 +131,7 @@ describe('HeartbeatService - Tests Unitaires', () => {
           statistics: state.statistics
         }, null, 2));
       }
-      
+
       // Recréer le service pour charger l'état modifié
       await heartbeatService.stopHeartbeatService();
       heartbeatService = new HeartbeatService(sharedPath, {
@@ -141,18 +141,16 @@ describe('HeartbeatService - Tests Unitaires', () => {
         autoSyncEnabled: false,
         autoSyncInterval: 60000
       });
-      
+
       // Act - Vérifier les heartbeats
       const result = await heartbeatService.checkHeartbeats();
-      
+
       // Assert
       expect(result.success).toBe(true);
-      expect(result.newlyOfflineMachines).toContain('machine-1');
-      
+      expect(result.newlyOfflineMachines).toContain('machine-1'); // UNKNOWN maps to offlineMachines
+
       const heartbeatDataAfter = heartbeatService.getHeartbeatData('machine-1');
-      expect(heartbeatDataAfter?.status).toBe('offline');
-      expect(heartbeatDataAfter?.offlineSince).toBeDefined();
-      expect(heartbeatDataAfter?.missedHeartbeats).toBeGreaterThan(0);
+      expect(heartbeatDataAfter?.status).toBe('unknown'); // ADR 008: no more 'offline', use 'unknown'
     });
 
     it('devrait détecter une machine en avertissement avant offline', async () => {
@@ -165,9 +163,8 @@ describe('HeartbeatService - Tests Unitaires', () => {
       
       const heartbeatData = state.heartbeats.get('machine-1');
       if (heartbeatData) {
-        // Mettre le timestamp à 119 secondes pour déclencher l'avertissement
-        // (>= 4 * 30s = 120s pour warning, mais < 120s pour offline)
-        heartbeatData.lastHeartbeat = new Date(Date.now() - 119000).toISOString();
+        // #1953 ADR 008: IDLE threshold is 30-120 min
+        heartbeatData.lastHeartbeat = new Date(Date.now() - 45 * 60 * 1000).toISOString(); // 45 min → IDLE
         state.heartbeats.set('machine-1', heartbeatData);
         
         await fs.writeFile(heartbeatPath, JSON.stringify({
@@ -197,8 +194,8 @@ describe('HeartbeatService - Tests Unitaires', () => {
       expect(result.warningMachines).toContain('machine-1');
       
       const heartbeatDataAfter = heartbeatService.getHeartbeatData('machine-1');
-      expect(heartbeatDataAfter?.status).toBe('warning');
-      expect(heartbeatDataAfter?.missedHeartbeats).toBe(3); // 119s / 30s = 3 heartbeats manqués
+      expect(heartbeatDataAfter?.status).toBe('idle'); // ADR 008: 'idle' replaces 'warning'
+      expect(heartbeatDataAfter?.missedHeartbeats).toBe(1);
     });
 
     it('devrait détecter le retour online d\'une machine', async () => {
@@ -469,15 +466,15 @@ describe('HeartbeatService - Tests Unitaires', () => {
       // Enregistrer un heartbeat initial
       await heartbeatService.registerHeartbeat('machine-1');
       
-      // Simuler une machine offline en modifiant directement le fichier
+      // #1953 ADR 008: UNKNOWN threshold is >120 min
       const heartbeatPath = join(sharedPath, 'heartbeat.json');
       const state = heartbeatService.getState();
-      
+
       const heartbeatData = state.heartbeats.get('machine-1');
       if (heartbeatData) {
-        heartbeatData.lastHeartbeat = new Date(Date.now() - 130000).toISOString();
+        heartbeatData.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString(); // 150 min → UNKNOWN
         state.heartbeats.set('machine-1', heartbeatData);
-        
+
         await fs.writeFile(heartbeatPath, JSON.stringify({
           heartbeats: Object.fromEntries(state.heartbeats),
           onlineMachines: state.onlineMachines,
@@ -486,7 +483,7 @@ describe('HeartbeatService - Tests Unitaires', () => {
           statistics: state.statistics
         }, null, 2));
       }
-      
+
       // Recréer le service avec callbacks
       await heartbeatService.stopHeartbeatService();
       heartbeatService = new HeartbeatService(sharedPath, {
@@ -616,6 +613,9 @@ describe('HeartbeatService - Tests Unitaires', () => {
     it('should write heartbeat files atomically (no 0-byte on interrupt)', async () => {
       await heartbeatService.registerHeartbeat('test-atomic');
 
+      // #1953 ADR 008: registerHeartbeat is in-memory only, must stop to persist
+      await heartbeatService.stopHeartbeatService();
+
       // Verify the heartbeat file exists and is valid JSON
       const heartbeatDir = join(sharedPath, 'heartbeats');
       const filePath = join(heartbeatDir, 'test-atomic.json');
@@ -631,15 +631,17 @@ describe('HeartbeatService - Tests Unitaires', () => {
       // Register a machine first
       await heartbeatService.registerHeartbeat('machine-clean');
 
-      // Create a 0-byte file simulating corruption
+      // #1953 ADR 008: must stop to persist to disk before creating corrupt file
+      await heartbeatService.stopHeartbeatService();
+
+      // Create a 0-byte file simulating corruption (directory exists after stopHeartbeatService)
       const heartbeatDir = join(sharedPath, 'heartbeats');
       const corruptPath = join(heartbeatDir, 'corrupt-machine.json');
       await fs.writeFile(corruptPath, '', 'utf-8'); // 0-byte file
 
       expect(existsSync(corruptPath)).toBe(true);
 
-      // Stop and reload — should clean up the 0-byte file
-      await heartbeatService.stopHeartbeatService();
+      // Reload — should clean up the 0-byte file
       const newService = new HeartbeatService(sharedPath, {
         heartbeatInterval: 30000,
         offlineTimeout: 120000,


### PR DESCRIPTION
## Summary
- Implements ADR 008 Phase 1: Passive Activity Derivation (Option A)
- Identity source changed from `config.machineId` to `os.hostname()` (fixes identity drift across machines)
- `registerHeartbeat` is now in-memory only — no GDrive writes during registration. Disk persistence happens via `stopHeartbeatService`/`saveState` only.
- New status model: ONLINE (<30min), IDLE (30-120min), UNKNOWN (>120min). No more OFFLINE status.

## Changes
- `RooSyncService.ts`: `registerHeartbeat` uses `os.hostname()` instead of `this.config.machineId`
- `HeartbeatService.ts`: Simplified `registerHeartbeat` (in-memory only), `checkHeartbeats` uses hardcoded thresholds with new status derivation
- `updateMachineStatus`: Maps IDLE→warningMachines, UNKNOWN→offlineMachines for backward compatibility
- Zod schemas: Extended status enum with 'idle' and 'unknown'
- Tests: 12 tests updated across 3 files to match new behavior

## Test plan
- [x] `npm run build` passes (0 errors)
- [x] `npx vitest run --config vitest.config.ci.ts` — 456 passed, 0 failed (9162 tests)
- [ ] 48h validation in production (Phase 3 after merge)

## References
- ADR: `docs/harness/adr/008-heartbeat-redesign.md`
- Issue: #1953
- Approved by: po-2024 (ADR review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)