### PR TITLE
feat(#1410): cleanup error reporting — failed_reasons in bulkOperation

### DIFF
--- a/servers/roo-state-manager/src/services/MessageManager.ts
+++ b/servers/roo-state-manager/src/services/MessageManager.ts
@@ -1060,12 +1060,13 @@ export class MessageManager {
     errors: number;
     message_ids: string[];
     failed_ids: string[];
+    failed_reasons: Record<string, string>;
   }> {
     const effectiveWorkspaceId = workspaceId || getLocalWorkspaceId();
     logger.info(`Bulk ${operation} for ${machineId}:${effectiveWorkspaceId}`, { filters });
 
     if (!existsSync(this.inboxPath)) {
-      return { operation, matched: 0, processed: 0, errors: 0, message_ids: [], failed_ids: [] };
+      return { operation, matched: 0, processed: 0, errors: 0, message_ids: [], failed_ids: [], failed_reasons: {} };
     }
 
     // Use cached data for filtering (#638 perf optimization)
@@ -1116,21 +1117,24 @@ export class MessageManager {
 
     // Apply the operation to matched messages
     let processed = 0;
+    const failedReasons: Record<string, string> = {};
     for (const id of matchedIds) {
       try {
         if (operation === 'mark_read') {
           const success = await this.markAsRead(id, machineId);
           if (success) processed++;
-          else { errors++; failedIds.push(id); }
+          else { errors++; failedIds.push(id); failedReasons[id] = 'mark_read returned false'; }
         } else if (operation === 'archive') {
           const success = await this.archiveMessage(id);
           if (success) processed++;
-          else { errors++; failedIds.push(id); }
+          else { errors++; failedIds.push(id); failedReasons[id] = 'archive returned false'; }
         }
       } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
         logger.error(`Error processing message ${id}`, error);
         errors++;
         failedIds.push(id);
+        failedReasons[id] = msg;
       }
     }
 
@@ -1141,7 +1145,8 @@ export class MessageManager {
       processed,
       errors,
       message_ids: matchedIds,
-      failed_ids: failedIds
+      failed_ids: failedIds,
+      failed_reasons: failedReasons
     };
   }
 

--- a/servers/roo-state-manager/src/tools/roosync/manage.ts
+++ b/servers/roo-state-manager/src/tools/roosync/manage.ts
@@ -282,8 +282,12 @@ async function bulkOperationHandler(
   if (args.tag) filtersDesc.push(`tag: ${args.tag}`);
 
   const failedIds = result.failed_ids ?? [];
+  const failedReasons = (result as any).failed_reasons as Record<string, string> | undefined;
   const failedSection = failedIds.length > 0
-    ? `\n\n**IDs en échec (${failedIds.length}) :** ${failedIds.slice(0, 10).map(id => `❌ \`${id}\``).join(', ')}${failedIds.length > 10 ? ` ... et ${failedIds.length - 10} autres` : ''}`
+    ? `\n\n**IDs en échec (${failedIds.length}) :** ${failedIds.slice(0, 10).map(id => {
+      const reason = failedReasons?.[id];
+      return reason ? `❌ \`${id}\` (${reason})` : `❌ \`${id}\``;
+    }).join(', ')}${failedIds.length > 10 ? ` ... et ${failedIds.length - 10} autres` : ''}`
     : '';
 
   return `✅ **Opération bulk terminée : ${opName}**
@@ -309,6 +313,7 @@ async function cleanupMessages(
   const machineId = getLocalMachineId();
   const results: string[] = [];
   const allFailedIds: string[] = [];
+  const allFailedReasons: Record<string, string> = {};
 
   // 0a. Cleanup expired auto-destruct messages (#629)
   try {
@@ -345,6 +350,7 @@ async function cleanupMessages(
   if (testResult.failed_ids.length > 0) {
     results.push(`- ⚠️ Échecs test mark_read : ${testResult.failed_ids.length} (${testResult.failed_ids.slice(0, 5).join(', ')}${testResult.failed_ids.length > 5 ? '…' : ''})`);
     allFailedIds.push(...testResult.failed_ids);
+    Object.assign(allFailedReasons, testResult.failed_reasons || {});
   }
 
   // 2. Archive old read messages (>30 days)
@@ -360,6 +366,7 @@ async function cleanupMessages(
   if (oldReadResult.failed_ids.length > 0) {
     results.push(`- ⚠️ Échecs archive >30j : ${oldReadResult.failed_ids.length} (${oldReadResult.failed_ids.slice(0, 5).join(', ')}${oldReadResult.failed_ids.length > 5 ? '…' : ''})`);
     allFailedIds.push(...oldReadResult.failed_ids);
+    Object.assign(allFailedReasons, oldReadResult.failed_reasons || {});
   }
 
   // 3. Mark old LOW priority messages as read (>7 days)
@@ -375,13 +382,17 @@ async function cleanupMessages(
   if (oldLowResult.failed_ids.length > 0) {
     results.push(`- ⚠️ Échecs LOW mark_read : ${oldLowResult.failed_ids.length} (${oldLowResult.failed_ids.slice(0, 5).join(', ')}${oldLowResult.failed_ids.length > 5 ? '…' : ''})`);
     allFailedIds.push(...oldLowResult.failed_ids);
+    Object.assign(allFailedReasons, oldLowResult.failed_reasons || {});
   }
 
   // 4. Get current stats
   const stats = await messageManager.getInboxStats(machineId);
 
   const errorSection = allFailedIds.length > 0
-    ? `\n\n### Échecs (${allFailedIds.length} messages)\n${allFailedIds.slice(0, 10).map(id => `- \`${id}\``).join('\n')}${allFailedIds.length > 10 ? `\n… et ${allFailedIds.length - 10} autres` : ''}`
+    ? `\n\n### Échecs (${allFailedIds.length} messages)\n${allFailedIds.slice(0, 10).map(id => {
+      const reason = allFailedReasons[id];
+      return reason ? `- \`${id}\` — ${reason}` : `- \`${id}\``;
+    }).join('\n')}${allFailedIds.length > 10 ? `\n… et ${allFailedIds.length - 10} autres` : ''}`
     : '';
 
   return `🧹 **Cleanup terminé**


### PR DESCRIPTION
## Summary

- Add `failed_reasons: Record<string, string>` to `bulkOperation()` return type
- `cleanupMessages()` now shows **why** each message failed, not just the ID
- `formatBulkResult()` also displays reasons in bulk_mark_read/bulk_archive output
- No breaking changes to `markAsRead`/`archiveMessage` public API (still return `boolean`)

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 457 passed, 0 failed
- [ ] Manual: trigger `roosync_manage(action: "cleanup")` with a corrupted message to verify error reason appears

## Related

- Issue #1410 item 3
- Part of executor mandate from ai-01 (2026-05-12 deadline)