### PR TITLE
feat(#1843): ProfileApplicabilityHelper — category-based profile matching

### DIFF
--- a/servers/roo-state-manager/src/services/roosync/NonNominativeBaselineService.ts
+++ b/servers/roo-state-manager/src/services/roosync/NonNominativeBaselineService.ts
@@ -31,6 +31,7 @@ import {
 import { MachineInventory as LegacyMachineInventory, BaselineConfig, BaselineFileConfig } from '../../types/baseline.js';
 import { BaselineServiceError, BaselineServiceErrorCode } from '../../types/baseline.js';
 import { readJSONFileWithoutBOM } from '../../utils/encoding-helpers.js';
+import { ProfileApplicabilityHelper } from './ProfileApplicabilityHelper.js';
 
 /**
  * Service pour la gestion des baselines non-nominatives
@@ -557,8 +558,7 @@ export class NonNominativeBaselineService {
    * Vérifie si un profil est applicable à une machine
    */
   private isProfileApplicable(profile: ConfigurationProfile, inventory: MachineInventory): boolean {
-    // Implémentation simplifiée - à améliorer avec des règles plus complexes
-    return true;
+    return ProfileApplicabilityHelper.isApplicable(profile, inventory);
   }
 
   /**

--- a/servers/roo-state-manager/src/services/roosync/ProfileApplicabilityHelper.ts
+++ b/servers/roo-state-manager/src/services/roosync/ProfileApplicabilityHelper.ts
@@ -1,0 +1,148 @@
+/**
+ * Profile applicability matching for non-nominative baselines.
+ *
+ * Determines whether a ConfigurationProfile is applicable to a machine
+ * based on its inventory data. Category-specific rules:
+ * - roo-*: Always applicable (all fleet machines run Roo)
+ * - hardware-*: Always applicable except hardware-gpu (needs GPU)
+ * - software-*: Only if the software is installed and detected
+ * - system-*: Always applicable
+ *
+ * @module services/roosync/ProfileApplicabilityHelper
+ * @issue #1843 finding #4
+ */
+
+import type { ConfigurationProfile, ConfigurationCategory, MachineInventory } from '../../types/non-nominative-baseline.js';
+
+export class ProfileApplicabilityHelper {
+  /**
+   * Check if a profile is applicable to a machine based on its inventory.
+   * Pure function — no side effects, safe for concurrent use.
+   */
+  static isApplicable(profile: ConfigurationProfile, inventory: MachineInventory): boolean {
+    switch (profile.category) {
+      case 'roo-core':
+      case 'roo-advanced':
+        return true;
+
+      case 'hardware-cpu':
+      case 'hardware-memory':
+      case 'hardware-storage':
+        return true;
+
+      case 'hardware-gpu':
+        return this.hasGpu(inventory);
+
+      case 'software-powershell':
+        return this.hasSoftware(
+          inventory.inventory?.systemInfo?.powershellVersion,
+          inventory.inventory?.tools?.powershell?.version,
+          inventory.config?.software?.powershell
+        );
+
+      case 'software-node':
+        return this.hasSoftware(
+          undefined,
+          inventory.inventory?.tools?.node?.version,
+          inventory.config?.software?.node
+        );
+
+      case 'software-python':
+        return this.hasSoftware(
+          undefined,
+          inventory.inventory?.tools?.python?.version,
+          inventory.config?.software?.python
+        );
+
+      case 'system-os':
+      case 'system-architecture':
+        return true;
+
+      default:
+        return true;
+    }
+  }
+
+  /**
+   * Get all applicable profiles from a list, returning both matches and exclusions.
+   */
+  static filterApplicable(
+    profiles: ConfigurationProfile[],
+    inventory: MachineInventory
+  ): { applicable: ConfigurationProfile[]; excluded: Array<{ profile: ConfigurationProfile; reason: string }> } {
+    const applicable: ConfigurationProfile[] = [];
+    const excluded: Array<{ profile: ConfigurationProfile; reason: string }> = [];
+
+    for (const profile of profiles) {
+      if (this.isApplicable(profile, inventory)) {
+        applicable.push(profile);
+      } else {
+        excluded.push({
+          profile,
+          reason: this.getExclusionReason(profile, inventory),
+        });
+      }
+    }
+
+    return { applicable, excluded };
+  }
+
+  /** Check if the machine has a GPU. */
+  private static hasGpu(inventory: MachineInventory): boolean {
+    if (inventory.config?.hardware?.gpu) return true;
+    const si = inventory.inventory?.systemInfo;
+    if (si?.gpu && Array.isArray(si.gpu) && si.gpu.length > 0) return true;
+    if (inventory.inventory?.gpuDetails && inventory.inventory.gpuDetails.length > 0) return true;
+    return false;
+  }
+
+  /** Check if software is installed (non-Unknown version in any source). */
+  private static hasSoftware(
+    systemInfoVersion: string | undefined,
+    toolsVersion: string | undefined,
+    legacyVersion: string | undefined
+  ): boolean {
+    return [systemInfoVersion, toolsVersion, legacyVersion]
+      .some(v => v != null && v !== '' && v !== 'Unknown');
+  }
+
+  /** Human-readable reason for exclusion. */
+  private static getExclusionReason(profile: ConfigurationProfile, inventory: MachineInventory): string {
+    const cat = profile.category;
+
+    if (cat === 'hardware-gpu' && !this.hasGpu(inventory)) {
+      return 'Machine has no GPU';
+    }
+    if (cat === 'software-powershell' && !this.hasSoftware(
+      inventory.inventory?.systemInfo?.powershellVersion,
+      inventory.inventory?.tools?.powershell?.version,
+      inventory.config?.software?.powershell
+    )) {
+      return 'PowerShell not detected';
+    }
+    if (cat === 'software-node' && !this.hasSoftware(
+      undefined,
+      inventory.inventory?.tools?.node?.version,
+      inventory.config?.software?.node
+    )) {
+      return 'Node.js not detected';
+    }
+    if (cat === 'software-python' && !this.hasSoftware(
+      undefined,
+      inventory.inventory?.tools?.python?.version,
+      inventory.config?.software?.python
+    )) {
+      return 'Python not detected';
+    }
+
+    return `Category ${cat} not applicable`;
+  }
+}
+
+/** All valid categories — used by tests for exhaustive coverage. */
+export const ALL_CATEGORIES: ConfigurationCategory[] = [
+  'roo-core', 'roo-advanced',
+  'hardware-cpu', 'hardware-memory', 'hardware-storage', 'hardware-gpu',
+  'software-powershell', 'software-node', 'software-python',
+  'system-os', 'system-architecture',
+];

--- a/servers/roo-state-manager/tests/unit/services/roosync/ProfileApplicabilityHelper.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/roosync/ProfileApplicabilityHelper.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for ProfileApplicabilityHelper (#1843 finding #4)
+ * Validates category-specific profile matching against machine inventory.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ProfileApplicabilityHelper,
+  ALL_CATEGORIES,
+} from '../../../../src/services/roosync/ProfileApplicabilityHelper.js';
+import type { ConfigurationProfile, MachineInventory } from '../../../../src/types/non-nominative-baseline.js';
+
+function makeProfile(category: ConfigurationCategory, overrides?: Partial<ConfigurationProfile>): ConfigurationProfile {
+  return {
+    profileId: `test-${category}`,
+    category,
+    name: `Test ${category}`,
+    description: `Test profile for ${category}`,
+    configuration: {},
+    priority: 1,
+    compatibility: { requiredProfiles: [], conflictingProfiles: [], optionalProfiles: [] },
+    metadata: { createdAt: '2026-01-01', updatedAt: '2026-01-01', version: '1.0', tags: [], stability: 'stable' },
+    ...overrides,
+  };
+}
+
+function makeInventory(overrides?: Partial<MachineInventory>): MachineInventory {
+  return {
+    machineId: 'test-machine',
+    ...overrides,
+  };
+}
+
+const FULL_INVENTORY: MachineInventory = makeInventory({
+  inventory: {
+    systemInfo: {
+      powershellVersion: '7.4.6',
+      os: 'Windows_NT',
+      architecture: 'x64',
+      cpuCores: 16,
+      hostname: 'test-machine',
+      username: 'test-user',
+    },
+    tools: {
+      node: { version: '22.0.0' },
+      python: { version: '3.12.0' },
+      powershell: { version: '7.4.6' },
+    },
+    gpuDetails: [{ index: 0, name: 'RTX 3080', memoryTotal: 10240, memoryFree: 5120, memoryUsed: 5120, driverVersion: '550', temperature: 45, source: 'nvidia-smi' }],
+  },
+});
+
+// === Category: always-applicable ===
+
+describe('ProfileApplicabilityHelper — always applicable categories', () => {
+  const alwaysCategories: ConfigurationCategory[] = [
+    'roo-core', 'roo-advanced',
+    'hardware-cpu', 'hardware-memory', 'hardware-storage',
+    'system-os', 'system-architecture',
+  ];
+
+  it.each(alwaysCategories)('returns true for %s with minimal inventory', (cat) => {
+    const profile = makeProfile(cat);
+    const inventory = makeInventory();
+    expect(ProfileApplicabilityHelper.isApplicable(profile, inventory)).toBe(true);
+  });
+
+  it.each(alwaysCategories)('returns true for %s with full inventory', (cat) => {
+    const profile = makeProfile(cat);
+    expect(ProfileApplicabilityHelper.isApplicable(profile, FULL_INVENTORY)).toBe(true);
+  });
+});
+
+// === Category: hardware-gpu ===
+
+describe('ProfileApplicabilityHelper — hardware-gpu', () => {
+  it('returns true when gpuDetails present', () => {
+    const profile = makeProfile('hardware-gpu');
+    expect(ProfileApplicabilityHelper.isApplicable(profile, FULL_INVENTORY)).toBe(true);
+  });
+
+  it('returns true when legacy config.hardware.gpu present', () => {
+    const profile = makeProfile('hardware-gpu');
+    const inventory = makeInventory({ config: { hardware: { gpu: { model: 'GTX 1060' } } } });
+    expect(ProfileApplicabilityHelper.isApplicable(profile, inventory)).toBe(true);
+  });
+
+  it('returns false when no GPU detected', () => {
+    const profile = makeProfile('hardware-gpu');
+    const inventory = makeInventory();
+    expect(ProfileApplicabilityHelper.isApplicable(profile, inventory)).toBe(false);
+  });
+
+  it('returns false when gpuDetails is empty array', () => {
+    const profile = makeProfile('hardware-gpu');
+    const inventory = makeInventory({ inventory: { gpuDetails: [] } });
+    expect(ProfileApplicabilityHelper.isApplicable(profile, inventory)).toBe(false);
+  });
+});
+
+// === Category: software-powershell ===
+
+describe('ProfileApplicabilityHelper — software-powershell', () => {
+  it('returns true when systemInfo.powershellVersion present', () => {
+    const profile = makeProfile('software-powershell');
+    const inventory = makeInventory({
+      inventory: { systemInfo: { powershellVersion: '7.4.6' } },
+    });
+    expect(ProfileApplicabilityHelper.isApplicable(profile, inventory)).toBe(true);
+  });
+
+  it('returns true when tools.powershell.version present', () => {
+    const profile = makeProfile('software-powershell');
+    const inventory = makeInventory({
+      inventory: { tools: { powershell: { version: '7.4.6' } } },
+    });
+    expect(ProfileApplicabilityHelper.isApplicable(profile, inventory)).toBe(true);
+  });
+
+  it('returns true when legacy config.software.powershell present', () => {
+    const profile = makeProfile('software-powershell');
+    const inventory = makeInventory({
+      config: { software: { powershell: '5.1' } },
+    });
+    expect(ProfileApplicabilityHelper.isApplicable(profile, inventory)).toBe(true);
+  });
+
+  it('returns false when version is "Unknown"', () => {
+    const profile = makeProfile('software-powershell');
+    const inventory = makeInventory({
+      inventory: { systemInfo: { powershellVersion: 'Unknown' } },
+    });
+    expect(ProfileApplicabilityHelper.isApplicable(profile, inventory)).toBe(false);
+  });
+
+  it('returns false when no PowerShell detected at all', () => {
+    const profile = makeProfile('software-powershell');
+    const inventory = makeInventory();
+    expect(ProfileApplicabilityHelper.isApplicable(profile, inventory)).toBe(false);
+  });
+});
+
+// === Category: software-node ===
+
+describe('ProfileApplicabilityHelper — software-node', () => {
+  it('returns true when tools.node.version present', () => {
+    const profile = makeProfile('software-node');
+    const inventory = makeInventory({
+      inventory: { tools: { node: { version: '22.0.0' } } },
+    });
+    expect(ProfileApplicabilityHelper.isApplicable(profile, inventory)).toBe(true);
+  });
+
+  it('returns true when legacy config.software.node present', () => {
+    const profile = makeProfile('software-node');
+    const inventory = makeInventory({
+      config: { software: { node: '20.0.0' } },
+    });
+    expect(ProfileApplicabilityHelper.isApplicable(profile, inventory)).toBe(true);
+  });
+
+  it('returns false when no Node.js detected', () => {
+    const profile = makeProfile('software-node');
+    expect(ProfileApplicabilityHelper.isApplicable(profile, makeInventory())).toBe(false);
+  });
+});
+
+// === Category: software-python ===
+
+describe('ProfileApplicabilityHelper — software-python', () => {
+  it('returns true when tools.python.version present', () => {
+    const profile = makeProfile('software-python');
+    const inventory = makeInventory({
+      inventory: { tools: { python: { version: '3.12.0' } } },
+    });
+    expect(ProfileApplicabilityHelper.isApplicable(profile, inventory)).toBe(true);
+  });
+
+  it('returns true when legacy config.software.python present', () => {
+    const profile = makeProfile('software-python');
+    const inventory = makeInventory({
+      config: { software: { python: '3.11.0' } },
+    });
+    expect(ProfileApplicabilityHelper.isApplicable(profile, inventory)).toBe(true);
+  });
+
+  it('returns false when no Python detected', () => {
+    const profile = makeProfile('software-python');
+    expect(ProfileApplicabilityHelper.isApplicable(profile, makeInventory())).toBe(false);
+  });
+});
+
+// === filterApplicable ===
+
+describe('ProfileApplicabilityHelper — filterApplicable', () => {
+  it('separates applicable from excluded profiles', () => {
+    const profiles = ALL_CATEGORIES.map(cat => makeProfile(cat));
+    const inventory = FULL_INVENTORY;
+
+    const result = ProfileApplicabilityHelper.filterApplicable(profiles, inventory);
+
+    // All categories should be applicable on FULL_INVENTORY
+    expect(result.applicable).toHaveLength(ALL_CATEGORIES.length);
+    expect(result.excluded).toHaveLength(0);
+  });
+
+  it('excludes GPU and software profiles on minimal machine', () => {
+    const profiles = ALL_CATEGORIES.map(cat => makeProfile(cat));
+    const inventory = makeInventory(); // No GPU, no software
+
+    const result = ProfileApplicabilityHelper.filterApplicable(profiles, inventory);
+
+    expect(result.applicable.length).toBeLessThan(ALL_CATEGORIES.length);
+    expect(result.excluded.length).toBeGreaterThan(0);
+
+    // Excluded categories should include hardware-gpu and software-*
+    const excludedCats = result.excluded.map(e => e.profile.category);
+    expect(excludedCats).toContain('hardware-gpu');
+    expect(excludedCats).toContain('software-powershell');
+    expect(excludedCats).toContain('software-node');
+    expect(excludedCats).toContain('software-python');
+
+    // Always-applicable categories should not be excluded
+    expect(excludedCats).not.toContain('roo-core');
+    expect(excludedCats).not.toContain('system-os');
+  });
+
+  it('provides human-readable exclusion reasons', () => {
+    const profiles = [makeProfile('hardware-gpu')];
+    const inventory = makeInventory();
+
+    const result = ProfileApplicabilityHelper.filterApplicable(profiles, inventory);
+
+    expect(result.excluded).toHaveLength(1);
+    expect(result.excluded[0].reason).toContain('GPU');
+  });
+});
+
+// === Exhaustive coverage ===
+
+describe('ProfileApplicabilityHelper — ALL_CATEGORIES constant', () => {
+  it('has exactly 11 categories', () => {
+    expect(ALL_CATEGORIES).toHaveLength(11);
+  });
+
+  it('includes all defined categories', () => {
+    const expected: ConfigurationCategory[] = [
+      'roo-core', 'roo-advanced',
+      'hardware-cpu', 'hardware-memory', 'hardware-storage', 'hardware-gpu',
+      'software-powershell', 'software-node', 'software-python',
+      'system-os', 'system-architecture',
+    ];
+    expect(ALL_CATEGORIES.sort()).toEqual(expected.sort());
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `ProfileApplicabilityHelper` class with category-specific matching rules for non-nominative baseline profiles
- Replaces the stub `isProfileApplicable()` in `NonNominativeBaselineService.ts` that always returned `true`
- Adds `filterApplicable()` for batch processing with human-readable exclusion reasons

## Matching rules
| Category | Rule |
|----------|------|
| `roo-core`, `roo-advanced` | Always applicable |
| `hardware-cpu/memory/storage` | Always applicable |
| `hardware-gpu` | Only if GPU detected (gpuDetails, legacy config, or systemInfo) |
| `software-powershell/node/python` | Only if version detected and non-Unknown |
| `system-os/architecture` | Always applicable |

## Test plan
- [x] 34 new test cases covering all 11 categories
- [x] Edge cases: empty gpuDetails, Unknown versions, minimal inventory
- [x] filterApplicable batch processing with exclusion reasons
- [x] Full CI suite: 9196 pass, 0 fail
- [x] Build clean

Addresses #1843 finding #4 (audit: `isProfileApplicable()` returns always true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)