### PR TITLE
fix(#2018): deterministic chunk_id to prevent Qdrant duplication

### DIFF
--- a/servers/roo-state-manager/src/services/task-indexer/ChunkExtractor.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/ChunkExtractor.ts
@@ -1,11 +1,33 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { v4 as uuidv4, v5 as uuidv5 } from 'uuid';
+import * as crypto from 'crypto';
+import { v5 as uuidv5 } from 'uuid';
 import { StateManagerError } from '../../types/errors.js';
 
 // Namespace pour UUID v5 (généré aléatoirement une fois, constant pour le projet)
 const UUID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+
+/**
+ * #2018: Compute a deterministic chunk_id from logical chunk identity.
+ *
+ * Same (task_id, chunk_type, sequence_order, content) → same UUID.
+ * Re-indexation upserts existing points instead of creating duplicates.
+ *
+ * Seed: `${task_id}|${chunk_type}|seq:${sequence_order}|${sha256_16}`
+ * sha256 truncated to 16 hex chars: 64-bit collision resistance, sufficient
+ * intra-task where the seq+task_id already disambiguate non-content collisions.
+ */
+export function computeChunkId(
+    taskId: string,
+    chunkType: string,
+    sequenceOrder: number,
+    content: string
+): string {
+    const contentHash = crypto.createHash('sha256').update(content).digest('hex').slice(0, 16);
+    const seed = `${taskId}|${chunkType}|seq:${sequenceOrder}|${contentHash}`;
+    return uuidv5(seed, UUID_NAMESPACE);
+}
 
 /**
  * Maximum content size (in chars) before truncation for indexing.
@@ -207,13 +229,14 @@ export async function extractChunksFromTask(taskId: string, taskPath: string): P
                         lowerContent.includes('❌') ||
                         lowerContent.includes('erreur');
 
+                    const seq = sequenceOrder++;
                     chunks.push({
-                        chunk_id: uuidv4(),
+                        chunk_id: computeChunkId(taskId, 'message_exchange', seq, contentText),
                         task_id: taskId,
                         parent_task_id: parentTaskId || null,
                         root_task_id: null,
                         chunk_type: 'message_exchange',
-                        sequence_order: sequenceOrder++,
+                        sequence_order: seq,
                         timestamp: msg.timestamp || new Date().toISOString(),
                         indexed: true,
                         content: contentText,
@@ -248,13 +271,14 @@ export async function extractChunksFromTask(taskId: string, taskPath: string): P
                         `tool_call:${toolCall.function.name}`
                     );
 
+                    const seq = sequenceOrder++;
                     chunks.push({
-                        chunk_id: uuidv4(),
+                        chunk_id: computeChunkId(taskId, 'tool_interaction', seq, toolContent),
                         task_id: taskId,
                         parent_task_id: parentTaskId || null,
                         root_task_id: null,
                         chunk_type: 'tool_interaction',
-                        sequence_order: sequenceOrder++,
+                        sequence_order: seq,
                         timestamp: msg.timestamp || new Date().toISOString(),
                         indexed: false,
                         content: toolContent,
@@ -307,13 +331,14 @@ export async function extractChunksFromTask(taskId: string, taskPath: string): P
 
             const uiContent = truncateForIndexing(msg.text || '', `ui_message:${msg.author}`);
 
+            const seq = sequenceOrder++;
             chunks.push({
-                chunk_id: uuidv4(),
+                chunk_id: computeChunkId(taskId, 'ui_message', seq, uiContent),
                 task_id: taskId,
                 parent_task_id: parentTaskId || null,
                 root_task_id: null,
                 chunk_type: 'message_exchange',
-                sequence_order: sequenceOrder++,
+                sequence_order: seq,
                 timestamp: msg.timestamp || new Date().toISOString(),
                 indexed: true,
                 content: uiContent,
@@ -355,8 +380,8 @@ export function splitChunk(chunk: Chunk, maxSize: number): Chunk[] {
         const contentPart = content.substring(0, maxSize);
         content = content.substring(maxSize);
 
-        // 🚨 FIX CRITIQUE: Qdrant exige des UUIDs valides pour les IDs
-        // On utilise uuidv5 pour générer un UUID déterministe à partir de l'ID composite
+        // #2018: chunk.chunk_id is now deterministic upstream (computeChunkId),
+        // so the split parts inherit determinism: same input → same UUIDs.
         const compositeId = `${chunk.chunk_id}_part_${chunkIndex}`;
         const deterministicUuid = uuidv5(compositeId, UUID_NAMESPACE);
 
@@ -473,13 +498,14 @@ export async function extractChunksFromClaudeSession(
                         const ccLower = contentText.toLowerCase();
                         const ccHasError = ccLower.includes('error') || ccLower.includes('failed') || ccLower.includes('❌');
 
+                        const seq = sequenceOrder++;
                         chunks.push({
-                            chunk_id: uuidv4(),
+                            chunk_id: computeChunkId(taskId, 'claude_message', seq, contentText),
                             task_id: taskId,
                             parent_task_id: null,
                             root_task_id: null,
                             chunk_type: 'message_exchange',
-                            sequence_order: sequenceOrder++,
+                            sequence_order: seq,
                             timestamp: entry.timestamp || new Date().toISOString(),
                             indexed: true,
                             content: contentText,

--- a/servers/roo-state-manager/src/services/task-indexer/__tests__/ChunkExtractor.test.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/__tests__/ChunkExtractor.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { splitChunk, getHostIdentifier, Chunk } from '../ChunkExtractor.js';
+import { splitChunk, getHostIdentifier, computeChunkId, Chunk } from '../ChunkExtractor.js';
 
 // Reset uuid mock and use real implementation
 vi.mock('uuid', () => vi.importActual('uuid'));
@@ -247,4 +247,83 @@ describe('ChunkExtractor', () => {
   // which is not compatible with vitest's vi.spyOn for ESM modules.
   // These tests should be implemented in a separate test file with proper vi.mock setup.
   // See: https://vitest.dev/guide/browser/#limitations
+
+  describe('computeChunkId (#2018)', () => {
+    const uuidV5Pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+    it('returns a valid UUID v5', () => {
+      const id = computeChunkId('task-1', 'message_exchange', 0, 'hello');
+      expect(id).toMatch(uuidV5Pattern);
+    });
+
+    it('is deterministic — same input produces same UUID', () => {
+      const id1 = computeChunkId('task-abc', 'message_exchange', 5, 'content here');
+      const id2 = computeChunkId('task-abc', 'message_exchange', 5, 'content here');
+      expect(id1).toBe(id2);
+    });
+
+    it('different sequence_order produces different UUIDs', () => {
+      const id0 = computeChunkId('task-1', 'message_exchange', 0, 'same content');
+      const id1 = computeChunkId('task-1', 'message_exchange', 1, 'same content');
+      expect(id0).not.toBe(id1);
+    });
+
+    it('different content produces different UUIDs', () => {
+      const idA = computeChunkId('task-1', 'message_exchange', 0, 'content A');
+      const idB = computeChunkId('task-1', 'message_exchange', 0, 'content B');
+      expect(idA).not.toBe(idB);
+    });
+
+    it('different chunk_type produces different UUIDs', () => {
+      const idMsg = computeChunkId('task-1', 'message_exchange', 0, 'shared');
+      const idTool = computeChunkId('task-1', 'tool_interaction', 0, 'shared');
+      expect(idMsg).not.toBe(idTool);
+    });
+
+    it('different task_id produces different UUIDs', () => {
+      const idA = computeChunkId('task-A', 'message_exchange', 0, 'shared');
+      const idB = computeChunkId('task-B', 'message_exchange', 0, 'shared');
+      expect(idA).not.toBe(idB);
+    });
+
+    it('handles empty content', () => {
+      const id = computeChunkId('task-1', 'message_exchange', 0, '');
+      expect(id).toMatch(uuidV5Pattern);
+    });
+
+    it('handles unicode content deterministically', () => {
+      const text = 'Héllo Wörld 日本語 🎉';
+      const id1 = computeChunkId('task-1', 'message_exchange', 0, text);
+      const id2 = computeChunkId('task-1', 'message_exchange', 0, text);
+      expect(id1).toBe(id2);
+    });
+
+    it('splitChunk produces deterministic UUIDs given a deterministic input chunk_id', () => {
+      const taskId = 'task-deterministic';
+      const content = 'x'.repeat(250);
+      const inputId = computeChunkId(taskId, 'message_exchange', 0, content);
+
+      const chunkA: Chunk = {
+        chunk_id: inputId,
+        task_id: taskId,
+        parent_task_id: null,
+        root_task_id: null,
+        chunk_type: 'message_exchange',
+        sequence_order: 0,
+        timestamp: '2024-01-01T00:00:00Z',
+        indexed: true,
+        content,
+      };
+      const chunkB: Chunk = { ...chunkA };
+
+      const partsA = splitChunk(chunkA, 100);
+      const partsB = splitChunk(chunkB, 100);
+
+      expect(partsA).toHaveLength(3);
+      expect(partsB).toHaveLength(3);
+      partsA.forEach((part, i) => {
+        expect(part.chunk_id).toBe(partsB[i].chunk_id);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Context

Issue #2018 (jsboige/roo-extensions) reports that the Qdrant collections currently hold ~60M points with up to **1166× intra-task duplication**. Diagnosis: `ChunkExtractor` generates `chunk_id` via `uuidv4()` (random) at 4 sites, so re-indexation of the same logical chunk produces a fresh UUID and Qdrant inserts a new point instead of upserting the old one.

## Fix

Replace the 4 uses of `uuidv4()` with a new `computeChunkId(taskId, chunkType, sequenceOrder, content)` helper that returns a deterministic UUID v5:

```
seed = `${task_id}|${chunk_type}|seq:${sequence_order}|${sha256(content)[:16]}`
chunk_id = uuidv5(seed, UUID_NAMESPACE)
```

Same logical chunk → same UUID across re-runs. Qdrant upsert is now idempotent.

### Sites changed in `ChunkExtractor.ts`

| Old line | Site | New chunk_type seed |
|----------|------|---------------------|
| 211 | Roo `message_exchange` | `message_exchange` |
| 252 | Roo `tool_interaction` | `tool_interaction` |
| 311 | Roo `ui_messages.json` | `ui_message` |
| 477 | Claude Code JSONL | `claude_message` |

`splitChunk` at line 360 was already `uuidv5` but seeded from a random `chunk_id` upstream — its "deterministic" comment was misleading. Now truly deterministic via the upstream fix; comment updated.

## Tests

9 new tests in `__tests__/ChunkExtractor.test.ts` (`describe('computeChunkId (#2018)')`):

- ✅ Returns valid UUID v5
- ✅ Same input → same UUID (determinism)
- ✅ Different sequence_order → different UUID
- ✅ Different content → different UUID
- ✅ Different chunk_type → different UUID
- ✅ Different task_id → different UUID
- ✅ Empty content handled
- ✅ Unicode content deterministic
- ✅ `splitChunk` parts deterministic given deterministic input

Local validation:
- `npm run build` ✅
- `npx vitest run --config vitest.config.ci.ts src/services/task-indexer/__tests__/ChunkExtractor.test.ts` → 29/29 ✅
- Full CI suite: 9212 passed / 16 skipped / 0 failed (98.9s)

## Trade-offs (per #2018 acceptance criteria)

- **Storage spike during transition**: First re-indexation will write deterministic IDs while old random-ID points remain. Cleanup happens via Phase 1bis migration script (separate PR per #2018 plan) or natural decay. Acceptable since Phase A just freed 300 GB.
- **Content edits create new chunks**: If content changes mid-task, the hash changes → new UUID → new point. Old point not auto-deleted. Same trade-off as before, but at least same-content re-indexations now dedupe.
- **No payload-only chunkSignature dedup**: Qdrant doesn't dedupe by payload, only by `id`. UUID-based fix is the only correct path.

## Next steps (out of this PR)

1. Bundle pointer-bump in `roo-extensions` parent (after this submod merges).
2. Phase 1bis migration script — re-index existing collections to migrate from random to deterministic IDs (separate PR per #2018).

## Issue

Closes part of jsboige/roo-extensions#2018 (Phase 1 — MCP fix). Phase 1bis (migration script) and Phase 2 (12-MCP race condition on `dedupByContentHash`) tracked separately.