### PR TITLE
refactor(#2013): complete heartbeat terminology rename offline→unknown, warning→idle

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
@@ -101,7 +101,7 @@ describe('get-status (Option B)', () => {
     test('validates HEALTHY result', () => {
       const result = GetStatusResultSchema.parse({
         status: 'HEALTHY',
-        machines: { online: 6, offline: 0, total: 6 },
+        machines: { online: 6, unknown: 0, total: 6 },
         inbox: { unread: 0, urgent: 0 },
         decisions: { pending: 0 },
         dashboards: { active: 1 },
@@ -114,11 +114,11 @@ describe('get-status (Option B)', () => {
     test('validates CRITICAL result with flags', () => {
       const result = GetStatusResultSchema.parse({
         status: 'CRITICAL',
-        machines: { online: 4, offline: 2, total: 6 },
+        machines: { online: 4, unknown: 2, total: 6 },
         inbox: { unread: 15, urgent: 2 },
         decisions: { pending: 3 },
         dashboards: { active: 1 },
-        flags: ['OFFLINE:myia-po-2025', 'INBOX_URGENT:2', 'DECISIONS_PENDING:3'],
+        flags: ['UNKNOWN:myia-po-2025', 'INBOX_URGENT:2', 'DECISIONS_PENDING:3'],
         lastUpdated: '2026-04-08T00:00:00Z'
       });
       expect(result.status).toBe('CRITICAL');
@@ -128,7 +128,7 @@ describe('get-status (Option B)', () => {
     test('rejects old status values', () => {
       expect(() => GetStatusResultSchema.parse({
         status: 'synced',
-        machines: { online: 6, offline: 0, total: 6 },
+        machines: { online: 6, unknown: 0, total: 6 },
         inbox: { unread: 0, urgent: 0 },
         decisions: { pending: 0 },
         dashboards: { active: 1 },
@@ -155,7 +155,7 @@ describe('get-status (Option B)', () => {
       expect(result.flags).toHaveLength(0);
     });
 
-    test('returns CRITICAL when machines offline', async () => {
+    test('returns CRITICAL when machines unknown', async () => {
       mockGetHeartbeatService.mockReturnValue({
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
@@ -168,8 +168,8 @@ describe('get-status (Option B)', () => {
       const result = await roosyncGetStatus({});
 
       expect(result.status).toBe('CRITICAL');
-      expect(result.machines.offline).toBe(1);
-      expect(result.flags).toContain('OFFLINE:myia-po-2025');
+      expect(result.machines.unknown).toBe(1);
+      expect(result.flags).toContain('UNKNOWN:myia-po-2025');
     });
 
     test('returns CRITICAL when urgent messages', async () => {
@@ -264,8 +264,8 @@ describe('get-status (Option B)', () => {
   });
 
   describe('#1365 orphan test entry filtering', () => {
-    test('excludes orphan test machines from offline count', async () => {
-      // Simulates real scenario: 6 real machines online + 3 test artifacts offline
+    test('excludes orphan test machines from unknown count', async () => {
+      // Simulates real scenario: 6 real machines online + 3 test artifacts unknown
       mockGetHeartbeatService.mockReturnValue({
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
@@ -279,9 +279,9 @@ describe('get-status (Option B)', () => {
 
       // Orphan test machines should NOT trigger CRITICAL
       expect(result.status).toBe('HEALTHY');
-      expect(result.machines.offline).toBe(0);
-      expect(result.flags).not.toContain('OFFLINE:test-machine');
-      expect(result.flags).not.toContain('OFFLINE:persistent-machine');
+      expect(result.machines.unknown).toBe(0);
+      expect(result.flags).not.toContain('UNKNOWN:test-machine');
+      expect(result.flags).not.toContain('UNKNOWN:persistent-machine');
     });
 
     test('excludes orphan test machines from dashboard total', async () => {
@@ -291,7 +291,7 @@ describe('get-status (Option B)', () => {
         machines: {
           'myia-ai-01': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 },
           'myia-po-2023': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 },
-          'test-machine': { status: 'offline', lastSync: '2025-01-01', pendingDecisions: 0, diffsCount: 0 }
+          'test-machine': { status: 'unknown', lastSync: '2025-01-01', pendingDecisions: 0, diffsCount: 0 }
         }
       });
 
@@ -301,7 +301,7 @@ describe('get-status (Option B)', () => {
       expect(result.machines.total).toBe(2);
     });
 
-    test('excludes orphan warning machines from status derivation', async () => {
+    test('excludes orphan idle machines from status derivation', async () => {
       mockGetHeartbeatService.mockReturnValue({
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
@@ -313,12 +313,12 @@ describe('get-status (Option B)', () => {
 
       const result = await roosyncGetStatus({});
 
-      // test-machine warning should NOT trigger WARNING status
+      // test-machine idle should NOT trigger WARNING status
       expect(result.status).toBe('HEALTHY');
       expect(result.flags).not.toContain('HEARTBEAT_STALE:test-machine');
     });
 
-    test('still detects real offline machines correctly', async () => {
+    test('still detects real unknown machines correctly', async () => {
       mockGetHeartbeatService.mockReturnValue({
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
@@ -330,11 +330,11 @@ describe('get-status (Option B)', () => {
 
       const result = await roosyncGetStatus({});
 
-      // Should be CRITICAL from real offline machine only
+      // Should be CRITICAL from real unknown machine only
       expect(result.status).toBe('CRITICAL');
-      expect(result.machines.offline).toBe(1);  // Only myia-po-2025
-      expect(result.flags).toContain('OFFLINE:myia-po-2025');
-      expect(result.flags).not.toContain('OFFLINE:test-machine');
+      expect(result.machines.unknown).toBe(1);  // Only myia-po-2025
+      expect(result.flags).toContain('UNKNOWN:myia-po-2025');
+      expect(result.flags).not.toContain('UNKNOWN:test-machine');
     });
   });
 });

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/machines.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/machines.test.ts
@@ -2,8 +2,8 @@
  * Tests unitaires pour roosync_machines
  *
  * Couvre tous les status de l'outil consolidé :
- * - status: 'offline' : Machines offline
- * - status: 'warning' : Machines en avertissement
+ * - status: 'unknown' : Machines unknown
+ * - status: 'idle' : Machines idle
  * - status: 'all' : Les deux
  *
  * Framework: Vitest
@@ -110,13 +110,13 @@ describe('machinesTool', () => {
   });
 
   // ============================================================
-  // Tests pour status: 'offline'
+  // Tests pour status: 'unknown'
   // ============================================================
 
-  describe('status: offline', () => {
-    test('should return offline machines', async () => {
+  describe('status: unknown', () => {
+    test('should return unknown machines', async () => {
       const result = await machinesTool.execute(
-        { status: 'offline' },
+        { status: 'unknown' },
         mockExecutionContext
       );
 
@@ -126,9 +126,9 @@ describe('machinesTool', () => {
       expect(result.data.idleMachines).toBeUndefined();
     });
 
-    test('should return offline machines with details', async () => {
+    test('should return unknown machines with details', async () => {
       const result = await machinesTool.execute(
-        { status: 'offline', includeDetails: true },
+        { status: 'unknown', includeDetails: true },
         mockExecutionContext
       );
 
@@ -143,7 +143,7 @@ describe('machinesTool', () => {
       });
 
       const result = await machinesTool.execute(
-        { status: 'offline' },
+        { status: 'unknown' },
         mockExecutionContext
       );
 
@@ -154,13 +154,13 @@ describe('machinesTool', () => {
   });
 
   // ============================================================
-  // Tests pour status: 'warning'
+  // Tests pour status: 'idle'
   // ============================================================
 
-  describe('status: warning', () => {
-    test('should return warning machines', async () => {
+  describe('status: idle', () => {
+    test('should return idle machines', async () => {
       const result = await machinesTool.execute(
-        { status: 'warning' },
+        { status: 'idle' },
         mockExecutionContext
       );
 
@@ -170,9 +170,9 @@ describe('machinesTool', () => {
       expect(result.data.unknownMachines).toBeUndefined();
     });
 
-    test('should return warning machines with details', async () => {
+    test('should return idle machines with details', async () => {
       const result = await machinesTool.execute(
-        { status: 'warning', includeDetails: true },
+        { status: 'idle', includeDetails: true },
         mockExecutionContext
       );
 
@@ -186,7 +186,7 @@ describe('machinesTool', () => {
   // ============================================================
 
   describe('status: all', () => {
-    test('should return both offline and warning machines', async () => {
+    test('should return both unknown and idle machines', async () => {
       const result = await machinesTool.execute(
         { status: 'all' },
         mockExecutionContext
@@ -217,7 +217,7 @@ describe('machinesTool', () => {
       expect(machinesToolMetadata.name).toBe('roosync_machines');
       expect(machinesToolMetadata.description).toContain('machines');
       expect(machinesToolMetadata.inputSchema.properties.status).toBeDefined();
-      expect(machinesToolMetadata.inputSchema.properties.status.enum).toEqual(['offline', 'warning', 'all']);
+      expect(machinesToolMetadata.inputSchema.properties.status.enum).toEqual(['unknown', 'idle', 'all']);
     });
 
     test('should require status parameter', () => {
@@ -231,8 +231,8 @@ describe('machinesTool', () => {
 
   describe('integration', () => {
     test('should handle multiple calls with different status', async () => {
-      const r1 = await machinesTool.execute({ status: 'offline' }, mockExecutionContext);
-      const r2 = await machinesTool.execute({ status: 'warning' }, mockExecutionContext);
+      const r1 = await machinesTool.execute({ status: 'unknown' }, mockExecutionContext);
+      const r2 = await machinesTool.execute({ status: 'idle' }, mockExecutionContext);
       const r3 = await machinesTool.execute({ status: 'all' }, mockExecutionContext);
 
       expect(r1.success).toBe(true);
@@ -242,7 +242,7 @@ describe('machinesTool', () => {
 
     test('should return execution time metrics', async () => {
       const result = await machinesTool.execute(
-        { status: 'offline' },
+        { status: 'unknown' },
         mockExecutionContext
       );
 

--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -56,7 +56,7 @@ export const GetStatusResultSchema = z.object({
 
   machines: z.object({
     online: z.number(),
-    offline: z.number(),
+    unknown: z.number(),
     total: z.number()
   }).describe('Compteurs machines par état'),
 
@@ -139,7 +139,7 @@ function buildFlags(
 
   // Unknown machines (ADR 008: was "offline")
   for (const machineId of heartbeatState.unknownMachines) {
-    flags.push(`OFFLINE:${machineId}`);
+    flags.push(`UNKNOWN:${machineId}`);
   }
 
   // Idle machines (ADR 008: was "warning"/heartbeat stale)
@@ -373,7 +373,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
     if (filteredUnknownMachines.length > 0 || inboxStats.urgent > 0) {
       status = 'CRITICAL';
     } else if (inboxStats.unread > 5 || filteredIdleMachines.length > 0) {
-      // WARNING if: high unread count OR heartbeat warning machines (but no offline)
+      // WARNING if: high unread count OR heartbeat idle machines (but no unknown)
       status = 'WARNING';
     }
 
@@ -395,7 +395,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
       status,
       machines: {
         online: filteredOnlineMachines.length,
-        offline: filteredUnknownMachines.length,
+        unknown: filteredUnknownMachines.length,
         total: totalMachines,
         ...(dashboardOverrides.length > 0 ? { dashboardOverrides } : {})
       },

--- a/servers/roo-state-manager/src/tools/roosync/heartbeat-service.ts
+++ b/servers/roo-state-manager/src/tools/roosync/heartbeat-service.ts
@@ -42,7 +42,7 @@ export const RegisterResultSchema = z.object({
     .describe('Identifiant de la machine'),
   timestamp: z.string()
     .describe('Timestamp du heartbeat (ISO 8601)'),
-  status: z.enum(['online', 'offline', 'warning', 'idle', 'unknown'])
+  status: z.enum(['online', 'idle', 'unknown'])
     .describe('Statut de la machine apres l\'enregistrement'),
   isNewMachine: z.boolean()
     .describe('Indique si c\'est une nouvelle machine')
@@ -175,13 +175,13 @@ export async function roosyncHeartbeatService(args: HeartbeatServiceArgs): Promi
         // Demarrer le service de heartbeat
         await heartbeatService.startHeartbeatService(
           args.machineId,
-          // Callback pour detection offline
-          (offlineMachineId) => {
-            console.log(`[Heartbeat] Machine offline detectee: ${offlineMachineId}`);
+          // Callback pour detection unknown (no heartbeat)
+          (unknownMachineId) => {
+            console.log(`[Heartbeat] Machine unknown detectee: ${unknownMachineId}`);
           },
           // Callback pour retour online
           (onlineMachineId) => {
-            console.log(`[Heartbeat] Machine redevenue online: ${onlineMachineId}`);
+            console.log(`[Heartbeat] Machine online again: ${onlineMachineId}`);
           }
         );
 

--- a/servers/roo-state-manager/src/tools/roosync/inventory.ts
+++ b/servers/roo-state-manager/src/tools/roosync/inventory.ts
@@ -18,14 +18,14 @@ import { HeartbeatServiceError } from '../../services/roosync/HeartbeatService.j
  */
 export const InventoryArgsSchema = z.object({
   type: z.enum(['machine', 'heartbeat', 'all', 'machines', 'status'])
-    .describe('Type d\'inventaire à récupérer. "machines" = offline/warning machines. "status" = compact system snapshot (fused from roosync_get_status)'),
+    .describe('Type d\'inventaire à récupérer. "machines" = unknown/idle machines. "status" = compact system snapshot (fused from roosync_get_status)'),
   machineId: z.string().optional()
     .describe('Identifiant optionnel de la machine (défaut: hostname)'),
   includeHeartbeats: z.boolean().optional()
     .describe('Inclure les données de heartbeat de chaque machine (défaut: true)'),
   // Pour type="machines" (fused from roosync_machines)
-  status: z.enum(['offline', 'warning', 'all']).optional()
-    .describe('Filtrer par statut machines (type="machines": offline, warning, all)'),
+  status: z.enum(['unknown', 'idle', 'all']).optional()
+    .describe('Filtrer par statut machines (type="machines": unknown, idle, all)'),
   includeDetails: z.boolean().optional()
     .describe('Inclure les détails complets des machines (type="machines") ou stats outil (type="status")'),
   summary: z.boolean().optional()
@@ -195,7 +195,7 @@ export const inventoryTool: UnifiedToolContract = {
 
         machinesData = { unknownMachines: [], unknownCount: 0, idleMachines: [], idleCount: 0 };
 
-        if (machinesStatus === 'offline' || machinesStatus === 'all') {
+        if (machinesStatus === 'unknown' || machinesStatus === 'all') {
           const unknownMachines = heartbeatService.getUnknownMachines();
           if (wantDetails) {
             const detailed: any[] = [];
@@ -213,7 +213,7 @@ export const inventoryTool: UnifiedToolContract = {
           }
         }
 
-        if (machinesStatus === 'warning' || machinesStatus === 'all') {
+        if (machinesStatus === 'idle' || machinesStatus === 'all') {
           const idleMachines = heartbeatService.getIdleMachines();
           if (wantDetails) {
             const detailed: any[] = [];
@@ -310,7 +310,7 @@ export const inventoryToolMetadata = {
       type: {
         type: 'string',
         enum: ['machine', 'heartbeat', 'all', 'machines', 'status'],
-        description: 'Type d\'inventaire. "machines" = offline/warning. "status" = snapshot système avec flags.'
+        description: 'Type d\'inventaire. "machines" = unknown/idle. "status" = snapshot système avec flags.'
       },
       machineId: {
         type: 'string',
@@ -322,8 +322,8 @@ export const inventoryToolMetadata = {
       },
       status: {
         type: 'string',
-        enum: ['offline', 'warning', 'all'],
-        description: 'Filtrer par statut machines (type="machines": offline, warning, all)'
+        enum: ['unknown', 'idle', 'all'],
+        description: 'Filtrer par statut machines (type="machines": unknown, idle, all)'
       },
       includeDetails: {
         type: 'boolean',

--- a/servers/roo-state-manager/src/tools/roosync/machines.ts
+++ b/servers/roo-state-manager/src/tools/roosync/machines.ts
@@ -1,10 +1,10 @@
 /**
  * Outil MCP : roosync_machines
  *
- * Récupération des machines offline et/ou en avertissement.
+ * Récupération des machines unknown et/ou idle.
  *
  * @module tools/roosync/machines
- * @version 3.0.0
+ * @version 3.1.0
  */
 
 import { z } from 'zod';
@@ -16,7 +16,7 @@ import { HeartbeatServiceError } from '../../services/roosync/HeartbeatService.j
  * Schema de validation pour roosync_machines
  */
 export const MachinesArgsSchema = z.object({
-  status: z.enum(['offline', 'warning', 'all'])
+  status: z.enum(['unknown', 'idle', 'all'])
     .describe('Statut des machines à récupérer'),
   includeDetails: z.boolean().optional()
     .describe('Inclure les détails complets de chaque machine (défaut: false)')
@@ -25,9 +25,9 @@ export const MachinesArgsSchema = z.object({
 export type MachinesArgs = z.infer<typeof MachinesArgsSchema>;
 
 /**
- * Détails d'une machine offline
+ * Détails d'une machine unknown
  */
-export const OfflineMachineDetailsSchema = z.object({
+export const UnknownMachineDetailsSchema = z.object({
   machineId: z.string()
     .describe('Identifiant de la machine'),
   lastHeartbeat: z.string()
@@ -42,12 +42,12 @@ export const OfflineMachineDetailsSchema = z.object({
   })
 });
 
-export type OfflineMachineDetails = z.infer<typeof OfflineMachineDetailsSchema>;
+export type UnknownMachineDetails = z.infer<typeof UnknownMachineDetailsSchema>;
 
 /**
- * Détails d'une machine en avertissement
+ * Détails d'une machine idle
  */
-export const WarningMachineDetailsSchema = z.object({
+export const IdleMachineDetailsSchema = z.object({
   machineId: z.string()
     .describe('Identifiant de la machine'),
   lastHeartbeat: z.string()
@@ -62,7 +62,7 @@ export const WarningMachineDetailsSchema = z.object({
   })
 });
 
-export type WarningMachineDetails = z.infer<typeof WarningMachineDetailsSchema>;
+export type IdleMachineDetails = z.infer<typeof IdleMachineDetailsSchema>;
 
 /**
  * Schema de retour pour roosync_machines
@@ -72,12 +72,12 @@ export const MachinesResultSchema = z.object({
     .describe('Indique si la récupération a réussi'),
   unknownMachines: z.union([
     z.array(z.string()).describe('Liste des IDs des machines unknown'),
-    z.array(OfflineMachineDetailsSchema).describe('Liste détaillée des machines unknown')
+    z.array(UnknownMachineDetailsSchema).describe('Liste détaillée des machines unknown')
   ]).optional()
     .describe('Liste des machines unknown (IDs ou détails selon includeDetails)'),
   idleMachines: z.union([
     z.array(z.string()).describe('Liste des IDs des machines idle'),
-    z.array(WarningMachineDetailsSchema).describe('Liste détaillée des machines idle')
+    z.array(IdleMachineDetailsSchema).describe('Liste détaillée des machines idle')
   ]).optional()
     .describe('Liste des machines idle (IDs ou détails selon includeDetails)'),
   unknownCount: z.number().optional()
@@ -93,11 +93,11 @@ export type MachinesResult = z.infer<typeof MachinesResultSchema>;
 /**
  * Outil roosync_machines (UnifiedToolContract)
  *
- * Récupération des machines offline et/ou en avertissement.
+ * Récupération des machines unknown et/ou idle.
  */
 export const machinesTool: UnifiedToolContract = {
   name: 'roosync_machines',
-  description: 'Récupération des machines offline et/ou en avertissement.',
+  description: 'Récupération des machines unknown et/ou idle.',
   category: ToolCategory.UTILITY,
   processingLevel: ProcessingLevel.IMMEDIATE,
   version: '3.0.0',
@@ -115,12 +115,12 @@ export const machinesTool: UnifiedToolContract = {
         checkedAt
       };
 
-      // Récupérer les machines offline si demandé
-      if (status === 'offline' || status === 'all') {
+      // Récupérer les machines unknown si demandé
+      if (status === 'unknown' || status === 'all') {
         const unknownMachines = heartbeatService.getUnknownMachines();
 
         if (includeDetails) {
-          const detailedMachines: OfflineMachineDetails[] = [];
+          const detailedMachines: UnknownMachineDetails[] = [];
 
           for (const machineId of unknownMachines) {
             const heartbeatData = heartbeatService.getHeartbeatData(machineId);
@@ -143,12 +143,12 @@ export const machinesTool: UnifiedToolContract = {
         }
       }
 
-      // Récupérer les machines en avertissement si demandé
-      if (status === 'warning' || status === 'all') {
+      // Récupérer les machines idle si demandé
+      if (status === 'idle' || status === 'all') {
         const idleMachines = heartbeatService.getIdleMachines();
 
         if (includeDetails) {
-          const detailedMachines: WarningMachineDetails[] = [];
+          const detailedMachines: IdleMachineDetails[] = [];
 
           for (const machineId of idleMachines) {
             const heartbeatData = heartbeatService.getHeartbeatData(machineId);
@@ -207,13 +207,13 @@ export async function roosyncMachines(args: MachinesArgs, context?: any): Promis
  */
 export const machinesToolMetadata = {
   name: 'roosync_machines',
-  description: 'Récupération des machines offline et/ou en avertissement.',
+  description: 'Récupération des machines unknown et/ou idle.',
   inputSchema: {
     type: 'object' as const,
     properties: {
       status: {
         type: 'string',
-        enum: ['offline', 'warning', 'all'],
+        enum: ['unknown', 'idle', 'all'],
         description: 'Statut des machines à récupérer'
       },
       includeDetails: {

--- a/servers/roo-state-manager/src/types/machine-config.ts
+++ b/servers/roo-state-manager/src/types/machine-config.ts
@@ -155,8 +155,7 @@ export interface RooSyncState {
   heartbeat?: {
     registered: boolean;
     lastHeartbeat?: string;
-    status?: 'online' | 'offline' | 'warning';
-    missedHeartbeats?: number;
+    status?: 'online' | 'unknown' | 'idle';
   };
 
   /** Messaging stats */

--- a/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
@@ -110,14 +110,14 @@ describe('#1863 Fusion A2: machines → inventory(type: "machines")', () => {
       }
     });
 
-    it('should validate type="machines" with status="offline"', () => {
+    it('should validate type="machines" with status="unknown"', () => {
       const result = InventoryArgsSchema.safeParse({
         type: 'machines',
-        status: 'offline'
+        status: 'unknown'
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.status).toBe('offline');
+        expect(result.data.status).toBe('unknown');
       }
     });
 

--- a/servers/roo-state-manager/tests/unit/tools/roosync/get-status.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/get-status.test.ts
@@ -170,7 +170,7 @@ describe('roosync_get_status', () => {
             expect(result.status).toBe('HEALTHY');
         });
 
-        it('returns CRITICAL when machines offline', async () => {
+        it('returns CRITICAL when machines unknown', async () => {
             setupMocks({
                 heartbeatState: {
                     onlineMachines: ['myia-ai-01'],
@@ -180,7 +180,7 @@ describe('roosync_get_status', () => {
             });
             const result = await roosyncGetStatus({});
             expect(result.status).toBe('CRITICAL');
-            expect(result.flags).toContain('OFFLINE:myia-web1');
+            expect(result.flags).toContain('UNKNOWN:myia-web1');
         });
 
         it('returns CRITICAL when urgent messages', async () => {

--- a/servers/roo-state-manager/tests/unit/tools/roosync/inventory.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/inventory.test.ts
@@ -113,23 +113,23 @@ describe('roosync_inventory tool', () => {
     });
 
     describe('type=machines (fused from roosync_machines)', () => {
-        it('returns offline machines when status=offline', async () => {
+        it('returns unknown machines when status=unknown', async () => {
             mockGetUnknownMachines.mockReturnValue(['web1', 'po-2024']);
-            const result = await inventoryTool.execute({ type: 'machines', status: 'offline' }, {});
+            const result = await inventoryTool.execute({ type: 'machines', status: 'unknown' }, {});
             expect(result.success).toBe(true);
             expect(result.data.unknownMachines).toEqual(['web1', 'po-2024']);
             expect(result.data.unknownCount).toBe(2);
         });
 
-        it('returns warning machines when status=warning', async () => {
+        it('returns idle machines when status=idle', async () => {
             mockGetIdleMachines.mockReturnValue(['po-2023']);
-            const result = await inventoryTool.execute({ type: 'machines', status: 'warning' }, {});
+            const result = await inventoryTool.execute({ type: 'machines', status: 'idle' }, {});
             expect(result.success).toBe(true);
             expect(result.data.idleMachines).toEqual(['po-2023']);
             expect(result.data.idleCount).toBe(1);
         });
 
-        it('returns both offline and warning when status=all (default)', async () => {
+        it('returns both unknown and idle when status=all (default)', async () => {
             mockGetUnknownMachines.mockReturnValue(['web1']);
             mockGetIdleMachines.mockReturnValue(['po-2023']);
             const result = await inventoryTool.execute({ type: 'machines' }, {});
@@ -148,21 +148,21 @@ describe('roosync_inventory tool', () => {
                 };
                 return null;
             });
-            const result = await inventoryTool.execute({ type: 'machines', status: 'offline', includeDetails: true }, {});
+            const result = await inventoryTool.execute({ type: 'machines', status: 'unknown', includeDetails: true }, {});
             expect(result.data.unknownMachines).toHaveLength(1);
             expect(result.data.unknownMachines[0].machineId).toBe('web1');
             expect(result.data.unknownMachines[0].status).toBe('unknown');
             expect(result.data.unknownCount).toBe(1);
         });
 
-        it('skips machines without heartbeat data in detailed offline mode', async () => {
+        it('skips machines without heartbeat data in detailed unknown mode', async () => {
             mockGetUnknownMachines.mockReturnValue(['web1']);
             mockGetHeartbeatData.mockReturnValue(null);
-            const result = await inventoryTool.execute({ type: 'machines', status: 'offline', includeDetails: true }, {});
+            const result = await inventoryTool.execute({ type: 'machines', status: 'unknown', includeDetails: true }, {});
             expect(result.data.unknownMachines).toHaveLength(0);
         });
 
-        it('returns detailed warning machines', async () => {
+        it('returns detailed idle machines', async () => {
             mockGetIdleMachines.mockReturnValue(['po-2023']);
             mockGetHeartbeatData.mockImplementation((mid: string) => ({
                 machineId: mid,
@@ -170,7 +170,7 @@ describe('roosync_inventory tool', () => {
                 status: 'idle',
                 metadata: { firstSeen: '2026-01-01', lastUpdated: '2026-05-04' },
             }));
-            const result = await inventoryTool.execute({ type: 'machines', status: 'warning', includeDetails: true }, {});
+            const result = await inventoryTool.execute({ type: 'machines', status: 'idle', includeDetails: true }, {});
             expect(result.data.idleMachines).toHaveLength(1);
             expect(result.data.idleMachines[0].machineId).toBe('po-2023');
         });
@@ -178,7 +178,7 @@ describe('roosync_inventory tool', () => {
         it('skips null heartbeat data in detailed mode', async () => {
             mockGetUnknownMachines.mockReturnValue(['unknown']);
             mockGetHeartbeatData.mockReturnValue(null);
-            const result = await inventoryTool.execute({ type: 'machines', status: 'offline', includeDetails: true }, {});
+            const result = await inventoryTool.execute({ type: 'machines', status: 'unknown', includeDetails: true }, {});
             expect(result.data.unknownMachines).toHaveLength(0);
         });
     });


### PR DESCRIPTION
## Summary

Completes the ADR 008 Phase 2 heartbeat terminology rename across all remaining production and test files. Follow-up to PR #337 which renamed HeartbeatService internals but left terminology drift in 6 production files and their tests.

### Production changes

| File | Changes |
|------|---------|
| `machines.ts` | `OfflineMachineDetailsSchema` → `UnknownMachineDetailsSchema`, `WarningMachineDetailsSchema` → `IdleMachineDetailsSchema`, enum `['offline','warning','all']` → `['unknown','idle','all']` |
| `inventory.ts` | Matching enum + condition renames for `type="machines"` |
| `get-status.ts` | `machines.offline` → `machines.unknown`, `OFFLINE:` flags → `UNKNOWN:` |
| `heartbeat-service.ts` | Status enum cleaned (removed `'offline'`, `'warning'`), callback renames |
| `machine-config.ts` | `RooSyncState.heartbeat.status` enum updated, removed `missedHeartbeats` |

### Test updates

5 test files updated to match new terminology (get-status, machines, inventory, fusions-1863 — both `src/` and `tests/unit/` copies).

### Already done (no changes needed)

- `dashboard-activity.ts` — already uses `UNKNOWN/IDLE/ONLINE` terminology from PR #337

### Test plan
- [x] `npm run build` passes (tsc clean)
- [x] `npx vitest run --config vitest.config.ci.ts` — 9203/9203 pass, 0 failures
- [x] All renamed schemas/types still exported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)