### PR TITLE
feat(#1410): cleanup error reporting — failure reasons per message

### DIFF
--- a/servers/roo-state-manager/src/services/MessageManager.ts
+++ b/servers/roo-state-manager/src/services/MessageManager.ts
@@ -1060,12 +1060,13 @@ export class MessageManager {
     errors: number;
     message_ids: string[];
     failed_ids: string[];
+    failed: Array<{ id: string; reason: string }>;
   }> {
     const effectiveWorkspaceId = workspaceId || getLocalWorkspaceId();
     logger.info(`Bulk ${operation} for ${machineId}:${effectiveWorkspaceId}`, { filters });
 
     if (!existsSync(this.inboxPath)) {
-      return { operation, matched: 0, processed: 0, errors: 0, message_ids: [], failed_ids: [] };
+      return { operation, matched: 0, processed: 0, errors: 0, message_ids: [], failed_ids: [], failed: [] };
     }
 
     // Use cached data for filtering (#638 perf optimization)
@@ -1073,6 +1074,7 @@ export class MessageManager {
     const matchedIds: string[] = [];
     let errors = 0;
     const failedIds: string[] = [];
+    const failed: Array<{ id: string; reason: string }> = [];
 
     for (const item of items) {
       const message = full.get(item.id);
@@ -1121,16 +1123,26 @@ export class MessageManager {
         if (operation === 'mark_read') {
           const success = await this.markAsRead(id, machineId);
           if (success) processed++;
-          else { errors++; failedIds.push(id); }
+          else {
+            errors++;
+            failedIds.push(id);
+            failed.push({ id, reason: 'mark_as_read returned false (message file may be missing or locked)' });
+          }
         } else if (operation === 'archive') {
           const success = await this.archiveMessage(id);
           if (success) processed++;
-          else { errors++; failedIds.push(id); }
+          else {
+            errors++;
+            failedIds.push(id);
+            failed.push({ id, reason: 'archive returned false (message file may be missing or locked)' });
+          }
         }
       } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
         logger.error(`Error processing message ${id}`, error);
         errors++;
         failedIds.push(id);
+        failed.push({ id, reason });
       }
     }
 
@@ -1141,7 +1153,8 @@ export class MessageManager {
       processed,
       errors,
       message_ids: matchedIds,
-      failed_ids: failedIds
+      failed_ids: failedIds,
+      failed
     };
   }
 

--- a/servers/roo-state-manager/src/tools/roosync/cleanup.ts
+++ b/servers/roo-state-manager/src/tools/roosync/cleanup.ts
@@ -78,14 +78,22 @@ function formatCleanupResult(result: {
   errors: number;
   message_ids: string[];
   failed_ids?: string[];
+  failed?: Array<{ id: string; reason: string }>;
 }, verbose: boolean = true): string {
   let output = `## 🧹 Cleanup RooSync - ${result.operation}\n\n`;
   output += `**Messages correspondants :** ${result.matched}\n`;
   output += `**Messages traités :** ${result.processed}\n`;
   output += `**Erreurs :** ${result.errors}\n\n`;
 
+  const failedItems = result.failed ?? [];
   const failedIds = result.failed_ids ?? [];
-  if (failedIds.length > 0) {
+  if (failedItems.length > 0) {
+    output += `**Messages en échec** (${failedItems.length}) :\n\n`;
+    for (const item of failedItems) {
+      output += `- ❌ \`${item.id}\` — ${item.reason}\n`;
+    }
+    output += '\n';
+  } else if (failedIds.length > 0) {
     output += `**IDs en échec** (${failedIds.length}) :\n\n`;
     for (const id of failedIds) {
       output += `- ❌ ${id}\n`;


### PR DESCRIPTION
## Summary
- `bulkOperation` now returns `failed: Array<{id, reason}>` alongside existing `failed_ids`
- cleanup tool format shows error reasons inline with each failure (e.g., "file missing or locked", parse error message)
- Backward compatible: `failed_ids` still populated, `failed` is additive

## Changes
- `MessageManager.ts`: `bulkOperation` captures reasons when `markAsRead`/`archiveMessage` fail or throw
- `cleanup.ts`: `formatCleanupResult` displays reasons when available, falls back to plain IDs

## Test plan
- [x] Existing 13 cleanup tests pass
- [x] Existing 74 MessageManager tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)