### PR TITLE
feat(#2018): preflight dedup before embedding to fix 12-MCP race

### DIFF
--- a/servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts
@@ -379,11 +379,9 @@ async function dedupByContentHash(points: PointStruct[]): Promise<PointStruct[]>
     try {
         const qdrant = getQdrantClient();
 
-        // Batch-check content hashes (Qdrant scroll with filter)
         const uniqueHashes = [...new Set(contentHashes)];
         const existingHashes = new Set<string>();
 
-        // Query in batches of 100 to avoid payload filter limits
         const BATCH_SIZE = 100;
         for (let i = 0; i < uniqueHashes.length; i += BATCH_SIZE) {
             const batch = uniqueHashes.slice(i, i + BATCH_SIZE);
@@ -405,7 +403,6 @@ async function dedupByContentHash(points: PointStruct[]): Promise<PointStruct[]>
                     if (hash) existingHashes.add(hash);
                 }
 
-                // Continue scrolling if there are more results
                 while (results.next_page_offset) {
                     const nextResults = await qdrant.scroll(COLLECTION_NAME, {
                         filter: {
@@ -426,7 +423,6 @@ async function dedupByContentHash(points: PointStruct[]): Promise<PointStruct[]>
                     if (!nextResults.next_page_offset) break;
                 }
             } catch (scrollError: any) {
-                // Non-fatal: if scroll fails, proceed without dedup (don't block indexing)
                 console.warn(`[#1985] Dedup scroll failed for batch ${i}: ${scrollError?.message || scrollError}`);
             }
         }
@@ -441,9 +437,69 @@ async function dedupByContentHash(points: PointStruct[]): Promise<PointStruct[]>
         console.log(`[#1985] Content-hash dedup: ${before - filtered.length}/${before} points already in Qdrant`);
         return filtered;
     } catch (error: any) {
-        // Non-fatal: if dedup check fails entirely, proceed without dedup
         console.warn(`[#1985] Dedup check failed (non-blocking): ${error?.message || error}`);
         return points;
+    }
+}
+
+/**
+ * #2018 Phase 2: Pre-flight dedup using deterministic chunk_ids.
+ * Checks Qdrant for existing points BEFORE computing expensive embeddings.
+ * Uses retrieve() API (O(1) per ID) instead of scroll-based contentHash filter.
+ *
+ * This eliminates the race condition window: with deterministic chunk_ids from Phase 1,
+ * concurrent MCPs that write the same chunk_id produce identical points (idempotent upsert).
+ * The pre-flight check skips embedding computation entirely for already-indexed chunks.
+ */
+async function preflightDedupByChunkId(
+    subChunks: Array<{ chunk: Chunk; contentHash: string }>
+): Promise<Array<{ chunk: Chunk; contentHash: string }>> {
+    if (subChunks.length === 0) return subChunks;
+
+    try {
+        const qdrant = getQdrantClient();
+        const chunkIds = subChunks.map(sc => sc.chunk.chunk_id);
+        const existingContentHashes = new Map<string, string>(); // chunk_id -> contentHash
+
+        // Batch retrieve — check which chunk_ids already exist (O(1) per ID)
+        const BATCH_SIZE = 100;
+        for (let i = 0; i < chunkIds.length; i += BATCH_SIZE) {
+            const batch = chunkIds.slice(i, i + BATCH_SIZE);
+            try {
+                const points = await qdrant.retrieve(COLLECTION_NAME, {
+                    ids: batch,
+                    with_payload: true,
+                    with_vector: false,
+                });
+
+                for (const point of points) {
+                    const hash = (point.payload as any)?.contentHash as string | undefined;
+                    if (hash) existingContentHashes.set(point.id as string, hash);
+                }
+            } catch (retrieveError: any) {
+                console.warn(`[#2018] Preflight retrieve failed for batch ${i}: ${retrieveError?.message || retrieveError}`);
+            }
+        }
+
+        if (existingContentHashes.size === 0) return subChunks;
+
+        // Filter: skip chunks that exist with same contentHash (unchanged content)
+        const newSubChunks = subChunks.filter(sc => {
+            const existingHash = existingContentHashes.get(sc.chunk.chunk_id);
+            if (!existingHash) return true; // Doesn't exist — needs indexing
+            return existingHash !== sc.contentHash; // Keep if content changed
+        });
+
+        const skipped = subChunks.length - newSubChunks.length;
+        if (skipped > 0) {
+            console.log(`[#2018] Preflight dedup: ${skipped}/${subChunks.length} chunks already indexed, computing embeddings for ${newSubChunks.length}`);
+        }
+
+        return newSubChunks;
+    } catch (error: any) {
+        // Non-fatal: if pre-flight fails, proceed with all chunks (fall through to post-dedup)
+        console.warn(`[#2018] Preflight dedup failed (non-blocking): ${error?.message || error}`);
+        return subChunks;
     }
 }
 
@@ -475,76 +531,83 @@ export async function indexTask(taskId: string, taskPath: string, source: 'roo' 
             chunks.length = MAX_CHUNKS_PER_TASK;
         }
 
-        let pointsToIndex: PointStruct[] = [];
+        // Phase A: Extract all subChunks with contentHashes (cheap — no API calls)
+        const allSubChunks: Array<{ chunk: Chunk; contentHash: string }> = [];
 
         for (const chunk of chunks) {
             if (chunk.indexed) {
                 const subChunks = splitChunk(chunk, MAX_CHUNK_SIZE);
-                console.log(`📊 Original chunk size: ${chunk.content?.length || 0} chars, split into ${subChunks.length} subchunks`);
-
                 for (const subChunk of subChunks) {
-                    if(!subChunk.content || subChunk.content.trim() === '') continue;
-
-                    console.log(`📝 Processing subchunk: ${subChunk.content.length} characters (estimated ~${Math.ceil(subChunk.content.length / 4)} tokens)`);
-
-                    // 🛡️ PROTECTION ANTI-FUITE: Rate limiting
-                    const now = Date.now();
-                    operationTimestamps = operationTimestamps.filter(ts => now - ts < RATE_LIMIT_WINDOW);
-                    if (operationTimestamps.length >= MAX_OPERATIONS_PER_WINDOW) {
-                        console.warn(`[RATE-LIMIT] Trop d'opérations récentes (${operationTimestamps.length}/${MAX_OPERATIONS_PER_WINDOW}). Attente...`);
-                        await new Promise(resolve => setTimeout(resolve, RATE_LIMIT_WINDOW));
-                        operationTimestamps = []; // Reset after wait
-                    }
-
-                    // 🛡️ CACHE EMBEDDINGS pour éviter appels OpenAI répétés
+                    if (!subChunk.content || subChunk.content.trim() === '') continue;
                     const contentHash = crypto.createHash('sha256').update(subChunk.content).digest('hex');
-                    let vector: number[];
-
-                    const cached = embeddingCache.get(contentHash);
-
-                    if (cached && (now - cached.timestamp < EMBEDDING_CACHE_TTL)) {
-                        console.log(`[CACHE] Embedding trouvé en cache pour subchunk ${subChunk.chunk_id}`);
-                        vector = cached.vector;
-                    } else {
-                        const embeddingModel = getEmbeddingModel();
-                        const expectedDims = getEmbeddingDimensions();
-
-                        const embeddingResponse = await getOpenAIClient().embeddings.create({
-                            model: embeddingModel,
-                            input: subChunk.content,
-                        });
-                        vector = embeddingResponse.data[0].embedding;
-
-                        console.log(`[DEBUG] Embedding response reçu:`, {
-                            model: embeddingResponse.model,
-                            usage: embeddingResponse.usage,
-                            vectorLength: vector?.length || 'undefined',
-                            chunkId: subChunk.chunk_id
-                        });
-
-                        if (!vector || !Array.isArray(vector)) {
-                            console.error(`❌ [indexTask] Embedding invalide: pas un tableau pour chunk ${subChunk.chunk_id}`);
-                            continue;
-                        }
-
-                        if (vector.length !== expectedDims) {
-                            console.warn(`⚠️ [indexTask] Dimension inattendue: ${vector.length} (attendu: ${expectedDims}) pour chunk ${subChunk.chunk_id}`);
-                            console.warn(`⚠️ [indexTask] Modèle utilisé: ${embeddingModel}`);
-                        }
-
-                        embeddingCache.set(contentHash, { vector, timestamp: now });
-                        operationTimestamps.push(now);
-                        console.log(`[CACHE] Embedding mis en cache pour subchunk ${subChunk.chunk_id} (dimension: ${vector.length})`);
-                    }
-
-                    const point: PointStruct = {
-                        id: subChunk.chunk_id,
-                        vector: vector,
-                        payload: { ...subChunk, source: source, contentHash },
-                    };
-                    pointsToIndex.push(point);
+                    allSubChunks.push({ chunk: subChunk, contentHash });
                 }
             }
+        }
+
+        // Phase B: #2018 Phase 2 — Pre-flight dedup (skip already-indexed chunks BEFORE embeddings)
+        const subChunksToEmbed = await preflightDedupByChunkId(allSubChunks);
+
+        // Phase C: Compute embeddings only for new/changed chunks
+        let pointsToIndex: PointStruct[] = [];
+
+        for (const { chunk: subChunk, contentHash } of subChunksToEmbed) {
+            console.log(`📝 Processing subchunk: ${subChunk.content.length} chars (estimated ~${Math.ceil(subChunk.content.length / 4)} tokens)`);
+
+            // 🛡️ PROTECTION ANTI-FUITE: Rate limiting
+            const now = Date.now();
+            operationTimestamps = operationTimestamps.filter(ts => now - ts < RATE_LIMIT_WINDOW);
+            if (operationTimestamps.length >= MAX_OPERATIONS_PER_WINDOW) {
+                console.warn(`[RATE-LIMIT] Trop d'opérations récentes (${operationTimestamps.length}/${MAX_OPERATIONS_PER_WINDOW}). Attente...`);
+                await new Promise(resolve => setTimeout(resolve, RATE_LIMIT_WINDOW));
+                operationTimestamps = [];
+            }
+
+            let vector: number[];
+
+            const cached = embeddingCache.get(contentHash);
+
+            if (cached && (now - cached.timestamp < EMBEDDING_CACHE_TTL)) {
+                console.log(`[CACHE] Embedding trouvé en cache pour subchunk ${subChunk.chunk_id}`);
+                vector = cached.vector;
+            } else {
+                const embeddingModel = getEmbeddingModel();
+                const expectedDims = getEmbeddingDimensions();
+
+                const embeddingResponse = await getOpenAIClient().embeddings.create({
+                    model: embeddingModel,
+                    input: subChunk.content,
+                });
+                vector = embeddingResponse.data[0].embedding;
+
+                console.log(`[DEBUG] Embedding response reçu:`, {
+                    model: embeddingResponse.model,
+                    usage: embeddingResponse.usage,
+                    vectorLength: vector?.length || 'undefined',
+                    chunkId: subChunk.chunk_id
+                });
+
+                if (!vector || !Array.isArray(vector)) {
+                    console.error(`❌ [indexTask] Embedding invalide: pas un tableau pour chunk ${subChunk.chunk_id}`);
+                    continue;
+                }
+
+                if (vector.length !== expectedDims) {
+                    console.warn(`⚠️ [indexTask] Dimension inattendue: ${vector.length} (attendu: ${expectedDims}) pour chunk ${subChunk.chunk_id}`);
+                    console.warn(`⚠️ [indexTask] Modèle utilisé: ${embeddingModel}`);
+                }
+
+                embeddingCache.set(contentHash, { vector, timestamp: now });
+                operationTimestamps.push(now);
+                console.log(`[CACHE] Embedding mis en cache pour subchunk ${subChunk.chunk_id} (dimension: ${vector.length})`);
+            }
+
+            const point: PointStruct = {
+                id: subChunk.chunk_id,
+                vector: vector,
+                payload: { ...subChunk, source: source, contentHash },
+            };
+            pointsToIndex.push(point);
         }
 
         /**

--- a/servers/roo-state-manager/src/services/task-indexer/__tests__/VectorIndexer.test.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/__tests__/VectorIndexer.test.ts
@@ -6,26 +6,54 @@
  */
 
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as crypto from 'crypto';
+
+// Hoisted mock declarations (accessible in vi.mock factories)
+const { mockGetCollections, mockCreateCollection, mockUpsert, mockDeleteCollection, mockCount, mockRetrieve, mockScroll } = vi.hoisted(() => ({
+	mockGetCollections: vi.fn(),
+	mockCreateCollection: vi.fn(),
+	mockUpsert: vi.fn(),
+	mockDeleteCollection: vi.fn(),
+	mockCount: vi.fn(),
+	mockRetrieve: vi.fn(),
+	mockScroll: vi.fn()
+}));
+
+const { mockEmbeddingsCreate } = vi.hoisted(() => ({
+	mockEmbeddingsCreate: vi.fn().mockResolvedValue({
+		data: [{ embedding: new Array(1536).fill(0.1) }],
+		model: 'text-embedding-3-small',
+		usage: { prompt_tokens: 10, total_tokens: 10 }
+	})
+}));
+
+/** Re-apply embeddings mock after vi.clearAllMocks() resets return values */
+function setupEmbeddingMock() {
+	mockEmbeddingsCreate.mockResolvedValue({
+		data: [{ embedding: new Array(1536).fill(0.1) }],
+		model: 'text-embedding-3-small',
+		usage: { prompt_tokens: 10, total_tokens: 10 }
+	});
+	mockUpsert.mockResolvedValue(undefined);
+}
 
 // Mock external dependencies
-const mockGetCollections = vi.fn();
-const mockCreateCollection = vi.fn();
-const mockUpsert = vi.fn();
-const mockDeleteCollection = vi.fn();
-const mockCount = vi.fn();
-
 vi.mock('../../qdrant.js', () => ({
 	getQdrantClient: vi.fn(() => ({
 		getCollections: mockGetCollections,
 		createCollection: mockCreateCollection,
 		upsert: mockUpsert,
 		deleteCollection: mockDeleteCollection,
-		count: mockCount
+		count: mockCount,
+		retrieve: mockRetrieve,
+		scroll: mockScroll
 	}))
 }));
 
 vi.mock('../../openai.js', () => ({
-	default: vi.fn(),
+	default: vi.fn(() => ({
+		embeddings: { create: mockEmbeddingsCreate }
+	})),
 	getEmbeddingModel: vi.fn(() => 'text-embedding-3-small'),
 	getEmbeddingDimensions: vi.fn(() => 1536)
 }));
@@ -37,7 +65,9 @@ vi.mock('../EmbeddingValidator.js', () => ({
 
 vi.mock('../ChunkExtractor.js', () => ({
 	extractChunksFromTask: vi.fn().mockResolvedValue([]),
-	splitChunk: vi.fn((chunk: any) => [chunk])
+	splitChunk: vi.fn((chunk: any) => [chunk]),
+	MAX_CHUNKS_PER_TASK: 5000,
+	computeChunkId: vi.fn(() => 'mock-deterministic-uuid')
 }));
 
 vi.mock('../QdrantHealthMonitor.js', () => ({
@@ -379,6 +409,127 @@ describe('VectorIndexer', () => {
 		test('is an exported function', async () => {
 			const mod = await import('../VectorIndexer.js');
 			expect(typeof mod.updateSkeletonIndexTimestamp).toBe('function');
+		});
+	});
+
+	// ============================================================
+	// #2018 Phase 2 — preflightDedupByChunkId tests
+	// ============================================================
+
+	describe('#2018 Phase 2: preflightDedupByChunkId', () => {
+		test('skips chunks that already exist with same contentHash', async () => {
+			const { indexTask } = await import('../VectorIndexer.js');
+			const { extractChunksFromTask } = await import('../ChunkExtractor.js');
+			const { splitChunk } = await import('../ChunkExtractor.js');
+			const expectedCollection = process.env.QDRANT_COLLECTION_NAME || 'roo_tasks_semantic_index';
+
+			const chunkContent = 'Hello world test content';
+			const contentHash = crypto.createHash('sha256').update(chunkContent).digest('hex');
+			const chunkId = 'test-chunk-id-1';
+
+			(extractChunksFromTask as any).mockResolvedValue([{
+				chunk_id: chunkId, content: chunkContent, indexed: true,
+				sequence_order: 0, chunk_type: 'message_exchange', role: 'user',
+				total_chunks: 1, chunk_index: 0
+			}]);
+			(splitChunk as any).mockImplementation((c: any) => [c]);
+
+			mockGetCollections.mockResolvedValue({ collections: [{ name: expectedCollection }] });
+
+			// Simulate: Qdrant retrieve finds the chunk already exists
+			mockRetrieve.mockResolvedValue([{
+				id: chunkId,
+				payload: { contentHash }
+			}]);
+
+			const result = await indexTask('task-dedup-1', '/fake/path');
+
+			// Should skip embedding entirely (no upsert needed)
+			expect(mockUpsert).not.toHaveBeenCalled();
+			expect(result).toEqual([]);
+		});
+
+		test('indexes chunks not present in Qdrant', async () => {
+			vi.useRealTimers();
+			const { indexTask } = await import('../VectorIndexer.js');
+			const { extractChunksFromTask } = await import('../ChunkExtractor.js');
+			const { splitChunk } = await import('../ChunkExtractor.js');
+			const expectedCollection = process.env.QDRANT_COLLECTION_NAME || 'roo_tasks_semantic_index';
+
+			setupEmbeddingMock();
+
+			(extractChunksFromTask as any).mockResolvedValue([{
+				chunk_id: 'new-chunk-1', content: 'New content to index', indexed: true,
+				sequence_order: 0, chunk_type: 'message_exchange', role: 'user',
+				total_chunks: 1, chunk_index: 0
+			}]);
+			(splitChunk as any).mockImplementation((c: any) => [c]);
+
+			mockGetCollections.mockResolvedValue({ collections: [{ name: expectedCollection }] });
+
+			// Simulate: Qdrant retrieve finds nothing
+			mockRetrieve.mockResolvedValue([]);
+
+			const result = await indexTask('task-new-1', '/fake/path');
+
+			expect(mockUpsert).toHaveBeenCalled();
+			expect(result.length).toBeGreaterThan(0);
+		});
+
+		test('re-indexes chunks with changed contentHash (content edit)', async () => {
+			vi.useRealTimers();
+			const { indexTask } = await import('../VectorIndexer.js');
+			const { extractChunksFromTask } = await import('../ChunkExtractor.js');
+			const { splitChunk } = await import('../ChunkExtractor.js');
+			const expectedCollection = process.env.QDRANT_COLLECTION_NAME || 'roo_tasks_semantic_index';
+
+			setupEmbeddingMock();
+
+			(extractChunksFromTask as any).mockResolvedValue([{
+				chunk_id: 'chunk-edit-1', content: 'Updated content after edit', indexed: true,
+				sequence_order: 0, chunk_type: 'message_exchange', role: 'user',
+				total_chunks: 1, chunk_index: 0
+			}]);
+			(splitChunk as any).mockImplementation((c: any) => [c]);
+
+			mockGetCollections.mockResolvedValue({ collections: [{ name: expectedCollection }] });
+
+			// Qdrant has old version with different contentHash
+			mockRetrieve.mockResolvedValue([{
+				id: 'chunk-edit-1',
+				payload: { contentHash: 'old-hash-different-from-current' }
+			}]);
+
+			const result = await indexTask('task-edit-1', '/fake/path');
+
+			expect(mockUpsert).toHaveBeenCalled();
+		});
+
+		test('falls through gracefully on retrieve failure', async () => {
+			vi.useRealTimers();
+			const { indexTask } = await import('../VectorIndexer.js');
+			const { extractChunksFromTask } = await import('../ChunkExtractor.js');
+			const { splitChunk } = await import('../ChunkExtractor.js');
+			const expectedCollection = process.env.QDRANT_COLLECTION_NAME || 'roo_tasks_semantic_index';
+
+			setupEmbeddingMock();
+
+			(extractChunksFromTask as any).mockResolvedValue([{
+				chunk_id: 'chunk-fail-1', content: 'Content despite failure', indexed: true,
+				sequence_order: 0, chunk_type: 'message_exchange', role: 'user',
+				total_chunks: 1, chunk_index: 0
+			}]);
+			(splitChunk as any).mockImplementation((c: any) => [c]);
+
+			mockGetCollections.mockResolvedValue({ collections: [{ name: expectedCollection }] });
+
+			// Qdrant retrieve throws
+			mockRetrieve.mockRejectedValue(new Error('Network timeout'));
+
+			const result = await indexTask('task-fail-1', '/fake/path');
+
+			// Should proceed with embedding + upsert (fallback path)
+			expect(mockUpsert).toHaveBeenCalled();
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Adds `preflightDedupByChunkId()` using Qdrant `retrieve()` (O(1) per ID) to check existing chunks BEFORE expensive embedding computation
- Restructures `indexTask()` into phased approach: extract → preflight dedup → embed → upsert
- Keeps existing `dedupByContentHash()` as safety net (now filters far fewer points)
- 4 new tests: skip existing, index new, re-index changed, graceful failure

## Problem
12 concurrent MCP instances (one per VS Code workspace) race in `dedupByContentHash()` — the check-then-write window allows concurrent MCPs to duplicate expensive embedding work. With `text-embedding-3-small` at $0.02/1M tokens across 6 machines, wasted compute is significant.

## Solution
Move dedup BEFORE embedding computation using deterministic chunk_ids (from Phase 1) and Qdrant's `retrieve()` API. This reduces the critical section to a single Qdrant upsert with deterministic IDs (already idempotent from Phase 1).

## Test plan
- [x] 4 new unit tests for preflight dedup scenarios (skip/new/edit/failure)
- [x] All 9229 existing tests pass (0 failures, 16 skipped)
- [x] Build succeeds
- [ ] Manual: Verify Qdrant retrieve logs during indexing show `[#2018] Preflight dedup` messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)