### PR TITLE
fix(#1410): forward page/per_page from conversation_browser to listConversationsTool

### DIFF
--- a/servers/roo-state-manager/src/tools/conversation/conversation-browser.ts
+++ b/servers/roo-state-manager/src/tools/conversation/conversation-browser.ts
@@ -40,6 +40,10 @@ export interface ConversationBrowserArgs {
     // ===== Arguments pour action='list' (via list_conversations) =====
     /** [list] Nombre maximum de conversations à retourner */
     limit?: number;
+    /** [list] Page number (1-based). Requires per_page. */
+    page?: number;
+    /** [list] Results per page (10-100). Default: 10. */
+    per_page?: number;
     /** [list] Critère de tri */
     sortBy?: 'lastActivity' | 'messageCount' | 'totalSize';
     /** [list] Ordre de tri */
@@ -184,6 +188,14 @@ export const conversationBrowserTool: Tool = {
             limit: {
                 type: 'number',
                 description: '[list] Max conversations to return.'
+            },
+            page: {
+                type: 'number',
+                description: '[list] Page number (1-based). Default: 1.'
+            },
+            per_page: {
+                type: 'number',
+                description: '[list] Results per page. Default: 10. Min: 10. Max: 100.'
             },
             sortBy: {
                 type: 'string',
@@ -661,6 +673,8 @@ async function handleConversationBrowserCore(
                 return await listConversationsTool.handler(
                     {
                         limit: args.limit,
+                        page: args.page,
+                        per_page: args.per_page,
                         sortBy: args.sortBy,
                         sortOrder: args.sortOrder,
                         workspace: args.workspace,


### PR DESCRIPTION
## Summary
- `page` and `per_page` parameters existed in `listConversationsTool` but were not accessible through `conversation_browser(action: "list")` because they were missing from the interface, inputSchema, and forwarding code
- Added `page` and `per_page` to `ConversationBrowserArgs` interface, inputSchema properties, and the `case 'list'` forwarding block

## Test plan
- [x] Build passes (`tsc` clean)
- [x] 79 existing conversation-browser tests pass
- [ ] Manual test: `conversation_browser(action: "list", page: 2, per_page: 20)` returns paginated results

🤖 Generated with [Claude Code](https://claude.com/claude-code)