### PR TITLE
refactor(#1935): Cluster D — fuse get_mcp_best_practices into roosync_diagnose

### DIFF
--- a/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
@@ -17,7 +17,7 @@ import {
     roosyncIndexingDefinition,
     codebaseSearchDefinition,
     readVscodeLogsDefinition,
-    getMcpBestPracticesDefinition,
+    // [REMOVED #1935 Cluster D] getMcpBestPracticesDefinition — fused into roosync_diagnose(action: "best-practices")
     exportDataDefinition,
     exportConfigDefinition,
     viewTaskDetailsDefinition,
@@ -246,13 +246,20 @@ describe('tool-definitions.ts — Schema Validation', () => {
 
         // #1609: roosync_heartbeat test removed — auto-heartbeat on any tool call
 
-        it('roosync_diagnose should have env/debug/reset/test/analyze actions', () => {
+        it('roosync_diagnose should have env/debug/reset/test/analyze/best-practices actions', () => {
             const actions = (roosyncDiagnoseDefinition.inputSchema.properties.action as Record<string, unknown>).enum as string[];
             expect(actions).toContain('env');
             expect(actions).toContain('debug');
             expect(actions).toContain('reset');
             expect(actions).toContain('test');
             expect(actions).toContain('analyze'); // #1935 Cluster D: fused from analyze_roosync_problems
+            expect(actions).toContain('best-practices'); // #1935 Cluster D: fused from get_mcp_best_practices
+        });
+
+        it('roosync_diagnose should have mcp_name parameter for best-practices', () => {
+            const props = roosyncDiagnoseDefinition.inputSchema.properties as Record<string, unknown>;
+            expect(props).toHaveProperty('mcp_name');
+            expect((props.mcp_name as Record<string, unknown>).description).toContain('best-practices');
         });
 
         it('roosync_config should support collect/publish/apply/apply_profile', () => {

--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -349,8 +349,9 @@ export function registerCallToolHandler(
                 break;
             }
             case 'get_mcp_best_practices': {
+                // #1935 Cluster D: backward compat — call original handler directly
                 const m = await import('./get_mcp_best_practices.js');
-                result = await m.getMcpBestPractices.handler();
+                result = await m.getMcpBestPractices.handler({ mcp_name: (args as any)?.mcp_name });
                 break;
             }
             // #814: rebuild_task_index redirects to new implementation (backward compat)

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/diagnose.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/diagnose.test.ts
@@ -328,6 +328,47 @@ describe('roosync_diagnose', () => {
   });
 
   // ============================================================
+  // Tests action: 'best-practices' (#1935 Cluster D)
+  // ============================================================
+
+  describe('action: best-practices', () => {
+    it('should dispatch to getMcpBestPractices and return structured result', async () => {
+      const mockResult = {
+        content: [{ type: 'text' as const, text: '# MCP Best Practices\n\nGeneral guidance...' }]
+      };
+
+      vi.doMock('../../../tools/get_mcp_best_practices.js', () => ({
+        getMcpBestPractices: {
+          handler: vi.fn().mockResolvedValue(mockResult)
+        }
+      }));
+
+      const args: DiagnoseArgs = { action: 'best-practices' };
+      const result = await roosyncDiagnose(args);
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe('best-practices');
+      expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(result.data).toEqual(mockResult);
+    });
+
+    it('should forward mcp_name to handler', async () => {
+      const mockHandler = vi.fn().mockResolvedValue({
+        content: [{ type: 'text' as const, text: 'Specific MCP guide' }]
+      });
+
+      vi.doMock('../../../tools/get_mcp_best_practices.js', () => ({
+        getMcpBestPractices: { handler: mockHandler }
+      }));
+
+      const args: DiagnoseArgs = { action: 'best-practices', mcp_name: 'roo-state-manager' };
+      await roosyncDiagnose(args);
+
+      expect(mockHandler).toHaveBeenCalledWith({ mcp_name: 'roo-state-manager' });
+    });
+  });
+
+  // ============================================================
   // Tests d'erreurs
   // ============================================================
 

--- a/servers/roo-state-manager/src/tools/roosync/diagnose.ts
+++ b/servers/roo-state-manager/src/tools/roosync/diagnose.ts
@@ -28,8 +28,8 @@ async function getLazyModule(): Promise<LazyRooSyncModule> {
 // ====================================================================
 
 export const DiagnoseArgsSchema = z.object({
-  action: z.enum(['env', 'debug', 'reset', 'test', 'health', 'analyze'])
-    .describe('Type d\'opération: env, debug, reset, test, health, analyze (roadmap analysis, fused from analyze_roosync_problems)'),
+  action: z.enum(['env', 'debug', 'reset', 'test', 'health', 'analyze', 'best-practices'])
+    .describe('Operation: env, debug, reset, test, health, analyze (roadmap), best-practices (MCP guide, fused from get_mcp_best_practices)'),
   // Paramètres pour action: 'env'
   checkDiskSpace: z.boolean().optional()
     .describe('Vérifier l\'espace disque (action: env)'),
@@ -52,7 +52,11 @@ export const DiagnoseArgsSchema = z.object({
   roadmapPath: z.string().optional()
     .describe('Chemin vers sync-roadmap.md (action: analyze, auto-détecté si omis)'),
   generateReport: z.boolean().optional()
-    .describe('Générer un rapport dans roo-config/reports (action: analyze)')
+    .describe('Générer un rapport dans roo-config/reports (action: analyze)'),
+
+  // #1935 Cluster D: Paramètres pour action: 'best-practices' (fused from get_mcp_best_practices)
+  mcp_name: z.string().optional()
+    .describe('Nom du MCP spécifique à analyser (action: best-practices)')
 });
 
 export type DiagnoseArgs = z.infer<typeof DiagnoseArgsSchema>;
@@ -60,7 +64,7 @@ export type DiagnoseArgs = z.infer<typeof DiagnoseArgsSchema>;
 export const DiagnoseResultSchema = z.object({
   success: z.boolean()
     .describe('Indique si l\'opération a réussi'),
-  action: z.enum(['env', 'debug', 'reset', 'test', 'health', 'analyze'])
+  action: z.enum(['env', 'debug', 'reset', 'test', 'health', 'analyze', 'best-practices'])
     .describe('Type d\'opération effectuée'),
   timestamp: z.string()
     .describe('Timestamp de l\'opération (ISO 8601)'),
@@ -112,6 +116,18 @@ export async function roosyncDiagnose(args: DiagnoseArgs): Promise<DiagnoseResul
           action: 'analyze',
           timestamp,
           data: analyzeResult
+        };
+      }
+
+      // #1935 Cluster D: fused from get_mcp_best_practices
+      case 'best-practices': {
+        const m = await import('../get_mcp_best_practices.js');
+        const result = await m.getMcpBestPractices.handler({ mcp_name: args.mcp_name });
+        return {
+          success: true,
+          action: 'best-practices',
+          timestamp,
+          data: result
         };
       }
 

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -187,16 +187,8 @@ export const readVscodeLogsDefinition = {
 // ============================================================
 // get_mcp_best_practices
 // ============================================================
-export const getMcpBestPracticesDefinition = {
-    name: 'get_mcp_best_practices',
-    description: '📚 **BONNES PRATIQUES MCP** - Guide de référence sur les patterns de configuration et de débogage pour les MCPs, basé sur l\'expérience de stabilisation. Inclut des recommandations essentielles pour la maintenabilité et la performance.',
-    inputSchema: {
-        type: 'object',
-        properties: {
-            mcp_name: { type: 'string', description: 'Nom optionnel du MCP spécifique à analyser (ex: "roo-state-manager", "quickfiles", etc.). Si fourni, inclut l\'arborescence de développement et la configuration du MCP.' }
-        }
-    }
-};
+// [REMOVED #1935 Cluster D] getMcpBestPracticesDefinition — fused into roosync_diagnose(action: "best-practices")
+// CallTool redirect in registry.ts preserved for backward compat.
 
 // ============================================================
 // export_data
@@ -462,18 +454,19 @@ export const roosyncStorageManagementDefinition = {
 
 export const roosyncDiagnoseDefinition = {
     name: 'roosync_diagnose',
-    description: 'Diagnostic et debug RooSync. Actions: env, debug, reset, test, analyze (fused from analyze_roosync_problems).',
+    description: 'Diagnostic et debug RooSync. Actions: env, debug, reset, test, analyze (fused from analyze_roosync_problems), best-practices (fused from get_mcp_best_practices).',
     inputSchema: {
         type: 'object',
         properties: {
-            action: { type: 'string', enum: ['env', 'debug', 'reset', 'test', 'analyze'], description: 'Operation: env, debug, reset, test, analyze (roadmap analysis)' },
+            action: { type: 'string', enum: ['env', 'debug', 'reset', 'test', 'analyze', 'best-practices'], description: 'Operation: env, debug, reset, test, analyze (roadmap), best-practices (MCP guide)' },
             checkDiskSpace: { type: 'boolean', description: 'Check disk space (env)' },
             verbose: { type: 'boolean', description: 'Verbose mode (debug)' },
             clearCache: { type: 'boolean', description: 'Clear cache on reset' },
             confirm: { type: 'boolean', description: 'Confirmation for reset' },
             message: { type: 'string', description: 'Custom test message (test)' },
             roadmapPath: { type: 'string', description: 'Path to sync-roadmap.md (action: analyze, auto-detected if omitted)' },
-            generateReport: { type: 'boolean', description: 'Generate report in roo-config/reports (action: analyze)' }
+            generateReport: { type: 'boolean', description: 'Generate report in roo-config/reports (action: analyze)' },
+            mcp_name: { type: 'string', description: 'MCP name to analyze (action: best-practices)' }
         },
         required: ['action'],
         additionalProperties: false


### PR DESCRIPTION
## Summary
- Completes Cluster D consolidation: fuse `get_mcp_best_practices` into `roosync_diagnose(action: "best-practices")`
- Adds `best-practices` action to `roosync_diagnose` with `mcp_name` parameter
- Removes `getMcpBestPracticesDefinition` from tool definitions
- Backward-compat redirect in registry.ts preserves original handler for `get_mcp_best_practices` callers

## Changes
- `diagnose.ts`: Add `best-practices` to action enum, add `mcp_name` parameter, add switch case that calls original handler
- `tool-definitions.ts`: Replace definition with removal comment
- `registry.ts`: Update `get_mcp_best_practices` case comment for #1935 Cluster D

## Cluster D summary
| Tool | Status |
|------|--------|
| `analyze_roosync_problems` | Fused into `roosync_diagnose(action: "analyze")` (prior PR) |
| `get_mcp_best_practices` | Fused into `roosync_diagnose(action: "best-practices")` (this PR) |
| `roosync_diagnose` | Consolidated tool (7 actions) |

## Test plan
- [x] `npm run build` — clean (0 errors)
- [x] `npx vitest run --config vitest.config.ci.ts` — 9162/9162 pass (0 failures)
- [x] Tool count: 22 (unchanged — get_mcp_best_practices was already absent from allToolDefinitions)
- [x] Backward compat: `get_mcp_best_practices` still works via registry redirect