### PR TITLE
fix(#1410): auto-cleanup stale worktree dashboards

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/compare-config.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/compare-config.test.ts
@@ -355,6 +355,64 @@ describe('compare-config', () => {
 			expect(mockCompareRealConfigurations).toHaveBeenCalledWith('ai-01', 'po-2023', false);
 		});
 
+		// #1410: Deduplicate baseline-induced false positives
+		test('deduplicates identical diffs from baseline comparison', async () => {
+			mockLoadDashboard.mockResolvedValue({
+				machines: {
+					'ai-01': { status: 'online' },
+					'po-2023': { status: 'online' }
+				}
+			});
+			// Simulates compareRealConfigurations output where both machines
+			// deviate from baseline identically (e.g. both have "Unknown" GPU)
+			mockCompareRealConfigurations.mockResolvedValue({
+				sourceMachine: 'ai-01',
+				targetMachine: 'po-2023',
+				hostId: 'ai-01',
+				differences: [
+					{
+						category: 'hardware',
+						severity: 'INFO',
+						path: 'hardware.gpu',
+						description: 'GPU diff : Unknown vs None',
+						recommendedAction: 'Check GPU config',
+						machineId: 'ai-01'
+					},
+					{
+						category: 'hardware',
+						severity: 'INFO',
+						path: 'hardware.gpu',
+						description: 'GPU diff : Unknown vs None',
+						recommendedAction: 'Check GPU config',
+						machineId: 'po-2023'
+					},
+					{
+						category: 'software',
+						severity: 'INFO',
+						path: 'software.node',
+						description: 'Node diff : Unknown vs N/A',
+						recommendedAction: 'Update Node',
+						machineId: 'ai-01'
+					},
+					{
+						category: 'software',
+						severity: 'INFO',
+						path: 'software.node',
+						description: 'Node diff : Unknown vs N/A',
+						recommendedAction: 'Update Node',
+						machineId: 'po-2023'
+					}
+				]
+			});
+
+			const result = await roosyncCompareConfig({ target: 'po-2023' });
+
+			// 4 raw diffs -> 2 deduplicated (plus possible env diffs)
+			const nonEnvDiffs = result.differences.filter(d => d.category !== 'environment');
+			expect(nonEnvDiffs.length).toBe(2);
+			expect(nonEnvDiffs.map(d => d.path).sort()).toEqual(['hardware.gpu', 'software.node']);
+		});
+
 		// ============================================================
 		// Settings granularity tests (#498/#547)
 		// ============================================================

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
@@ -1988,4 +1988,73 @@ describe('roosync_dashboard', () => {
       expect(replyMsg?.acknowledged_at?.['test-machine']).toBeDefined();
     });
   });
+
+  // #1410 item 4: Worktree dashboard cleanup
+  describe('worktree dashboard cleanup', () => {
+    it('archives stale worktree dashboards (>7 days, <100 chars status)', async () => {
+      // Create a stale worktree dashboard
+      await roosyncDashboard({
+        action: 'write', type: 'workspace',
+        content: 'short status',
+        workspace: 'wt-worker-test-cleanup'
+      });
+
+      // Backdate the file to be >7 days old
+      const dashboardsDir = path.join(tmpDir, 'dashboards');
+      const wtFile = path.join(dashboardsDir, 'workspace-wt-worker-test-cleanup.md');
+      const oldDate = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+      const content = await import('fs/promises').then(f => f.readFile(wtFile, 'utf8'));
+      const updated = content.replace(/lastModified: .+/, `lastModified: ${oldDate}`);
+      await import('fs/promises').then(f => f.writeFile(wtFile, updated, 'utf8'));
+
+      // List triggers cleanup
+      const result = await roosyncDashboard({ action: 'list' });
+      expect(result.success).toBe(true);
+
+      // The stale worktree dashboard should be gone from the list
+      const keys = result.dashboards?.map((d: any) => d.key) ?? [];
+      expect(keys).not.toContain('workspace-wt-worker-test-cleanup');
+
+      // But it should be in the archive
+      const archiveDir = path.join(dashboardsDir, 'archive');
+      const { readdirSync } = await import('fs');
+      const archives = readdirSync(archiveDir);
+      const wtArchive = archives.find(f => f.includes('wt-worker-test-cleanup'));
+      expect(wtArchive).toBeDefined();
+    });
+
+    it('preserves recent worktree dashboards (<7 days)', async () => {
+      // Create a recent worktree dashboard
+      await roosyncDashboard({
+        action: 'write', type: 'workspace',
+        content: 'short status',
+        workspace: 'wt-worker-recent'
+      });
+
+      const result = await roosyncDashboard({ action: 'list' });
+      const keys = result.dashboards?.map((d: any) => d.key) ?? [];
+      expect(keys).toContain('workspace-wt-worker-recent');
+    });
+
+    it('preserves worktree dashboards with substantial status (>100 chars)', async () => {
+      const longStatus = 'x'.repeat(200);
+      await roosyncDashboard({
+        action: 'write', type: 'workspace',
+        content: longStatus,
+        workspace: 'wt-worker-substantial'
+      });
+
+      // Backdate
+      const dashboardsDir = path.join(tmpDir, 'dashboards');
+      const wtFile = path.join(dashboardsDir, 'workspace-wt-worker-substantial.md');
+      const oldDate = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+      const content = await import('fs/promises').then(f => f.readFile(wtFile, 'utf8'));
+      const updated = content.replace(/lastModified: .+/, `lastModified: ${oldDate}`);
+      await import('fs/promises').then(f => f.writeFile(wtFile, updated, 'utf8'));
+
+      const result = await roosyncDashboard({ action: 'list' });
+      const keys = result.dashboards?.map((d: any) => d.key) ?? [];
+      expect(keys).toContain('workspace-wt-worker-substantial');
+    });
+  });
 });

