### PR TITLE
fix(#1410 item 5): conversation_browser limit caps total_count

### DIFF
--- a/servers/roo-state-manager/src/tools/conversation/__tests__/conversation-browser.test.ts
+++ b/servers/roo-state-manager/src/tools/conversation/__tests__/conversation-browser.test.ts
@@ -721,7 +721,7 @@ describe('conversation_browser', () => {
 		});
 
 		test('list respects limit as hard cap (#1410: limit is total cap, not page size)', async () => {
-			// mockCache has 3 tasks. limit=2 gets clamped to 10 → all 3 returned in sorted order.
+			// mockCache has 3 tasks. limit=2 caps total to 2, totalPages=1, has_next=false.
 			const result = await handleConversationBrowser(
 				{ action: 'list', limit: 2, sortBy: 'lastActivity', sortOrder: 'desc' },
 				mockCache,
@@ -734,6 +734,10 @@ describe('conversation_browser', () => {
 			expect(parsed.length).toBe(2);
 			expect(parsed[0].taskId).toBe('task-new');
 			expect(parsed[1].taskId).toBe('task-middle');
+			// #1410 fix: total_count and has_next must be capped by limit
+			expect(_response.pagination.total_count).toBe(2);
+			expect(_response.pagination.total_pages).toBe(1);
+			expect(_response.pagination.has_next).toBe(false);
 		});
 
 		test('list filters by workspace when specified', async () => {

--- a/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
+++ b/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
@@ -951,15 +951,22 @@ export const listConversationsTool = {
         //   When only `limit` is provided (no `per_page`), it acts as both page size and total cap.
         //   The floor of 10 does NOT apply to `limit` — the caller explicitly asked for fewer.
         const hasExplicitPerPage = args.per_page !== undefined && args.per_page !== null;
+        const hasLimit = !hasExplicitPerPage && args.limit !== undefined && args.limit !== null;
         const rawPerPage = (hasExplicitPerPage ? args.per_page : (args.limit || 10)) as number;
         const perPage = hasExplicitPerPage
             ? Math.min(Math.max(rawPerPage, 10), 100)
             : Math.min(rawPerPage, 100);
         const page = Math.max(args.page || 1, 1);
-        const totalCount = forest.length;
-        const totalPages = Math.ceil(totalCount / perPage);
-        const startIdx = (page - 1) * perPage;
-        const paginatedForest = forest.slice(startIdx, startIdx + perPage);
+        const totalCount = hasLimit
+            ? Math.min(forest.length, args.limit!)
+            : forest.length;
+        const totalPages = hasLimit
+            ? 1
+            : Math.ceil(totalCount / perPage);
+        const startIdx = hasLimit ? 0 : (page - 1) * perPage;
+        const paginatedForest = hasLimit
+            ? forest.slice(0, Math.min(args.limit!, perPage))
+            : forest.slice(startIdx, startIdx + perPage);
 
         // Phase 2: Détecter les synthèses UNIQUEMENT pour les nœuds de la page courante
         // #834: Moved AFTER pagination — was running on ALL 3000+ skeletons before,


### PR DESCRIPTION
## Summary
- Fixes #1410 item 5: `conversation_browser(action: "list", limit: N)` now correctly caps `total_count`, `total_pages`, and `has_next` in the pagination response
- Previously, `limit` was used as `perPage` but `total_count` remained `forest.length` (all items), making `has_next: true` even when the caller asked for a hard cap

## Changes
- `list-conversations.tool.ts`: When `limit` is provided without `per_page`, `totalCount = Math.min(forest.length, limit)`, `totalPages = 1`, `has_next = false`
- `conversation-browser.test.ts`: Added assertions for `total_count`, `total_pages`, `has_next` in the limit test

## Test plan
- [x] `npx vitest run src/tools/conversation/__tests__/conversation-browser.test.ts -t "limit"` — passes
- [x] Full CI config: 9187/9187 passed (455 files, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)