### PR TITLE
feat(#2017): resilient ROOSYNC_SHARED_PATH with retry/backoff

### DIFF
--- a/servers/roo-state-manager/src/services/RooSyncService.ts
+++ b/servers/roo-state-manager/src/services/RooSyncService.ts
@@ -63,9 +63,16 @@ export { RooSyncServiceError };
 
 /**
  * Service Singleton pour gérer RooSync
+ *
+ * #2017 FIX: Resilient shared path — getInstance() retries initialization
+ * when ROOSYNC_SHARED_PATH is unavailable (GDrive not mounted at boot).
+ * Retries every call with a 30s backoff. No cached absence.
  */
 export class RooSyncService {
   private static instance: RooSyncService | null = null;
+  private static _initError: Error | null = null;
+  private static _lastInitAttempt: number = 0;
+  private static readonly INIT_RETRY_INTERVAL_MS = 30_000; // 30s backoff
 
   private config: RooSyncConfig;
   private cache: Map<string, CacheEntry<any>>;
@@ -376,23 +383,54 @@ export class RooSyncService {
   /**
    * Obtenir l'instance du service (Singleton)
    *
+   * #2017 FIX: Retries initialization when shared path was unavailable.
+   * If the previous attempt failed, checks if the path is now accessible
+   * and retries automatically. Returns user-friendly errors during backoff.
+   *
    * @param cacheOptions Options de cache (utilisées seulement à la première création)
    * @param config Configuration optionnelle (pour injection de dépendance/tests)
    * @returns Instance du service
    */
   public static getInstance(cacheOptions?: CacheOptions, config?: RooSyncConfig): RooSyncService {
-    console.log('[DEBUG] getInstance() appelé, instance existe:', !!RooSyncService.instance);
-    if (!RooSyncService.instance) {
-      console.log('[DEBUG] Création nouvelle instance RooSyncService...');
-      try {
-        RooSyncService.instance = new RooSyncService(cacheOptions, config);
-        console.log('[DEBUG] Instance RooSyncService créée avec succès. Config sharedPath:', RooSyncService.instance.config.sharedPath);
-      } catch (error) {
-        console.error('[DEBUG] Erreur lors création instance RooSyncService:', error);
-        throw error;
-      }
+    if (RooSyncService.instance) {
+      return RooSyncService.instance;
     }
-    return RooSyncService.instance;
+
+    const now = Date.now();
+
+    // If a previous init failed, check backoff before retrying
+    if (RooSyncService._initError && RooSyncService._lastInitAttempt) {
+      const elapsed = now - RooSyncService._lastInitAttempt;
+      if (elapsed < RooSyncService.INIT_RETRY_INTERVAL_MS) {
+        const retryInSec = Math.ceil((RooSyncService.INIT_RETRY_INTERVAL_MS - elapsed) / 1000);
+        throw new RooSyncServiceError(
+          `RooSync non disponible: ${RooSyncService._initError.message}. ` +
+          `Le chemin partagé n'est pas accessible — réessai automatique dans ${retryInSec}s.`,
+          'ROOSYNC_PATH_UNAVAILABLE'
+        );
+      }
+      // Backoff elapsed — retry initialization
+      console.log(`[RooSyncService] Retrying initialization after ${Math.round(elapsed / 1000)}s (previous error: ${RooSyncService._initError.message})`);
+    }
+
+    // Attempt to create instance
+    try {
+      RooSyncService.instance = new RooSyncService(cacheOptions, config);
+      RooSyncService._initError = null;
+      RooSyncService._lastInitAttempt = 0;
+      console.log('[RooSyncService] Instance created successfully. sharedPath:', RooSyncService.instance.config.sharedPath);
+      return RooSyncService.instance;
+    } catch (error) {
+      RooSyncService.instance = null;
+      RooSyncService._initError = error as Error;
+      RooSyncService._lastInitAttempt = now;
+      const msg = error instanceof Error ? error.message : String(error);
+      throw new RooSyncServiceError(
+        `RooSync non disponible: ${msg}. ` +
+        `GDrive non monté ou chemin partagé inaccessible — réessai automatique dans 30s.`,
+        'ROOSYNC_PATH_UNAVAILABLE'
+      );
+    }
   }
 
   /**
@@ -400,6 +438,23 @@ export class RooSyncService {
    */
   public static resetInstance(): void {
     RooSyncService.instance = null;
+    RooSyncService._initError = null;
+    RooSyncService._lastInitAttempt = 0;
+  }
+
+  /**
+   * Vérifier si le service est en état dégradé (path indisponible)
+   * #2017: Permet aux outils de vérifier l'état sans déclencher un retry.
+   */
+  public static isDegraded(): boolean {
+    return RooSyncService.instance === null && RooSyncService._initError !== null;
+  }
+
+  /**
+   * Obtenir la dernière erreur d'initialisation (pour diagnostics)
+   */
+  public static getInitError(): Error | null {
+    return RooSyncService._initError;
   }
 
   /**

--- a/servers/roo-state-manager/src/services/__tests__/shared-path-resilience.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/shared-path-resilience.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for #2017: ROOSYNC_SHARED_PATH resilience
+ *
+ * Tests the static retry/recovery logic on RooSyncService by directly
+ * manipulating the internal state, without constructing real service instances.
+ *
+ * @module services/__tests__/shared-path-resilience.test
+ */
+
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+// Bypass the broad mock from jest.setup.js — we need the REAL class with new static methods
+vi.unmock('../RooSyncService.js');
+vi.unmock('../../src/services/RooSyncService.js');
+
+import { RooSyncService } from '../RooSyncService.js';
+
+beforeEach(() => {
+  // Reset static state between tests
+  RooSyncService.resetInstance();
+});
+
+describe('#2017 Shared Path Resilience', () => {
+
+  describe('Static state management', () => {
+    test('isDegraded() returns false after resetInstance()', () => {
+      expect(RooSyncService.isDegraded()).toBe(false);
+    });
+
+    test('getInitError() returns null after resetInstance()', () => {
+      expect(RooSyncService.getInitError()).toBeNull();
+    });
+
+    test('isDegraded() returns true when instance is null and _initError is set', () => {
+      // Directly set the internal state to simulate a failed init
+      (RooSyncService as any).instance = null;
+      (RooSyncService as any)._initError = new Error('Shared path not found');
+      (RooSyncService as any)._lastInitAttempt = Date.now();
+
+      expect(RooSyncService.isDegraded()).toBe(true);
+    });
+
+    test('getInitError() returns the cached error', () => {
+      const error = new Error('ROOSYNC_SHARED_PATH n\'existe pas');
+      (RooSyncService as any)._initError = error;
+
+      expect(RooSyncService.getInitError()).toBe(error);
+    });
+
+    test('resetInstance() clears all degraded state', () => {
+      (RooSyncService as any)._initError = new Error('test');
+      (RooSyncService as any)._lastInitAttempt = Date.now();
+      (RooSyncService as any).instance = null;
+
+      RooSyncService.resetInstance();
+
+      expect(RooSyncService.isDegraded()).toBe(false);
+      expect(RooSyncService.getInitError()).toBeNull();
+      expect((RooSyncService as any)._lastInitAttempt).toBe(0);
+      expect((RooSyncService as any).instance).toBeNull();
+    });
+  });
+
+  describe('getInstance() retry logic', () => {
+    test('getInstance() with degraded state and recent _lastInitAttempt throws backoff error', () => {
+      // Simulate a recent failed init (5 seconds ago)
+      (RooSyncService as any).instance = null;
+      (RooSyncService as any)._initError = new Error('Shared path absent');
+      (RooSyncService as any)._lastInitAttempt = Date.now() - 5_000;
+
+      // Should throw with backoff message (not retry yet)
+      try {
+        RooSyncService.getInstance();
+        expect.unreachable('Should have thrown');
+      } catch (e: any) {
+        expect(e.message).toContain('réessai automatique dans');
+        // Verify it didn't retry — _lastInitAttempt should still be ~5s ago
+        const savedAttempt = (RooSyncService as any)._lastInitAttempt;
+        expect(savedAttempt).toBeGreaterThan(Date.now() - 6_000);
+        expect(savedAttempt).toBeLessThan(Date.now() - 4_000);
+      }
+    });
+
+    test('getInstance() with degraded state and expired backoff attempts reinit', () => {
+      // Simulate a failed init 31 seconds ago (past the 30s backoff)
+      (RooSyncService as any).instance = null;
+      (RooSyncService as any)._initError = new Error('Shared path absent');
+      (RooSyncService as any)._lastInitAttempt = Date.now() - 31_000;
+
+      // Will attempt to construct (which will fail because no real config),
+      // then update the _lastInitAttempt timestamp
+      try {
+        RooSyncService.getInstance();
+      } catch (e: any) {
+        // The retry happened — _lastInitAttempt should be updated
+        expect((RooSyncService as any)._lastInitAttempt).toBeGreaterThan(Date.now() - 5_000);
+      }
+    });
+  });
+
+  describe('INIT_RETRY_INTERVAL_MS constant', () => {
+    test('backoff interval is 30 seconds', () => {
+      expect((RooSyncService as any).INIT_RETRY_INTERVAL_MS).toBe(30_000);
+    });
+  });
+});

--- a/servers/roo-state-manager/src/services/lazy-roosync.ts
+++ b/servers/roo-state-manager/src/services/lazy-roosync.ts
@@ -51,6 +51,8 @@ export async function getRooSyncService() {
 export interface LazyRooSyncServiceStatic {
     resetInstance(): Promise<void>;
     getInstance(options?: { enabled?: boolean }): Promise<import('./RooSyncService.js').RooSyncService>;
+    isDegraded(): Promise<boolean>;
+    getInitError(): Promise<Error | null>;
 }
 
 export const RooSyncService: LazyRooSyncServiceStatic = {
@@ -61,5 +63,13 @@ export const RooSyncService: LazyRooSyncServiceStatic = {
     async getInstance(options?: { enabled?: boolean }) {
         const mod = await _ensureLoaded();
         return mod.RooSyncService.getInstance(options);
+    },
+    async isDegraded(): Promise<boolean> {
+        const mod = await _ensureLoaded();
+        return mod.RooSyncService.isDegraded();
+    },
+    async getInitError(): Promise<Error | null> {
+        const mod = await _ensureLoaded();
+        return mod.RooSyncService.getInitError();
     },
 };


### PR DESCRIPTION
## Summary

Fixes #2017 — RooSyncService singleton permanently fails when `ROOSYNC_SHARED_PATH` is unavailable at MCP boot (GDrive not mounted yet).

### Problem
`getInstance()` called `new RooSyncService()` once. If it threw (path missing), `instance` stayed `null` forever. Every subsequent tool call re-threw the original error with no retry, no recovery.

### Solution
`getInstance()` now implements automatic retry with 30s backoff:
- **First failure**: caches the error + timestamp, throws user-friendly message with `ROOSYNC_PATH_UNAVAILABLE` code
- **Within 30s**: throws backoff message with countdown ("réessai automatique dans Xs")
- **After 30s**: retries initialization automatically
- **On success**: clears degraded state, returns the singleton

### New APIs
- `RooSyncService.isDegraded()` — check if in degraded state (doesn't trigger retry)
- `RooSyncService.getInitError()` — retrieve last init error for diagnostics
- Both exposed through `lazy-roosync.ts` facade (async versions)

### Files changed
- `src/services/RooSyncService.ts` — retry/backoff logic in `getInstance()`, new static methods
- `src/services/lazy-roosync.ts` — async facade for new methods
- `src/services/__tests__/shared-path-resilience.test.ts` — 8 tests (static state, backoff, retry)

### Test plan
- [x] `npm run build` passes
- [x] `npx vitest run --config vitest.config.ci.ts` passes (9194/9194 + 8 new = all green)
- [x] Tests cover: resetInstance, isDegraded, getInitError, backoff within interval, retry after interval, constant verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)