### PR TITLE
fix(#1410 item 2): sync baselineToolMetadata with tool-definitions

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/baseline.ts
+++ b/servers/roo-state-manager/src/tools/roosync/baseline.ts
@@ -1276,13 +1276,13 @@ function countParameters(config: any): number {
  */
 export const baselineToolMetadata = {
   name: 'roosync_baseline',
-  description: 'Outil consolidé pour gérer les baselines RooSync (update, version, restore, export, list_versions)',
+  description: 'Outil consolidé pour gérer les baselines RooSync (update, version, restore, export, list_versions, current_version)',
   inputSchema: {
     type: 'object' as const,
     properties: {
       action: {
         type: 'string',
-        enum: ['update', 'version', 'restore', 'export', 'list_versions'],
+        enum: ['update', 'version', 'restore', 'export', 'list_versions', 'current_version'],
         description: 'Action à effectuer sur la baseline'
       },
       machineId: {


### PR DESCRIPTION
## Summary
- Fixes #1410 item 2 (already implemented, metadata gap): `baselineToolMetadata` was missing `current_version` from its action enum and description was outdated
- The `current_version` action is fully implemented and tested in `baseline.ts:858-909`, registered in `tool-definitions.ts:353`, but the secondary metadata export was out of sync

## Changes
- `baseline.ts`: Added `current_version` to `baselineToolMetadata` action enum + updated description

## Test plan
- [x] Build passes (`tsc` clean)
- [x] No functional change — metadata sync only

🤖 Generated with [Claude Code](https://claude.com/claude-code)