### PR TITLE
feat(#1841 Cluster G): consolidate send+read+manage+attachments → roosync_messages

### DIFF
--- a/servers/roo-state-manager/src/tools/__tests__/registry.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/registry.test.ts
@@ -133,7 +133,7 @@ describe('registry.ts - Tool Registration', () => {
         // [REMOVED #291] export_config test removed — tool removed from allToolDefinitions (ListTools)
         // Backward compat redirect preserved in registry.ts for CallTool
 
-        it('should have tools count greater than 20', async () => {
+        it('should have tools count greater than 15', async () => {
             const mockServer = {
                 setRequestHandler: vi.fn()
             } as any;
@@ -142,7 +142,7 @@ describe('registry.ts - Tool Registration', () => {
 
             const handler = mockServer.setRequestHandler.mock.calls[0][1];
             const result = await handler();
-            expect(result.tools.length).toBeGreaterThan(20);
+            expect(result.tools.length).toBeGreaterThan(15);
         });
     });
 
@@ -561,13 +561,11 @@ describe('registry.ts - Tool Registration', () => {
             // These tools form the minimum viable agent workflow:
             // 1. conversation_browser (list → get IDs, tree → navigate, current → active task, view → inspect)
             // 2. roosync_search (find tasks by content)
-            // 3. roosync_send/read/manage (communicate)
+            // 3. roosync_messages (consolidated messaging, #1841 Cluster G)
             const essentialTools = [
                 'conversation_browser',
                 'roosync_search',
-                'roosync_send',
-                'roosync_read',
-                'roosync_manage',
+                'roosync_messages',
             ];
 
             for (const tool of essentialTools) {

--- a/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
@@ -37,14 +37,16 @@ import {
     roosyncStorageManagementDefinition,
     roosyncDiagnoseDefinition,
     // #1935 Cluster B: roosyncRefreshDashboardDefinition, roosyncUpdateDashboardDefinition removed from tools/list
+    // #1841 Cluster G: roosyncSend/Read/Manage/Attachments removed — fused into roosync_messages
     roosyncSendDefinition,
     roosyncReadDefinition,
     roosyncManageDefinition,
     roosyncAttachmentsDefinition,
-    roosyncDashboardDefinition
+    roosyncDashboardDefinition,
+    roosyncMessagesDefinition
 } from '../tool-definitions.js';
 
-const EXPECTED_TOOL_COUNT = 22;
+const EXPECTED_TOOL_COUNT = 19;
 
 // Order MUST mirror allToolDefinitions in tool-definitions.ts.
 // #1863: 3 deprecated definitions removed from allToolDefinitions
@@ -77,17 +79,18 @@ const allDefinitions = [
     roosyncDiagnoseDefinition,
     // [REMOVED #291] roosyncRefreshDashboardDefinition — removed from allToolDefinitions
     // [REMOVED #291] roosyncUpdateDashboardDefinition — removed from allToolDefinitions
-    roosyncSendDefinition,
-    roosyncReadDefinition,
-    roosyncManageDefinition,
-    roosyncAttachmentsDefinition,
+    // [REMOVED #1841 Cluster G] roosyncSendDefinition — fused into roosync_messages
+    // [REMOVED #1841 Cluster G] roosyncReadDefinition — fused into roosync_messages
+    // [REMOVED #1841 Cluster G] roosyncManageDefinition — fused into roosync_messages
+    // [REMOVED #1841 Cluster G] roosyncAttachmentsDefinition — fused into roosync_messages
+    roosyncMessagesDefinition,
     roosyncDashboardDefinition
 ];
 
 describe('tool-definitions.ts — Schema Validation', () => {
 
     describe('allToolDefinitions array', () => {
-        it('should have exactly 23 tool definitions', () => {
+        it('should have exactly 19 tool definitions', () => {
             expect(allToolDefinitions).toHaveLength(EXPECTED_TOOL_COUNT);
         });
 

--- a/servers/roo-state-manager/src/tools/__tests__/tool-discoverability.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-discoverability.test.ts
@@ -130,8 +130,8 @@ describe('Category 1: ListTools → CallTool Consistency', () => {
 
     it('ListTools should expose a reasonable number of tools (20-50 range)', async () => {
         const toolNames = await getListToolsNames();
-        // Currently 22 tools (24 after #297 - 1 Cluster D fusion - 1 Cluster E fusion). This guards against accidental mass removal or explosion
-        expect(toolNames.length).toBeGreaterThanOrEqual(20);
+        // Currently 19 tools (#1841 Cluster G: 22 - 3 net after send+read+manage+attachments→messages). This guards against accidental mass removal or explosion
+        expect(toolNames.length).toBeGreaterThanOrEqual(15);
         expect(toolNames.length).toBeLessThanOrEqual(50);
     });
 
@@ -312,20 +312,17 @@ describe('Category 3: Consolidated Tool Action Completeness', () => {
             field: 'action',
             actions: ['env', 'debug', 'reset', 'test'],
         },
-        'roosync_send': {
-            field: 'action',
-            actions: ['send', 'reply', 'amend'],
-        },
-        'roosync_read': {
-            field: 'mode',
-            actions: ['inbox', 'message'],
-        },
-        'roosync_manage': {
-            field: 'action',
-            actions: ['mark_read', 'archive'],
-        },
+        // #1841 Cluster G: roosync_send/read/manage removed from allToolDefinitions — fused into roosync_messages
+        // Backward compat handlers preserved in registry.ts
         // B4: storage_info removed from ListTools — covered by roosync_storage_management(action: 'storage')
         // CallTool handler preserved for backward compat
+        // #1841 Cluster G: consolidated messaging tool
+        'roosync_messages': {
+            field: 'action',
+            actions: ['send', 'reply', 'amend', 'inbox', 'message', 'mark_read', 'archive',
+                      'bulk_mark_read', 'bulk_archive', 'cleanup', 'stats',
+                      'attachments_list', 'attachments_get', 'attachments_delete'],
+        },
     };
 
     it('consolidated tools must declare their action/mode enum in inputSchema', async () => {
@@ -410,9 +407,8 @@ describe('Category 4: Essential Tools for Agent Workflows', () => {
         // [REMOVED #291] get_raw_conversation removed from allToolDefinitions — backward compat via registry.ts redirect
 
         // Communication
-        'roosync_send',          // send messages
-        'roosync_read',          // read inbox
-        'roosync_manage',        // manage messages
+        // #1841 Cluster G: send+read+manage+attachments fused into roosync_messages
+        'roosync_messages',      // consolidated messaging
 
         // Configuration & Management
         'roosync_config',        // collect/publish/apply config
@@ -477,8 +473,8 @@ describe('Category 5: Description Discoverability', () => {
         // Descriptions are mostly in French, so use French keywords where applicable
         'conversation_browser': ['conversation'],
         'roosync_search': ['recherche', 'tâches'],       // "Outil unifié de recherche dans les tâches Roo..."
-        'roosync_send': ['message'],                     // "Envoyer un message structuré"
-        'roosync_read': ['réception', 'messages'],       // "Lire la boîte de réception des messages RooSync..."
+        // #1841 Cluster G: roosync_send/read removed from allToolDefinitions — fused into roosync_messages
+        'roosync_messages': ['messagerie', 'send', 'inbox'], // #1841 Cluster G: consolidated messaging
         'roosync_config': ['config'],                    // "Gestion de configuration RooSync"
         'roosync_compare_config': ['compare', 'config'], // "Compare les configurations Roo"
         // #1609: roosync_heartbeat removed — auto-heartbeat on any tool call

--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -59,6 +59,7 @@ export const TOOL_CAPABILITIES: Record<string, Capability[]> = {
 	roosync_send: ['sharedPath'],
 	roosync_manage: ['sharedPath'],
 	roosync_attachments: ['sharedPath'],
+	roosync_messages: ['sharedPath'], // #1841 Cluster G: consolidated messaging
 	roosync_dashboard: ['sharedPath'],
 	roosync_update_dashboard: ['sharedPath'],
 	roosync_refresh_dashboard: ['sharedPath'],
@@ -551,6 +552,16 @@ export function registerCallToolHandler(
                try {
                    const m = await import('./roosync/manage.js');
                    result = await m.roosyncManage(args as any) as CallToolResult;
+               } catch (error) {
+                   result = { content: [{ type: 'text', text: `Error: ${(error as Error).message}` }], isError: true };
+               }
+               break;
+           }
+          // #1841 Cluster G: Outil consolide messagerie (4→1: send+read+manage+attachments)
+           case 'roosync_messages': {
+               try {
+                   const m = await import('./roosync/messages.js');
+                   result = await m.roosyncMessages(args as any) as CallToolResult;
                } catch (error) {
                    result = { content: [{ type: 'text', text: `Error: ${(error as Error).message}` }], isError: true };
                }

--- a/servers/roo-state-manager/src/tools/roosync/index.ts
+++ b/servers/roo-state-manager/src/tools/roosync/index.ts
@@ -134,6 +134,9 @@ export { roosyncRead, readToolMetadata } from './read.js';
 export { roosyncSend, sendToolMetadata } from './send.js';
 export { roosyncManage, manageToolMetadata } from './manage.js';
 
+// CONS-8 (#1841 Cluster G): Outil consolide messagerie (4→1: send+read+manage+attachments)
+export { roosyncMessages, messagesToolMetadata } from './messages.js';
+
 // [REMOVED #1863] Deprecated cleanup_messages exports — fused into roosync_manage(action: "bulk_*")
 // Source file cleanup.ts retained for: registry.ts redirect + tests
 

--- a/servers/roo-state-manager/src/tools/roosync/messages.ts
+++ b/servers/roo-state-manager/src/tools/roosync/messages.ts
@@ -1,0 +1,269 @@
+/**
+ * Outil MCP : roosync_messages
+ *
+ * Outil consolide pour la messagerie inter-machines RooSync.
+ * Regroupe : roosync_send + roosync_read + roosync_manage + roosync_attachments (4→1)
+ *
+ * Actions: send, reply, amend, inbox, message, mark_read, archive,
+ *          bulk_mark_read, bulk_archive, cleanup, stats, attachments_list,
+ *          attachments_get, attachments_delete
+ *
+ * @module tools/roosync/messages
+ * @version 1.0.0
+ * @see #1841 (Cluster G: messagerie)
+ */
+
+import { z } from 'zod';
+import { roosyncSend } from './send.js';
+import { roosyncRead } from './read.js';
+import { roosyncManage } from './manage.js';
+import { roosyncAttachments } from './roosync-attachments.tool.js';
+
+// ====================================================================
+// SCHEMA
+// ====================================================================
+
+export const MessagesArgsSchema = z.object({
+  action: z.enum([
+    // Send family
+    'send', 'reply', 'amend',
+    // Read family
+    'inbox', 'message',
+    // Manage family
+    'mark_read', 'archive', 'bulk_mark_read', 'bulk_archive', 'cleanup', 'stats',
+    // Attachments family
+    'attachments_list', 'attachments_get', 'attachments_delete'
+  ]).describe('Action a effectuer'),
+
+  // --- Send/Reply/Amend params ---
+  to: z.string().optional().describe('Destinataire (requis pour send): machine ou machine:workspace'),
+  subject: z.string().optional().describe('Sujet (requis pour send)'),
+  body: z.string().optional().describe('Corps du message (requis pour send/reply)'),
+  priority: z.enum(['LOW', 'MEDIUM', 'HIGH', 'URGENT']).optional().describe('Priorite (defaut: MEDIUM)'),
+  tags: z.array(z.string()).optional().describe('Tags optionnels'),
+  thread_id: z.string().optional().describe('ID du thread pour regroupement'),
+  reply_to: z.string().optional().describe('ID du message auquel repondre (pour send)'),
+  message_id: z.string().optional().describe('ID du message (requis pour reply/amend/mark_read/archive/message/attachments_list)'),
+  new_content: z.string().optional().describe('Nouveau contenu (requis pour amend)'),
+  reason: z.string().optional().describe('Raison de la modification (amend)'),
+  auto_destruct: z.boolean().optional().describe('Auto-destruction apres lecture'),
+  destruct_after_read_by: z.array(z.string()).optional().describe('Machines devant lire avant destruction'),
+  destruct_after: z.string().optional().describe('TTL avant destruction (ex: 30m, 2h, 1d)'),
+  attachments: z.array(z.object({
+    path: z.string(),
+    filename: z.string().optional()
+  })).optional().describe('Pieces jointes (pour send)'),
+
+  // --- Read/Inbox params ---
+  status: z.enum(['unread', 'read', 'all']).optional().describe('Filtrer inbox par statut (defaut: all)'),
+  limit: z.number().optional().describe('Max messages inbox'),
+  page: z.number().optional().describe('Numero de page (1-based, requiert per_page)'),
+  per_page: z.number().optional().describe('Messages par page (requiert page)'),
+  mark_as_read: z.boolean().optional().describe('Marquer comme lu (mode message, defaut: false)'),
+  workspace: z.string().optional().describe('Override workspace filter (#1498)'),
+  to_machine: z.string().optional().describe('Override machine filter (#1498, avance)'),
+
+  // --- Manage bulk params ---
+  from: z.string().optional().describe('Filtrer par expediteur (bulk)'),
+  before_date: z.string().optional().describe('Filtrer avant date ISO-8601 (bulk)'),
+  subject_contains: z.string().optional().describe('Filtrer par sujet (bulk)'),
+  tag: z.string().optional().describe('Filtrer par tag (bulk)'),
+
+  // --- Attachments params ---
+  uuid: z.string().optional().describe('UUID piece jointe (requis pour attachments_get/delete)'),
+  targetPath: z.string().optional().describe('Chemin local destination (requis pour attachments_get)')
+});
+
+export type MessagesArgs = z.infer<typeof MessagesArgsSchema>;
+
+// ====================================================================
+// IMPLEMENTATION
+// ====================================================================
+
+export async function roosyncMessages(args: MessagesArgs) {
+  const { action } = args;
+
+  switch (action) {
+    // --- Send family ---
+    case 'send':
+      return roosyncSend({
+        action: 'send',
+        to: args.to,
+        subject: args.subject,
+        body: args.body,
+        priority: args.priority,
+        tags: args.tags,
+        thread_id: args.thread_id,
+        reply_to: args.reply_to,
+        auto_destruct: args.auto_destruct,
+        destruct_after_read_by: args.destruct_after_read_by,
+        destruct_after: args.destruct_after,
+        attachments: args.attachments
+      });
+
+    case 'reply':
+      return roosyncSend({
+        action: 'reply',
+        message_id: args.message_id,
+        body: args.body,
+        priority: args.priority,
+        tags: args.tags
+      });
+
+    case 'amend':
+      return roosyncSend({
+        action: 'amend',
+        message_id: args.message_id,
+        new_content: args.new_content,
+        reason: args.reason
+      });
+
+    // --- Read family ---
+    case 'inbox':
+      return roosyncRead({
+        mode: 'inbox',
+        status: args.status,
+        limit: args.limit,
+        page: args.page,
+        per_page: args.per_page,
+        workspace: args.workspace,
+        to_machine: args.to_machine
+      });
+
+    case 'message':
+      return roosyncRead({
+        mode: 'message',
+        message_id: args.message_id,
+        mark_as_read: args.mark_as_read
+      });
+
+    // --- Manage family ---
+    case 'mark_read':
+      return roosyncManage({ action: 'mark_read', message_id: args.message_id });
+
+    case 'archive':
+      return roosyncManage({ action: 'archive', message_id: args.message_id });
+
+    case 'bulk_mark_read':
+      return roosyncManage({
+        action: 'bulk_mark_read',
+        from: args.from,
+        priority: args.priority,
+        before_date: args.before_date,
+        subject_contains: args.subject_contains,
+        tag: args.tag
+      });
+
+    case 'bulk_archive':
+      return roosyncManage({
+        action: 'bulk_archive',
+        from: args.from,
+        priority: args.priority,
+        before_date: args.before_date,
+        subject_contains: args.subject_contains,
+        tag: args.tag
+      });
+
+    case 'cleanup':
+      return roosyncManage({ action: 'cleanup' });
+
+    case 'stats':
+      return roosyncManage({ action: 'stats' });
+
+    // --- Attachments family ---
+    case 'attachments_list':
+      return roosyncAttachments({
+        action: 'list',
+        message_id: args.message_id
+      });
+
+    case 'attachments_get':
+      return roosyncAttachments({
+        action: 'get',
+        uuid: args.uuid,
+        targetPath: args.targetPath
+      });
+
+    case 'attachments_delete':
+      return roosyncAttachments({
+        action: 'delete',
+        uuid: args.uuid
+      });
+
+    default: {
+      const _exhaustive: never = action;
+      throw new Error(`Unknown action: ${_exhaustive}`);
+    }
+  }
+}
+
+/**
+ * Metadonnees de l'outil pour l'enregistrement MCP
+ */
+export const messagesToolMetadata = {
+  name: 'roosync_messages',
+  description: `Gestion complète de la messagerie inter-machines RooSync. Actions :
+- send, reply, amend : envoyer / répondre / modifier un message
+- inbox, message : lire la boîte de réception / détails d'un message
+- mark_read, archive : gestion individuelle
+- bulk_mark_read, bulk_archive : opérations en lot (filtres: from, priority, before_date, subject_contains, tag)
+- cleanup : nettoyage automatique, stats : statistiques inbox
+- attachments_list, attachments_get, attachments_delete : gestion des pièces jointes
+
+Remplace : roosync_send + roosync_read + roosync_manage + roosync_attachments (4→1, #1841 Cluster G)`,
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      action: {
+        type: 'string',
+        enum: [
+          'send', 'reply', 'amend',
+          'inbox', 'message',
+          'mark_read', 'archive', 'bulk_mark_read', 'bulk_archive', 'cleanup', 'stats',
+          'attachments_list', 'attachments_get', 'attachments_delete'
+        ],
+        description: 'Action à effectuer'
+      },
+      to: { type: 'string', description: 'Destinataire (send): machine ou machine:workspace' },
+      subject: { type: 'string', description: 'Sujet du message (send)' },
+      body: { type: 'string', description: 'Corps du message (send/reply)' },
+      priority: { type: 'string', enum: ['LOW', 'MEDIUM', 'HIGH', 'URGENT'], description: 'Priorité (défaut: MEDIUM)' },
+      tags: { type: 'array', items: { type: 'string' }, description: 'Tags optionnels' },
+      thread_id: { type: 'string', description: 'ID thread pour regroupement' },
+      reply_to: { type: 'string', description: 'ID message référence (send)' },
+      message_id: { type: 'string', description: 'ID message (reply/amend/mark_read/archive/message/attachments_list)' },
+      new_content: { type: 'string', description: 'Nouveau contenu (amend)' },
+      reason: { type: 'string', description: 'Raison modification (amend)' },
+      auto_destruct: { type: 'boolean', description: 'Auto-destruction après lecture' },
+      destruct_after_read_by: { type: 'array', items: { type: 'string' }, description: 'Machines devant lire avant destruction' },
+      destruct_after: { type: 'string', description: 'TTL avant destruction (30m, 2h, 1d)' },
+      attachments: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            path: { type: 'string' },
+            filename: { type: 'string' }
+          },
+          required: ['path']
+        },
+        description: 'Pièces jointes (send)'
+      },
+      status: { type: 'string', enum: ['unread', 'read', 'all'], description: 'Filtre inbox (défaut: all)' },
+      limit: { type: 'number', description: 'Max messages inbox' },
+      page: { type: 'number', description: 'Page (1-based, requiert per_page)' },
+      per_page: { type: 'number', description: 'Messages par page' },
+      mark_as_read: { type: 'boolean', description: 'Marquer lu (message, défaut: false)' },
+      workspace: { type: 'string', description: 'Override workspace (#1498)' },
+      to_machine: { type: 'string', description: 'Override machine (#1498)' },
+      from: { type: 'string', description: 'Filtre expediteur (bulk)' },
+      before_date: { type: 'string', description: 'Filtre avant date ISO (bulk)' },
+      subject_contains: { type: 'string', description: 'Filtre sujet (bulk)' },
+      tag: { type: 'string', description: 'Filtre tag (bulk)' },
+      uuid: { type: 'string', description: 'UUID pièce jointe (attachments_get/delete)' },
+      targetPath: { type: 'string', description: 'Chemin local destination (attachments_get)' }
+    },
+    required: ['action'],
+    additionalProperties: false
+  }
+};

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -556,6 +556,72 @@ export const roosyncAttachmentsDefinition = {
     }
 };
 
+// #1841 Cluster G: Outil consolide messagerie (4→1: send+read+manage+attachments)
+export const roosyncMessagesDefinition = {
+    name: 'roosync_messages',
+    description: `Gestion complète de la messagerie inter-machines RooSync (CONS-8). Actions :
+- send, reply, amend : envoyer / répondre / modifier un message
+- inbox, message : lire la boîte de réception / détails d'un message
+- mark_read, archive : gestion individuelle
+- bulk_mark_read, bulk_archive : opérations en lot (filtres: from, priority, before_date, subject_contains, tag)
+- cleanup : nettoyage automatique, stats : statistiques inbox
+- attachments_list, attachments_get, attachments_delete : gestion des pièces jointes
+
+Remplace : roosync_send + roosync_read + roosync_manage + roosync_attachments (4→1, #1841 Cluster G)`,
+    inputSchema: {
+        type: 'object' as const,
+        properties: {
+            action: {
+                type: 'string',
+                enum: [
+                    'send', 'reply', 'amend',
+                    'inbox', 'message',
+                    'mark_read', 'archive', 'bulk_mark_read', 'bulk_archive', 'cleanup', 'stats',
+                    'attachments_list', 'attachments_get', 'attachments_delete'
+                ],
+                description: 'Action à effectuer'
+            },
+            to: { type: 'string', description: 'Destinataire (send): machine ou machine:workspace' },
+            subject: { type: 'string', description: 'Sujet (send)' },
+            body: { type: 'string', description: 'Corps du message (send/reply)' },
+            priority: { type: 'string', enum: ['LOW', 'MEDIUM', 'HIGH', 'URGENT'], description: 'Priorité (défaut: MEDIUM)' },
+            tags: { type: 'array', items: { type: 'string' }, description: 'Tags optionnels' },
+            thread_id: { type: 'string', description: 'ID thread' },
+            reply_to: { type: 'string', description: 'ID message référence (send)' },
+            message_id: { type: 'string', description: 'ID message (reply/amend/mark_read/archive/message/attachments_list)' },
+            new_content: { type: 'string', description: 'Nouveau contenu (amend)' },
+            reason: { type: 'string', description: 'Raison (amend)' },
+            auto_destruct: { type: 'boolean', description: 'Auto-destruction après lecture' },
+            destruct_after_read_by: { type: 'array', items: { type: 'string' }, description: 'Machines devant lire avant destruction' },
+            destruct_after: { type: 'string', description: 'TTL destruction (30m, 2h, 1d)' },
+            attachments: {
+                type: 'array',
+                items: {
+                    type: 'object',
+                    properties: { path: { type: 'string' }, filename: { type: 'string' } },
+                    required: ['path']
+                },
+                description: 'Pièces jointes (send)'
+            },
+            status: { type: 'string', enum: ['unread', 'read', 'all'], description: 'Filtre inbox (défaut: all)' },
+            limit: { type: 'number', description: 'Max messages inbox' },
+            page: { type: 'number', description: 'Page (1-based)' },
+            per_page: { type: 'number', description: 'Messages par page' },
+            mark_as_read: { type: 'boolean', description: 'Marquer lu (message, défaut: false)' },
+            workspace: { type: 'string', description: 'Override workspace (#1498)' },
+            to_machine: { type: 'string', description: 'Override machine (#1498)' },
+            from: { type: 'string', description: 'Filtre expediteur (bulk)' },
+            before_date: { type: 'string', description: 'Filtre avant date ISO (bulk)' },
+            subject_contains: { type: 'string', description: 'Filtre sujet (bulk)' },
+            tag: { type: 'string', description: 'Filtre tag (bulk)' },
+            uuid: { type: 'string', description: 'UUID pièce jointe (attachments_get/delete)' },
+            targetPath: { type: 'string', description: 'Chemin local destination (attachments_get)' }
+        },
+        required: ['action'],
+        additionalProperties: false
+    }
+};
+
 // #1470: Derived from Zod schema in dashboard-schemas.ts (single source of truth)
 export const roosyncDashboardDefinition = dashboardToolMetadata;
 
@@ -596,9 +662,10 @@ export const allToolDefinitions = [
     roosyncDiagnoseDefinition,
     // [REMOVED #1935 Cluster B] roosyncRefreshDashboardDefinition — fused into roosync_dashboard(action: "refresh"), redirect in registry.ts
     // [REMOVED #1935 Cluster B] roosyncUpdateDashboardDefinition — fused into roosync_dashboard(action: "update"), redirect in registry.ts
-    roosyncSendDefinition,
-    roosyncReadDefinition,
-    roosyncManageDefinition,
-    roosyncAttachmentsDefinition,
+    // [REMOVED #1841 Cluster G] roosyncSendDefinition — fused into roosync_messages(action: "send"/"reply"/"amend"), redirect in registry.ts
+    // [REMOVED #1841 Cluster G] roosyncReadDefinition — fused into roosync_messages(action: "inbox"/"message"), redirect in registry.ts
+    // [REMOVED #1841 Cluster G] roosyncManageDefinition — fused into roosync_messages(action: "mark_read"/"archive"/"bulk_*"/"cleanup"/"stats"), redirect in registry.ts
+    // [REMOVED #1841 Cluster G] roosyncAttachmentsDefinition — fused into roosync_messages(action: "attachments_*"), redirect in registry.ts
+    roosyncMessagesDefinition,
     roosyncDashboardDefinition
 ];

--- a/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
@@ -177,9 +177,9 @@ describe('#1863 Fusion A2: machines → inventory(type: "machines")', () => {
 // FUSION A3: cleanup → manage redirect
 // ============================================================
 describe('#1863 Fusion A3: cleanup → manage redirect', () => {
-  describe('Canonical call via manage(bulk_mark_read/bulk_archive)', () => {
-    it('should have bulk_mark_read in manage definition action enum', () => {
-      const actionEnum = (allToolDefinitions.find(d => d.name === 'roosync_manage')!.inputSchema as any).properties.action.enum;
+  describe('Canonical call via messages(action: bulk_mark_read/bulk_archive)', () => {
+    it('should have bulk_mark_read in messages definition action enum', () => {
+      const actionEnum = (allToolDefinitions.find(d => d.name === 'roosync_messages')!.inputSchema as any).properties.action.enum;
       expect(actionEnum).toContain('bulk_mark_read');
       expect(actionEnum).toContain('bulk_archive');
     });
@@ -306,8 +306,9 @@ describe('#1863 Cross-cutting: tool count and deprecation markers', () => {
     // Actually #297 consolidated to 24 active in ListTools (less low-usage). allToolDefinitions baseline = 24.
     // Cluster D (#1935) fused analyze_roosync_problems → roosync_diagnose(action: "analyze"): 24 → 23
     // Cluster E (#1935) fused get_status → inventory(type: "status"): 23 → 22
+    // Cluster G (#1841) fused send+read+manage+attachments → roosync_messages: 22 → 19
     // Backward compat redirect handlers in registry.ts are preserved
-    expect(allToolDefinitions.length).toBe(22);
+    expect(allToolDefinitions.length).toBe(19);
   });
 
   it('deprecated tools should NOT be in allToolDefinitions', () => {


### PR DESCRIPTION
## Summary
- Consolidate 4 messaging tools (roosync_send, roosync_read, roosync_manage, roosync_attachments) into 1 unified `roosync_messages` tool with 14 actions
- Net tool count: 22 → 19 (3 tools removed from tools/list)
- Backward compat handlers preserved in registry.ts for all 4 old tool names

## Tool: roosync_messages
Actions: `send`, `reply`, `amend`, `inbox`, `message`, `mark_read`, `archive`, `bulk_mark_read`, `bulk_archive`, `cleanup`, `stats`, `attachments_list`, `attachments_get`, `attachments_delete`

## Changes
- **New**: `src/tools/roosync/messages.ts` — consolidated handler with switch/case delegating to existing functions
- **Modified**: `tool-definitions.ts` — replaced 4 definitions with 1, updated allToolDefinitions array
- **Modified**: `registry.ts` — added `roosync_messages` case handler + TOOL_CAPABILITIES entry
- **Modified**: `index.ts` — added messages export, updated barrel
- **Updated tests**: registry.test.ts, tool-definitions.test.ts, tool-discoverability.test.ts, fusions-1863.test.ts

## Test plan
- [x] `npm run build` passes clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 456 files, 9200 tests passed, 0 failed
- [x] Tool count assertion: 19 (updated from 22)
- [x] Essential tools discoverability: roosync_messages present in ListTools
- [x] Backward compat: old tool names still routed via registry.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)