### PR TITLE
perf(#251): contentPattern fast path via cached skeleton fields

### DIFF
--- a/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
+++ b/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
@@ -1043,6 +1043,19 @@ async function matchesContentPattern(skeleton: ConversationSkeleton, pattern: st
     const normalizedPattern = pattern.toLowerCase().trim();
     if (normalizedPattern.length === 0) return true;
 
+    // 0. Fast path — check cached fields first (no I/O)
+    // #251: Avoids disk reads for the majority of cases where the pattern
+    // matches in the title or truncated instruction.
+    const cachedFields = [
+        skeleton.metadata?.title,
+        skeleton.truncatedInstruction,
+    ];
+    for (const field of cachedFields) {
+        if (field && field.toLowerCase().includes(normalizedPattern)) {
+            return true;
+        }
+    }
+
     // 1. Sequence deja chargee (Tier 2 Claude / Tier 3 Archive) — recherche memoire
     const sequence = (skeleton as any).sequence;
     if (Array.isArray(sequence) && sequence.length > 0) {
@@ -1054,7 +1067,7 @@ async function matchesContentPattern(skeleton: ConversationSkeleton, pattern: st
     }
 
     // 2. Tier 1 (Roo local) — lire api_conversation_history depuis le disque
-    //    (les taches Roo n'ont pas de sequence en cache, juste un SkeletonHeader)
+    //    #251: Only reached if cached fields didn't match — dramatically reduces I/O
     if (!skeleton.taskId.startsWith('claude-')) {
         try {
             const apiMessages = await loadApiMessages(skeleton.taskId);
@@ -1068,7 +1081,7 @@ async function matchesContentPattern(skeleton: ConversationSkeleton, pattern: st
         }
     }
 
-    // 3. Claude session without cached sequence (Tier 2 disabled / load failed) — pas de fallback fiable
+    // 3. Claude session without cached sequence — pas de fallback fiable
     return false;
 }
 


### PR DESCRIPTION
## Summary

Fixes #251 — `conversation_browser(list, contentPattern)` performs O(n) disk I/O, taking **27s** on 8508 conversations.

**Root cause:** `matchesContentPattern()` reads `api_conversation_history.json` from disk for every Roo task, even when the pattern matches cached fields that are already in memory.

**Fix:** Add a fast path that checks `metadata.title` and `truncatedInstruction` before falling through to disk I/O. For common searches (e.g., "dashboard"), this eliminates thousands of unnecessary file reads.

**Expected impact:** Queries matching titles/instructions drop from ~27s to ~ms. Queries requiring full message scan still work but are now the exception rather than the rule.

## Files changed

- `src/tools/conversation/list-conversations.tool.ts` — Added cached field check in `matchesContentPattern()`

## Test plan

- [x] `npm run build` passes
- [x] `npx vitest run --config vitest.config.ci.ts` — 455 files, 9187 tests pass
- [x] All 47 contentPattern-specific tests pass
- [ ] Manual: Run `conversation_browser(list, contentPattern: "dashboard")` and compare timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)