### PR TITLE
fix(#2019): heartbeat cross-check covers all dashboards + 8h threshold

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -317,22 +317,31 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
     let filteredIdleMachines = (heartbeatState?.idleMachines ?? []).filter(isKnownMachine);
     const filteredDashboardMachines = machines.filter(m => isKnownMachine(m.id));
 
-    // #1953: Cross-check heartbeat-derived status against dashboard activity.
+    // #1953, #2016: Cross-check heartbeat-derived status against dashboard activity.
     // Dashboard message timestamps are embedded in file content (immune to GDrive
-    // propagation latency on file mod time), preventing false OFFLINE detection.
+    // propagation latency on file mod time), preventing false UNKNOWN detection.
+    // #2016: Aggregate ALL dashboards (workspace-*, machine-*, global) so a machine
+    // active on any dashboard counts as ONLINE — not only roo-extensions workspace.
     let dashboardOverrides: string[] = [];
     try {
       const dashboardsDir = join(getSharedStatePath(), 'dashboards');
-      const workspaceDashboard = join(dashboardsDir, 'workspace-roo-extensions.md');
-      const dashboardContent = readFileSync(workspaceDashboard, 'utf-8');
+      const dashboardContents: string[] = [];
+      for (const file of readdirSync(dashboardsDir)) {
+        if (!file.endsWith('.md') || file.endsWith('.tmp')) continue;
+        try {
+          dashboardContents.push(readFileSync(join(dashboardsDir, file), 'utf-8'));
+        } catch (err) {
+          logger.debug(`Dashboard ${file} unreadable`, { error: String(err) });
+        }
+      }
       const { crossCheckWithDashboard } = await import('../../utils/dashboard-activity.js');
       const crossChecked = crossCheckWithDashboard(
-        { onlineMachines: filteredOnlineMachines, offlineMachines: filteredUnknownMachines, warningMachines: filteredIdleMachines },
-        dashboardContent
+        { onlineMachines: filteredOnlineMachines, unknownMachines: filteredUnknownMachines, idleMachines: filteredIdleMachines },
+        dashboardContents
       );
       filteredOnlineMachines = crossChecked.onlineMachines;
-      filteredUnknownMachines = crossChecked.offlineMachines;
-      filteredIdleMachines = crossChecked.warningMachines;
+      filteredUnknownMachines = crossChecked.unknownMachines;
+      filteredIdleMachines = crossChecked.idleMachines;
       dashboardOverrides = crossChecked.overrides;
     } catch (err) {
       logger.debug('Dashboard cross-check skipped', { error: String(err) });

--- a/servers/roo-state-manager/src/utils/__tests__/dashboard-activity.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/dashboard-activity.test.ts
@@ -1,9 +1,9 @@
 /**
- * Tests for dashboard-derived machine status utility (#1953)
+ * Tests for dashboard-derived machine status utility (#1953, #2016)
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { extractMachineActivity, isRecentlyActive, crossCheckWithDashboard } from '../dashboard-activity.js';
+import { extractMachineActivity, isRecentlyActive, crossCheckWithDashboard, DEFAULT_ACTIVITY_THRESHOLD_MS } from '../dashboard-activity.js';
 
 describe('dashboard-activity', () => {
 	describe('extractMachineActivity', () => {
@@ -47,6 +47,24 @@ describe('dashboard-activity', () => {
 			expect(extractMachineActivity('').size).toBe(0);
 			expect(extractMachineActivity('no matching content').size).toBe(0);
 		});
+
+		it('should aggregate activity across multiple dashboards (#2016)', () => {
+			const wsRooExt = '### [2026-05-03T18:00:00.000Z] myia-po-2024|roo-extensions\nOld';
+			const wsCoursIA = '### [2026-05-03T20:00:00.000Z] myia-po-2024|coursia\nNew';
+
+			const activity = extractMachineActivity([wsRooExt, wsCoursIA]);
+			expect(activity.get('myia-po-2024')).toBe('2026-05-03T20:00:00.000Z');
+		});
+
+		it('should merge distinct machines from multiple dashboards (#2016)', () => {
+			const wsA = '### [2026-05-03T20:00:00.000Z] myia-po-2024|workspace-a';
+			const wsB = '### [2026-05-03T20:01:00.000Z] myia-web1|workspace-b';
+
+			const activity = extractMachineActivity([wsA, wsB]);
+			expect(activity.size).toBe(2);
+			expect(activity.get('myia-po-2024')).toBe('2026-05-03T20:00:00.000Z');
+			expect(activity.get('myia-web1')).toBe('2026-05-03T20:01:00.000Z');
+		});
 	});
 
 	describe('isRecentlyActive', () => {
@@ -60,19 +78,27 @@ describe('dashboard-activity', () => {
 		});
 
 		it('should return true for recent timestamp', () => {
-			expect(isRecentlyActive('2026-05-03T19:30:00Z')).toBe(true); // 30 min ago
+			expect(isRecentlyActive('2026-05-03T19:30:00Z')).toBe(true);
 		});
 
-		it('should return false for old timestamp with default threshold', () => {
-			expect(isRecentlyActive('2026-05-03T18:00:00Z')).toBe(false); // 2h ago, default 60min
+		it('should return true within the new 8h default threshold (#2016)', () => {
+			expect(isRecentlyActive('2026-05-03T18:00:00Z')).toBe(true);
+		});
+
+		it('should return false beyond the 8h default threshold', () => {
+			expect(isRecentlyActive('2026-05-03T10:00:00Z')).toBe(false);
 		});
 
 		it('should respect custom threshold', () => {
-			expect(isRecentlyActive('2026-05-03T18:00:00Z', 3 * 60 * 60 * 1000)).toBe(true); // 2h ago, threshold 3h
+			expect(isRecentlyActive('2026-05-03T10:00:00Z', 12 * 60 * 60 * 1000)).toBe(true);
 		});
 
 		it('should return false for invalid timestamp', () => {
 			expect(isRecentlyActive('invalid')).toBe(false);
+		});
+
+		it('should expose default threshold as 8h', () => {
+			expect(DEFAULT_ACTIVITY_THRESHOLD_MS).toBe(8 * 60 * 60 * 1000);
 		});
 	});
 
@@ -86,52 +112,69 @@ describe('dashboard-activity', () => {
 			vi.useRealTimers();
 		});
 
-		it('should override OFFLINE to ONLINE when dashboard shows recent activity', () => {
+		it('should override UNKNOWN to ONLINE when dashboard shows recent activity', () => {
 			const heartbeatState = {
 				onlineMachines: ['myia-po-2023'],
-				offlineMachines: ['myia-po-2024'],
-				warningMachines: [],
+				unknownMachines: ['myia-po-2024'],
+				idleMachines: [],
 			};
 			const dashboardContent = '### [2026-05-03T19:30:00Z] myia-po-2024|roo-extensions\nRecent message';
 
 			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
 			expect(result.onlineMachines).toContain('myia-po-2024');
-			expect(result.offlineMachines).not.toContain('myia-po-2024');
+			expect(result.unknownMachines).not.toContain('myia-po-2024');
 			expect(result.overrides).toContain('myia-po-2024');
 		});
 
-		it('should override WARNING to ONLINE when dashboard shows recent activity', () => {
+		it('should override IDLE to ONLINE when dashboard shows recent activity', () => {
 			const heartbeatState = {
 				onlineMachines: [],
-				offlineMachines: [],
-				warningMachines: ['myia-web1'],
+				unknownMachines: [],
+				idleMachines: ['myia-web1'],
 			};
 			const dashboardContent = '### [2026-05-03T19:45:00Z] myia-web1|roo-extensions\nRecent message';
 
 			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
 			expect(result.onlineMachines).toContain('myia-web1');
-			expect(result.warningMachines).not.toContain('myia-web1');
+			expect(result.idleMachines).not.toContain('myia-web1');
 			expect(result.overrides).toContain('myia-web1');
 		});
 
-		it('should NOT override when dashboard activity is too old', () => {
+		it('should NOT override when dashboard activity is older than threshold', () => {
 			const heartbeatState = {
 				onlineMachines: [],
-				offlineMachines: ['myia-po-2025'],
-				warningMachines: [],
+				unknownMachines: ['myia-po-2025'],
+				idleMachines: [],
 			};
-			const dashboardContent = '### [2026-05-03T10:00:00Z] myia-po-2025|roo-extensions\nOld message';
+			const dashboardContent = '### [2026-05-03T08:00:00Z] myia-po-2025|roo-extensions\nOld message';
 
 			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
-			expect(result.offlineMachines).toContain('myia-po-2025');
+			expect(result.unknownMachines).toContain('myia-po-2025');
 			expect(result.overrides).toHaveLength(0);
+		});
+
+		it('should override using activity from any of multiple dashboards (#2016)', () => {
+			const heartbeatState = {
+				onlineMachines: [],
+				unknownMachines: ['myia-po-2024'],
+				idleMachines: [],
+			};
+			const dashboards = [
+				'### [2026-05-03T05:00:00Z] myia-po-2024|roo-extensions\nStale',
+				'### [2026-05-03T19:30:00Z] myia-po-2024|coursia\nRecent',
+			];
+
+			const result = crossCheckWithDashboard(heartbeatState, dashboards);
+			expect(result.onlineMachines).toContain('myia-po-2024');
+			expect(result.unknownMachines).not.toContain('myia-po-2024');
+			expect(result.overrides).toContain('myia-po-2024');
 		});
 
 		it('should handle multiple overrides', () => {
 			const heartbeatState = {
 				onlineMachines: [],
-				offlineMachines: ['myia-po-2024', 'myia-po-2025'],
-				warningMachines: ['myia-web1'],
+				unknownMachines: ['myia-po-2024', 'myia-po-2025'],
+				idleMachines: ['myia-web1'],
 			};
 			const dashboardContent = [
 				'### [2026-05-03T19:50:00Z] myia-po-2024|roo-extensions',
@@ -150,8 +193,8 @@ describe('dashboard-activity', () => {
 		it('should not modify already online machines', () => {
 			const heartbeatState = {
 				onlineMachines: ['myia-ai-01'],
-				offlineMachines: [],
-				warningMachines: [],
+				unknownMachines: [],
+				idleMachines: [],
 			};
 			const dashboardContent = '### [2026-05-03T19:50:00Z] myia-ai-01|roo-extensions\nMessage';
 

--- a/servers/roo-state-manager/src/utils/dashboard-activity.ts
+++ b/servers/roo-state-manager/src/utils/dashboard-activity.ts
@@ -1,9 +1,9 @@
 /**
- * Dashboard-derived machine status utility (#1953)
+ * Dashboard-derived machine status utility (#1953, #2016)
  *
  * Parses dashboard message timestamps to determine last-seen time per machine.
- * Used as a cross-check against heartbeat files to prevent false OFFLINE detection
- * caused by GDrive propagation latency.
+ * Used as a cross-check against heartbeat files to prevent false UNKNOWN/IDLE detection
+ * caused by GDrive propagation latency or activity on workspaces other than the caller's.
  *
  * Dashboard messages embed timestamps INSIDE the content (written by the posting machine),
  * which are immune to GDrive file modification time delays.
@@ -11,7 +11,7 @@
  * Message format: ### [2026-05-03T20:08:15.436Z] myia-po-2024|roo-extensions
  *
  * @module utils/dashboard-activity
- * @version 1.0.0
+ * @version 2.0.0
  */
 
 import { createLogger } from './logger.js';
@@ -21,33 +21,46 @@ const logger = createLogger('DashboardActivity');
 const DASHBOARD_MSG_PATTERN = /^###\s*\[(\d{4}-\d{2}-\d{2}T[\d:.]+Z)\]\s*(\S+)/gm;
 
 /**
- * Extract last-seen timestamp per machine from dashboard content.
+ * Default activity threshold (8 hours).
  *
- * @param dashboardContent - Raw dashboard markdown content
- * @returns Map of machineId → last-seen ISO timestamp
+ * Aligned with the coordinator scheduler interval (480 min). A machine that ran its
+ * last scheduled cycle within the last 8h is considered ONLINE regardless of
+ * heartbeat file modification time, which can lag due to GDrive sync.
  */
-export function extractMachineActivity(dashboardContent: string): Map<string, string> {
+export const DEFAULT_ACTIVITY_THRESHOLD_MS = 8 * 60 * 60 * 1000;
+
+/**
+ * Extract last-seen timestamp per machine from one or more dashboard contents.
+ *
+ * @param dashboardContent - A single dashboard string OR a list of dashboard strings
+ *                          (typically one per workspace/machine/global dashboard file).
+ * @returns Map of machineId -> most recent ISO timestamp seen across all inputs.
+ */
+export function extractMachineActivity(dashboardContent: string | string[]): Map<string, string> {
 	const activity = new Map<string, string>();
+	const inputs = Array.isArray(dashboardContent) ? dashboardContent : [dashboardContent];
 
-	if (!dashboardContent) return activity;
+	for (const content of inputs) {
+		if (!content) continue;
 
-	let match: RegExpExecArray | null;
-	const pattern = new RegExp(DASHBOARD_MSG_PATTERN.source, 'gm');
+		const pattern = new RegExp(DASHBOARD_MSG_PATTERN.source, 'gm');
+		let match: RegExpExecArray | null;
 
-	while ((match = pattern.exec(dashboardContent)) !== null) {
-		const timestamp = match[1];
-		const authorField = match[2];
+		while ((match = pattern.exec(content)) !== null) {
+			const timestamp = match[1];
+			const authorField = match[2];
 
-		const machineId = authorField.split('|')[0].toLowerCase().trim();
-		if (!machineId.startsWith('myia-')) continue;
+			const machineId = authorField.split('|')[0].toLowerCase().trim();
+			if (!machineId.startsWith('myia-')) continue;
 
-		const existing = activity.get(machineId);
-		if (!existing || timestamp > existing) {
-			activity.set(machineId, timestamp);
+			const existing = activity.get(machineId);
+			if (!existing || timestamp > existing) {
+				activity.set(machineId, timestamp);
+			}
 		}
 	}
 
-	logger.debug(`Dashboard activity extracted: ${activity.size} machines seen`);
+	logger.debug(`Dashboard activity extracted: ${activity.size} machines seen across ${inputs.length} dashboard(s)`);
 	return activity;
 }
 
@@ -55,10 +68,10 @@ export function extractMachineActivity(dashboardContent: string): Map<string, st
  * Determine if a machine should be considered ONLINE based on dashboard activity.
  *
  * @param lastSeen - ISO timestamp of last dashboard message from the machine
- * @param thresholdMs - How far back to consider "recent" (default: 60 min)
+ * @param thresholdMs - How far back to consider "recent" (default: 8h)
  * @returns true if machine posted within the threshold
  */
-export function isRecentlyActive(lastSeen: string, thresholdMs: number = 60 * 60 * 1000): boolean {
+export function isRecentlyActive(lastSeen: string, thresholdMs: number = DEFAULT_ACTIVITY_THRESHOLD_MS): boolean {
 	const lastSeenMs = new Date(lastSeen).getTime();
 	if (isNaN(lastSeenMs)) return false;
 	return Date.now() - lastSeenMs < thresholdMs;
@@ -67,56 +80,57 @@ export function isRecentlyActive(lastSeen: string, thresholdMs: number = 60 * 60
 /**
  * Cross-check heartbeat-derived status against dashboard activity.
  *
- * For machines marked "offline" or "warning" by heartbeat files,
- * if dashboard shows recent activity, override the status to "online".
+ * For machines marked UNKNOWN (heartbeat stale) or IDLE by HeartbeatService,
+ * if any dashboard shows recent activity, override the status to ONLINE.
  *
  * @param heartbeatState - State from HeartbeatService.checkHeartbeats()
- * @param dashboardContent - Raw dashboard markdown content
- * @param thresholdMs - Dashboard activity threshold (default: 60 min)
- * @returns Updated lists of online/offline/warning machines
+ * @param dashboardContent - One or more dashboard contents (string or string[]).
+ *                          When passing string[], activity is merged across all.
+ * @param thresholdMs - Dashboard activity threshold (default: 8h)
+ * @returns Updated lists with overrides applied.
  */
 export function crossCheckWithDashboard(
 	heartbeatState: {
 		onlineMachines: string[];
-		offlineMachines: string[];
-		warningMachines: string[];
+		unknownMachines: string[];
+		idleMachines: string[];
 	},
-	dashboardContent: string,
-	thresholdMs: number = 60 * 60 * 1000
+	dashboardContent: string | string[],
+	thresholdMs: number = DEFAULT_ACTIVITY_THRESHOLD_MS
 ): {
 	onlineMachines: string[];
-	offlineMachines: string[];
-	warningMachines: string[];
+	unknownMachines: string[];
+	idleMachines: string[];
 	overrides: string[];
 } {
 	const activity = extractMachineActivity(dashboardContent);
 	const overrides: string[] = [];
 
-	const offlineMachines = [...heartbeatState.offlineMachines];
-	const warningMachines = [...heartbeatState.warningMachines];
+	const unknownMachines = [...heartbeatState.unknownMachines];
+	const idleMachines = [...heartbeatState.idleMachines];
 	const onlineMachines = [...heartbeatState.onlineMachines];
 
-	for (let i = offlineMachines.length - 1; i >= 0; i--) {
-		const machineId = offlineMachines[i];
+	for (let i = unknownMachines.length - 1; i >= 0; i--) {
+		const machineId = unknownMachines[i];
 		const lastSeen = activity.get(machineId);
 		if (lastSeen && isRecentlyActive(lastSeen, thresholdMs)) {
-			offlineMachines.splice(i, 1);
+			unknownMachines.splice(i, 1);
 			onlineMachines.push(machineId);
 			overrides.push(machineId);
-			logger.info(`Dashboard override: ${machineId} OFFLINE→ONLINE (last seen ${lastSeen})`);
+			logger.info(`Dashboard override: ${machineId} UNKNOWN->ONLINE (last seen ${lastSeen})`);
 		}
 	}
 
-	for (let i = warningMachines.length - 1; i >= 0; i--) {
-		const machineId = warningMachines[i];
+	for (let i = idleMachines.length - 1; i >= 0; i--) {
+		const machineId = idleMachines[i];
 		const lastSeen = activity.get(machineId);
 		if (lastSeen && isRecentlyActive(lastSeen, thresholdMs)) {
-			warningMachines.splice(i, 1);
+			idleMachines.splice(i, 1);
 			onlineMachines.push(machineId);
 			overrides.push(machineId);
-			logger.info(`Dashboard override: ${machineId} WARNING→ONLINE (last seen ${lastSeen})`);
+			logger.info(`Dashboard override: ${machineId} IDLE->ONLINE (last seen ${lastSeen})`);
 		}
 	}
 
-	return { onlineMachines, offlineMachines, warningMachines, overrides };
+	return { onlineMachines, unknownMachines, idleMachines, overrides };
 }


### PR DESCRIPTION
## Summary

Fixes two bugs in `servers/roo-state-manager/src/utils/dashboard-activity.ts` that caused active machines to be flagged heartbeat-stale even when they had posted recently. See parent issue jsboige/roo-extensions#2019 for full symptom + repro.

### Bug 1 — 60-min threshold too short
`DEFAULT_ACTIVITY_THRESHOLD_MS` was 60 min, but the coordinator scheduler runs every 480 min (8h). A machine that posted 1h34min ago (e.g. myia-po-2024 at 08:04Z observed at 09:38Z, 2026-05-06) was failing the cross-check and being flagged offline. **Bumped to 8h** so a machine that ran its last scheduled cycle is still considered ONLINE.

### Bug 2 — Only one dashboard inspected
`get-status.ts:326` only read `workspace-roo-extensions.md`. Machines active on `coursia` / `nanoclaw` / `qdrant` workspaces were not detected, leading to false UNKNOWN status. **Now iterates all `*.md` files** under `dashboards/`, and `extractMachineActivity` accepts `string | string[]`, merging activity across all inputs (latest timestamp wins).

### Bonus — API rename addresses #2013
`crossCheckWithDashboard` previously used legacy `offlineMachines`/`warningMachines` parameter names while the rest of `HeartbeatService` had migrated to `unknownMachines`/`idleMachines` (#337, ADR 008 Phase 2). Renamed for consistency. The call site in `get-status.ts:336-339` is updated accordingly.

## Test plan

- [x] `extractMachineActivity` aggregates across multiple dashboards (2 new tests)
- [x] `isRecentlyActive` 8h default threshold (2 new tests + updated existing)
- [x] `crossCheckWithDashboard` overrides via any-dashboard activity (1 new test)
- [x] Renamed parameter names propagate (existing test cases updated)
- [x] `npx vitest run --config vitest.config.ci.ts` — **9203/9203 pass**

Closes jsboige/roo-extensions#2019

🤖 Generated with [Claude Code](https://claude.com/claude-code)