--- a/servers/roo-state-manager/src/tools/roosync/compare-config.ts
+++ b/servers/roo-state-manager/src/tools/roosync/compare-config.ts
@@ -608,7 +608,7 @@ function formatComparisonReport(report: any, granularity: string = 'full'): Comp
   // Vérifier les variables d'environnement critiques manquantes (#495)
   const envDiffs = checkMissingEnvVars();
 
-  const allDifferences = [
+  const rawDifferences = [
     ...report.differences.map((diff: any) => ({
       category: diff.category,
       severity: diff.severity,
@@ -618,6 +618,17 @@ function formatComparisonReport(report: any, granularity: string = 'full'): Comp
     })),
     ...envDiffs
   ];
+
+  // #1410: Deduplicate — compareRealConfigurations compares each machine vs baseline,
+  // then combines. Same diff on both machines produces duplicates.
+  // Dedup key = (category, path, description).
+  const seen = new Set<string>();
+  const allDifferences = rawDifferences.filter(diff => {
+    const dedupKey = `${diff.category}|${diff.path}|${diff.description}`;
+    if (seen.has(dedupKey)) return false;
+    seen.add(dedupKey);
+    return true;
+  });
 
   // Recalculer le summary avec les env vars
   const summary = {

--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -2480,6 +2480,9 @@ async function handleReadOverview(
 }
 
 async function handleList(requestEcho: DashboardRequestEcho): Promise<DashboardResult> {
+  // #1410 item 4: auto-cleanup stale worktree dashboards before listing
+  const cleanedUp = await cleanupStaleWorktreeDashboards();
+
   const dir = getDashboardsDir();
   try {
     await fs.mkdir(dir, { recursive: true });
@@ -2511,6 +2514,7 @@ async function handleList(requestEcho: DashboardRequestEcho): Promise<DashboardR
     }
 
     summaries.sort((a, b) => b.lastModified.localeCompare(a.lastModified));
+    const cleanupNote = cleanedUp > 0 ? ` (${cleanedUp} worktree(s) expiré(s) archivé(s))` : '';
     return {
       success: true,
       action: 'list',
@@ -2518,7 +2522,7 @@ async function handleList(requestEcho: DashboardRequestEcho): Promise<DashboardR
       type: '',
       request: requestEcho,
       dashboards: summaries,
-      message: `${summaries.length} dashboard(s) trouvé(s)`
+      message: `${summaries.length} dashboard(s) trouvé(s)${cleanupNote}`
     };
   } catch (error) {
     return {
@@ -2538,6 +2542,72 @@ async function handleList(requestEcho: DashboardRequestEcho): Promise<DashboardR
  * Protection against accidental mass-deletion by agents (incident 2026-04-05 #1128).
  */
 const DASHBOARD_PROTECTION_DAYS = 7;
+
+// #1410 item 4: Worktree dashboard cleanup thresholds
+const WORKTREE_DASHBOARD_PATTERN = /^workspace-wt-/;
+const WORKTREE_CLEANUP_MAX_STATUS_LENGTH = 100;
+
+/**
+ * #1410 item 4: Clean up stale worktree dashboards.
+ *
+ * When agents run in worktrees (.claude/worktrees/wt-*), the worktree detection
+ * (#1364) resolves the parent workspace. But before that fix, or if detection fails,
+ * orphan dashboard files like `workspace-wt-worker-*` accumulate. This function
+ * archives dashboards matching the worktree pattern that are both:
+ *   - Older than DASHBOARD_PROTECTION_DAYS (7 days)
+ *   - Have a status section shorter than WORKTREE_CLEANUP_MAX_STATUS_LENGTH chars
+ *
+ * Called during `list` action so stale entries don't pollute the dashboard list.
+ * Archives (not deletes) for safety.
+ */
+async function cleanupStaleWorktreeDashboards(): Promise<number> {
+  const dir = getDashboardsDir();
+  try {
+    const files = await fs.readdir(dir);
+    const wtFiles = files.filter(f =>
+      f.endsWith('.md') && WORKTREE_DASHBOARD_PATTERN.test(f.replace(/\.md$/, ''))
+    );
+
+    if (wtFiles.length === 0) return 0;
+
+    let archived = 0;
+    const now = Date.now();
+
+    for (const file of wtFiles) {
+      const key = file.replace(/\.md$/, '');
+      try {
+        const dashboard = await readDashboardFile(key);
+        if (!dashboard) continue;
+
+        const ageMs = now - new Date(dashboard.lastModified).getTime();
+        const ageDays = ageMs / (1000 * 60 * 60 * 24);
+        const sizes = buildSizes(dashboard);
+
+        if (ageDays >= DASHBOARD_PROTECTION_DAYS && sizes.statusLength < WORKTREE_CLEANUP_MAX_STATUS_LENGTH) {
+          const archiveDir = getArchiveDir();
+          await fs.mkdir(archiveDir, { recursive: true });
+          const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+          const archivePath = path.join(archiveDir, `${key}-wt-cleanup-${timestamp}.md`);
+          const originalPath = path.join(dir, file);
+          const content = await fs.readFile(originalPath, 'utf8');
+          await fs.writeFile(archivePath, content, 'utf8');
+          await fs.unlink(originalPath);
+          archived++;
+          logger.info('Archived stale worktree dashboard', {
+            key, ageDays: ageDays.toFixed(1), statusLength: sizes.statusLength
+          });
+        }
+      } catch (e) {
+        logger.warn('Failed to process worktree dashboard for cleanup', {
+          key, error: e instanceof Error ? e.message : String(e)
+        });
+      }
+    }
+    return archived;
+  } catch {
+    return 0;
+  }
+}
 
 async function handleDelete(key: string, args: DashboardArgs, requestEcho: DashboardRequestEcho): Promise<DashboardResult> {
   const filePath = getDashboardPath(key);


### PR DESCRIPTION
## Summary
- **Item 4**: Auto-cleanup stale worktree dashboards (>7 days, statusLength<100) on `list` action
- **Item 1**: Deduplicate `compare_config` false positives in non-granular comparison path

### Item 4: Worktree dashboard cleanup
- New `cleanupStaleWorktreeDashboards()` archives expired worktree dashboards
- Triggered automatically on `dashboard(list)` action
- Archives to `archive/` subdirectory (not deletes)
- Tests: stale archived, recent preserved, substantial-status preserved

### Item 1: compare_config dedup
- `compareRealConfigurations` compares each machine vs baseline then combines. Same diff on both machines produces duplicates.
- Added dedup in `formatComparisonReport` using `(category, path, description)` as key
- Before: 6 diffs (3 duplicated) → After: 3 unique diffs
- Test: verifies 4 raw diffs → 2 deduplicated

## Test plan
- [x] `npx vitest run src/tools/roosync/__tests__/dashboard.test.ts -t "worktree dashboard"` — 3 tests pass
- [x] `npx vitest run src/tools/roosync/__tests__/compare-config.test.ts -t "deduplicates"` — 1 test pass
- [x] Full CI suite: 9215 passed, 2 pre-existing failures (unrelated)

Closes items 1 and 4 of #1410