### PR TITLE
refactor(#2013): rename heartbeat status offline→unknown, warning→idle

### DIFF
--- a/servers/roo-state-manager/src/services/RooSyncService.ts
+++ b/servers/roo-state-manager/src/services/RooSyncService.ts
@@ -941,15 +941,15 @@ export class RooSyncService {
   /**
    * Obtient les machines actuellement offline
    */
-  public getOfflineMachines(): string[] {
-    return this.heartbeatService.getOfflineMachines();
+  public getUnknownMachines(): string[] {
+    return this.heartbeatService.getUnknownMachines();
   }
 
   /**
    * Obtient les machines en avertissement
    */
-  public getWarningMachines(): string[] {
-    return this.heartbeatService.getWarningMachines();
+  public getIdleMachines(): string[] {
+    return this.heartbeatService.getIdleMachines();
   }
 
   /**

--- a/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
+++ b/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
@@ -75,7 +75,7 @@ export interface HeartbeatData {
   lastHeartbeat: string;
 
   /** Statut de la machine */
-  status: 'online' | 'offline' | 'warning' | 'idle' | 'unknown';
+  status: 'online' | 'unknown' | 'idle';
 
   /** Nombre de heartbeats manqués consécutifs */
   missedHeartbeats: number;
@@ -102,10 +102,10 @@ export interface HeartbeatServiceState {
   onlineMachines: string[];
 
   /** Machines actuellement offline */
-  offlineMachines: string[];
+  unknownMachines: string[];
 
   /** Machines en avertissement */
-  warningMachines: string[];
+  idleMachines: string[];
 
   /** Statistiques */
   statistics: {
@@ -125,13 +125,13 @@ export interface HeartbeatCheckResult {
   success: boolean;
 
   /** Machines détectées offline */
-  newlyOfflineMachines: string[];
+  newlyUnknownMachines: string[];
 
   /** Machines redevenues online */
   newlyOnlineMachines: string[];
 
   /** Machines en avertissement */
-  warningMachines: string[];
+  idleMachines: string[];
 
   /** Timestamp de la vérification */
   checkedAt: string;
@@ -184,8 +184,8 @@ export class HeartbeatService {
     this.state = {
       heartbeats: new Map(),
       onlineMachines: [],
-      offlineMachines: [],
-      warningMachines: [],
+      unknownMachines: [],
+      idleMachines: [],
       statistics: {
         totalMachines: 0,
         onlineCount: 0,
@@ -261,8 +261,8 @@ export class HeartbeatService {
       logger.info('État du service chargé', {
         totalMachines: this.state.heartbeats.size,
         online: this.state.onlineMachines.length,
-        offline: this.state.offlineMachines.length,
-        warning: this.state.warningMachines.length
+        offline: this.state.unknownMachines.length,
+        warning: this.state.idleMachines.length
       });
     } catch (error) {
       logger.error('Erreur chargement état', error);
@@ -507,9 +507,9 @@ export class HeartbeatService {
     const now = Date.now();
     const result: HeartbeatCheckResult = {
       success: true,
-      newlyOfflineMachines: [],
+      newlyUnknownMachines: [],
       newlyOnlineMachines: [],
-      warningMachines: [],
+      idleMachines: [],
       checkedAt: new Date().toISOString()
     };
 
@@ -528,15 +528,15 @@ export class HeartbeatService {
         // UNKNOWN — no recent activity, not necessarily down
         if (previousStatus !== 'unknown') {
           heartbeatData.status = 'unknown';
-          result.newlyOfflineMachines.push(machineId);
+          result.newlyUnknownMachines.push(machineId);
           logger.info(`Machine status → UNKNOWN: ${machineId}`, { timeSinceLastHeartbeat });
         }
       } else if (timeSinceLastHeartbeat > ONLINE_THRESHOLD) {
         // IDLE — machine active within last 2h but not in last 30min
-        if (previousStatus !== 'idle' && previousStatus !== 'warning') {
+        if (previousStatus !== 'idle') {
           heartbeatData.status = 'idle';
           heartbeatData.missedHeartbeats = 1;
-          result.warningMachines.push(machineId);
+          result.idleMachines.push(machineId);
           logger.info(`Machine status → IDLE: ${machineId}`, { timeSinceLastHeartbeat });
         }
       } else {
@@ -558,7 +558,7 @@ export class HeartbeatService {
     this.state.statistics.lastHeartbeatCheck = new Date().toISOString();
 
     if (this.onOfflineDetectedCallback) {
-      for (const machineId of result.newlyOfflineMachines) {
+      for (const machineId of result.newlyUnknownMachines) {
         this.onOfflineDetectedCallback(machineId);
       }
     }
@@ -577,33 +577,31 @@ export class HeartbeatService {
    */
   private updateMachineStatus(): void {
     const onlineMachines: string[] = [];
-    const offlineMachines: string[] = [];
-    const warningMachines: string[] = [];
+    const unknownMachines: string[] = [];
+    const idleMachines: string[] = [];
 
     for (const [machineId, heartbeatData] of this.state.heartbeats.entries()) {
       switch (heartbeatData.status) {
         case 'online':
           onlineMachines.push(machineId);
           break;
-        case 'offline':
         case 'unknown':
-          offlineMachines.push(machineId);
+          unknownMachines.push(machineId);
           break;
-        case 'warning':
         case 'idle':
-          warningMachines.push(machineId);
+          idleMachines.push(machineId);
           break;
       }
     }
 
     this.state.onlineMachines = onlineMachines;
-    this.state.offlineMachines = offlineMachines;
-    this.state.warningMachines = warningMachines;
+    this.state.unknownMachines = unknownMachines;
+    this.state.idleMachines = idleMachines;
 
     this.state.statistics.totalMachines = this.state.heartbeats.size;
     this.state.statistics.onlineCount = onlineMachines.length;
-    this.state.statistics.offlineCount = offlineMachines.length;
-    this.state.statistics.warningCount = warningMachines.length;
+    this.state.statistics.offlineCount = unknownMachines.length;
+    this.state.statistics.warningCount = idleMachines.length;
   }
 
   /**
@@ -687,15 +685,15 @@ export class HeartbeatService {
   /**
    * Obtient toutes les machines offline
    */
-  public getOfflineMachines(): string[] {
-    return [...this.state.offlineMachines];
+  public getUnknownMachines(): string[] {
+    return [...this.state.unknownMachines];
   }
 
   /**
    * Obtient toutes les machines en avertissement
    */
-  public getWarningMachines(): string[] {
-    return [...this.state.warningMachines];
+  public getIdleMachines(): string[] {
+    return [...this.state.idleMachines];
   }
 
   /**
@@ -705,8 +703,8 @@ export class HeartbeatService {
     return {
       heartbeats: new Map(this.state.heartbeats),
       onlineMachines: [...this.state.onlineMachines],
-      offlineMachines: [...this.state.offlineMachines],
-      warningMachines: [...this.state.warningMachines],
+      unknownMachines: [...this.state.unknownMachines],
+      idleMachines: [...this.state.idleMachines],
       statistics: { ...this.state.statistics }
     };
   }
@@ -745,7 +743,7 @@ export class HeartbeatService {
   /**
    * Nettoie les machines offline depuis longtemps
    */
-  public async cleanupOldOfflineMachines(maxAge: number = 86400000): Promise<number> {
+  public async cleanupOldUnknownMachines(maxAge: number = 86400000): Promise<number> {
     // maxAge par défaut: 24 heures
     // #1409: Don't delete heartbeat files for production machines (myia-*) — just keep as offline.
     // Deleting production files causes machineCount to drop below the actual cluster size.
@@ -760,8 +758,8 @@ export class HeartbeatService {
 
         if (offlineAge > maxAge) {
           if (isProduction(machineId)) {
-            // Production machines: keep in state as offline, don't remove file
-            heartbeatData.status = 'offline';
+            // Production machines: keep in state as unknown, don't remove file
+            heartbeatData.status = 'unknown';
             cleanedCount++;
           } else {
             // Non-production (test artifacts): delete file and remove from state

--- a/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
@@ -9,11 +9,11 @@
  * - registerHeartbeat : nouvelle machine + writes per-machine file
  * - registerHeartbeat : machine existante (update)
  * - checkHeartbeats : reloads from disk, détecte offline/warning/online
- * - getOnlineMachines / getOfflineMachines / getWarningMachines
+ * - getOnlineMachines / getUnknownMachines / getIdleMachines
  * - getHeartbeatData : défini après register, undefined avant
  * - getState : retourne copie défensive
  * - removeMachine : suppression + file deletion
- * - cleanupOldOfflineMachines : supprime anciennes, garde récentes
+ * - cleanupOldUnknownMachines : supprime anciennes, garde récentes
  * - stopHeartbeatService : saves all per-machine files
  * - updateConfig : accepte config partielle
  *
@@ -171,8 +171,8 @@ describe('HeartbeatService', () => {
       const service = new HeartbeatService(TEST_PATH);
 
       expect(service.getOnlineMachines()).toEqual([]);
-      expect(service.getOfflineMachines()).toEqual([]);
-      expect(service.getWarningMachines()).toEqual([]);
+      expect(service.getUnknownMachines()).toEqual([]);
+      expect(service.getIdleMachines()).toEqual([]);
     });
 
     test('charge les machines depuis le répertoire per-machine', () => {
@@ -198,14 +198,14 @@ describe('HeartbeatService', () => {
     test('charge les machines offline depuis les fichiers per-machine', () => {
       const offlineMachine = {
         ...makeOnlineMachine('offline-machine'),
-        status: 'offline',
+        status: 'unknown',
         offlineSince: new Date(Date.now() - 5000).toISOString(),
       };
       setupPerMachineFiles({ 'offline-machine': offlineMachine });
 
       const service = new HeartbeatService(TEST_PATH);
 
-      expect(service.getOfflineMachines()).toContain('offline-machine');
+      expect(service.getUnknownMachines()).toContain('offline-machine');
     });
 
     test('charge plusieurs machines depuis les fichiers per-machine', () => {
@@ -399,7 +399,7 @@ describe('HeartbeatService', () => {
 
       const result = await service.checkHeartbeats();
 
-      expect(result.newlyOfflineMachines).toEqual([]);
+      expect(result.newlyUnknownMachines).toEqual([]);
       expect(result.newlyOnlineMachines).toEqual([]);
     });
 
@@ -413,8 +413,8 @@ describe('HeartbeatService', () => {
 
       const result = await service.checkHeartbeats();
 
-      expect(result.newlyOfflineMachines).toContain('slow-machine'); // UNKNOWN maps to offlineMachines
-      expect(service.getOfflineMachines()).toContain('slow-machine');
+      expect(result.newlyUnknownMachines).toContain('slow-machine'); // UNKNOWN maps to unknownMachines
+      expect(service.getUnknownMachines()).toContain('slow-machine');
       expect(service.getHeartbeatData('slow-machine')!.status).toBe('unknown');
     });
 
@@ -428,8 +428,8 @@ describe('HeartbeatService', () => {
 
       const result = await service.checkHeartbeats();
 
-      expect(result.warningMachines).toContain('idle-machine'); // IDLE maps to warningMachines
-      expect(service.getWarningMachines()).toContain('idle-machine');
+      expect(result.idleMachines).toContain('idle-machine'); // IDLE maps to idleMachines
+      expect(service.getIdleMachines()).toContain('idle-machine');
       expect(service.getHeartbeatData('idle-machine')!.status).toBe('idle');
     });
 
@@ -443,12 +443,12 @@ describe('HeartbeatService', () => {
 
       // First check → detected UNKNOWN
       await service.checkHeartbeats();
-      expect(service.getOfflineMachines()).toContain('recovering-machine');
+      expect(service.getUnknownMachines()).toContain('recovering-machine');
 
       // Re-register → revient online (in-memory update)
       await service.registerHeartbeat('recovering-machine');
       expect(service.getOnlineMachines()).toContain('recovering-machine');
-      expect(service.getOfflineMachines()).not.toContain('recovering-machine');
+      expect(service.getUnknownMachines()).not.toContain('recovering-machine');
     });
 
     test('machine online stable reste online #1953 ADR 008', async () => {
@@ -459,7 +459,7 @@ describe('HeartbeatService', () => {
 
       const result = await service.checkHeartbeats();
 
-      expect(result.newlyOfflineMachines).not.toContain('stable-machine');
+      expect(result.newlyUnknownMachines).not.toContain('stable-machine');
       expect(service.getOnlineMachines()).toContain('stable-machine');
     });
 
@@ -552,8 +552,8 @@ describe('HeartbeatService', () => {
       const state = service.getState();
       expect(state.heartbeats).toBeDefined();
       expect(state.onlineMachines).toBeDefined();
-      expect(state.offlineMachines).toBeDefined();
-      expect(state.warningMachines).toBeDefined();
+      expect(state.unknownMachines).toBeDefined();
+      expect(state.idleMachines).toBeDefined();
       expect(state.statistics).toBeDefined();
     });
 
@@ -618,34 +618,34 @@ describe('HeartbeatService', () => {
   });
 
   // ============================================================
-  // cleanupOldOfflineMachines
+  // cleanupOldUnknownMachines
   // ============================================================
 
-  describe('cleanupOldOfflineMachines', () => {
+  describe('cleanupOldUnknownMachines', () => {
     test('retourne 0 si aucune machine offline', async () => {
       const service = new HeartbeatService(TEST_PATH);
 
       await service.registerHeartbeat('active-machine');
 
-      const removed = await service.cleanupOldOfflineMachines();
+      const removed = await service.cleanupOldUnknownMachines();
 
       expect(removed).toBe(0);
     });
 
-    test('garde les machines offline anciennes en statut offline (#1409)', async () => {
+    test('garde les machines offline anciennes en statut unknown (#1409)', async () => {
       const service = new HeartbeatService(TEST_PATH, { offlineTimeout: 10 });
 
       await service.registerHeartbeat('myia-old-offline');
       const hb = service.getHeartbeatData('myia-old-offline')!;
-      hb.status = 'offline';
+      hb.status = 'unknown';
       hb.offlineSince = new Date(Date.now() - 100_000).toISOString(); // offline depuis 100s
 
-      const removed = await service.cleanupOldOfflineMachines(50_000); // maxAge = 50s
+      const removed = await service.cleanupOldUnknownMachines(50_000); // maxAge = 50s
 
       expect(removed).toBe(1);
-      // #1409: Production machines (myia-*) kept in state as offline, not deleted
+      // #1409: Production machines (myia-*) kept in state as unknown, not deleted
       expect(service.getHeartbeatData('myia-old-offline')).toBeDefined();
-      expect(service.getHeartbeatData('myia-old-offline')!.status).toBe('offline');
+      expect(service.getHeartbeatData('myia-old-offline')!.status).toBe('unknown');
     });
 
     test('garde les machines offline récentes', async () => {
@@ -653,10 +653,10 @@ describe('HeartbeatService', () => {
 
       await service.registerHeartbeat('recent-offline');
       const hb = service.getHeartbeatData('recent-offline')!;
-      hb.status = 'offline';
+      hb.status = 'unknown';
       hb.offlineSince = new Date().toISOString(); // offline depuis maintenant
 
-      const removed = await service.cleanupOldOfflineMachines(86_400_000); // maxAge = 24h
+      const removed = await service.cleanupOldUnknownMachines(86_400_000); // maxAge = 24h
 
       expect(removed).toBe(0);
       expect(service.getHeartbeatData('recent-offline')).toBeDefined();
@@ -667,7 +667,7 @@ describe('HeartbeatService', () => {
 
       await service.registerHeartbeat('online-machine');
 
-      const removed = await service.cleanupOldOfflineMachines(0); // maxAge = 0
+      const removed = await service.cleanupOldUnknownMachines(0); // maxAge = 0
 
       expect(removed).toBe(0);
     });
@@ -677,12 +677,12 @@ describe('HeartbeatService', () => {
 
       await service.registerHeartbeat('test-artifact-machine');
       const hb = service.getHeartbeatData('test-artifact-machine')!;
-      hb.status = 'offline';
+      hb.status = 'unknown';
       hb.offlineSince = new Date(Date.now() - 100_000).toISOString();
 
       mockExistsSync.mockReturnValue(true);
 
-      await service.cleanupOldOfflineMachines(50_000);
+      await service.cleanupOldUnknownMachines(50_000);
 
       // #1409: Non-production machines (not myia-*) ARE deleted
       expect(service.getHeartbeatData('test-artifact-machine')).toBeUndefined();
@@ -693,14 +693,14 @@ describe('HeartbeatService', () => {
 
       await service.registerHeartbeat('myia-cleanup-target');
       const hb = service.getHeartbeatData('myia-cleanup-target')!;
-      hb.status = 'offline';
+      hb.status = 'unknown';
       hb.offlineSince = new Date(Date.now() - 100_000).toISOString();
 
       mockExistsSync.mockReturnValue(true);
 
-      await service.cleanupOldOfflineMachines(50_000);
+      await service.cleanupOldUnknownMachines(50_000);
 
-      // #1409: Production machines (myia-*) kept as offline, files NOT deleted
+      // #1409: Production machines (myia-*) kept as unknown, files NOT deleted
       expect(mockUnlink).not.toHaveBeenCalled();
       expect(service.getHeartbeatData('myia-cleanup-target')).toBeDefined();
     });

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
@@ -66,8 +66,8 @@ describe('get-status (Option B)', () => {
       checkHeartbeats: vi.fn(),
       getState: vi.fn(() => ({
         onlineMachines: ['myia-ai-01', 'myia-po-2023'],
-        offlineMachines: [],
-        warningMachines: []
+        unknownMachines: [],
+        idleMachines: []
       }))
     });
     mockGetInboxStats.mockResolvedValue({ unread: 0, urgent: 0, by_priority: {} });
@@ -101,7 +101,7 @@ describe('get-status (Option B)', () => {
     test('validates HEALTHY result', () => {
       const result = GetStatusResultSchema.parse({
         status: 'HEALTHY',
-        machines: { online: 6, offline: 0, total: 6 },
+        machines: { online: 6, unknown: 0, total: 6 },
         inbox: { unread: 0, urgent: 0 },
         decisions: { pending: 0 },
         dashboards: { active: 1 },
@@ -114,7 +114,7 @@ describe('get-status (Option B)', () => {
     test('validates CRITICAL result with flags', () => {
       const result = GetStatusResultSchema.parse({
         status: 'CRITICAL',
-        machines: { online: 4, offline: 2, total: 6 },
+        machines: { online: 4, unknown: 2, total: 6 },
         inbox: { unread: 15, urgent: 2 },
         decisions: { pending: 3 },
         dashboards: { active: 1 },
@@ -128,7 +128,7 @@ describe('get-status (Option B)', () => {
     test('rejects old status values', () => {
       expect(() => GetStatusResultSchema.parse({
         status: 'synced',
-        machines: { online: 6, offline: 0, total: 6 },
+        machines: { online: 6, unknown: 0, total: 6 },
         inbox: { unread: 0, urgent: 0 },
         decisions: { pending: 0 },
         dashboards: { active: 1 },
@@ -160,15 +160,15 @@ describe('get-status (Option B)', () => {
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
           onlineMachines: ['myia-ai-01'],
-          offlineMachines: ['myia-po-2025'],
-          warningMachines: []
+          unknownMachines: ['myia-po-2025'],
+          idleMachines: []
         }))
       });
 
       const result = await roosyncGetStatus({});
 
       expect(result.status).toBe('CRITICAL');
-      expect(result.machines.offline).toBe(1);
+      expect(result.machines.unknown).toBe(1);
       expect(result.flags).toContain('OFFLINE:myia-po-2025');
     });
 
@@ -211,8 +211,8 @@ describe('get-status (Option B)', () => {
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
           onlineMachines: ['myia-ai-01'],
-          offlineMachines: [],
-          warningMachines: ['myia-po-2023']
+          unknownMachines: [],
+          idleMachines: ['myia-po-2023']
         }))
       });
 
@@ -270,8 +270,8 @@ describe('get-status (Option B)', () => {
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
           onlineMachines: ['myia-ai-01', 'myia-po-2023', 'myia-po-2024'],
-          offlineMachines: ['test-machine', 'persistent-machine', 'machine-2'],
-          warningMachines: []
+          unknownMachines: ['test-machine', 'persistent-machine', 'machine-2'],
+          idleMachines: []
         }))
       });
 
@@ -279,7 +279,7 @@ describe('get-status (Option B)', () => {
 
       // Orphan test machines should NOT trigger CRITICAL
       expect(result.status).toBe('HEALTHY');
-      expect(result.machines.offline).toBe(0);
+      expect(result.machines.unknown).toBe(0);
       expect(result.flags).not.toContain('OFFLINE:test-machine');
       expect(result.flags).not.toContain('OFFLINE:persistent-machine');
     });
@@ -291,7 +291,7 @@ describe('get-status (Option B)', () => {
         machines: {
           'myia-ai-01': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 },
           'myia-po-2023': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 },
-          'test-machine': { status: 'offline', lastSync: '2025-01-01', pendingDecisions: 0, diffsCount: 0 }
+          'test-machine': { status: 'unknown', lastSync: '2025-01-01', pendingDecisions: 0, diffsCount: 0 }
         }
       });
 
@@ -306,8 +306,8 @@ describe('get-status (Option B)', () => {
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
           onlineMachines: ['myia-ai-01'],
-          offlineMachines: [],
-          warningMachines: ['test-machine']  // Orphan, should be filtered
+          unknownMachines: [],
+          idleMachines: ['test-machine']  // Orphan, should be filtered
         }))
       });
 
@@ -323,8 +323,8 @@ describe('get-status (Option B)', () => {
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
           onlineMachines: ['myia-ai-01'],
-          offlineMachines: ['myia-po-2025', 'test-machine'],  // 1 real + 1 orphan
-          warningMachines: []
+          unknownMachines: ['myia-po-2025', 'test-machine'],  // 1 real + 1 orphan
+          idleMachines: []
         }))
       });
 
@@ -332,7 +332,7 @@ describe('get-status (Option B)', () => {
 
       // Should be CRITICAL from real offline machine only
       expect(result.status).toBe('CRITICAL');
-      expect(result.machines.offline).toBe(1);  // Only myia-po-2025
+      expect(result.machines.unknown).toBe(1);  // Only myia-po-2025
       expect(result.flags).toContain('OFFLINE:myia-po-2025');
       expect(result.flags).not.toContain('OFFLINE:test-machine');
     });

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/heartbeat-status.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/heartbeat-status.test.ts
@@ -50,8 +50,8 @@ import { roosyncHeartbeatStatus } from '../heartbeat-status.js';
 function makeState(overrides: Record<string, any> = {}) {
   return {
     onlineMachines: ['myia-ai-01', 'myia-po-2025'],
-    offlineMachines: ['myia-web1'],
-    warningMachines: ['myia-po-2023'],
+    unknownMachines: ['myia-web1'],
+    idleMachines: ['myia-po-2023'],
     heartbeats: new Map([
       ['myia-ai-01', {
         machineId: 'myia-ai-01', lastHeartbeat: '2026-02-22T10:00:00.000Z',
@@ -65,12 +65,12 @@ function makeState(overrides: Record<string, any> = {}) {
       }],
       ['myia-web1', {
         machineId: 'myia-web1', lastHeartbeat: '2026-02-21T10:00:00.000Z',
-        status: 'offline', missedHeartbeats: 5,
+        status: 'unknown', missedHeartbeats: 5,
         metadata: { firstSeen: '2026-01-01T00:00:00.000Z', lastUpdated: '2026-02-21T10:00:00.000Z', version: '1.0' }
       }],
       ['myia-po-2023', {
         machineId: 'myia-po-2023', lastHeartbeat: '2026-02-22T09:30:00.000Z',
-        status: 'warning', missedHeartbeats: 2,
+        status: 'idle', missedHeartbeats: 2,
         metadata: { firstSeen: '2026-01-01T00:00:00.000Z', lastUpdated: '2026-02-22T09:30:00.000Z', version: '1.0' }
       }]
     ]),
@@ -87,9 +87,9 @@ function makeState(overrides: Record<string, any> = {}) {
 
 function makeCheckResult(overrides: Record<string, any> = {}) {
   return {
-    newlyOfflineMachines: [],
+    newlyUnknownMachines: [],
     newlyOnlineMachines: [],
-    warningMachines: [],
+    idleMachines: [],
     ...overrides
   };
 }
@@ -110,8 +110,8 @@ describe('roosyncHeartbeatStatus', () => {
 
     expect(result.success).toBe(true);
     expect(result.onlineMachines).toEqual(['myia-ai-01', 'myia-po-2025']);
-    expect(result.offlineMachines).toEqual(['myia-web1']);
-    expect(result.warningMachines).toEqual(['myia-po-2023']);
+    expect(result.unknownMachines).toEqual(['myia-web1']);
+    expect(result.idleMachines).toEqual(['myia-po-2023']);
     expect(result.statistics.totalMachines).toBe(4);
     expect(result.retrievedAt).toBeDefined();
     expect(result.changes).toBeUndefined();
@@ -135,28 +135,28 @@ describe('roosyncHeartbeatStatus', () => {
 
   // ── filtres ──
 
-  test('filter=online : vide offlineMachines et warningMachines', async () => {
+  test('filter=online : vide unknownMachines et idleMachines', async () => {
     const result = await roosyncHeartbeatStatus({ filter: 'online' });
 
     expect(result.onlineMachines).toEqual(['myia-ai-01', 'myia-po-2025']);
-    expect(result.offlineMachines).toEqual([]);
-    expect(result.warningMachines).toEqual([]);
+    expect(result.unknownMachines).toEqual([]);
+    expect(result.idleMachines).toEqual([]);
   });
 
-  test('filter=offline : vide onlineMachines et warningMachines', async () => {
-    const result = await roosyncHeartbeatStatus({ filter: 'offline' });
+  test('filter=unknown : vide onlineMachines et idleMachines', async () => {
+    const result = await roosyncHeartbeatStatus({ filter: 'unknown' });
 
     expect(result.onlineMachines).toEqual([]);
-    expect(result.offlineMachines).toEqual(['myia-web1']);
-    expect(result.warningMachines).toEqual([]);
+    expect(result.unknownMachines).toEqual(['myia-web1']);
+    expect(result.idleMachines).toEqual([]);
   });
 
-  test('filter=warning : vide onlineMachines et offlineMachines', async () => {
-    const result = await roosyncHeartbeatStatus({ filter: 'warning' });
+  test('filter=idle : vide onlineMachines et unknownMachines', async () => {
+    const result = await roosyncHeartbeatStatus({ filter: 'idle' });
 
     expect(result.onlineMachines).toEqual([]);
-    expect(result.offlineMachines).toEqual([]);
-    expect(result.warningMachines).toEqual(['myia-po-2023']);
+    expect(result.unknownMachines).toEqual([]);
+    expect(result.idleMachines).toEqual(['myia-po-2023']);
   });
 
   test('filter=online avec includeHeartbeats : ne garde que les heartbeats online', async () => {
@@ -168,15 +168,15 @@ describe('roosyncHeartbeatStatus', () => {
     expect(Object.keys(result.heartbeats!)).not.toContain('myia-po-2023');
   });
 
-  test('filter=offline avec includeHeartbeats : ne garde que les heartbeats offline', async () => {
-    const result = await roosyncHeartbeatStatus({ filter: 'offline', includeHeartbeats: true });
+  test('filter=unknown avec includeHeartbeats : ne garde que les heartbeats unknown', async () => {
+    const result = await roosyncHeartbeatStatus({ filter: 'unknown', includeHeartbeats: true });
 
     expect(result.heartbeats).toBeDefined();
     expect(Object.keys(result.heartbeats!)).toEqual(['myia-web1']);
   });
 
-  test('filter=warning avec includeHeartbeats : ne garde que les heartbeats warning', async () => {
-    const result = await roosyncHeartbeatStatus({ filter: 'warning', includeHeartbeats: true });
+  test('filter=idle avec includeHeartbeats : ne garde que les heartbeats idle', async () => {
+    const result = await roosyncHeartbeatStatus({ filter: 'idle', includeHeartbeats: true });
 
     expect(result.heartbeats).toBeDefined();
     expect(Object.keys(result.heartbeats!)).toEqual(['myia-po-2023']);
@@ -186,16 +186,16 @@ describe('roosyncHeartbeatStatus', () => {
 
   test('forceCheck=true appelle checkHeartbeats et retourne les changes', async () => {
     mockCheckHeartbeats.mockResolvedValue(makeCheckResult({
-      newlyOfflineMachines: ['myia-po-2024'],
+      newlyUnknownMachines: ['myia-po-2024'],
       newlyOnlineMachines: [],
-      warningMachines: []
+      idleMachines: []
     }));
 
     const result = await roosyncHeartbeatStatus({ forceCheck: true });
 
     expect(mockCheckHeartbeats).toHaveBeenCalledTimes(1);
     expect(result.changes).toBeDefined();
-    expect(result.changes!.newlyOfflineMachines).toEqual(['myia-po-2024']);
+    expect(result.changes!.newlyUnknownMachines).toEqual(['myia-po-2024']);
     expect(result.changes!.totalChanges).toBe(1);
   });
 
@@ -209,9 +209,9 @@ describe('roosyncHeartbeatStatus', () => {
 
   test('forceCheck=true avec changements multiples calcule totalChanges correctement', async () => {
     mockCheckHeartbeats.mockResolvedValue(makeCheckResult({
-      newlyOfflineMachines: ['myia-po-2024'],
+      newlyUnknownMachines: ['myia-po-2024'],
       newlyOnlineMachines: ['myia-po-2026'],
-      warningMachines: ['myia-ai-01']
+      idleMachines: ['myia-ai-01']
     }));
 
     const result = await roosyncHeartbeatStatus({ forceCheck: true });

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/heartbeat.integration.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/heartbeat.integration.test.ts
@@ -132,20 +132,20 @@ describe('roosyncHeartbeat (integration)', () => {
       expect(result.action).toBe('status');
     });
 
-    test('should filter by status: offline', async () => {
+    test('should filter by status: unknown', async () => {
       const result = await roosyncHeartbeat({
         action: 'status',
-        filter: 'offline'
+        filter: 'unknown'
       });
 
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
     });
 
-    test('should filter by status: warning', async () => {
+    test('should filter by status: idle', async () => {
       const result = await roosyncHeartbeat({
         action: 'status',
-        filter: 'warning'
+        filter: 'idle'
       });
 
       expect(result).toBeDefined();
@@ -566,10 +566,10 @@ describe('roosyncHeartbeat (integration)', () => {
       expect(result.success).toBe(true);
     });
 
-    test('should correctly identify offline machines', async () => {
+    test('should correctly identify unknown machines', async () => {
       const result = await roosyncHeartbeat({
         action: 'status',
-        filter: 'offline',
+        filter: 'unknown',
         includeHeartbeats: true
       });
 

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/heartbeat.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/heartbeat.test.ts
@@ -35,8 +35,8 @@ describe('roosyncHeartbeat', () => {
       const mockStatusResult = {
         success: true,
         onlineMachines: ['myia-ai-01', 'myia-po-2024'],
-        offlineMachines: [],
-        warningMachines: [],
+        unknownMachines: [],
+        idleMachines: [],
         statistics: {
           totalMachines: 2,
           onlineCount: 2,
@@ -71,8 +71,8 @@ describe('roosyncHeartbeat', () => {
       const mockStatusResult = {
         success: true,
         onlineMachines: ['myia-ai-01', 'myia-po-2024'],
-        offlineMachines: [],
-        warningMachines: [],
+        unknownMachines: [],
+        idleMachines: [],
         statistics: {
           totalMachines: 2,
           onlineCount: 2,
@@ -106,8 +106,8 @@ describe('roosyncHeartbeat', () => {
       const mockStatusResult = {
         success: true,
         onlineMachines: ['myia-ai-01'],
-        offlineMachines: ['myia-po-2024'],
-        warningMachines: [],
+        unknownMachines: ['myia-po-2024'],
+        idleMachines: [],
         statistics: {
           totalMachines: 2,
           onlineCount: 1,
@@ -116,7 +116,7 @@ describe('roosyncHeartbeat', () => {
           lastHeartbeatCheck: '2026-02-11T08:00:00Z'
         },
         changes: {
-          newlyOfflineMachines: ['myia-po-2024'],
+          newlyUnknownMachines: ['myia-po-2024'],
           newlyOnlineMachines: [],
           newWarnings: [],
           totalChanges: 1
@@ -440,8 +440,8 @@ describe('roosyncHeartbeat', () => {
       const mockStatusResult = {
         success: true,
         onlineMachines: [],
-        offlineMachines: [],
-        warningMachines: [],
+        unknownMachines: [],
+        idleMachines: [],
         statistics: {
           totalMachines: 0,
           onlineCount: 0,
@@ -496,8 +496,8 @@ describe('roosyncHeartbeat', () => {
       const mockResult = {
         success: true,
         onlineMachines: [],
-        offlineMachines: [],
-        warningMachines: [],
+        unknownMachines: [],
+        idleMachines: [],
         statistics: {
           totalMachines: 0,
           onlineCount: 0,

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/inventory.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/inventory.test.ts
@@ -39,8 +39,8 @@ vi.mock('../../../services/RooSyncService.js', () => ({
     getHeartbeatService: vi.fn(() => ({
       getState: vi.fn(() => ({
         onlineMachines: ['machine-1', 'machine-2'],
-        offlineMachines: ['machine-3'],
-        warningMachines: ['machine-4'],
+        unknownMachines: ['machine-3'],
+        idleMachines: ['machine-4'],
         statistics: {
           totalMachines: 4,
           onlineCount: 2,
@@ -197,8 +197,8 @@ describe('inventoryTool', () => {
       expect(result.data).toBeDefined();
       expect(result.data.heartbeatState).toBeDefined();
       expect(result.data.heartbeatState.onlineMachines).toEqual(['machine-1', 'machine-2']);
-      expect(result.data.heartbeatState.offlineMachines).toEqual(['machine-3']);
-      expect(result.data.heartbeatState.warningMachines).toEqual(['machine-4']);
+      expect(result.data.heartbeatState.unknownMachines).toEqual(['machine-3']);
+      expect(result.data.heartbeatState.idleMachines).toEqual(['machine-4']);
       expect(result.data.machineInventory).toBeUndefined();
     });
 
@@ -330,7 +330,7 @@ describe('inventoryTool', () => {
       expect(result.data.summary).toContain('Machine:');
       expect(result.data.summary).toContain('Cluster status:');
       expect(result.data.summary).toContain('Online');
-      expect(result.data.summary).toContain('Offline');
+      expect(result.data.summary).toContain('Unknown');
     });
 
     test('should not return full JSON when summary=true', async () => {

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/machines.smoke.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/machines.smoke.test.ts
@@ -35,7 +35,7 @@ describe('SMOKE: roosync_machines', () => {
    */
   function makeHeartbeatData(
     machineId: string,
-    status: 'online' | 'offline' | 'warning',
+    status: 'online' | 'unknown' | 'idle',
     minutesAgo: number = 0
   ): Record<string, any> {
     const now = Date.now();
@@ -55,7 +55,7 @@ describe('SMOKE: roosync_machines', () => {
 
     // For offline machines, include offlineSince timestamp
     // (HeartbeatService sets this when marking a machine as offline)
-    if (status === 'offline') {
+    if (status === 'unknown') {
       data.offlineSince = lastHeartbeat;
       data.missedHeartbeats = Math.floor(minutesAgo / 5); // ~5 min heartbeat interval
     }
@@ -124,16 +124,16 @@ describe('SMOKE: roosync_machines', () => {
     writeHeartbeatFiles(initialMachines);
 
     // Step 2: Initial call to get baseline (should show no offline machines)
-    const result1 = await roosyncMachines({ status: 'offline', includeDetails: true });
+    const result1 = await roosyncMachines({ status: 'unknown', includeDetails: true });
 
     expect(result1.success).toBe(true);
     expect(result1.data).toBeDefined();
-    expect(result1.data.offlineMachines).toHaveLength(0); // No offline machines initially
+    expect(result1.data.unknownMachines).toHaveLength(0); // No offline machines initially
 
     // Step 3: Modify the underlying state (simulate machine going offline)
     const modifiedMachines = {
       ...initialMachines,
-      'test-machine-1': makeHeartbeatData('test-machine-1', 'offline', 20), // 20 minutes ago
+      'test-machine-1': makeHeartbeatData('test-machine-1', 'unknown', 20), // 20 minutes ago
     };
 
     writeHeartbeatFiles(modifiedMachines);
@@ -142,12 +142,12 @@ describe('SMOKE: roosync_machines', () => {
     RooSyncService.resetInstance();
 
     // Second call to get offline machines with details
-    const result2 = await roosyncMachines({ status: 'offline', includeDetails: true });
+    const result2 = await roosyncMachines({ status: 'unknown', includeDetails: true });
 
     // Step 5: Verify that result2 reflects the state change (fresh offline list, not cached)
     expect(result2.success).toBe(true);
-    expect(result2.data.offlineMachines).toHaveLength(1);
-    expect(result2.data.offlineMachines[0].machineId).toBe('test-machine-1');
+    expect(result2.data.unknownMachines).toHaveLength(1);
+    expect(result2.data.unknownMachines[0].machineId).toBe('test-machine-1');
 
     // This validates that offline machines are read fresh from heartbeat state,
     // not from stale cached data that would show 0 offline machines
@@ -162,15 +162,15 @@ describe('SMOKE: roosync_machines', () => {
     writeHeartbeatFiles(initialMachines);
 
     // Step 2: Initial call to get baseline (should show no warning machines)
-    const result1 = await roosyncMachines({ status: 'warning', includeDetails: true });
+    const result1 = await roosyncMachines({ status: 'idle', includeDetails: true });
 
     expect(result1.success).toBe(true);
-    expect(result1.data.warningMachines).toBeDefined();
-    expect(result1.data.warningMachines).toHaveLength(0); // No warning machines initially
+    expect(result1.data.idleMachines).toBeDefined();
+    expect(result1.data.idleMachines).toHaveLength(0); // No warning machines initially
 
     // Step 3: Modify the underlying state (simulate machine entering warning state)
     const modifiedMachines = {
-      'test-machine-3': makeHeartbeatData('test-machine-3', 'warning', 8), // 8 minutes ago
+      'test-machine-3': makeHeartbeatData('test-machine-3', 'idle', 8), // 8 minutes ago
     };
 
     writeHeartbeatFiles(modifiedMachines);
@@ -179,12 +179,12 @@ describe('SMOKE: roosync_machines', () => {
     RooSyncService.resetInstance();
 
     // Second call to get warning machines with details
-    const result2 = await roosyncMachines({ status: 'warning', includeDetails: true });
+    const result2 = await roosyncMachines({ status: 'idle', includeDetails: true });
 
     // Step 5: Verify that result2 reflects the state change (fresh warning list, not cached)
     expect(result2.success).toBe(true);
-    expect(result2.data.warningMachines).toHaveLength(1);
-    expect(result2.data.warningMachines[0].machineId).toBe('test-machine-3');
+    expect(result2.data.idleMachines).toHaveLength(1);
+    expect(result2.data.idleMachines[0].machineId).toBe('test-machine-3');
 
     // This validates that warning machines are read fresh from heartbeat state,
     // not returning stale cached results
@@ -202,14 +202,14 @@ describe('SMOKE: roosync_machines', () => {
     const result1 = await roosyncMachines({ status: 'all', includeDetails: true });
 
     expect(result1.success).toBe(true);
-    expect(result1.data.offlineMachines).toHaveLength(0);
-    expect(result1.data.warningMachines).toHaveLength(0);
+    expect(result1.data.unknownMachines).toHaveLength(0);
+    expect(result1.data.idleMachines).toHaveLength(0);
 
     // Step 3: Modify the underlying state (add more machines with different statuses)
     const modifiedMachines = {
       ...initialMachines,
-      'test-machine-5': makeHeartbeatData('test-machine-5', 'offline', 12),
-      'test-machine-6': makeHeartbeatData('test-machine-6', 'warning', 7),
+      'test-machine-5': makeHeartbeatData('test-machine-5', 'unknown', 12),
+      'test-machine-6': makeHeartbeatData('test-machine-6', 'idle', 7),
     };
 
     writeHeartbeatFiles(modifiedMachines);
@@ -222,13 +222,13 @@ describe('SMOKE: roosync_machines', () => {
 
     // Step 5: Verify that result2 reflects the state change
     expect(result2.success).toBe(true);
-    // With status: 'all', we get both offlineMachines and warningMachines
-    expect(result2.data.offlineMachines).toHaveLength(1);
-    expect(result2.data.warningMachines).toHaveLength(1);
+    // With status: 'all', we get both unknownMachines and idleMachines
+    expect(result2.data.unknownMachines).toHaveLength(1);
+    expect(result2.data.idleMachines).toHaveLength(1);
 
     // Verify machine IDs are correct
-    expect(result2.data.offlineMachines[0].machineId).toBe('test-machine-5');
-    expect(result2.data.warningMachines[0].machineId).toBe('test-machine-6');
+    expect(result2.data.unknownMachines[0].machineId).toBe('test-machine-5');
+    expect(result2.data.idleMachines[0].machineId).toBe('test-machine-6');
 
     // This validates that the machine list is computed fresh from heartbeat state,
     // not showing stale list that would only have 1 machine

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/machines.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/machines.test.ts
@@ -2,8 +2,8 @@
  * Tests unitaires pour roosync_machines
  *
  * Couvre tous les status de l'outil consolidé :
- * - status: 'offline' : Machines offline
- * - status: 'warning' : Machines en avertissement
+ * - status: 'unknown' : Machines unknown
+ * - status: 'idle' : Machines idle
  * - status: 'all' : Les deux
  *
  * Framework: Vitest
@@ -19,8 +19,8 @@ import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 vi.mock('../../../services/RooSyncService.js', () => ({
   getRooSyncService: vi.fn(() => ({
     getHeartbeatService: vi.fn(() => ({
-      getOfflineMachines: vi.fn(() => ['machine-3', 'machine-5']),
-      getWarningMachines: vi.fn(() => ['machine-4', 'machine-6']),
+      getUnknownMachines: vi.fn(() => ['machine-3', 'machine-5']),
+      getIdleMachines: vi.fn(() => ['machine-4', 'machine-6']),
       getHeartbeatData: vi.fn((machineId) => {
         const data: any = {
           machineId,
@@ -116,30 +116,30 @@ describe('machinesTool', () => {
   });
 
   // ============================================================
-  // Tests pour status: 'offline'
+  // Tests pour status: 'unknown'
   // ============================================================
 
-  describe('status: offline', () => {
-    test('should return offline machines', async () => {
+  describe('status: unknown', () => {
+    test('should return unknown machines', async () => {
       const result = await machinesTool.execute(
-        { status: 'offline' },
+        { status: 'unknown' },
         mockExecutionContext
       );
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.data.offlineMachines).toEqual(['machine-3', 'machine-5']);
-      expect(result.data.warningMachines).toBeUndefined();
+      expect(result.data.unknownMachines).toEqual(['machine-3', 'machine-5']);
+      expect(result.data.idleMachines).toBeUndefined();
     });
 
-    test('should return offline machines with details', async () => {
+    test('should return unknown machines with details', async () => {
       const result = await machinesTool.execute(
-        { status: 'offline', includeDetails: true },
+        { status: 'unknown', includeDetails: true },
         mockExecutionContext
       );
 
       expect(result.success).toBe(true);
-      expect(result.data.offlineMachines![0].offlineSince).toBeDefined();
+      expect(result.data.unknownMachines![0].offlineSince).toBeDefined();
     });
 
     test('should handle errors gracefully', async () => {
@@ -149,7 +149,7 @@ describe('machinesTool', () => {
       });
 
       const result = await machinesTool.execute(
-        { status: 'offline' },
+        { status: 'unknown' },
         mockExecutionContext
       );
 
@@ -160,30 +160,30 @@ describe('machinesTool', () => {
   });
 
   // ============================================================
-  // Tests pour status: 'warning'
+  // Tests pour status: 'idle'
   // ============================================================
 
-  describe('status: warning', () => {
-    test('should return warning machines', async () => {
+  describe('status: idle', () => {
+    test('should return idle machines', async () => {
       const result = await machinesTool.execute(
-        { status: 'warning' },
+        { status: 'idle' },
         mockExecutionContext
       );
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.data.warningMachines).toEqual(['machine-4', 'machine-6']);
-      expect(result.data.offlineMachines).toBeUndefined();
+      expect(result.data.idleMachines).toEqual(['machine-4', 'machine-6']);
+      expect(result.data.unknownMachines).toBeUndefined();
     });
 
-    test('should return warning machines with details', async () => {
+    test('should return idle machines with details', async () => {
       const result = await machinesTool.execute(
-        { status: 'warning', includeDetails: true },
+        { status: 'idle', includeDetails: true },
         mockExecutionContext
       );
 
       expect(result.success).toBe(true);
-      expect(result.data.warningMachines![0].missedHeartbeats).toBe(3);
+      expect(result.data.idleMachines![0].missedHeartbeats).toBe(3);
     });
   });
 
@@ -192,15 +192,15 @@ describe('machinesTool', () => {
   // ============================================================
 
   describe('status: all', () => {
-    test('should return both offline and warning machines', async () => {
+    test('should return both unknown and idle machines', async () => {
       const result = await machinesTool.execute(
         { status: 'all' },
         mockExecutionContext
       );
 
       expect(result.success).toBe(true);
-      expect(result.data.offlineMachines).toEqual(['machine-3', 'machine-5']);
-      expect(result.data.warningMachines).toEqual(['machine-4', 'machine-6']);
+      expect(result.data.unknownMachines).toEqual(['machine-3', 'machine-5']);
+      expect(result.data.idleMachines).toEqual(['machine-4', 'machine-6']);
     });
 
     test('should include details when requested', async () => {
@@ -209,8 +209,8 @@ describe('machinesTool', () => {
         mockExecutionContext
       );
 
-      expect(result.data.offlineMachines![0].offlineSince).toBeDefined();
-      expect(result.data.warningMachines![0].missedHeartbeats).toBe(3);
+      expect(result.data.unknownMachines![0].offlineSince).toBeDefined();
+      expect(result.data.idleMachines![0].missedHeartbeats).toBe(3);
     });
   });
 
@@ -223,7 +223,7 @@ describe('machinesTool', () => {
       expect(machinesToolMetadata.name).toBe('roosync_machines');
       expect(machinesToolMetadata.description).toContain('machines');
       expect(machinesToolMetadata.inputSchema.properties.status).toBeDefined();
-      expect(machinesToolMetadata.inputSchema.properties.status.enum).toEqual(['offline', 'warning', 'all']);
+      expect(machinesToolMetadata.inputSchema.properties.status.enum).toEqual(['unknown', 'idle', 'all']);
     });
 
     test('should require status parameter', () => {
@@ -237,8 +237,8 @@ describe('machinesTool', () => {
 
   describe('integration', () => {
     test('should handle multiple calls with different status', async () => {
-      const r1 = await machinesTool.execute({ status: 'offline' }, mockExecutionContext);
-      const r2 = await machinesTool.execute({ status: 'warning' }, mockExecutionContext);
+      const r1 = await machinesTool.execute({ status: 'unknown' }, mockExecutionContext);
+      const r2 = await machinesTool.execute({ status: 'idle' }, mockExecutionContext);
       const r3 = await machinesTool.execute({ status: 'all' }, mockExecutionContext);
 
       expect(r1.success).toBe(true);
@@ -248,7 +248,7 @@ describe('machinesTool', () => {
 
     test('should return execution time metrics', async () => {
       const result = await machinesTool.execute(
-        { status: 'offline' },
+        { status: 'unknown' },
         mockExecutionContext
       );
 

--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -56,7 +56,7 @@ export const GetStatusResultSchema = z.object({
 
   machines: z.object({
     online: z.number(),
-    offline: z.number(),
+    unknown: z.number(),
     total: z.number()
   }).describe('Compteurs machines par état'),
 
@@ -130,7 +130,7 @@ export type GetStatusResult = z.infer<typeof GetStatusResultSchema>;
  * Génère les flags actionnables à partir des données collectées
  */
 function buildFlags(
-  heartbeatState: { onlineMachines: string[]; offlineMachines: string[]; warningMachines: string[] },
+  heartbeatState: { onlineMachines: string[]; unknownMachines: string[]; idleMachines: string[] },
   inboxStats: { unread: number; urgent: number },
   pendingDecisions: number,
   machines: Array<{ id: string; status: string; lastSync?: string }>
@@ -138,12 +138,12 @@ function buildFlags(
   const flags: string[] = [];
 
   // Offline machines
-  for (const machineId of heartbeatState.offlineMachines) {
+  for (const machineId of heartbeatState.unknownMachines) {
     flags.push(`OFFLINE:${machineId}`);
   }
 
   // Warning machines (heartbeat stale)
-  for (const machineId of heartbeatState.warningMachines) {
+  for (const machineId of heartbeatState.idleMachines) {
     flags.push(`HEARTBEAT_STALE:${machineId}`);
   }
 
@@ -167,7 +167,7 @@ function buildFlags(
   for (const m of machines) {
     if (m.lastSync) {
       const syncDate = new Date(m.lastSync).getTime();
-      if (!isNaN(syncDate) && syncDate < oneDayAgo && m.status !== 'offline') {
+      if (!isNaN(syncDate) && syncDate < oneDayAgo && m.status !== 'unknown') {
         flags.push(`SYNC_STALE:${m.id}`);
       }
     }
@@ -259,7 +259,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
           return heartbeatService.getState();
         } catch (err) {
           logger.warn('Heartbeat check failed', { error: String(err) });
-          return { onlineMachines: [] as string[], offlineMachines: [] as string[], warningMachines: [] as string[] };
+          return { onlineMachines: [] as string[], unknownMachines: [] as string[], idleMachines: [] as string[] };
         }
       })(),
       (async () => {
@@ -313,8 +313,8 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
     // #1365: Filter out orphan test entries (test-machine, persistent-machine, etc.)
     // Only keep machines matching the known pattern: myia-*
     let filteredOnlineMachines = (heartbeatState?.onlineMachines ?? []).filter(isKnownMachine);
-    let filteredOfflineMachines = (heartbeatState?.offlineMachines ?? []).filter(isKnownMachine);
-    let filteredWarningMachines = (heartbeatState?.warningMachines ?? []).filter(isKnownMachine);
+    let filteredUnknownMachines = (heartbeatState?.unknownMachines ?? []).filter(isKnownMachine);
+    let filteredIdleMachines = (heartbeatState?.idleMachines ?? []).filter(isKnownMachine);
     const filteredDashboardMachines = machines.filter(m => isKnownMachine(m.id));
 
     // #1953: Cross-check heartbeat-derived status against dashboard activity.
@@ -327,12 +327,12 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
       const dashboardContent = readFileSync(workspaceDashboard, 'utf-8');
       const { crossCheckWithDashboard } = await import('../../utils/dashboard-activity.js');
       const crossChecked = crossCheckWithDashboard(
-        { onlineMachines: filteredOnlineMachines, offlineMachines: filteredOfflineMachines, warningMachines: filteredWarningMachines },
+        { onlineMachines: filteredOnlineMachines, unknownMachines: filteredUnknownMachines, idleMachines: filteredIdleMachines },
         dashboardContent
       );
       filteredOnlineMachines = crossChecked.onlineMachines;
-      filteredOfflineMachines = crossChecked.offlineMachines;
-      filteredWarningMachines = crossChecked.warningMachines;
+      filteredUnknownMachines = crossChecked.unknownMachines;
+      filteredIdleMachines = crossChecked.idleMachines;
       dashboardOverrides = crossChecked.overrides;
     } catch (err) {
       logger.debug('Dashboard cross-check skipped', { error: String(err) });
@@ -340,7 +340,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
 
     // #1409: Use machine registry as authoritative source for total count
     const registryMachineIds = service.getKnownMachineIds();
-    const heartbeatTotal = filteredOnlineMachines.length + filteredOfflineMachines.length;
+    const heartbeatTotal = filteredOnlineMachines.length + filteredUnknownMachines.length;
     const totalMachines = Math.max(
       registryMachineIds.length,
       filteredDashboardMachines.length,
@@ -351,8 +351,8 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
     const flags = buildFlags(
       {
         onlineMachines: filteredOnlineMachines,
-        offlineMachines: filteredOfflineMachines,
-        warningMachines: filteredWarningMachines
+        unknownMachines: filteredUnknownMachines,
+        idleMachines: filteredIdleMachines
       },
       inboxStats,
       pendingDecisions,
@@ -361,9 +361,9 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
 
     // Derive overall status (based on KNOWN machines only)
     let status: 'HEALTHY' | 'WARNING' | 'CRITICAL' = 'HEALTHY';
-    if (filteredOfflineMachines.length > 0 || inboxStats.urgent > 0) {
+    if (filteredUnknownMachines.length > 0 || inboxStats.urgent > 0) {
       status = 'CRITICAL';
-    } else if (inboxStats.unread > 5 || filteredWarningMachines.length > 0) {
+    } else if (inboxStats.unread > 5 || filteredIdleMachines.length > 0) {
       // WARNING if: high unread count OR heartbeat warning machines (but no offline)
       status = 'WARNING';
     }
@@ -372,7 +372,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
     if (args.machineFilter) {
       const machineExists = filteredDashboardMachines.some(m => m.id === args.machineFilter) ||
         filteredOnlineMachines.includes(args.machineFilter) ||
-        filteredOfflineMachines.includes(args.machineFilter);
+        filteredUnknownMachines.includes(args.machineFilter);
 
       if (!machineExists) {
         throw new RooSyncServiceError(
@@ -386,7 +386,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
       status,
       machines: {
         online: filteredOnlineMachines.length,
-        offline: filteredOfflineMachines.length,
+        unknown: filteredUnknownMachines.length,
         total: totalMachines,
         ...(dashboardOverrides.length > 0 ? { dashboardOverrides } : {})
       },
@@ -408,9 +408,9 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
             machineId: mid,
             status: 'online'
           }));
-          filteredWarningMachines.forEach(mid => {
+          filteredIdleMachines.forEach(mid => {
             if (!onlineAgents.some(a => a.machineId === mid)) {
-              onlineAgents.push({ machineId: mid, status: 'warning' });
+              onlineAgents.push({ machineId: mid, status: 'idle' });
             }
           });
 

--- a/servers/roo-state-manager/src/tools/roosync/heartbeat-service.ts
+++ b/servers/roo-state-manager/src/tools/roosync/heartbeat-service.ts
@@ -42,7 +42,7 @@ export const RegisterResultSchema = z.object({
     .describe('Identifiant de la machine'),
   timestamp: z.string()
     .describe('Timestamp du heartbeat (ISO 8601)'),
-  status: z.enum(['online', 'offline', 'warning', 'idle', 'unknown'])
+  status: z.enum(['online', 'unknown', 'idle'])
     .describe('Statut de la machine apres l\'enregistrement'),
   isNewMachine: z.boolean()
     .describe('Indique si c\'est une nouvelle machine')

--- a/servers/roo-state-manager/src/tools/roosync/heartbeat-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/heartbeat-status.ts
@@ -1,7 +1,7 @@
 /**
  * Outil MCP : roosync_heartbeat_status
  *
- * État complet du service de heartbeat (machines online, offline, warning).
+ * État complet du service de heartbeat (machines online, unknown, idle).
  *
  * @module tools/roosync/heartbeat-status
  * @version 3.1.0
@@ -15,7 +15,7 @@ import { HeartbeatServiceError } from '../../services/roosync/HeartbeatService.j
  * Schema de validation pour roosync_heartbeat_status
  */
 export const HeartbeatStatusArgsSchema = z.object({
-  filter: z.enum(['all', 'online', 'offline', 'warning']).optional()
+  filter: z.enum(['all', 'online', 'unknown', 'idle']).optional()
     .describe('Filtrer par statut de machine (defaut: all)'),
   includeHeartbeats: z.boolean().optional()
     .describe('Inclure les donnees de heartbeat de chaque machine (defaut: true)'),
@@ -35,7 +35,7 @@ export const HeartbeatDataSchema = z.object({
     .describe('Identifiant de la machine'),
   lastHeartbeat: z.string()
     .describe('Timestamp du dernier heartbeat (ISO 8601)'),
-  status: z.enum(['online', 'offline', 'warning', 'idle', 'unknown'])
+  status: z.enum(['online', 'unknown', 'idle'])
     .describe('Statut de la machine'),
   missedHeartbeats: z.number()
     .describe('Nombre de heartbeats manques consecutifs'),
@@ -75,7 +75,7 @@ export type HeartbeatStatistics = z.infer<typeof HeartbeatStatisticsSchema>;
  * Changements de statut (si forceCheck ou includeChanges)
  */
 export const StatusChangesSchema = z.object({
-  newlyOfflineMachines: z.array(z.string())
+  newlyUnknownMachines: z.array(z.string())
     .describe('Machines nouvellement detectees offline'),
   newlyOnlineMachines: z.array(z.string())
     .describe('Machines redevenues online'),
@@ -95,9 +95,9 @@ export const HeartbeatStatusResultSchema = z.object({
     .describe('Indique si la recuperation a reussi'),
   onlineMachines: z.array(z.string())
     .describe('Liste des IDs des machines online'),
-  offlineMachines: z.array(z.string())
+  unknownMachines: z.array(z.string())
     .describe('Liste des IDs des machines offline'),
-  warningMachines: z.array(z.string())
+  idleMachines: z.array(z.string())
     .describe('Liste des IDs des machines en avertissement'),
   statistics: HeartbeatStatisticsSchema
     .describe('Statistiques du service'),
@@ -139,12 +139,12 @@ export async function roosyncHeartbeatStatus(args: HeartbeatStatusArgs): Promise
     if (forceCheck || includeChanges) {
       const checkResult = await heartbeatService.checkHeartbeats();
       changes = {
-        newlyOfflineMachines: checkResult.newlyOfflineMachines,
+        newlyUnknownMachines: checkResult.newlyUnknownMachines,
         newlyOnlineMachines: checkResult.newlyOnlineMachines,
-        newWarnings: checkResult.warningMachines,
-        totalChanges: checkResult.newlyOfflineMachines.length +
+        newWarnings: checkResult.idleMachines,
+        totalChanges: checkResult.newlyUnknownMachines.length +
                       checkResult.newlyOnlineMachines.length +
-                      checkResult.warningMachines.length
+                      checkResult.idleMachines.length
       };
     }
 
@@ -153,18 +153,18 @@ export async function roosyncHeartbeatStatus(args: HeartbeatStatusArgs): Promise
 
     // Appliquer le filtre si necessaire
     let onlineMachines = state.onlineMachines;
-    let offlineMachines = state.offlineMachines;
-    let warningMachines = state.warningMachines;
+    let unknownMachines = state.unknownMachines;
+    let idleMachines = state.idleMachines;
 
     if (filter === 'online') {
-      offlineMachines = [];
-      warningMachines = [];
-    } else if (filter === 'offline') {
+      unknownMachines = [];
+      idleMachines = [];
+    } else if (filter === 'unknown') {
       onlineMachines = [];
-      warningMachines = [];
-    } else if (filter === 'warning') {
+      idleMachines = [];
+    } else if (filter === 'idle') {
       onlineMachines = [];
-      offlineMachines = [];
+      unknownMachines = [];
     }
 
     // Filtrer les heartbeats si necessaire
@@ -175,8 +175,8 @@ export async function roosyncHeartbeatStatus(args: HeartbeatStatusArgs): Promise
         heartbeats = allHeartbeats;
       } else {
         const filteredIds = filter === 'online' ? onlineMachines :
-                           filter === 'offline' ? offlineMachines :
-                           warningMachines;
+                           filter === 'unknown' ? unknownMachines :
+                           idleMachines;
         heartbeats = {};
         for (const id of filteredIds) {
           if (allHeartbeats[id]) {
@@ -189,8 +189,8 @@ export async function roosyncHeartbeatStatus(args: HeartbeatStatusArgs): Promise
     return {
       success: true,
       onlineMachines,
-      offlineMachines,
-      warningMachines,
+      unknownMachines,
+      idleMachines,
       statistics: state.statistics,
       heartbeats,
       changes,
@@ -213,13 +213,13 @@ export async function roosyncHeartbeatStatus(args: HeartbeatStatusArgs): Promise
  */
 export const heartbeatStatusToolMetadata = {
   name: 'roosync_heartbeat_status',
-  description: 'État complet du service de heartbeat (machines online, offline, warning, heartbeats).',
+  description: 'État complet du service de heartbeat (machines online, unknown, idle, heartbeats).',
   inputSchema: {
     type: 'object' as const,
     properties: {
       filter: {
         type: 'string',
-        enum: ['all', 'online', 'offline', 'warning'],
+        enum: ['all', 'online', 'unknown', 'idle'],
         description: 'Filtrer par statut de machine (defaut: all)'
       },
       includeHeartbeats: {

--- a/servers/roo-state-manager/src/tools/roosync/heartbeat.ts
+++ b/servers/roo-state-manager/src/tools/roosync/heartbeat.ts
@@ -29,7 +29,7 @@ export const HeartbeatArgsSchema = z.object({
     .describe('Type d\'opération: status (état), register (enregistrer), start (démarrer), stop (arrêter)'),
 
   // Paramètres pour action: 'status'
-  filter: z.enum(['all', 'online', 'offline', 'warning']).optional()
+  filter: z.enum(['all', 'online', 'unknown', 'idle']).optional()
     .describe('Filtrer par statut de machine (action: status)'),
   includeHeartbeats: z.boolean().optional()
     .describe('Inclure les données de heartbeat (action: status)'),
@@ -189,7 +189,7 @@ export const heartbeatToolMetadata = {
       },
       filter: {
         type: 'string',
-        enum: ['all', 'online', 'offline', 'warning'],
+        enum: ['all', 'online', 'unknown', 'idle'],
         description: 'Filtrer par statut de machine (action: status)'
       },
       includeHeartbeats: {

--- a/servers/roo-state-manager/src/tools/roosync/inventory.ts
+++ b/servers/roo-state-manager/src/tools/roosync/inventory.ts
@@ -24,8 +24,8 @@ export const InventoryArgsSchema = z.object({
   includeHeartbeats: z.boolean().optional()
     .describe('Inclure les données de heartbeat de chaque machine (défaut: true)'),
   // Pour type="machines" (fused from roosync_machines)
-  status: z.enum(['offline', 'warning', 'all']).optional()
-    .describe('Filtrer par statut machines (type="machines": offline, warning, all)'),
+  status: z.enum(['unknown', 'idle', 'all']).optional()
+    .describe('Filtrer par statut machines (type="machines": unknown, idle, all)'),
   includeDetails: z.boolean().optional()
     .describe('Inclure les détails complets des machines (type="machines") ou stats outil (type="status")'),
   summary: z.boolean().optional()
@@ -47,7 +47,7 @@ export const HeartbeatDataSchema = z.object({
     .describe('Identifiant de la machine'),
   lastHeartbeat: z.string()
     .describe('Timestamp du dernier heartbeat (ISO 8601)'),
-  status: z.enum(['online', 'offline', 'warning'])
+  status: z.enum(['online', 'unknown', 'idle'])
     .describe('Statut de la machine'),
   missedHeartbeats: z.number()
     .describe('Nombre de heartbeats manqués consécutifs'),
@@ -94,9 +94,9 @@ export const InventoryResultSchema = z.object({
   heartbeatState: z.object({
     onlineMachines: z.array(z.string())
       .describe('Liste des IDs des machines online'),
-    offlineMachines: z.array(z.string())
+    unknownMachines: z.array(z.string())
       .describe('Liste des IDs des machines offline'),
-    warningMachines: z.array(z.string())
+    idleMachines: z.array(z.string())
       .describe('Liste des IDs des machines en avertissement'),
     statistics: HeartbeatStatisticsSchema
       .describe('Statistiques du service'),
@@ -181,8 +181,8 @@ export const inventoryTool: UnifiedToolContract = {
 
         heartbeatState = {
           onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
+          unknownMachines: state.unknownMachines,
+          idleMachines: state.idleMachines,
           statistics: state.statistics,
           heartbeats: includeHeartbeats ? Object.fromEntries(state.heartbeats) : undefined,
           retrievedAt
@@ -199,41 +199,41 @@ export const inventoryTool: UnifiedToolContract = {
         const machinesStatus = input.status || 'all';
         const wantDetails = input.includeDetails || false;
 
-        machinesData = { offlineMachines: [], offlineCount: 0, warningMachines: [], warningCount: 0 };
+        machinesData = { unknownMachines: [], offlineCount: 0, idleMachines: [], warningCount: 0 };
 
-        if (machinesStatus === 'offline' || machinesStatus === 'all') {
-          const offlineMachines = heartbeatService.getOfflineMachines();
+        if (machinesStatus === 'unknown' || machinesStatus === 'all') {
+          const unknownMachines = heartbeatService.getUnknownMachines();
           if (wantDetails) {
             const detailed: any[] = [];
-            for (const mid of offlineMachines) {
+            for (const mid of unknownMachines) {
               const data = heartbeatService.getHeartbeatData(mid);
               if (data && data.offlineSince) {
                 detailed.push({ machineId: data.machineId, lastHeartbeat: data.lastHeartbeat, offlineSince: data.offlineSince, missedHeartbeats: data.missedHeartbeats, metadata: data.metadata });
               }
             }
-            machinesData.offlineMachines = detailed;
+            machinesData.unknownMachines = detailed;
             machinesData.offlineCount = detailed.length;
           } else {
-            machinesData.offlineMachines = offlineMachines;
-            machinesData.offlineCount = offlineMachines.length;
+            machinesData.unknownMachines = unknownMachines;
+            machinesData.offlineCount = unknownMachines.length;
           }
         }
 
-        if (machinesStatus === 'warning' || machinesStatus === 'all') {
-          const warningMachines = heartbeatService.getWarningMachines();
+        if (machinesStatus === 'idle' || machinesStatus === 'all') {
+          const idleMachines = heartbeatService.getIdleMachines();
           if (wantDetails) {
             const detailed: any[] = [];
-            for (const mid of warningMachines) {
+            for (const mid of idleMachines) {
               const data = heartbeatService.getHeartbeatData(mid);
               if (data) {
                 detailed.push({ machineId: data.machineId, lastHeartbeat: data.lastHeartbeat, missedHeartbeats: data.missedHeartbeats, metadata: data.metadata });
               }
             }
-            machinesData.warningMachines = detailed;
+            machinesData.idleMachines = detailed;
             machinesData.warningCount = detailed.length;
           } else {
-            machinesData.warningMachines = warningMachines;
-            machinesData.warningCount = warningMachines.length;
+            machinesData.idleMachines = idleMachines;
+            machinesData.warningCount = idleMachines.length;
           }
         }
         if (!summary) {
@@ -260,13 +260,13 @@ export const inventoryTool: UnifiedToolContract = {
           const hs = heartbeatState;
           lines.push(`**Cluster status:** ${hs.statistics.totalMachines} machines`);
           lines.push(`- Online (${hs.onlineMachines.length}): ${hs.onlineMachines.join(', ') || 'none'}`);
-          lines.push(`- Offline (${hs.offlineMachines.length}): ${hs.offlineMachines.join(', ') || 'none'}`);
-          lines.push(`- Warning (${hs.warningMachines.length}): ${hs.warningMachines.join(', ') || 'none'}`);
+          lines.push(`- Unknown (${hs.unknownMachines.length}): ${hs.unknownMachines.join(', ') || 'none'}`);
+          lines.push(`- Idle (${hs.idleMachines.length}): ${hs.idleMachines.join(', ') || 'none'}`);
           lines.push('');
         }
 
         if (machinesData) {
-          lines.push(`**Filtered machines:** offline=${machinesData.offlineCount}, warning=${machinesData.warningCount}`);
+          lines.push(`**Filtered machines:** unknown=${machinesData.offlineCount}, idle=${machinesData.warningCount}`);
           lines.push('');
         }
 
@@ -316,7 +316,7 @@ export const inventoryToolMetadata = {
       type: {
         type: 'string',
         enum: ['machine', 'heartbeat', 'all', 'machines', 'status'],
-        description: 'Type d\'inventaire. "machines" = offline/warning. "status" = snapshot système avec flags.'
+        description: 'Type d\'inventaire. "machines" = unknown/idle. "status" = snapshot système avec flags.'
       },
       machineId: {
         type: 'string',
@@ -328,8 +328,8 @@ export const inventoryToolMetadata = {
       },
       status: {
         type: 'string',
-        enum: ['offline', 'warning', 'all'],
-        description: 'Filtrer par statut machines (type="machines": offline, warning, all)'
+        enum: ['unknown', 'idle', 'all'],
+        description: 'Filtrer par statut machines (type="machines": unknown, idle, all)'
       },
       includeDetails: {
         type: 'boolean',

--- a/servers/roo-state-manager/src/tools/roosync/machines.ts
+++ b/servers/roo-state-manager/src/tools/roosync/machines.ts
@@ -1,7 +1,7 @@
 /**
  * Outil MCP : roosync_machines
  *
- * Récupération des machines offline et/ou en avertissement.
+ * Récupération des machines unknown et/ou idle.
  *
  * @module tools/roosync/machines
  * @version 3.0.0
@@ -16,7 +16,7 @@ import { HeartbeatServiceError } from '../../services/roosync/HeartbeatService.j
  * Schema de validation pour roosync_machines
  */
 export const MachinesArgsSchema = z.object({
-  status: z.enum(['offline', 'warning', 'all'])
+  status: z.enum(['unknown', 'idle', 'all'])
     .describe('Statut des machines à récupérer'),
   includeDetails: z.boolean().optional()
     .describe('Inclure les détails complets de chaque machine (défaut: false)')
@@ -27,7 +27,7 @@ export type MachinesArgs = z.infer<typeof MachinesArgsSchema>;
 /**
  * Détails d'une machine offline
  */
-export const OfflineMachineDetailsSchema = z.object({
+export const UnknownMachineDetailsSchema = z.object({
   machineId: z.string()
     .describe('Identifiant de la machine'),
   lastHeartbeat: z.string()
@@ -46,12 +46,12 @@ export const OfflineMachineDetailsSchema = z.object({
   })
 });
 
-export type OfflineMachineDetails = z.infer<typeof OfflineMachineDetailsSchema>;
+export type UnknownMachineDetails = z.infer<typeof UnknownMachineDetailsSchema>;
 
 /**
  * Détails d'une machine en avertissement
  */
-export const WarningMachineDetailsSchema = z.object({
+export const IdleMachineDetailsSchema = z.object({
   machineId: z.string()
     .describe('Identifiant de la machine'),
   lastHeartbeat: z.string()
@@ -68,7 +68,7 @@ export const WarningMachineDetailsSchema = z.object({
   })
 });
 
-export type WarningMachineDetails = z.infer<typeof WarningMachineDetailsSchema>;
+export type IdleMachineDetails = z.infer<typeof IdleMachineDetailsSchema>;
 
 /**
  * Schema de retour pour roosync_machines
@@ -76,14 +76,14 @@ export type WarningMachineDetails = z.infer<typeof WarningMachineDetailsSchema>;
 export const MachinesResultSchema = z.object({
   success: z.boolean()
     .describe('Indique si la récupération a réussi'),
-  offlineMachines: z.union([
+  unknownMachines: z.union([
     z.array(z.string()).describe('Liste des IDs des machines offline'),
-    z.array(OfflineMachineDetailsSchema).describe('Liste détaillée des machines offline')
+    z.array(UnknownMachineDetailsSchema).describe('Liste détaillée des machines offline')
   ]).optional()
     .describe('Liste des machines offline (IDs ou détails selon includeDetails)'),
-  warningMachines: z.union([
+  idleMachines: z.union([
     z.array(z.string()).describe('Liste des IDs des machines en avertissement'),
-    z.array(WarningMachineDetailsSchema).describe('Liste détaillée des machines en avertissement')
+    z.array(IdleMachineDetailsSchema).describe('Liste détaillée des machines en avertissement')
   ]).optional()
     .describe('Liste des machines en avertissement (IDs ou détails selon includeDetails)'),
   offlineCount: z.number().optional()
@@ -99,11 +99,11 @@ export type MachinesResult = z.infer<typeof MachinesResultSchema>;
 /**
  * Outil roosync_machines (UnifiedToolContract)
  *
- * Récupération des machines offline et/ou en avertissement.
+ * Récupération des machines unknown et/ou idle.
  */
 export const machinesTool: UnifiedToolContract = {
   name: 'roosync_machines',
-  description: 'Récupération des machines offline et/ou en avertissement.',
+  description: 'Récupération des machines unknown et/ou idle.',
   category: ToolCategory.UTILITY,
   processingLevel: ProcessingLevel.IMMEDIATE,
   version: '3.0.0',
@@ -122,13 +122,13 @@ export const machinesTool: UnifiedToolContract = {
       };
 
       // Récupérer les machines offline si demandé
-      if (status === 'offline' || status === 'all') {
-        const offlineMachines = heartbeatService.getOfflineMachines();
+      if (status === 'unknown' || status === 'all') {
+        const unknownMachines = heartbeatService.getUnknownMachines();
 
         if (includeDetails) {
-          const detailedMachines: OfflineMachineDetails[] = [];
+          const detailedMachines: UnknownMachineDetails[] = [];
 
-          for (const machineId of offlineMachines) {
+          for (const machineId of unknownMachines) {
             const heartbeatData = heartbeatService.getHeartbeatData(machineId);
 
             if (heartbeatData && heartbeatData.offlineSince) {
@@ -142,22 +142,22 @@ export const machinesTool: UnifiedToolContract = {
             }
           }
 
-          result.offlineMachines = detailedMachines;
+          result.unknownMachines = detailedMachines;
           result.offlineCount = detailedMachines.length;
         } else {
-          result.offlineMachines = offlineMachines;
-          result.offlineCount = offlineMachines.length;
+          result.unknownMachines = unknownMachines;
+          result.offlineCount = unknownMachines.length;
         }
       }
 
       // Récupérer les machines en avertissement si demandé
-      if (status === 'warning' || status === 'all') {
-        const warningMachines = heartbeatService.getWarningMachines();
+      if (status === 'idle' || status === 'all') {
+        const idleMachines = heartbeatService.getIdleMachines();
 
         if (includeDetails) {
-          const detailedMachines: WarningMachineDetails[] = [];
+          const detailedMachines: IdleMachineDetails[] = [];
 
-          for (const machineId of warningMachines) {
+          for (const machineId of idleMachines) {
             const heartbeatData = heartbeatService.getHeartbeatData(machineId);
 
             if (heartbeatData) {
@@ -170,11 +170,11 @@ export const machinesTool: UnifiedToolContract = {
             }
           }
 
-          result.warningMachines = detailedMachines;
+          result.idleMachines = detailedMachines;
           result.warningCount = detailedMachines.length;
         } else {
-          result.warningMachines = warningMachines;
-          result.warningCount = warningMachines.length;
+          result.idleMachines = idleMachines;
+          result.warningCount = idleMachines.length;
         }
       }
 
@@ -214,13 +214,13 @@ export async function roosyncMachines(args: MachinesArgs, context?: any): Promis
  */
 export const machinesToolMetadata = {
   name: 'roosync_machines',
-  description: 'Récupération des machines offline et/ou en avertissement.',
+  description: 'Récupération des machines unknown et/ou idle.',
   inputSchema: {
     type: 'object' as const,
     properties: {
       status: {
         type: 'string',
-        enum: ['offline', 'warning', 'all'],
+        enum: ['unknown', 'idle', 'all'],
         description: 'Statut des machines à récupérer'
       },
       includeDetails: {

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -405,10 +405,10 @@ export const roosyncInventoryDefinition = {
     inputSchema: {
         type: 'object',
         properties: {
-            type: { type: 'string', enum: ['machine', 'heartbeat', 'all', 'machines', 'status'], description: 'Inventory type. "machines" = offline/warning only. "status" = compact system snapshot with flags.' },
+            type: { type: 'string', enum: ['machine', 'heartbeat', 'all', 'machines', 'status'], description: 'Inventory type. "machines" = unknown/idle only. "status" = compact system snapshot with flags.' },
             machineId: { type: 'string', description: 'Machine ID (default: hostname). For type="status", acts as machineFilter.' },
             includeHeartbeats: { type: 'boolean', description: 'Include heartbeat data (default: true, type=heartbeat|all)' },
-            status: { type: 'string', enum: ['offline', 'warning', 'all'], description: 'Filter by status (type="machines")' },
+            status: { type: 'string', enum: ['unknown', 'idle', 'all'], description: 'Filter by status (type="machines")' },
             includeDetails: { type: 'boolean', description: 'Full machine details (type="machines") or tool usage stats (type="status")' },
             detail: { type: 'string', enum: ['compact', 'full'], description: 'Detail level for type="status". "full" adds claims + pipeline stages (#1855 HUD)' },
             resetCache: { type: 'boolean', description: 'Force service cache reset (type="status" only, default: false)' }

--- a/servers/roo-state-manager/src/types/machine-config.ts
+++ b/servers/roo-state-manager/src/types/machine-config.ts
@@ -155,8 +155,7 @@ export interface RooSyncState {
   heartbeat?: {
     registered: boolean;
     lastHeartbeat?: string;
-    status?: 'online' | 'offline' | 'warning';
-    missedHeartbeats?: number;
+    status?: 'online' | 'unknown' | 'idle';
   };
 
   /** Messaging stats */

--- a/servers/roo-state-manager/src/utils/__tests__/dashboard-activity.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/dashboard-activity.test.ts
@@ -89,49 +89,49 @@ describe('dashboard-activity', () => {
 		it('should override OFFLINE to ONLINE when dashboard shows recent activity', () => {
 			const heartbeatState = {
 				onlineMachines: ['myia-po-2023'],
-				offlineMachines: ['myia-po-2024'],
-				warningMachines: [],
+				unknownMachines: ['myia-po-2024'],
+				idleMachines: [],
 			};
 			const dashboardContent = '### [2026-05-03T19:30:00Z] myia-po-2024|roo-extensions\nRecent message';
 
 			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
 			expect(result.onlineMachines).toContain('myia-po-2024');
-			expect(result.offlineMachines).not.toContain('myia-po-2024');
+			expect(result.unknownMachines).not.toContain('myia-po-2024');
 			expect(result.overrides).toContain('myia-po-2024');
 		});
 
 		it('should override WARNING to ONLINE when dashboard shows recent activity', () => {
 			const heartbeatState = {
 				onlineMachines: [],
-				offlineMachines: [],
-				warningMachines: ['myia-web1'],
+				unknownMachines: [],
+				idleMachines: ['myia-web1'],
 			};
 			const dashboardContent = '### [2026-05-03T19:45:00Z] myia-web1|roo-extensions\nRecent message';
 
 			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
 			expect(result.onlineMachines).toContain('myia-web1');
-			expect(result.warningMachines).not.toContain('myia-web1');
+			expect(result.idleMachines).not.toContain('myia-web1');
 			expect(result.overrides).toContain('myia-web1');
 		});
 
 		it('should NOT override when dashboard activity is too old', () => {
 			const heartbeatState = {
 				onlineMachines: [],
-				offlineMachines: ['myia-po-2025'],
-				warningMachines: [],
+				unknownMachines: ['myia-po-2025'],
+				idleMachines: [],
 			};
 			const dashboardContent = '### [2026-05-03T10:00:00Z] myia-po-2025|roo-extensions\nOld message';
 
 			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
-			expect(result.offlineMachines).toContain('myia-po-2025');
+			expect(result.unknownMachines).toContain('myia-po-2025');
 			expect(result.overrides).toHaveLength(0);
 		});
 
 		it('should handle multiple overrides', () => {
 			const heartbeatState = {
 				onlineMachines: [],
-				offlineMachines: ['myia-po-2024', 'myia-po-2025'],
-				warningMachines: ['myia-web1'],
+				unknownMachines: ['myia-po-2024', 'myia-po-2025'],
+				idleMachines: ['myia-web1'],
 			};
 			const dashboardContent = [
 				'### [2026-05-03T19:50:00Z] myia-po-2024|roo-extensions',
@@ -150,8 +150,8 @@ describe('dashboard-activity', () => {
 		it('should not modify already online machines', () => {
 			const heartbeatState = {
 				onlineMachines: ['myia-ai-01'],
-				offlineMachines: [],
-				warningMachines: [],
+				unknownMachines: [],
+				idleMachines: [],
 			};
 			const dashboardContent = '### [2026-05-03T19:50:00Z] myia-ai-01|roo-extensions\nMessage';
 

--- a/servers/roo-state-manager/src/utils/dashboard-activity.ts
+++ b/servers/roo-state-manager/src/utils/dashboard-activity.ts
@@ -2,7 +2,7 @@
  * Dashboard-derived machine status utility (#1953)
  *
  * Parses dashboard message timestamps to determine last-seen time per machine.
- * Used as a cross-check against heartbeat files to prevent false OFFLINE detection
+ * Used as a cross-check against heartbeat files to prevent false UNKNOWN detection
  * caused by GDrive propagation latency.
  *
  * Dashboard messages embed timestamps INSIDE the content (written by the posting machine),
@@ -67,56 +67,56 @@ export function isRecentlyActive(lastSeen: string, thresholdMs: number = 60 * 60
 /**
  * Cross-check heartbeat-derived status against dashboard activity.
  *
- * For machines marked "offline" or "warning" by heartbeat files,
+ * For machines marked "unknown" or "idle" by heartbeat files,
  * if dashboard shows recent activity, override the status to "online".
  *
  * @param heartbeatState - State from HeartbeatService.checkHeartbeats()
  * @param dashboardContent - Raw dashboard markdown content
  * @param thresholdMs - Dashboard activity threshold (default: 60 min)
- * @returns Updated lists of online/offline/warning machines
+ * @returns Updated lists of online/unknown/idle machines
  */
 export function crossCheckWithDashboard(
 	heartbeatState: {
 		onlineMachines: string[];
-		offlineMachines: string[];
-		warningMachines: string[];
+		unknownMachines: string[];
+		idleMachines: string[];
 	},
 	dashboardContent: string,
 	thresholdMs: number = 60 * 60 * 1000
 ): {
 	onlineMachines: string[];
-	offlineMachines: string[];
-	warningMachines: string[];
+	unknownMachines: string[];
+	idleMachines: string[];
 	overrides: string[];
 } {
 	const activity = extractMachineActivity(dashboardContent);
 	const overrides: string[] = [];
 
-	const offlineMachines = [...heartbeatState.offlineMachines];
-	const warningMachines = [...heartbeatState.warningMachines];
+	const unknownMachines = [...heartbeatState.unknownMachines];
+	const idleMachines = [...heartbeatState.idleMachines];
 	const onlineMachines = [...heartbeatState.onlineMachines];
 
-	for (let i = offlineMachines.length - 1; i >= 0; i--) {
-		const machineId = offlineMachines[i];
+	for (let i = unknownMachines.length - 1; i >= 0; i--) {
+		const machineId = unknownMachines[i];
 		const lastSeen = activity.get(machineId);
 		if (lastSeen && isRecentlyActive(lastSeen, thresholdMs)) {
-			offlineMachines.splice(i, 1);
+			unknownMachines.splice(i, 1);
 			onlineMachines.push(machineId);
 			overrides.push(machineId);
-			logger.info(`Dashboard override: ${machineId} OFFLINE→ONLINE (last seen ${lastSeen})`);
+			logger.info(`Dashboard override: ${machineId} UNKNOWN→ONLINE (last seen ${lastSeen})`);
 		}
 	}
 
-	for (let i = warningMachines.length - 1; i >= 0; i--) {
-		const machineId = warningMachines[i];
+	for (let i = idleMachines.length - 1; i >= 0; i--) {
+		const machineId = idleMachines[i];
 		const lastSeen = activity.get(machineId);
 		if (lastSeen && isRecentlyActive(lastSeen, thresholdMs)) {
-			warningMachines.splice(i, 1);
+			idleMachines.splice(i, 1);
 			onlineMachines.push(machineId);
 			overrides.push(machineId);
-			logger.info(`Dashboard override: ${machineId} WARNING→ONLINE (last seen ${lastSeen})`);
+			logger.info(`Dashboard override: ${machineId} IDLE→ONLINE (last seen ${lastSeen})`);
 		}
 	}
 
-	return { onlineMachines, offlineMachines, warningMachines, overrides };
+	return { onlineMachines, unknownMachines, idleMachines, overrides };
 }

--- a/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
@@ -126,8 +126,8 @@ describe('HeartbeatService - Tests Unitaires', () => {
         await fs.writeFile(heartbeatPath, JSON.stringify({
           heartbeats: Object.fromEntries(state.heartbeats),
           onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
+          unknownMachines: state.unknownMachines,
+          idleMachines: state.idleMachines,
           statistics: state.statistics
         }, null, 2));
       }
@@ -147,31 +147,31 @@ describe('HeartbeatService - Tests Unitaires', () => {
 
       // Assert
       expect(result.success).toBe(true);
-      expect(result.newlyOfflineMachines).toContain('machine-1'); // UNKNOWN maps to offlineMachines
+      expect(result.newlyUnknownMachines).toContain('machine-1');
 
       const heartbeatDataAfter = heartbeatService.getHeartbeatData('machine-1');
-      expect(heartbeatDataAfter?.status).toBe('unknown'); // ADR 008: no more 'offline', use 'unknown'
+      expect(heartbeatDataAfter?.status).toBe('unknown');
     });
 
     it('devrait détecter une machine en avertissement avant offline', async () => {
       // Arrange - Enregistrer un heartbeat
       await heartbeatService.registerHeartbeat('machine-1');
-      
+
       // Simuler le passage du temps pour un avertissement
       const heartbeatPath = join(sharedPath, 'heartbeat.json');
       const state = heartbeatService.getState();
-      
+
       const heartbeatData = state.heartbeats.get('machine-1');
       if (heartbeatData) {
         // #1953 ADR 008: IDLE threshold is 30-120 min
         heartbeatData.lastHeartbeat = new Date(Date.now() - 45 * 60 * 1000).toISOString(); // 45 min → IDLE
         state.heartbeats.set('machine-1', heartbeatData);
-        
+
         await fs.writeFile(heartbeatPath, JSON.stringify({
           heartbeats: Object.fromEntries(state.heartbeats),
           onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
+          unknownMachines: state.unknownMachines,
+          idleMachines: state.idleMachines,
           statistics: state.statistics
         }, null, 2));
       }
@@ -191,10 +191,10 @@ describe('HeartbeatService - Tests Unitaires', () => {
       
       // Assert
       expect(result.success).toBe(true);
-      expect(result.warningMachines).toContain('machine-1');
-      
+      expect(result.idleMachines).toContain('machine-1');
+
       const heartbeatDataAfter = heartbeatService.getHeartbeatData('machine-1');
-      expect(heartbeatDataAfter?.status).toBe('idle'); // ADR 008: 'idle' replaces 'warning'
+      expect(heartbeatDataAfter?.status).toBe('idle');
       expect(heartbeatDataAfter?.missedHeartbeats).toBe(1);
     });
 
@@ -216,8 +216,8 @@ describe('HeartbeatService - Tests Unitaires', () => {
         await fs.writeFile(heartbeatPath, JSON.stringify({
           heartbeats: Object.fromEntries(state.heartbeats),
           onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
+          unknownMachines: state.unknownMachines,
+          idleMachines: state.idleMachines,
           statistics: state.statistics
         }, null, 2));
       }
@@ -256,8 +256,8 @@ describe('HeartbeatService - Tests Unitaires', () => {
       expect(state).toBeDefined();
       expect(state.statistics.totalMachines).toBe(2);
       expect(state.onlineMachines).toHaveLength(2);
-      expect(state.offlineMachines).toHaveLength(0);
-      expect(state.warningMachines).toHaveLength(0);
+      expect(state.unknownMachines).toHaveLength(0);
+      expect(state.idleMachines).toHaveLength(0);
       expect(state.statistics.onlineCount).toBe(2);
       expect(state.statistics.offlineCount).toBe(0);
       expect(state.statistics.warningCount).toBe(0);
@@ -280,22 +280,22 @@ describe('HeartbeatService - Tests Unitaires', () => {
     it('devrait retourner les machines offline', async () => {
       // Arrange - Créer une machine offline
       await heartbeatService.registerHeartbeat('machine-1');
-      
+
       const heartbeatPath = join(sharedPath, 'heartbeat.json');
       const state = heartbeatService.getState();
-      
+
       const heartbeatData = state.heartbeats.get('machine-1');
       if (heartbeatData) {
         heartbeatData.lastHeartbeat = new Date(Date.now() - 130000).toISOString();
-        heartbeatData.status = 'offline';
+        heartbeatData.status = 'unknown';
         heartbeatData.offlineSince = new Date(Date.now() - 130000).toISOString();
         state.heartbeats.set('machine-1', heartbeatData);
         
         await fs.writeFile(heartbeatPath, JSON.stringify({
           heartbeats: Object.fromEntries(state.heartbeats),
           onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
+          unknownMachines: state.unknownMachines,
+          idleMachines: state.idleMachines,
           statistics: state.statistics
         }, null, 2));
       }
@@ -311,10 +311,10 @@ describe('HeartbeatService - Tests Unitaires', () => {
       });
       
       // Act
-      const offlineMachines = heartbeatService.getOfflineMachines();
-      
+      const unknownMachines = heartbeatService.getUnknownMachines();
+
       // Assert
-      expect(offlineMachines).toContain('machine-1');
+      expect(unknownMachines).toContain('machine-1');
     });
 
     it('devrait retourner les machines en avertissement', async () => {
@@ -327,15 +327,15 @@ describe('HeartbeatService - Tests Unitaires', () => {
       const heartbeatData = state.heartbeats.get('machine-1');
       if (heartbeatData) {
         heartbeatData.lastHeartbeat = new Date(Date.now() - 90000).toISOString();
-        heartbeatData.status = 'warning';
+        heartbeatData.status = 'idle';
         heartbeatData.missedHeartbeats = 3;
         state.heartbeats.set('machine-1', heartbeatData);
         
         await fs.writeFile(heartbeatPath, JSON.stringify({
           heartbeats: Object.fromEntries(state.heartbeats),
           onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
+          unknownMachines: state.unknownMachines,
+          idleMachines: state.idleMachines,
           statistics: state.statistics
         }, null, 2));
       }
@@ -351,10 +351,10 @@ describe('HeartbeatService - Tests Unitaires', () => {
       });
       
       // Act
-      const warningMachines = heartbeatService.getWarningMachines();
-      
+      const idleMachines = heartbeatService.getIdleMachines();
+
       // Assert
-      expect(warningMachines).toContain('machine-1');
+      expect(idleMachines).toContain('machine-1');
     });
   });
 
@@ -389,7 +389,7 @@ describe('HeartbeatService - Tests Unitaires', () => {
       const old1Data = state.heartbeats.get('myia-old-1');
       if (old1Data) {
         old1Data.lastHeartbeat = new Date(now - 90000000).toISOString(); // Plus de 24h
-        old1Data.status = 'offline';
+        old1Data.status = 'unknown';
         old1Data.offlineSince = new Date(now - 90000000).toISOString();
         state.heartbeats.set('myia-old-1', old1Data);
       }
@@ -397,7 +397,7 @@ describe('HeartbeatService - Tests Unitaires', () => {
       const old2Data = state.heartbeats.get('myia-old-2');
       if (old2Data) {
         old2Data.lastHeartbeat = new Date(now - 90000000).toISOString(); // Plus de 24h
-        old2Data.status = 'offline';
+        old2Data.status = 'unknown';
         old2Data.offlineSince = new Date(now - 90000000).toISOString();
         state.heartbeats.set('myia-old-2', old2Data);
       }
@@ -405,7 +405,7 @@ describe('HeartbeatService - Tests Unitaires', () => {
       const recentData = state.heartbeats.get('myia-recent');
       if (recentData) {
         recentData.lastHeartbeat = new Date(now - 3600000).toISOString(); // 1 heure
-        recentData.status = 'offline';
+        recentData.status = 'unknown';
         recentData.offlineSince = new Date(now - 3600000).toISOString();
         state.heartbeats.set('myia-recent', recentData);
       }
@@ -413,8 +413,8 @@ describe('HeartbeatService - Tests Unitaires', () => {
       await fs.writeFile(heartbeatPath, JSON.stringify({
         heartbeats: Object.fromEntries(state.heartbeats),
         onlineMachines: state.onlineMachines,
-        offlineMachines: state.offlineMachines,
-        warningMachines: state.warningMachines,
+        unknownMachines: state.unknownMachines,
+        idleMachines: state.idleMachines,
         statistics: state.statistics
       }, null, 2));
 
@@ -429,15 +429,15 @@ describe('HeartbeatService - Tests Unitaires', () => {
       });
 
       // Act - Nettoyer les machines offline depuis plus de 24h
-      const removedCount = await heartbeatService.cleanupOldOfflineMachines(86400000); // 24h
+      const removedCount = await heartbeatService.cleanupOldUnknownMachines(86400000); // 24h
 
       // Assert
       expect(removedCount).toBe(2);
-      // #1409: Production machines (myia-*) kept in state as offline, not deleted
+      // #1409: Production machines (myia-*) kept in state as unknown, not deleted
       expect(heartbeatService.getHeartbeatData('myia-old-1')).toBeDefined();
-      expect(heartbeatService.getHeartbeatData('myia-old-1')!.status).toBe('offline');
+      expect(heartbeatService.getHeartbeatData('myia-old-1')!.status).toBe('unknown');
       expect(heartbeatService.getHeartbeatData('myia-old-2')).toBeDefined();
-      expect(heartbeatService.getHeartbeatData('myia-old-2')!.status).toBe('offline');
+      expect(heartbeatService.getHeartbeatData('myia-old-2')!.status).toBe('unknown');
       expect(heartbeatService.getHeartbeatData('myia-recent')).toBeDefined(); // Pas supprimée
     });
   });
@@ -478,8 +478,8 @@ describe('HeartbeatService - Tests Unitaires', () => {
         await fs.writeFile(heartbeatPath, JSON.stringify({
           heartbeats: Object.fromEntries(state.heartbeats),
           onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
+          unknownMachines: state.unknownMachines,
+          idleMachines: state.idleMachines,
           statistics: state.statistics
         }, null, 2));
       }
@@ -501,7 +501,7 @@ describe('HeartbeatService - Tests Unitaires', () => {
       const result = await heartbeatService.checkHeartbeats();
       
       // Assert
-      expect(result.newlyOfflineMachines).toContain('machine-1');
+      expect(result.newlyUnknownMachines).toContain('machine-1');
       expect(offlineCallback).toHaveBeenCalledWith('machine-1');
     });
     it('devrait appeler le callback lors du retour online', async () => {
@@ -525,8 +525,8 @@ describe('HeartbeatService - Tests Unitaires', () => {
         await fs.writeFile(heartbeatPath, JSON.stringify({
           heartbeats: Object.fromEntries(state.heartbeats),
           onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
+          unknownMachines: state.unknownMachines,
+          idleMachines: state.idleMachines,
           statistics: state.statistics
         }, null, 2));
       }
@@ -556,8 +556,8 @@ describe('HeartbeatService - Tests Unitaires', () => {
         await fs.writeFile(heartbeatPath2, JSON.stringify({
           heartbeats: Object.fromEntries(state2.heartbeats),
           onlineMachines: state2.onlineMachines,
-          offlineMachines: state2.offlineMachines,
-          warningMachines: state2.warningMachines,
+          unknownMachines: state2.unknownMachines,
+          idleMachines: state2.idleMachines,
           statistics: state2.statistics
         }, null, 2));
       }

--- a/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
@@ -110,14 +110,14 @@ describe('#1863 Fusion A2: machines → inventory(type: "machines")', () => {
       }
     });
 
-    it('should validate type="machines" with status="offline"', () => {
+    it('should validate type="machines" with status="unknown"', () => {
       const result = InventoryArgsSchema.safeParse({
         type: 'machines',
-        status: 'offline'
+        status: 'unknown'
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.status).toBe('offline');
+        expect(result.data.status).toBe('unknown');
       }
     });
 

--- a/servers/roo-state-manager/tests/unit/tools/roosync/get-status.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/get-status.test.ts
@@ -71,8 +71,8 @@ vi.mock('fs', async (importOriginal) => {
 function setupMocks(overrides: Record<string, any> = {}) {
     const heartbeatState = overrides.heartbeatState || {
         onlineMachines: ['myia-ai-01'],
-        offlineMachines: [],
-        warningMachines: [],
+        unknownMachines: [],
+        idleMachines: [],
     };
     const inboxStats = overrides.inboxStats || { unread: 0, urgent: 0, by_priority: {} };
     const config = overrides.config || { machineId: 'myia-ai-01' };
@@ -174,8 +174,8 @@ describe('roosync_get_status', () => {
             setupMocks({
                 heartbeatState: {
                     onlineMachines: ['myia-ai-01'],
-                    offlineMachines: ['myia-web1'],
-                    warningMachines: [],
+                    unknownMachines: ['myia-web1'],
+                    idleMachines: [],
                 },
             });
             const result = await roosyncGetStatus({});
@@ -205,8 +205,8 @@ describe('roosync_get_status', () => {
             setupMocks({
                 heartbeatState: {
                     onlineMachines: ['myia-ai-01'],
-                    offlineMachines: [],
-                    warningMachines: ['myia-po-2023'],
+                    unknownMachines: [],
+                    idleMachines: ['myia-po-2023'],
                 },
             });
             const result = await roosyncGetStatus({});
@@ -220,8 +220,8 @@ describe('roosync_get_status', () => {
             setupMocks({
                 heartbeatState: {
                     onlineMachines: ['myia-ai-01', 'test-machine', 'persistent-machine'],
-                    offlineMachines: [],
-                    warningMachines: [],
+                    unknownMachines: [],
+                    idleMachines: [],
                 },
             });
             const result = await roosyncGetStatus({});

--- a/servers/roo-state-manager/tests/unit/tools/roosync/heartbeat-status.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/heartbeat-status.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for roosync_heartbeat_status tool
  *
- * Covers: filter=all/online/offline/warning, includeHeartbeats,
+ * Covers: filter=all/online/unknown/idle, includeHeartbeats,
  * forceCheck, includeChanges, error handling
  */
 
@@ -37,8 +37,8 @@ vi.mock('../../../../src/services/roosync/HeartbeatService.js', () => ({
 
 const defaultState = {
     onlineMachines: ['ai-01', 'po-2023'],
-    offlineMachines: ['web1'],
-    warningMachines: ['po-2024'],
+    unknownMachines: ['web1'],
+    idleMachines: ['po-2024'],
     statistics: {
         totalMachines: 4,
         onlineCount: 2,
@@ -49,8 +49,8 @@ const defaultState = {
     heartbeats: new Map([
         ['ai-01', { machineId: 'ai-01', status: 'online', lastHeartbeat: '2026-05-04T00:00:00.000Z' }],
         ['po-2023', { machineId: 'po-2023', status: 'online', lastHeartbeat: '2026-05-04T00:00:00.000Z' }],
-        ['web1', { machineId: 'web1', status: 'offline', lastHeartbeat: '2026-05-03T20:00:00.000Z' }],
-        ['po-2024', { machineId: 'po-2024', status: 'warning', lastHeartbeat: '2026-05-04T00:00:00.000Z' }],
+        ['web1', { machineId: 'web1', status: 'unknown', lastHeartbeat: '2026-05-03T20:00:00.000Z' }],
+        ['po-2024', { machineId: 'po-2024', status: 'idle', lastHeartbeat: '2026-05-04T00:00:00.000Z' }],
     ]),
 };
 
@@ -67,30 +67,30 @@ describe('roosync_heartbeat_status', () => {
         const result = await roosyncHeartbeatStatus({});
         expect(result.success).toBe(true);
         expect(result.onlineMachines).toEqual(['ai-01', 'po-2023']);
-        expect(result.offlineMachines).toEqual(['web1']);
-        expect(result.warningMachines).toEqual(['po-2024']);
+        expect(result.unknownMachines).toEqual(['web1']);
+        expect(result.idleMachines).toEqual(['po-2024']);
         expect(result.statistics.totalMachines).toBe(4);
     });
 
     it('returns only online machines with filter=online', async () => {
         const result = await roosyncHeartbeatStatus({ filter: 'online' });
         expect(result.onlineMachines).toEqual(['ai-01', 'po-2023']);
-        expect(result.offlineMachines).toEqual([]);
-        expect(result.warningMachines).toEqual([]);
+        expect(result.unknownMachines).toEqual([]);
+        expect(result.idleMachines).toEqual([]);
     });
 
-    it('returns only offline machines with filter=offline', async () => {
-        const result = await roosyncHeartbeatStatus({ filter: 'offline' });
+    it('returns only unknown machines with filter=unknown', async () => {
+        const result = await roosyncHeartbeatStatus({ filter: 'unknown' });
         expect(result.onlineMachines).toEqual([]);
-        expect(result.offlineMachines).toEqual(['web1']);
-        expect(result.warningMachines).toEqual([]);
+        expect(result.unknownMachines).toEqual(['web1']);
+        expect(result.idleMachines).toEqual([]);
     });
 
-    it('returns only warning machines with filter=warning', async () => {
-        const result = await roosyncHeartbeatStatus({ filter: 'warning' });
+    it('returns only idle machines with filter=idle', async () => {
+        const result = await roosyncHeartbeatStatus({ filter: 'idle' });
         expect(result.onlineMachines).toEqual([]);
-        expect(result.offlineMachines).toEqual([]);
-        expect(result.warningMachines).toEqual(['po-2024']);
+        expect(result.unknownMachines).toEqual([]);
+        expect(result.idleMachines).toEqual(['po-2024']);
     });
 
     describe('includeHeartbeats', () => {
@@ -113,15 +113,15 @@ describe('roosync_heartbeat_status', () => {
             expect(result.heartbeats!['web1']).toBeUndefined();
         });
 
-        it('filters heartbeats with filter=offline', async () => {
-            const result = await roosyncHeartbeatStatus({ filter: 'offline' });
+        it('filters heartbeats with filter=unknown', async () => {
+            const result = await roosyncHeartbeatStatus({ filter: 'unknown' });
             expect(result.heartbeats).toBeDefined();
             expect(Object.keys(result.heartbeats!)).toHaveLength(1);
             expect(result.heartbeats!['web1']).toBeDefined();
         });
 
-        it('filters heartbeats with filter=warning', async () => {
-            const result = await roosyncHeartbeatStatus({ filter: 'warning' });
+        it('filters heartbeats with filter=idle', async () => {
+            const result = await roosyncHeartbeatStatus({ filter: 'idle' });
             expect(result.heartbeats).toBeDefined();
             expect(Object.keys(result.heartbeats!)).toHaveLength(1);
             expect(result.heartbeats!['po-2024']).toBeDefined();
@@ -131,22 +131,22 @@ describe('roosync_heartbeat_status', () => {
     describe('forceCheck and includeChanges', () => {
         it('checks heartbeats with forceCheck=true', async () => {
             mockCheckHeartbeats.mockResolvedValue({
-                newlyOfflineMachines: ['web1'],
+                newlyUnknownMachines: ['web1'],
                 newlyOnlineMachines: ['po-2023'],
-                warningMachines: ['po-2024'],
+                idleMachines: ['po-2024'],
             });
             const result = await roosyncHeartbeatStatus({ forceCheck: true });
             expect(mockCheckHeartbeats).toHaveBeenCalled();
             expect(result.changes).toBeDefined();
-            expect(result.changes!.newlyOfflineMachines).toEqual(['web1']);
+            expect(result.changes!.newlyUnknownMachines).toEqual(['web1']);
             expect(result.changes!.totalChanges).toBe(3);
         });
 
         it('checks heartbeats with includeChanges=true', async () => {
             mockCheckHeartbeats.mockResolvedValue({
-                newlyOfflineMachines: [],
+                newlyUnknownMachines: [],
                 newlyOnlineMachines: [],
-                warningMachines: [],
+                idleMachines: [],
             });
             const result = await roosyncHeartbeatStatus({ includeChanges: true });
             expect(mockCheckHeartbeats).toHaveBeenCalled();

--- a/servers/roo-state-manager/tests/unit/tools/roosync/inventory.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/inventory.test.ts
@@ -19,15 +19,15 @@ vi.mock('../../../../src/services/roosync/InventoryService.js', () => ({
 }));
 
 // Mock lazy-roosync (getRooSyncService)
-const mockGetOfflineMachines = vi.fn();
-const mockGetWarningMachines = vi.fn();
+const mockGetUnknownMachines = vi.fn();
+const mockGetIdleMachines = vi.fn();
 const mockGetHeartbeatData = vi.fn();
 
 const mockHeartbeatService = {
     getState: vi.fn(() => ({
         onlineMachines: ['ai-01'],
-        offlineMachines: ['web1'],
-        warningMachines: ['po-2023'],
+        unknownMachines: ['web1'],
+        idleMachines: ['po-2023'],
         statistics: {
             totalMachines: 3,
             onlineCount: 1,
@@ -39,8 +39,8 @@ const mockHeartbeatService = {
             ['ai-01', { machineId: 'ai-01', lastHeartbeat: '2026-05-04T00:00:00.000Z', status: 'online' }],
         ]),
     })),
-    getOfflineMachines: mockGetOfflineMachines,
-    getWarningMachines: mockGetWarningMachines,
+    getUnknownMachines: mockGetUnknownMachines,
+    getIdleMachines: mockGetIdleMachines,
     getHeartbeatData: mockGetHeartbeatData,
 };
 
@@ -83,8 +83,8 @@ describe('roosync_inventory tool', () => {
             expect(result.success).toBe(true);
             expect(result.data.heartbeatState).toBeDefined();
             expect(result.data.heartbeatState.onlineMachines).toContain('ai-01');
-            expect(result.data.heartbeatState.offlineMachines).toContain('web1');
-            expect(result.data.heartbeatState.warningMachines).toContain('po-2023');
+            expect(result.data.heartbeatState.unknownMachines).toContain('web1');
+            expect(result.data.heartbeatState.idleMachines).toContain('po-2023');
         });
 
         it('includes heartbeats by default', async () => {
@@ -113,32 +113,32 @@ describe('roosync_inventory tool', () => {
     });
 
     describe('type=machines (fused from roosync_machines)', () => {
-        it('returns offline machines when status=offline', async () => {
-            mockGetOfflineMachines.mockReturnValue(['web1', 'po-2024']);
-            const result = await inventoryTool.execute({ type: 'machines', status: 'offline' }, {});
+        it('returns unknown machines when status=unknown', async () => {
+            mockGetUnknownMachines.mockReturnValue(['web1', 'po-2024']);
+            const result = await inventoryTool.execute({ type: 'machines', status: 'unknown' }, {});
             expect(result.success).toBe(true);
-            expect(result.data.offlineMachines).toEqual(['web1', 'po-2024']);
+            expect(result.data.unknownMachines).toEqual(['web1', 'po-2024']);
             expect(result.data.offlineCount).toBe(2);
         });
 
-        it('returns warning machines when status=warning', async () => {
-            mockGetWarningMachines.mockReturnValue(['po-2023']);
-            const result = await inventoryTool.execute({ type: 'machines', status: 'warning' }, {});
+        it('returns idle machines when status=idle', async () => {
+            mockGetIdleMachines.mockReturnValue(['po-2023']);
+            const result = await inventoryTool.execute({ type: 'machines', status: 'idle' }, {});
             expect(result.success).toBe(true);
-            expect(result.data.warningMachines).toEqual(['po-2023']);
+            expect(result.data.idleMachines).toEqual(['po-2023']);
             expect(result.data.warningCount).toBe(1);
         });
 
-        it('returns both offline and warning when status=all (default)', async () => {
-            mockGetOfflineMachines.mockReturnValue(['web1']);
-            mockGetWarningMachines.mockReturnValue(['po-2023']);
+        it('returns both unknown and idle when status=all (default)', async () => {
+            mockGetUnknownMachines.mockReturnValue(['web1']);
+            mockGetIdleMachines.mockReturnValue(['po-2023']);
             const result = await inventoryTool.execute({ type: 'machines' }, {});
-            expect(result.data.offlineMachines).toEqual(['web1']);
-            expect(result.data.warningMachines).toEqual(['po-2023']);
+            expect(result.data.unknownMachines).toEqual(['web1']);
+            expect(result.data.idleMachines).toEqual(['po-2023']);
         });
 
         it('returns detailed data when includeDetails=true', async () => {
-            mockGetOfflineMachines.mockReturnValue(['web1']);
+            mockGetUnknownMachines.mockReturnValue(['web1']);
             mockGetHeartbeatData.mockImplementation((mid: string) => {
                 if (mid === 'web1') return {
                     machineId: 'web1',
@@ -149,15 +149,15 @@ describe('roosync_inventory tool', () => {
                 };
                 return null;
             });
-            const result = await inventoryTool.execute({ type: 'machines', status: 'offline', includeDetails: true }, {});
-            expect(result.data.offlineMachines).toHaveLength(1);
-            expect(result.data.offlineMachines[0].machineId).toBe('web1');
-            expect(result.data.offlineMachines[0].offlineSince).toBeDefined();
+            const result = await inventoryTool.execute({ type: 'machines', status: 'unknown', includeDetails: true }, {});
+            expect(result.data.unknownMachines).toHaveLength(1);
+            expect(result.data.unknownMachines[0].machineId).toBe('web1');
+            expect(result.data.unknownMachines[0].offlineSince).toBeDefined();
             expect(result.data.offlineCount).toBe(1);
         });
 
-        it('skips machines without offlineSince in detailed offline mode', async () => {
-            mockGetOfflineMachines.mockReturnValue(['web1']);
+        it('skips machines without offlineSince in detailed unknown mode', async () => {
+            mockGetUnknownMachines.mockReturnValue(['web1']);
             mockGetHeartbeatData.mockReturnValue({
                 machineId: 'web1',
                 lastHeartbeat: '2026-05-04T00:00:00.000Z',
@@ -165,28 +165,28 @@ describe('roosync_inventory tool', () => {
                 missedHeartbeats: 0,
                 metadata: {},
             });
-            const result = await inventoryTool.execute({ type: 'machines', status: 'offline', includeDetails: true }, {});
-            expect(result.data.offlineMachines).toHaveLength(0);
+            const result = await inventoryTool.execute({ type: 'machines', status: 'unknown', includeDetails: true }, {});
+            expect(result.data.unknownMachines).toHaveLength(0);
         });
 
-        it('returns detailed warning machines', async () => {
-            mockGetWarningMachines.mockReturnValue(['po-2023']);
+        it('returns detailed idle machines', async () => {
+            mockGetIdleMachines.mockReturnValue(['po-2023']);
             mockGetHeartbeatData.mockImplementation((mid: string) => ({
                 machineId: mid,
                 lastHeartbeat: '2026-05-04T00:00:00.000Z',
                 missedHeartbeats: 2,
                 metadata: { firstSeen: '2026-01-01', lastUpdated: '2026-05-04', version: '1.0' },
             }));
-            const result = await inventoryTool.execute({ type: 'machines', status: 'warning', includeDetails: true }, {});
-            expect(result.data.warningMachines).toHaveLength(1);
-            expect(result.data.warningMachines[0].machineId).toBe('po-2023');
+            const result = await inventoryTool.execute({ type: 'machines', status: 'idle', includeDetails: true }, {});
+            expect(result.data.idleMachines).toHaveLength(1);
+            expect(result.data.idleMachines[0].machineId).toBe('po-2023');
         });
 
         it('skips null heartbeat data in detailed mode', async () => {
-            mockGetOfflineMachines.mockReturnValue(['unknown']);
+            mockGetUnknownMachines.mockReturnValue(['unknown']);
             mockGetHeartbeatData.mockReturnValue(null);
-            const result = await inventoryTool.execute({ type: 'machines', status: 'offline', includeDetails: true }, {});
-            expect(result.data.offlineMachines).toHaveLength(0);
+            const result = await inventoryTool.execute({ type: 'machines', status: 'unknown', includeDetails: true }, {});
+            expect(result.data.unknownMachines).toHaveLength(0);
         });
     });
 


### PR DESCRIPTION
## Summary
- ADR 008 Phase 2: Rename heartbeat status terminology across the codebase
- `offline` → `unknown`, `warning` → `idle` in all status enums, filter parameters, and variable names
- 25 files updated: tools (8), services (2), utils (2), types (1), tests (12)

## Scope
- **Status values**: z.enum and status string comparisons updated
- **Filter parameters**: Schema and tool-definitions enums updated
- **Variable names**: `getOfflineMachines`→`getUnknownMachines`, `getWarningMachines`→`getIdleMachines`, etc.
- **Dashboard strings**: Summary output uses new terminology
- **Comments/docs**: Descriptions updated to match new terminology

## Preserved (intentional)
- `sync-event.ts` `'online'`/`'offline'` action values (event actions, not heartbeat status)
- `offlineSince` field name (data field, not status)
- `offlineCount`/`warningCount` in statistics (internal field names matching HeartbeatService)
- Non-heartbeat contexts: `CacheAntiLeakManager`, `BaselineManager`, `PresenceManager`, `ConfigDiffService`

## Test plan
- [x] `npm run build` passes
- [x] `npx vitest run --config vitest.config.ci.ts` — 455 files, 9153 tests pass, 0 failures
- [x] No sync-event tests modified (separate concern)

Closes #2013

🤖 Generated with [Claude Code](https://claude.com/claude-code)