### PR TITLE
feat(#2013): Complete heartbeat terminology rename + pagination contract fixes

### DIFF
--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -592,26 +592,8 @@ export async function initializeBackgroundServices(state: ServerState): Promise<
             console.warn('[Qdrant] Background indexing init failed (non-blocking):', error?.message || error);
         });
 
-        // Heartbeat service: disabled by default to prevent GDrive sync storm (#607)
-        if (process.env.HEARTBEAT_AUTO_START === 'true') {
-            // #1140: Dynamic import to avoid loading RooSyncService at startup
-            const { RooSyncService } = await import('./RooSyncService.js');
-            const rooSyncService = RooSyncService.getInstance();
-            rooSyncService.startHeartbeatService(
-                (machineId: string) => {
-                    console.log(`[Heartbeat] Machine offline: ${machineId}`);
-                },
-                (machineId: string) => {
-                    console.log(`[Heartbeat] Machine online: ${machineId}`);
-                }
-            ).then(() => {
-                console.log('✅ Heartbeat service auto-started');
-            }).catch((error: any) => {
-                console.warn('⚠️ Heartbeat init failed (non-blocking):', error.message);
-            });
-        } else {
-            console.log('ℹ️ Heartbeat auto-start disabled (#607). Use roosync_heartbeat tool or set HEARTBEAT_AUTO_START=true');
-        }
+        // Heartbeat: ADR 008 passive model — no auto-start needed.
+        // Every MCP tool call IS the heartbeat. Status derived from timestamps.
 
         console.log('✅ Services background lancés');
     } catch (error: any) {

--- a/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
+++ b/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
@@ -1,145 +1,73 @@
 /**
  * Service de Heartbeat pour RooSync
  *
- * Responsable de la gestion des heartbeats entre agents,
- * la détection des machines offline et la synchronisation automatique.
+ * ADR 008: Passive activity derivation — every MCP tool call IS the heartbeat.
+ * No disk I/O, no background intervals, no GDrive writes.
  *
- * v3.1.0: Per-machine files to avoid GDrive sync conflicts.
- * Each machine writes ONLY its own file in heartbeats/{machineId}.json.
+ * Status model: ONLINE (<30min), IDLE (30-120min), UNKNOWN (>120min)
+ * No OFFLINE status — true machine failure detected by external tools.
  *
  * @module HeartbeatService
- * @version 3.1.0
+ * @version 4.0.0 (ADR 008 Phase 2)
  */
 
-import { promises as fs, existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync, unlinkSync, statSync, renameSync as fsRenameSync } from 'fs';
-import { join } from 'path';
 import { createLogger } from '../../utils/logger.js';
-import { getServerCapabilities } from '../../utils/server-capabilities.js';
 
 const logger = createLogger('HeartbeatService');
 
-/**
- * Atomic write: write to .tmp then rename. Prevents 0-byte corruption on GDrive/Windows
- * when the process is interrupted mid-write.
- */
-async function atomicWriteFile(filePath: string, data: string): Promise<void> {
-  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
-  await fs.writeFile(tmpPath, data, 'utf-8');
-  await fs.rename(tmpPath, filePath);
-}
+// Status thresholds (ADR 008)
+const ONLINE_THRESHOLD = 30 * 60 * 1000;  // 30 min
+const IDLE_THRESHOLD = 120 * 60 * 1000;   // 120 min
 
-/**
- * Synchronous atomic write for use during migration (called from sync context).
- */
-function atomicWriteFileSync(filePath: string, data: string): void {
-  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
-  writeFileSync(tmpPath, data, 'utf-8');
-  fsRenameSync(tmpPath, filePath);
-}
+export type MachineStatus = 'online' | 'idle' | 'unknown';
 
-/**
- * Configuration du heartbeat
- */
 export interface HeartbeatConfig {
-  /** Intervalle de heartbeat en millisecondes (défaut: 60s) */
-  heartbeatInterval: number;
-
-  /** Timeout avant de considérer une machine offline en millisecondes (défaut: 10min) */
-  offlineTimeout: number;
-
-  /** Nombre de heartbeats manqués avant alerte */
-  missedHeartbeatThreshold: number;
-
-  /** @deprecated Auto-sync removed — kept for backward compat in tool schemas */
+  /** @deprecated No longer used — kept for backward compat in tool schemas */
+  heartbeatInterval?: number;
+  /** @deprecated No longer used — kept for backward compat in tool schemas */
+  offlineTimeout?: number;
+  /** @deprecated No longer used */
+  missedHeartbeatThreshold?: number;
+  /** @deprecated No longer used — no disk writes */
   autoSyncEnabled?: boolean;
-
-  /** @deprecated Auto-sync removed — kept for backward compat in tool schemas */
+  /** @deprecated No longer used — no disk writes */
   autoSyncInterval?: number;
-
-  /**
-   * Intervalle minimal entre deux écritures sur disque en millisecondes (défaut: 5min).
-   * Réduit les syncs GDrive en n'écrivant que lors de changements de statut
-   * ou après ce délai minimum. Fix #607.
-   */
-  persistenceInterval: number;
+  /** @deprecated No longer used — no disk writes */
+  persistenceInterval?: number;
 }
 
-/**
- * Données de heartbeat d'une machine
- */
 export interface HeartbeatData {
-  /** Identifiant de la machine */
   machineId: string;
-
-  /** Timestamp du dernier heartbeat */
   lastHeartbeat: string;
-
-  /** Statut de la machine */
-  status: 'online' | 'offline' | 'warning' | 'idle' | 'unknown';
-
-  /** Nombre de heartbeats manqués consécutifs */
-  missedHeartbeats: number;
-
-  /** Timestamp de première détection offline */
-  offlineSince?: string;
-
-  /** Métadonnées */
+  status: MachineStatus;
   metadata: {
     firstSeen: string;
     lastUpdated: string;
-    version: string;
   };
 }
 
-/**
- * État du service de heartbeat
- */
 export interface HeartbeatServiceState {
-  /** Données de heartbeat par machine */
   heartbeats: Map<string, HeartbeatData>;
-
-  /** Machines actuellement online */
   onlineMachines: string[];
-
-  /** Machines actuellement offline */
-  offlineMachines: string[];
-
-  /** Machines en avertissement */
-  warningMachines: string[];
-
-  /** Statistiques */
+  idleMachines: string[];
+  unknownMachines: string[];
   statistics: {
     totalMachines: number;
     onlineCount: number;
-    offlineCount: number;
-    warningCount: number;
+    idleCount: number;
+    unknownCount: number;
     lastHeartbeatCheck: string;
   };
 }
 
-/**
- * Résultat de vérification de heartbeat
- */
 export interface HeartbeatCheckResult {
-  /** Succès de la vérification */
   success: boolean;
-
-  /** Machines détectées offline */
-  newlyOfflineMachines: string[];
-
-  /** Machines redevenues online */
+  newlyUnknownMachines: string[];
   newlyOnlineMachines: string[];
-
-  /** Machines en avertissement */
-  warningMachines: string[];
-
-  /** Timestamp de la vérification */
+  newlyIdleMachines: string[];
   checkedAt: string;
 }
 
-/**
- * Erreur du service de heartbeat
- */
 export class HeartbeatServiceError extends Error {
   constructor(message: string, public readonly code?: string) {
     super(`[HeartbeatService] ${message}`);
@@ -148,642 +76,244 @@ export class HeartbeatServiceError extends Error {
 }
 
 /**
- * Service de Heartbeat pour RooSync
+ * HeartbeatService — ADR 008 in-memory passive model
  *
- * Uses per-machine files in heartbeats/ subdirectory to avoid
- * GDrive sync conflicts from concurrent writes to a single file.
+ * No disk I/O. No background intervals. State lives in process memory.
+ * Server restart → all machines start UNKNOWN → first tool call → ONLINE.
  */
 export class HeartbeatService {
-  private heartbeatsDir: string;
-  private legacyHeartbeatPath: string;
   private state: HeartbeatServiceState;
-  private heartbeatInterval: NodeJS.Timeout | null = null;
-  private heartbeatCheckerInterval: NodeJS.Timeout | null = null;
   private config: HeartbeatConfig;
-  private onOfflineDetectedCallback?: (machineId: string) => void;
-  private onOnlineRestoredCallback?: (machineId: string) => void;
-  /** Tracks last disk write timestamp per machine for dirty-flag optimization (#607) */
-  private lastDiskWrite: Map<string, number> = new Map();
+  private onStatusChangeCallback?: (machineId: string, oldStatus: MachineStatus, newStatus: MachineStatus) => void;
 
   constructor(
-    private sharedPath: string,
+    _sharedPath?: string,
     config?: Partial<HeartbeatConfig>
   ) {
-    this.heartbeatsDir = join(sharedPath, 'heartbeats');
-    this.legacyHeartbeatPath = join(sharedPath, 'heartbeat.json');
-
-    // Configuration par défaut (#607 fix: réduit fréquence d'écriture GDrive)
-    this.config = {
-      heartbeatInterval: 60000,  // 1 minute (réduit de 30s)
-      offlineTimeout: 1200000,   // 20 minutes (4x persistence interval, tolerates GDrive sync delay) (#1409)
-      missedHeartbeatThreshold: 4,
-      persistenceInterval: 300000, // 5 minutes entre écritures GDrive (#607)
-      ...config
-    };
-
+    this.config = { ...config };
     this.state = {
       heartbeats: new Map(),
       onlineMachines: [],
-      offlineMachines: [],
-      warningMachines: [],
+      idleMachines: [],
+      unknownMachines: [],
       statistics: {
         totalMachines: 0,
         onlineCount: 0,
-        offlineCount: 0,
-        warningCount: 0,
+        idleCount: 0,
+        unknownCount: 0,
         lastHeartbeatCheck: new Date().toISOString()
       }
     };
-
-    this.initializeService();
+    logger.info('HeartbeatService v4.0 initialized (ADR 008 in-memory model)');
   }
 
   /**
-   * Initialise le service et charge les données existantes
-   */
-  private initializeService(): void {
-    try {
-      this.loadState();
-      logger.info('Service de heartbeat initialisé', {
-        heartbeatInterval: this.config.heartbeatInterval,
-        offlineTimeout: this.config.offlineTimeout
-      });
-    } catch (error) {
-      logger.error('Erreur lors de l\'initialisation', error);
-    }
-  }
-
-  /**
-   * #1918: Check if shared path (GDrive) is accessible for disk I/O.
-   * When degraded, heartbeat data stays in-memory only.
-   */
-  private isDiskAvailable(): boolean {
-    return getServerCapabilities().isAvailable('sharedPath');
-  }
-
-  /**
-   * Returns the file path for a machine's heartbeat file
-   */
-  private getMachineFilePath(machineId: string): string {
-    return join(this.heartbeatsDir, `${machineId.toLowerCase()}.json`);
-  }
-
-  /**
-   * Ensures the heartbeats/ directory exists
-   */
-  private ensureHeartbeatsDir(): void {
-    try {
-      if (!existsSync(this.heartbeatsDir)) {
-        mkdirSync(this.heartbeatsDir, { recursive: true });
-      }
-    } catch (error) {
-      logger.error('Erreur création répertoire heartbeats', error);
-    }
-  }
-
-  /**
-   * Charge l'état du service depuis le disque (synchrone)
-   * Checks per-machine files first, falls back to legacy single file with migration.
-   */
-  private loadState(): void {
-    try {
-      if (existsSync(this.heartbeatsDir)) {
-        // New format: per-machine files
-        this.loadFromPerMachineFiles();
-      } else if (existsSync(this.legacyHeartbeatPath)) {
-        // Legacy format: migrate from single file
-        this.migrateFromLegacyFile();
-      }
-      // else: fresh start with empty state
-
-      this.updateMachineStatus();
-
-      logger.info('État du service chargé', {
-        totalMachines: this.state.heartbeats.size,
-        online: this.state.onlineMachines.length,
-        offline: this.state.offlineMachines.length,
-        warning: this.state.warningMachines.length
-      });
-    } catch (error) {
-      logger.error('Erreur chargement état', error);
-      this.state.heartbeats = new Map();
-      this.updateMachineStatus();
-    }
-  }
-
-  /**
-   * Load heartbeat data from per-machine files in heartbeats/ directory
-   */
-  private loadFromPerMachineFiles(): void {
-    try {
-      const files = readdirSync(this.heartbeatsDir);
-      const jsonFiles = files.filter(f => f.endsWith('.json'));
-
-      for (const file of jsonFiles) {
-        try {
-          const filePath = join(this.heartbeatsDir, file);
-
-          // Clean up 0-byte files (corruption from interrupted non-atomic writes)
-          const stat = statSync(filePath);
-          if (stat.size === 0) {
-            logger.warn(`Suppression fichier heartbeat vide (0 bytes): ${file}`);
-            try { unlinkSync(filePath); } catch (_) { /* ignore cleanup failure */ }
-            continue;
-          }
-
-          const content = readFileSync(filePath, 'utf-8');
-          const data = JSON.parse(content) as HeartbeatData;
-          const machineId = data.machineId?.toLowerCase() || file.replace('.json', '').toLowerCase();
-          this.state.heartbeats.set(machineId, data);
-        } catch (fileError) {
-          logger.warn(`Erreur lecture fichier heartbeat ${file}`, { error: String(fileError) });
-        }
-      }
-
-      // Identity dedup: merge stale unprefixed files into myia-prefixed ones
-      // e.g. po-2025.json → myia-po-2025.json (the canonical identity)
-      this.dedupMachineIdentities();
-    } catch (error) {
-      logger.error('Erreur lecture répertoire heartbeats', error);
-    }
-  }
-
-  /**
-   * Deduplicate heartbeat files where a machine has both "shortname" and "myia-shortname" entries.
-   * Keeps the more recent entry, removes the stale one.
-   */
-  private dedupMachineIdentities(): void {
-    const entries = Array.from(this.state.heartbeats.entries());
-    const toRemove: string[] = [];
-
-    for (const [machineId, data] of entries) {
-      // Check if this is an unprefixed variant of a myia-prefixed machine
-      if (!machineId.startsWith('myia-')) {
-        const prefixedId = `myia-${machineId}`;
-        if (this.state.heartbeats.has(prefixedId)) {
-          const prefixedData = this.state.heartbeats.get(prefixedId)!;
-          // Keep the one with the most recent timestamp
-          const unprefixedTime = new Date(data.lastHeartbeat || 0).getTime();
-          const prefixedTime = new Date(prefixedData.lastHeartbeat || 0).getTime();
-
-          if (prefixedTime >= unprefixedTime) {
-            // Prefixed is newer or same — remove unprefixed
-            toRemove.push(machineId);
-            logger.info(`Dedup: suppression identité dupliquée ${machineId} (conserve ${prefixedId})`);
-          } else {
-            // Unprefixed is newer — merge into prefixed, remove unprefixed
-            this.state.heartbeats.set(prefixedId, data);
-            toRemove.push(machineId);
-            logger.info(`Dedup: fusion ${machineId} → ${prefixedId} (données plus récentes)`);
-          }
-
-          // Clean up the orphan file
-          try {
-            const orphanPath = this.getMachineFilePath(machineId);
-            if (existsSync(orphanPath)) {
-              unlinkSync(orphanPath);
-            }
-          } catch (e) {
-            logger.warn(`Dedup: impossible de supprimer fichier orphelin pour ${machineId}`, { error: String(e) });
-          }
-        }
-      }
-    }
-
-    for (const id of toRemove) {
-      this.state.heartbeats.delete(id);
-    }
-  }
-
-  /**
-   * Migrate from legacy single heartbeat.json to per-machine files
-   */
-  private migrateFromLegacyFile(): void {
-    try {
-      const content = readFileSync(this.legacyHeartbeatPath, 'utf-8');
-      const data = JSON.parse(content);
-      const heartbeats = data.heartbeats || {};
-
-      this.ensureHeartbeatsDir();
-
-      for (const [key, value] of Object.entries(heartbeats)) {
-        const machineId = key.toLowerCase();
-        const heartbeatData = value as HeartbeatData;
-        this.state.heartbeats.set(machineId, heartbeatData);
-
-        // Write individual file
-        try {
-          const filePath = this.getMachineFilePath(machineId);
-          atomicWriteFileSync(filePath, JSON.stringify(heartbeatData, null, 2));
-        } catch (writeError) {
-          logger.warn(`Erreur écriture heartbeat ${machineId} pendant migration`, { error: String(writeError) });
-        }
-      }
-
-      // Remove legacy file
-      try {
-        unlinkSync(this.legacyHeartbeatPath);
-        logger.info('Fichier legacy heartbeat.json migré et supprimé');
-      } catch (unlinkError) {
-        logger.warn('Impossible de supprimer heartbeat.json après migration', { error: String(unlinkError) });
-      }
-    } catch (error) {
-      logger.error('Erreur migration legacy heartbeat.json', error);
-    }
-  }
-
-  /**
-   * Reload all per-machine files from disk (useful before checkHeartbeats)
-   */
-  public reloadFromDisk(): void {
-    if (!this.isDiskAvailable()) {
-      // #1918: GDrive offline — keep in-memory state, skip disk reads
-      this.updateMachineStatus();
-      return;
-    }
-    this.state.heartbeats.clear();
-    if (existsSync(this.heartbeatsDir)) {
-      this.loadFromPerMachineFiles();
-    }
-    this.updateMachineStatus();
-  }
-
-  /**
-   * Save a single machine's heartbeat data to its own file
-   */
-  private async saveMachineHeartbeat(machineId: string): Promise<void> {
-    if (!this.isDiskAvailable()) {
-      // #1918: GDrive offline — keep heartbeat in-memory only
-      return;
-    }
-    try {
-      await fs.mkdir(this.heartbeatsDir, { recursive: true });
-
-      const heartbeatData = this.state.heartbeats.get(machineId.toLowerCase());
-      if (!heartbeatData) return;
-
-      const filePath = this.getMachineFilePath(machineId);
-      await atomicWriteFile(filePath, JSON.stringify(heartbeatData, null, 2));
-    } catch (error) {
-      logger.error(`Erreur sauvegarde heartbeat pour ${machineId}`, error);
-    }
-  }
-
-  /**
-   * Delete a machine's heartbeat file
-   */
-  private async removeMachineFile(machineId: string): Promise<void> {
-    if (!this.isDiskAvailable()) return;
-    try {
-      const filePath = this.getMachineFilePath(machineId);
-      if (existsSync(filePath)) {
-        await fs.unlink(filePath);
-      }
-    } catch (error) {
-      logger.error(`Erreur suppression fichier heartbeat pour ${machineId}`, error);
-    }
-  }
-
-  /**
-   * Sauvegarde l'état de TOUTES les machines (used at stop/config update)
-   */
-  private async saveState(): Promise<void> {
-    if (!this.isDiskAvailable()) return;
-    try {
-      await fs.mkdir(this.heartbeatsDir, { recursive: true });
-
-      for (const [machineId, heartbeatData] of this.state.heartbeats.entries()) {
-        const filePath = this.getMachineFilePath(machineId);
-        await atomicWriteFile(filePath, JSON.stringify(heartbeatData, null, 2));
-      }
-    } catch (error) {
-      logger.error('Erreur sauvegarde état', error);
-    }
-  }
-
-  /**
-   * Enregistre un heartbeat pour une machine
-   * #1953 ADR 008 Phase 1: In-memory only, no GDrive writes.
+   * Register activity for a machine (called by auto-heartbeat hook on every tool call)
    */
   public async registerHeartbeat(
     machineId: string,
-    metadata?: Record<string, any>
+    _metadata?: Record<string, unknown>
   ): Promise<void> {
     machineId = machineId.toLowerCase();
     const now = new Date().toISOString();
 
-    let heartbeatData = this.state.heartbeats.get(machineId);
+    let data = this.state.heartbeats.get(machineId);
+    const previousStatus = data?.status;
 
-    if (!heartbeatData) {
-      heartbeatData = {
+    if (!data) {
+      data = {
         machineId,
         lastHeartbeat: now,
         status: 'online',
-        missedHeartbeats: 0,
-        metadata: {
-          firstSeen: now,
-          lastUpdated: now,
-          version: '3.2.0'
-        }
+        metadata: { firstSeen: now, lastUpdated: now }
       };
-      logger.info(`Nouvelle machine enregistrée: ${machineId}`);
+      logger.info(`New machine registered: ${machineId}`);
     } else {
-      heartbeatData.lastHeartbeat = now;
-      heartbeatData.status = 'online';
-      heartbeatData.missedHeartbeats = 0;
-      heartbeatData.offlineSince = undefined;
-      heartbeatData.metadata.lastUpdated = now;
+      data.lastHeartbeat = now;
+      data.status = 'online';
+      data.metadata.lastUpdated = now;
     }
 
-    this.state.heartbeats.set(machineId, heartbeatData);
+    this.state.heartbeats.set(machineId, data);
     this.updateMachineStatus();
+
+    if (previousStatus && previousStatus !== 'online' && this.onStatusChangeCallback) {
+      this.onStatusChangeCallback(machineId, previousStatus, 'online');
+    }
   }
 
   /**
-   * Vérifie les heartbeats et dérive le statut des machines
-   * #1953 ADR 008 Phase 1: In-memory only, status = ONLINE/IDLE/UNKNOWN (no OFFLINE).
+   * Derive status for all machines based on last activity timestamps
    */
   public async checkHeartbeats(): Promise<HeartbeatCheckResult> {
     const now = Date.now();
     const result: HeartbeatCheckResult = {
       success: true,
-      newlyOfflineMachines: [],
+      newlyUnknownMachines: [],
       newlyOnlineMachines: [],
-      warningMachines: [],
+      newlyIdleMachines: [],
       checkedAt: new Date().toISOString()
     };
 
-    for (const [machineId, heartbeatData] of this.state.heartbeats.entries()) {
-      const lastHeartbeatTime = new Date(heartbeatData.lastHeartbeat).getTime();
-      const timeSinceLastHeartbeat = now - lastHeartbeatTime;
+    for (const [machineId, data] of this.state.heartbeats.entries()) {
+      const lastActivity = new Date(data.lastHeartbeat).getTime();
+      const elapsed = now - lastActivity;
+      const previousStatus = data.status;
 
-      // #1953 ADR 008: ONLINE (<30min), IDLE (30-120min), UNKNOWN (>120min)
-      // No OFFLINE status — true machine failure detected by external tools
-      const ONLINE_THRESHOLD = 30 * 60 * 1000;  // 30 min
-      const IDLE_THRESHOLD = 120 * 60 * 1000;   // 120 min
-
-      const previousStatus = heartbeatData.status;
-
-      if (timeSinceLastHeartbeat > IDLE_THRESHOLD) {
-        // UNKNOWN — no recent activity, not necessarily down
-        if (previousStatus !== 'unknown') {
-          heartbeatData.status = 'unknown';
-          result.newlyOfflineMachines.push(machineId);
-          logger.info(`Machine status → UNKNOWN: ${machineId}`, { timeSinceLastHeartbeat });
-        }
-      } else if (timeSinceLastHeartbeat > ONLINE_THRESHOLD) {
-        // IDLE — machine active within last 2h but not in last 30min
-        if (previousStatus !== 'idle' && previousStatus !== 'warning') {
-          heartbeatData.status = 'idle';
-          heartbeatData.missedHeartbeats = 1;
-          result.warningMachines.push(machineId);
-          logger.info(`Machine status → IDLE: ${machineId}`, { timeSinceLastHeartbeat });
-        }
+      let newStatus: MachineStatus;
+      if (elapsed > IDLE_THRESHOLD) {
+        newStatus = 'unknown';
+      } else if (elapsed > ONLINE_THRESHOLD) {
+        newStatus = 'idle';
       } else {
-        // ONLINE — active within last 30min
-        if (previousStatus !== 'online') {
-          heartbeatData.status = 'online';
-          heartbeatData.missedHeartbeats = 0;
-          heartbeatData.offlineSince = undefined;
-          result.newlyOnlineMachines.push(machineId);
-          logger.info(`Machine status → ONLINE: ${machineId}`);
+        newStatus = 'online';
+      }
+
+      if (previousStatus !== newStatus) {
+        data.status = newStatus;
+        data.metadata.lastUpdated = new Date().toISOString();
+
+        if (newStatus === 'unknown') result.newlyUnknownMachines.push(machineId);
+        else if (newStatus === 'idle') result.newlyIdleMachines.push(machineId);
+        else result.newlyOnlineMachines.push(machineId);
+
+        logger.info(`Status ${previousStatus} → ${newStatus}: ${machineId}`, { elapsedMs: elapsed });
+
+        if (this.onStatusChangeCallback) {
+          this.onStatusChangeCallback(machineId, previousStatus, newStatus);
         }
       }
 
-      heartbeatData.metadata.lastUpdated = new Date().toISOString();
-      this.state.heartbeats.set(machineId, heartbeatData);
+      this.state.heartbeats.set(machineId, data);
     }
 
     this.updateMachineStatus();
     this.state.statistics.lastHeartbeatCheck = new Date().toISOString();
-
-    if (this.onOfflineDetectedCallback) {
-      for (const machineId of result.newlyOfflineMachines) {
-        this.onOfflineDetectedCallback(machineId);
-      }
-    }
-
-    if (this.onOnlineRestoredCallback) {
-      for (const machineId of result.newlyOnlineMachines) {
-        this.onOnlineRestoredCallback(machineId);
-      }
-    }
-
     return result;
   }
 
   /**
-   * Met à jour les listes de machines par statut
+   * Set callback for status changes
    */
-  private updateMachineStatus(): void {
-    const onlineMachines: string[] = [];
-    const offlineMachines: string[] = [];
-    const warningMachines: string[] = [];
-
-    for (const [machineId, heartbeatData] of this.state.heartbeats.entries()) {
-      switch (heartbeatData.status) {
-        case 'online':
-          onlineMachines.push(machineId);
-          break;
-        case 'offline':
-        case 'unknown':
-          offlineMachines.push(machineId);
-          break;
-        case 'warning':
-        case 'idle':
-          warningMachines.push(machineId);
-          break;
-      }
-    }
-
-    this.state.onlineMachines = onlineMachines;
-    this.state.offlineMachines = offlineMachines;
-    this.state.warningMachines = warningMachines;
-
-    this.state.statistics.totalMachines = this.state.heartbeats.size;
-    this.state.statistics.onlineCount = onlineMachines.length;
-    this.state.statistics.offlineCount = offlineMachines.length;
-    this.state.statistics.warningCount = warningMachines.length;
+  public onStatusChange(callback: (machineId: string, oldStatus: MachineStatus, newStatus: MachineStatus) => void): void {
+    this.onStatusChangeCallback = callback;
   }
 
-  /**
-   * Démarre le service de heartbeat automatique
-   */
-  public async startHeartbeatService(
-    machineId: string,
-    onOfflineDetected?: (machineId: string) => void,
-    onOnlineRestored?: (machineId: string) => void
-  ): Promise<void> {
-    machineId = machineId.toLowerCase();
-    logger.info(`Démarrage du service heartbeat pour: ${machineId}`);
+  // --- Query methods ---
 
-    // Stocker les callbacks comme propriétés de classe
-    this.onOfflineDetectedCallback = onOfflineDetected;
-    this.onOnlineRestoredCallback = onOnlineRestored;
-
-    // Enregistrer le heartbeat initial
-    await this.registerHeartbeat(machineId);
-
-    // Démarrer l'intervalle de heartbeat
-    this.heartbeatInterval = setInterval(async () => {
-      try {
-        await this.registerHeartbeat(machineId);
-      } catch (error) {
-        logger.error(`Erreur heartbeat pour ${machineId}:`, error);
-      }
-    }, this.config.heartbeatInterval);
-
-    // Démarrer la vérification des heartbeats
-    this.startHeartbeatChecker();
-  }
-
-  /**
-   * Démarre le vérificateur de heartbeat
-   */
-  private startHeartbeatChecker(): void {
-    // Callbacks are already invoked inside checkHeartbeats() — no need to duplicate here
-    this.heartbeatCheckerInterval = setInterval(async () => {
-      try {
-        await this.checkHeartbeats();
-      } catch (error) {
-        logger.error('Erreur vérification heartbeat:', error);
-      }
-    }, this.config.heartbeatInterval);
-  }
-
-  /**
-   * Arrête le service de heartbeat
-   */
-  public async stopHeartbeatService(): Promise<void> {
-    logger.info('Arrêt du service de heartbeat');
-
-    if (this.heartbeatInterval) {
-      clearInterval(this.heartbeatInterval);
-      this.heartbeatInterval = null;
-    }
-
-    if (this.heartbeatCheckerInterval) {
-      clearInterval(this.heartbeatCheckerInterval);
-      this.heartbeatCheckerInterval = null;
-    }
-
-    await this.saveState();
-  }
-
-  /**
-   * Obtient les données de heartbeat d'une machine
-   */
   public getHeartbeatData(machineId: string): HeartbeatData | undefined {
     return this.state.heartbeats.get(machineId.toLowerCase());
   }
 
-  /**
-   * Obtient toutes les machines online
-   */
   public getOnlineMachines(): string[] {
     return [...this.state.onlineMachines];
   }
 
-  /**
-   * Obtient toutes les machines offline
-   */
+  /** @deprecated Use getUnknownMachines() — ADR 008 Phase 2 */
   public getOfflineMachines(): string[] {
-    return [...this.state.offlineMachines];
+    return this.getUnknownMachines();
   }
 
-  /**
-   * Obtient toutes les machines en avertissement
-   */
+  public getUnknownMachines(): string[] {
+    return [...this.state.unknownMachines];
+  }
+
+  /** @deprecated Use getIdleMachines() — ADR 008 Phase 2 */
   public getWarningMachines(): string[] {
-    return [...this.state.warningMachines];
+    return this.getIdleMachines();
   }
 
-  /**
-   * Obtient l'état complet du service
-   */
+  public getIdleMachines(): string[] {
+    return [...this.state.idleMachines];
+  }
+
   public getState(): HeartbeatServiceState {
     return {
       heartbeats: new Map(this.state.heartbeats),
       onlineMachines: [...this.state.onlineMachines],
-      offlineMachines: [...this.state.offlineMachines],
-      warningMachines: [...this.state.warningMachines],
+      idleMachines: [...this.state.idleMachines],
+      unknownMachines: [...this.state.unknownMachines],
       statistics: { ...this.state.statistics }
     };
   }
 
-  /**
-   * Met à jour la configuration du service
-   */
-  public async updateConfig(config: Partial<HeartbeatConfig>): Promise<void> {
-    this.config = { ...this.config, ...config };
-
-    logger.info('Configuration mise à jour', {
-      heartbeatInterval: this.config.heartbeatInterval,
-      offlineTimeout: this.config.offlineTimeout
-    });
-
-    // Redémarrer les intervalles si nécessaire
-    if (this.heartbeatInterval || this.heartbeatCheckerInterval) {
-      await this.stopHeartbeatService();
-      // Note: Le redémarrage nécessite d'appeler startHeartbeatService
-    }
-
-    await this.saveState();
-  }
-
-  /**
-   * Supprime une machine du service de heartbeat
-   */
   public async removeMachine(machineId: string): Promise<void> {
     this.state.heartbeats.delete(machineId.toLowerCase());
     this.updateMachineStatus();
-    await this.removeMachineFile(machineId);
+    logger.info(`Machine removed: ${machineId}`);
+  }
 
-    logger.info(`Machine supprimée du service heartbeat: ${machineId}`);
+  // --- Backward compat methods (no-ops or redirects for ADR 008 Phase 2) ---
+
+  /**
+   * @deprecated No-op in ADR 008. Background service no longer needed.
+   * Kept for backward compat with callers (background-services.ts, heartbeat-service tool).
+   */
+  public async startHeartbeatService(
+    _machineId: string,
+    onOfflineDetected?: (machineId: string) => void,
+    onOnlineRestored?: (machineId: string) => void
+  ): Promise<void> {
+    logger.info('startHeartbeatService called — no-op (ADR 008 passive model)');
+    // Set up status change callback if callers provide offline/online callbacks
+    if (onOfflineDetected || onOnlineRestored) {
+      this.onStatusChangeCallback = (machineId, oldStatus, newStatus) => {
+        if (newStatus === 'unknown' && onOfflineDetected) onOfflineDetected(machineId);
+        if (newStatus === 'online' && onOnlineRestored) onOnlineRestored(machineId);
+      };
+    }
   }
 
   /**
-   * Nettoie les machines offline depuis longtemps
+   * @deprecated No-op in ADR 008. No background interval to stop.
    */
-  public async cleanupOldOfflineMachines(maxAge: number = 86400000): Promise<number> {
-    // maxAge par défaut: 24 heures
-    // #1409: Don't delete heartbeat files for production machines (myia-*) — just keep as offline.
-    // Deleting production files causes machineCount to drop below the actual cluster size.
-    // Non-production machines (test artifacts, machine-2, workflow-machine) are deleted after maxAge.
-    const now = Date.now();
-    let cleanedCount = 0;
-    const isProduction = (id: string) => id.toLowerCase().startsWith('myia-');
+  public async stopHeartbeatService(): Promise<void> {
+    logger.info('stopHeartbeatService called — no-op (ADR 008 passive model)');
+  }
 
-    for (const [machineId, heartbeatData] of this.state.heartbeats.entries()) {
-      if (heartbeatData.offlineSince) {
-        const offlineAge = now - new Date(heartbeatData.offlineSince).getTime();
+  /**
+   * @deprecated No-op in ADR 008.
+   */
+  public async updateConfig(_config: Partial<HeartbeatConfig>): Promise<void> {
+    logger.info('updateConfig called — no-op (ADR 008 passive model)');
+  }
 
-        if (offlineAge > maxAge) {
-          if (isProduction(machineId)) {
-            // Production machines: keep in state as offline, don't remove file
-            heartbeatData.status = 'offline';
-            cleanedCount++;
-          } else {
-            // Non-production (test artifacts): delete file and remove from state
-            await this.removeMachineFile(machineId);
-            this.state.heartbeats.delete(machineId);
-            cleanedCount++;
-            logger.info(`Test machine supprimée (offline ${Math.round(offlineAge / 3600000)}h): ${machineId}`);
-            continue;
-          }
+  /**
+   * @deprecated No disk state to reload.
+   */
+  public reloadFromDisk(): void {
+    // No-op: ADR 008 in-memory only
+  }
 
-          logger.info(`Machine offline longue durée (conservée): ${machineId}`, {
-            offlineAge,
-            maxAge
-          });
-        }
+  /**
+   * @deprecated No disk state to clean up.
+   */
+  public async cleanupOldOfflineMachines(_maxAge?: number): Promise<number> {
+    return 0;
+  }
+
+  // --- Internal ---
+
+  private updateMachineStatus(): void {
+    const online: string[] = [];
+    const idle: string[] = [];
+    const unknown: string[] = [];
+
+    for (const [machineId, data] of this.state.heartbeats.entries()) {
+      switch (data.status) {
+        case 'online': online.push(machineId); break;
+        case 'idle': idle.push(machineId); break;
+        case 'unknown': unknown.push(machineId); break;
       }
     }
 
-    if (cleanedCount > 0) {
-      this.updateMachineStatus();
-    }
+    this.state.onlineMachines = online;
+    this.state.idleMachines = idle;
+    this.state.unknownMachines = unknown;
 
-    return cleanedCount;
+    this.state.statistics.totalMachines = this.state.heartbeats.size;
+    this.state.statistics.onlineCount = online.length;
+    this.state.statistics.idleCount = idle.length;
+    this.state.statistics.unknownCount = unknown.length;
   }
 }

--- a/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
@@ -1,155 +1,34 @@
 /**
  * Tests unitaires pour HeartbeatService
  *
+ * ADR 008 Phase 2 — in-memory passive model.
+ * No disk I/O, no background intervals, no GDrive writes.
+ *
  * Couvre :
- * - Initialisation avec per-machine files (heartbeats/ dir)
- * - Initialisation sans fichier → état vide
- * - Initialisation avec fichier corrompu → skip gracieux
- * - Migration: legacy heartbeat.json → per-machine files
- * - registerHeartbeat : nouvelle machine + writes per-machine file
- * - registerHeartbeat : machine existante (update)
- * - checkHeartbeats : reloads from disk, détecte offline/warning/online
- * - getOnlineMachines / getOfflineMachines / getWarningMachines
+ * - Initialisation → état vide (no disk load)
+ * - registerHeartbeat : nouvelle machine + machine existante (update)
+ * - checkHeartbeats : détection IDLE/UNKNOWN/ONLINE (computed from lastHeartbeat age)
+ * - getOnlineMachines / getOfflineMachines (deprecated alias) / getWarningMachines (deprecated alias)
  * - getHeartbeatData : défini après register, undefined avant
- * - getState : retourne copie défensive
- * - removeMachine : suppression + file deletion
- * - cleanupOldOfflineMachines : supprime anciennes, garde récentes
- * - stopHeartbeatService : saves all per-machine files
- * - updateConfig : accepte config partielle
+ * - getState : retourne copie défensive avec nouvelles clés (idleMachines, unknownMachines)
+ * - removeMachine : suppression in-memory
+ * - cleanupOldOfflineMachines : no-op (returns 0)
+ * - stopHeartbeatService : no-op
+ * - updateConfig : no-op
+ * - reloadFromDisk : no-op
  *
  * @module services/roosync/__tests__/HeartbeatService.test
- * @version 2.0.0 (per-machine files)
+ * @version 4.0.0 (ADR 008 Phase 2 — in-memory only)
  */
 
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
-import { join } from 'path';
-
-// ─────────────────── hoisted mocks ───────────────────
-
-const {
-  mockExistsSync,
-  mockReadFileSync,
-  mockReaddirSync,
-  mockMkdirSync,
-  mockWriteFileSync,
-  mockUnlinkSync,
-  mockStatSync,
-  mockRenameSync,
-  mockWriteFile,
-  mockMkdir,
-  mockUnlink,
-  mockRename,
-} = vi.hoisted(() => ({
-  mockExistsSync: vi.fn().mockReturnValue(false),
-  mockReadFileSync: vi.fn().mockReturnValue('{}'),
-  mockReaddirSync: vi.fn().mockReturnValue([] as string[]),
-  mockMkdirSync: vi.fn(),
-  mockWriteFileSync: vi.fn(),
-  mockUnlinkSync: vi.fn(),
-  mockStatSync: vi.fn().mockReturnValue({ size: 100 }),
-  mockRenameSync: vi.fn(),
-  mockWriteFile: vi.fn().mockResolvedValue(undefined),
-  mockMkdir: vi.fn().mockResolvedValue(undefined),
-  mockUnlink: vi.fn().mockResolvedValue(undefined),
-  mockRename: vi.fn().mockResolvedValue(undefined),
-}));
-
-vi.mock('fs', () => ({
-  existsSync: mockExistsSync,
-  readFileSync: mockReadFileSync,
-  readdirSync: mockReaddirSync,
-  mkdirSync: mockMkdirSync,
-  writeFileSync: mockWriteFileSync,
-  unlinkSync: mockUnlinkSync,
-  statSync: mockStatSync,
-  renameSync: mockRenameSync,
-  promises: {
-    writeFile: (...args: any[]) => mockWriteFile(...args),
-    mkdir: (...args: any[]) => mockMkdir(...args),
-    unlink: (...args: any[]) => mockUnlink(...args),
-    rename: (...args: any[]) => mockRename(...args),
-  },
-}));
 
 import { HeartbeatService } from '../HeartbeatService.js';
-
-// ─────────────────── helpers ───────────────────
-
-const TEST_PATH = '/test/shared';
-const HEARTBEATS_DIR = join(TEST_PATH, 'heartbeats');
-const LEGACY_PATH = join(TEST_PATH, 'heartbeat.json');
-
-function makeOnlineMachine(machineId: string): Record<string, any> {
-  return {
-    machineId,
-    lastHeartbeat: new Date().toISOString(),
-    status: 'online',
-    missedHeartbeats: 0,
-    metadata: {
-      firstSeen: new Date().toISOString(),
-      lastUpdated: new Date().toISOString(),
-      version: '3.1.0',
-    },
-  };
-}
-
-/**
- * Configure mocks to simulate per-machine files on disk.
- * Each key in `machines` is a machineId, value is the heartbeat data object.
- */
-function setupPerMachineFiles(machines: Record<string, any>): void {
-  const machineIds = Object.keys(machines);
-
-  mockExistsSync.mockImplementation((p: string) => {
-    if (p === HEARTBEATS_DIR) return true;
-    for (const id of machineIds) {
-      if (p === join(HEARTBEATS_DIR, `${id}.json`)) return true;
-    }
-    return false;
-  });
-
-  mockReaddirSync.mockReturnValue(machineIds.map(id => `${id}.json`));
-
-  mockReadFileSync.mockImplementation((p: string, _enc?: string) => {
-    for (const [id, data] of Object.entries(machines)) {
-      if (p === join(HEARTBEATS_DIR, `${id}.json`)) {
-        return JSON.stringify(data);
-      }
-    }
-    throw new Error(`ENOENT: ${p}`);
-  });
-}
-
-/**
- * Configure mocks to simulate a legacy heartbeat.json file.
- */
-function setupLegacyFile(machines: Record<string, any>): void {
-  mockExistsSync.mockImplementation((p: string) => p === LEGACY_PATH);
-
-  mockReadFileSync.mockReturnValue(JSON.stringify({
-    heartbeats: machines,
-    statistics: {
-      totalMachines: Object.keys(machines).length,
-      onlineCount: 0,
-      offlineCount: 0,
-      warningCount: 0,
-      lastHeartbeatCheck: new Date().toISOString(),
-    },
-  }));
-}
 
 // ─────────────────── setup ───────────────────
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockExistsSync.mockReturnValue(false);
-  mockReadFileSync.mockReturnValue('{}');
-  mockReaddirSync.mockReturnValue([]);
-  mockStatSync.mockReturnValue({ size: 100 });
-  mockWriteFile.mockResolvedValue(undefined);
-  mockMkdir.mockResolvedValue(undefined);
-  mockUnlink.mockResolvedValue(undefined);
-  mockRename.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -161,132 +40,38 @@ afterEach(() => {
 describe('HeartbeatService', () => {
 
   // ============================================================
-  // Initialisation (per-machine files)
+  // Initialisation (in-memory — always empty)
   // ============================================================
 
   describe('initialisation', () => {
-    test('état vide si pas de fichier heartbeat', () => {
-      mockExistsSync.mockReturnValue(false);
-
-      const service = new HeartbeatService(TEST_PATH);
+    test('état vide par défaut (pas de chargement disque)', () => {
+      const service = new HeartbeatService();
 
       expect(service.getOnlineMachines()).toEqual([]);
       expect(service.getOfflineMachines()).toEqual([]);
       expect(service.getWarningMachines()).toEqual([]);
+      expect(service.getUnknownMachines()).toEqual([]);
+      expect(service.getIdleMachines()).toEqual([]);
     });
 
-    test('charge les machines depuis le répertoire per-machine', () => {
-      const data = makeOnlineMachine('myia-ai-01');
-      setupPerMachineFiles({ 'myia-ai-01': data });
-
-      const service = new HeartbeatService(TEST_PATH);
-
-      expect(service.getOnlineMachines()).toContain('myia-ai-01');
-    });
-
-    test('état vide si fichier per-machine corrompu (pas de throw)', () => {
-      mockExistsSync.mockImplementation((p: string) => p === HEARTBEATS_DIR);
-      mockReaddirSync.mockReturnValue(['corrupted.json']);
-      mockReadFileSync.mockReturnValue('INVALID{{JSON');
-
-      // Ne doit pas throw
-      const service = new HeartbeatService(TEST_PATH);
+    test('accepte un sharedPath sans l\'utiliser', () => {
+      const service = new HeartbeatService('/some/path');
 
       expect(service.getOnlineMachines()).toEqual([]);
     });
 
-    test('charge les machines offline depuis les fichiers per-machine', () => {
-      const offlineMachine = {
-        ...makeOnlineMachine('offline-machine'),
-        status: 'offline',
-        offlineSince: new Date(Date.now() - 5000).toISOString(),
-      };
-      setupPerMachineFiles({ 'offline-machine': offlineMachine });
-
-      const service = new HeartbeatService(TEST_PATH);
-
-      expect(service.getOfflineMachines()).toContain('offline-machine');
-    });
-
-    test('charge plusieurs machines depuis les fichiers per-machine', () => {
-      setupPerMachineFiles({
-        'machine-a': makeOnlineMachine('machine-a'),
-        'machine-b': makeOnlineMachine('machine-b'),
+    test('accepte une config complète', () => {
+      const service = new HeartbeatService('/path', {
+        heartbeatInterval: 30000,
+        offlineTimeout: 120000,
+        missedHeartbeatThreshold: 4,
+        autoSyncEnabled: false,
+        autoSyncInterval: 60000,
+        persistenceInterval: 100,
       });
 
-      const service = new HeartbeatService(TEST_PATH);
-
-      expect(service.getOnlineMachines()).toContain('machine-a');
-      expect(service.getOnlineMachines()).toContain('machine-b');
-    });
-  });
-
-  // ============================================================
-  // Migration from legacy heartbeat.json
-  // ============================================================
-
-  describe('migration from legacy file', () => {
-    test('migrates legacy heartbeat.json to per-machine files', () => {
-      setupLegacyFile({
-        'machine-a': makeOnlineMachine('machine-a'),
-        'machine-b': makeOnlineMachine('machine-b'),
-      });
-
-      const service = new HeartbeatService(TEST_PATH);
-
-      // Machines loaded in memory
-      expect(service.getOnlineMachines()).toContain('machine-a');
-      expect(service.getOnlineMachines()).toContain('machine-b');
-
-      // Per-machine files written
-      expect(mockWriteFileSync).toHaveBeenCalledTimes(2);
-
-      // Legacy file deleted
-      expect(mockUnlinkSync).toHaveBeenCalledWith(LEGACY_PATH);
-
-      // Dir created
-      expect(mockMkdirSync).toHaveBeenCalled();
-    });
-
-    test('handles corrupted legacy file gracefully', () => {
-      mockExistsSync.mockImplementation((p: string) => p === LEGACY_PATH);
-      mockReadFileSync.mockReturnValue('CORRUPTED{{JSON');
-
-      const service = new HeartbeatService(TEST_PATH);
-
+      expect(service).toBeDefined();
       expect(service.getOnlineMachines()).toEqual([]);
-    });
-
-    test('directory takes precedence over legacy file', () => {
-      const dirData = makeOnlineMachine('from-dir');
-
-      // Both dir and legacy exist
-      mockExistsSync.mockImplementation((p: string) =>
-        p === HEARTBEATS_DIR || p === LEGACY_PATH
-      );
-      mockReaddirSync.mockReturnValue(['from-dir.json']);
-      mockReadFileSync.mockImplementation((p: string, _enc?: string) => {
-        if (p === join(HEARTBEATS_DIR, 'from-dir.json')) return JSON.stringify(dirData);
-        if (p === LEGACY_PATH) return JSON.stringify({ heartbeats: { 'from-legacy': makeOnlineMachine('from-legacy') } });
-        throw new Error(`ENOENT: ${p}`);
-      });
-
-      const service = new HeartbeatService(TEST_PATH);
-
-      // Dir wins, legacy not loaded
-      expect(service.getOnlineMachines()).toContain('from-dir');
-      expect(service.getOnlineMachines()).not.toContain('from-legacy');
-    });
-
-    test('continues if legacy file delete fails', () => {
-      setupLegacyFile({ 'machine-c': makeOnlineMachine('machine-c') });
-      mockUnlinkSync.mockImplementation(() => { throw new Error('EBUSY'); });
-
-      // Should not throw
-      const service = new HeartbeatService(TEST_PATH);
-
-      // Machine still loaded
-      expect(service.getOnlineMachines()).toContain('machine-c');
     });
   });
 
@@ -296,7 +81,7 @@ describe('HeartbeatService', () => {
 
   describe('registerHeartbeat', () => {
     test('enregistre une nouvelle machine avec statut online', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       await service.registerHeartbeat('new-machine');
 
@@ -304,11 +89,12 @@ describe('HeartbeatService', () => {
       expect(data).toBeDefined();
       expect(data!.machineId).toBe('new-machine');
       expect(data!.status).toBe('online');
-      expect(data!.missedHeartbeats).toBe(0);
+      expect(data!.metadata.firstSeen).toBeDefined();
+      expect(data!.metadata.lastUpdated).toBeDefined();
     });
 
     test('la nouvelle machine apparaît dans getOnlineMachines', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       await service.registerHeartbeat('machine-x');
 
@@ -316,7 +102,7 @@ describe('HeartbeatService', () => {
     });
 
     test('met à jour le lastHeartbeat d\'une machine existante', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       await service.registerHeartbeat('machine-a');
       const first = service.getHeartbeatData('machine-a')!.lastHeartbeat;
@@ -325,39 +111,15 @@ describe('HeartbeatService', () => {
       await new Promise(r => setTimeout(r, 5));
       await service.registerHeartbeat('machine-a');
 
-      expect(service.getHeartbeatData('machine-a')!.machineId).toBe('machine-a');
-      expect(service.getHeartbeatData('machine-a')!.status).toBe('online');
-    });
-
-    test('remet missedHeartbeats à 0 lors d\'une mise à jour', async () => {
-      const service = new HeartbeatService(TEST_PATH);
-
-      await service.registerHeartbeat('machine-b');
-      const hb = service.getHeartbeatData('machine-b')!;
-      hb.missedHeartbeats = 5; // Simuler des heartbeats manqués
-
-      await service.registerHeartbeat('machine-b');
-
-      expect(service.getHeartbeatData('machine-b')!.missedHeartbeats).toBe(0);
-    });
-
-    test('#1953 ADR 008: registerHeartbeat is in-memory only (no file writes)', async () => {
-      const service = new HeartbeatService(TEST_PATH);
-
-      await service.registerHeartbeat('machine-y');
-
-      // ADR 008 Phase 1: registerHeartbeat is in-memory only
-      expect(mockMkdir).not.toHaveBeenCalled();
-      expect(mockWriteFile).not.toHaveBeenCalled();
-      expect(mockRename).not.toHaveBeenCalled();
-
-      // But machine is registered in memory
-      expect(service.getHeartbeatData('machine-y')).toBeDefined();
-      expect(service.getHeartbeatData('machine-y')!.status).toBe('online');
+      const updated = service.getHeartbeatData('machine-a')!;
+      expect(updated.machineId).toBe('machine-a');
+      expect(updated.status).toBe('online');
+      // lastHeartbeat should be >= first
+      expect(new Date(updated.lastHeartbeat).getTime()).toBeGreaterThanOrEqual(new Date(first).getTime());
     });
 
     test('enregistre plusieurs machines indépendamment', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       await service.registerHeartbeat('machine-1');
       await service.registerHeartbeat('machine-2');
@@ -370,12 +132,20 @@ describe('HeartbeatService', () => {
     });
 
     test('normalizes machineId to lowercase', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       await service.registerHeartbeat('MyIA-AI-01');
 
       expect(service.getHeartbeatData('myia-ai-01')).toBeDefined();
-      // ADR 008 Phase 1: in-memory only, no file writes during registration
+    });
+
+    test('accepte des métadonnées optionnelles (ignorées)', async () => {
+      const service = new HeartbeatService();
+
+      await service.registerHeartbeat('meta-machine', { customField: 'value' });
+
+      expect(service.getHeartbeatData('meta-machine')).toBeDefined();
+      expect(service.getHeartbeatData('meta-machine')!.status).toBe('online');
     });
   });
 
@@ -385,7 +155,7 @@ describe('HeartbeatService', () => {
 
   describe('checkHeartbeats', () => {
     test('retourne success=true et checkedAt', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       const result = await service.checkHeartbeats();
 
@@ -395,16 +165,17 @@ describe('HeartbeatService', () => {
     });
 
     test('retourne des tableaux vides si aucune machine', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       const result = await service.checkHeartbeats();
 
-      expect(result.newlyOfflineMachines).toEqual([]);
+      expect(result.newlyUnknownMachines).toEqual([]);
       expect(result.newlyOnlineMachines).toEqual([]);
+      expect(result.newlyIdleMachines).toEqual([]);
     });
 
     test('détecte une machine UNKNOWN (lastHeartbeat >120 min) #1953 ADR 008', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       // Register machine then make its heartbeat stale (>120 min = UNKNOWN)
       await service.registerHeartbeat('slow-machine');
@@ -413,13 +184,14 @@ describe('HeartbeatService', () => {
 
       const result = await service.checkHeartbeats();
 
-      expect(result.newlyOfflineMachines).toContain('slow-machine'); // UNKNOWN maps to offlineMachines
-      expect(service.getOfflineMachines()).toContain('slow-machine');
+      expect(result.newlyUnknownMachines).toContain('slow-machine');
+      expect(service.getOfflineMachines()).toContain('slow-machine'); // deprecated alias
+      expect(service.getUnknownMachines()).toContain('slow-machine');
       expect(service.getHeartbeatData('slow-machine')!.status).toBe('unknown');
     });
 
     test('détecte une machine IDLE (30-120 min) #1953 ADR 008', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       // Register machine then make heartbeat 45 min old → IDLE
       await service.registerHeartbeat('idle-machine');
@@ -428,13 +200,14 @@ describe('HeartbeatService', () => {
 
       const result = await service.checkHeartbeats();
 
-      expect(result.warningMachines).toContain('idle-machine'); // IDLE maps to warningMachines
-      expect(service.getWarningMachines()).toContain('idle-machine');
+      expect(result.newlyIdleMachines).toContain('idle-machine');
+      expect(service.getWarningMachines()).toContain('idle-machine'); // deprecated alias
+      expect(service.getIdleMachines()).toContain('idle-machine');
       expect(service.getHeartbeatData('idle-machine')!.status).toBe('idle');
     });
 
     test('machine UNKNOWN revient online after re-registration #1953 ADR 008', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       // Register machine then make its heartbeat stale (>120 min)
       await service.registerHeartbeat('recovering-machine');
@@ -452,68 +225,45 @@ describe('HeartbeatService', () => {
     });
 
     test('machine online stable reste online #1953 ADR 008', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       // Register with current timestamp → stays ONLINE
       await service.registerHeartbeat('stable-machine');
 
       const result = await service.checkHeartbeats();
 
-      expect(result.newlyOfflineMachines).not.toContain('stable-machine');
+      expect(result.newlyUnknownMachines).not.toContain('stable-machine');
       expect(service.getOnlineMachines()).toContain('stable-machine');
     });
 
-    test('does not write files (status is computed in-memory only)', async () => {
-      const service = new HeartbeatService(TEST_PATH, {
-        offlineTimeout: 100,
-        heartbeatInterval: 30,
-        missedHeartbeatThreshold: 4,
-      });
+    test('no status change if checkHeartbeats called on fresh machine', async () => {
+      const service = new HeartbeatService();
 
-      const staleData = {
-        ...makeOnlineMachine('check-machine'),
-        lastHeartbeat: new Date(Date.now() - 200).toISOString(),
-      };
-      setupPerMachineFiles({ 'check-machine': staleData });
-      vi.clearAllMocks();
+      await service.registerHeartbeat('fresh-machine');
+      const result = await service.checkHeartbeats();
 
-      await service.checkHeartbeats();
-
-      // checkHeartbeats should NOT write files (status computed in-memory)
-      expect(mockWriteFile).not.toHaveBeenCalled();
+      expect(result.newlyUnknownMachines).toEqual([]);
+      expect(result.newlyIdleMachines).toEqual([]);
+      expect(result.newlyOnlineMachines).toEqual([]);
+      expect(service.getHeartbeatData('fresh-machine')!.status).toBe('online');
     });
   });
 
   // ============================================================
-  // reloadFromDisk
+  // reloadFromDisk (no-op in ADR 008)
   // ============================================================
 
   describe('reloadFromDisk', () => {
-    test('clears state and reloads from per-machine files', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+    test('no-op: in-memory state is preserved', async () => {
+      const service = new HeartbeatService();
 
-      // Register a machine in memory
-      await service.registerHeartbeat('in-memory-only');
-      expect(service.getOnlineMachines()).toContain('in-memory-only');
-
-      // Set up disk with different machine
-      setupPerMachineFiles({ 'from-disk': makeOnlineMachine('from-disk') });
+      await service.registerHeartbeat('in-memory-machine');
+      expect(service.getOnlineMachines()).toContain('in-memory-machine');
 
       service.reloadFromDisk();
 
-      // In-memory machine gone, disk machine loaded
-      expect(service.getOnlineMachines()).not.toContain('in-memory-only');
-      expect(service.getOnlineMachines()).toContain('from-disk');
-    });
-
-    test('empty state if heartbeats dir does not exist', async () => {
-      const service = new HeartbeatService(TEST_PATH);
-      await service.registerHeartbeat('some-machine');
-
-      mockExistsSync.mockReturnValue(false);
-      service.reloadFromDisk();
-
-      expect(service.getOnlineMachines()).toEqual([]);
+      // State unchanged — reloadFromDisk is a no-op
+      expect(service.getOnlineMachines()).toContain('in-memory-machine');
     });
   });
 
@@ -523,13 +273,13 @@ describe('HeartbeatService', () => {
 
   describe('getHeartbeatData', () => {
     test('retourne undefined si machine inconnue', () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       expect(service.getHeartbeatData('unknown-machine')).toBeUndefined();
     });
 
     test('retourne les données après registerHeartbeat', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       await service.registerHeartbeat('known-machine');
 
@@ -544,21 +294,21 @@ describe('HeartbeatService', () => {
   // ============================================================
 
   describe('getState', () => {
-    test('retourne un état complet avec statistiques', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+    test('retourne un état complet avec statistiques (ADR 008 naming)', async () => {
+      const service = new HeartbeatService();
 
       await service.registerHeartbeat('stat-machine');
 
       const state = service.getState();
       expect(state.heartbeats).toBeDefined();
       expect(state.onlineMachines).toBeDefined();
-      expect(state.offlineMachines).toBeDefined();
-      expect(state.warningMachines).toBeDefined();
+      expect(state.idleMachines).toBeDefined();
+      expect(state.unknownMachines).toBeDefined();
       expect(state.statistics).toBeDefined();
     });
 
     test('les listes de machines sont des copies (pas des références)', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       await service.registerHeartbeat('copy-machine');
 
@@ -570,13 +320,24 @@ describe('HeartbeatService', () => {
     });
 
     test('state.statistics.totalMachines correspond au nombre de machines', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       await service.registerHeartbeat('m1');
       await service.registerHeartbeat('m2');
 
       const state = service.getState();
       expect(state.statistics.totalMachines).toBe(2);
+    });
+
+    test('state.statistics contient onlineCount, idleCount, unknownCount', async () => {
+      const service = new HeartbeatService();
+
+      await service.registerHeartbeat('stat-m1');
+
+      const state = service.getState();
+      expect(state.statistics.onlineCount).toBe(1);
+      expect(state.statistics.idleCount).toBe(0);
+      expect(state.statistics.unknownCount).toBe(0);
     });
   });
 
@@ -586,7 +347,7 @@ describe('HeartbeatService', () => {
 
   describe('removeMachine', () => {
     test('supprime la machine des listes', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       await service.registerHeartbeat('to-remove');
       expect(service.getOnlineMachines()).toContain('to-remove');
@@ -598,32 +359,30 @@ describe('HeartbeatService', () => {
     });
 
     test('supprimer une machine inexistante ne throw pas', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       await expect(service.removeMachine('nonexistent')).resolves.not.toThrow();
     });
 
-    test('deletes per-machine file on removal', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+    test('mise à jour des statistiques après suppression', async () => {
+      const service = new HeartbeatService();
 
-      await service.registerHeartbeat('to-remove-2');
-      vi.clearAllMocks();
+      await service.registerHeartbeat('m1');
+      await service.registerHeartbeat('m2');
+      expect(service.getState().statistics.totalMachines).toBe(2);
 
-      // The file "exists" on disk
-      mockExistsSync.mockReturnValue(true);
-      await service.removeMachine('to-remove-2');
-
-      expect(mockUnlink).toHaveBeenCalledWith(join(HEARTBEATS_DIR, 'to-remove-2.json'));
+      await service.removeMachine('m1');
+      expect(service.getState().statistics.totalMachines).toBe(1);
     });
   });
 
   // ============================================================
-  // cleanupOldOfflineMachines
+  // cleanupOldOfflineMachines (no-op in ADR 008)
   // ============================================================
 
   describe('cleanupOldOfflineMachines', () => {
-    test('retourne 0 si aucune machine offline', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+    test('retourne toujours 0 (no-op ADR 008)', async () => {
+      const service = new HeartbeatService();
 
       await service.registerHeartbeat('active-machine');
 
@@ -632,122 +391,54 @@ describe('HeartbeatService', () => {
       expect(removed).toBe(0);
     });
 
-    test('garde les machines offline anciennes en statut offline (#1409)', async () => {
-      const service = new HeartbeatService(TEST_PATH, { offlineTimeout: 10 });
-
-      await service.registerHeartbeat('myia-old-offline');
-      const hb = service.getHeartbeatData('myia-old-offline')!;
-      hb.status = 'offline';
-      hb.offlineSince = new Date(Date.now() - 100_000).toISOString(); // offline depuis 100s
-
-      const removed = await service.cleanupOldOfflineMachines(50_000); // maxAge = 50s
-
-      expect(removed).toBe(1);
-      // #1409: Production machines (myia-*) kept in state as offline, not deleted
-      expect(service.getHeartbeatData('myia-old-offline')).toBeDefined();
-      expect(service.getHeartbeatData('myia-old-offline')!.status).toBe('offline');
-    });
-
-    test('garde les machines offline récentes', async () => {
-      const service = new HeartbeatService(TEST_PATH);
-
-      await service.registerHeartbeat('recent-offline');
-      const hb = service.getHeartbeatData('recent-offline')!;
-      hb.status = 'offline';
-      hb.offlineSince = new Date().toISOString(); // offline depuis maintenant
-
-      const removed = await service.cleanupOldOfflineMachines(86_400_000); // maxAge = 24h
-
-      expect(removed).toBe(0);
-      expect(service.getHeartbeatData('recent-offline')).toBeDefined();
-    });
-
-    test('ne touche pas aux machines sans offlineSince', async () => {
-      const service = new HeartbeatService(TEST_PATH);
-
-      await service.registerHeartbeat('online-machine');
-
-      const removed = await service.cleanupOldOfflineMachines(0); // maxAge = 0
-
-      expect(removed).toBe(0);
-    });
-
-    test('supprime les machines non-production (test artifacts) offline anciennes (#1409)', async () => {
-      const service = new HeartbeatService(TEST_PATH, { offlineTimeout: 10 });
+    test('ne supprime aucune machine (no-op ADR 008)', async () => {
+      const service = new HeartbeatService();
 
       await service.registerHeartbeat('test-artifact-machine');
-      const hb = service.getHeartbeatData('test-artifact-machine')!;
-      hb.status = 'offline';
-      hb.offlineSince = new Date(Date.now() - 100_000).toISOString();
 
-      mockExistsSync.mockReturnValue(true);
+      const removed = await service.cleanupOldOfflineMachines(0);
 
-      await service.cleanupOldOfflineMachines(50_000);
-
-      // #1409: Non-production machines (not myia-*) ARE deleted
-      expect(service.getHeartbeatData('test-artifact-machine')).toBeUndefined();
-    });
-
-    test('garde les machines production offline sans supprimer le fichier (#1409)', async () => {
-      const service = new HeartbeatService(TEST_PATH, { offlineTimeout: 10 });
-
-      await service.registerHeartbeat('myia-cleanup-target');
-      const hb = service.getHeartbeatData('myia-cleanup-target')!;
-      hb.status = 'offline';
-      hb.offlineSince = new Date(Date.now() - 100_000).toISOString();
-
-      mockExistsSync.mockReturnValue(true);
-
-      await service.cleanupOldOfflineMachines(50_000);
-
-      // #1409: Production machines (myia-*) kept as offline, files NOT deleted
-      expect(mockUnlink).not.toHaveBeenCalled();
-      expect(service.getHeartbeatData('myia-cleanup-target')).toBeDefined();
+      expect(removed).toBe(0);
+      expect(service.getHeartbeatData('test-artifact-machine')).toBeDefined();
     });
   });
 
   // ============================================================
-  // stopHeartbeatService
+  // stopHeartbeatService (no-op in ADR 008)
   // ============================================================
 
   describe('stopHeartbeatService', () => {
     test('s\'arrête sans erreur si jamais démarré', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+      const service = new HeartbeatService();
 
       await expect(service.stopHeartbeatService()).resolves.not.toThrow();
     });
 
-    test('saves all per-machine files on stop', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+    test('no-op: ne modifie pas l\'état', async () => {
+      const service = new HeartbeatService();
 
       await service.registerHeartbeat('persisted-machine');
-      vi.clearAllMocks();
-
       await service.stopHeartbeatService();
 
-      expect(mockMkdir).toHaveBeenCalledWith(HEARTBEATS_DIR, { recursive: true });
-      // Atomic write: writeFile gets .tmp path, then rename to final path
-      const writeFileCalls = mockWriteFile.mock.calls;
-      expect(writeFileCalls.length).toBeGreaterThanOrEqual(1);
-      expect(writeFileCalls[0][0]).toContain(join(HEARTBEATS_DIR, 'persisted-machine.json'));
-      expect(mockRename).toHaveBeenCalled();
+      // Machine still in memory (no disk write, no state change)
+      expect(service.getHeartbeatData('persisted-machine')).toBeDefined();
+      expect(service.getHeartbeatData('persisted-machine')!.status).toBe('online');
     });
   });
 
   // ============================================================
-  // Configuration
+  // Configuration (no-op in ADR 008)
   // ============================================================
 
   describe('configuration', () => {
-    test('utilise la config par défaut (heartbeatInterval=30s)', () => {
-      const service = new HeartbeatService(TEST_PATH);
+    test('utilise la config par défaut', () => {
+      const service = new HeartbeatService();
 
-      // Si le service démarre sans erreur avec la config par défaut, OK
       expect(service).toBeDefined();
     });
 
     test('accepte une config partielle', () => {
-      const service = new HeartbeatService(TEST_PATH, {
+      const service = new HeartbeatService('/path', {
         heartbeatInterval: 5_000,
         offlineTimeout: 30_000,
       });
@@ -755,11 +446,82 @@ describe('HeartbeatService', () => {
       expect(service).toBeDefined();
     });
 
-    test('updateConfig met à jour la configuration', async () => {
-      const service = new HeartbeatService(TEST_PATH);
+    test('updateConfig est un no-op (ne throw pas)', async () => {
+      const service = new HeartbeatService();
 
-      // Ne doit pas throw
       await expect(service.updateConfig({ heartbeatInterval: 10_000 })).resolves.not.toThrow();
+    });
+  });
+
+  // ============================================================
+  // onStatusChange callback
+  // ============================================================
+
+  describe('onStatusChange callback', () => {
+    test('appelé quand une machine passe de online à unknown', async () => {
+      const service = new HeartbeatService();
+      const callback = vi.fn();
+
+      service.onStatusChange(callback);
+
+      await service.registerHeartbeat('cb-machine');
+      // Make it stale
+      const hb = service.getHeartbeatData('cb-machine')!;
+      hb.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString();
+
+      await service.checkHeartbeats();
+
+      expect(callback).toHaveBeenCalledWith('cb-machine', 'online', 'unknown');
+    });
+
+    test('appelé quand une machine passe de unknown à online', async () => {
+      const service = new HeartbeatService();
+      const callback = vi.fn();
+
+      service.onStatusChange(callback);
+
+      await service.registerHeartbeat('cb-machine-2');
+      // Make it stale → unknown
+      const hb = service.getHeartbeatData('cb-machine-2')!;
+      hb.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString();
+      await service.checkHeartbeats();
+
+      expect(callback).toHaveBeenCalledWith('cb-machine-2', 'online', 'unknown');
+
+      // Re-register → online
+      callback.mockClear();
+      await service.registerHeartbeat('cb-machine-2');
+
+      expect(callback).toHaveBeenCalledWith('cb-machine-2', 'unknown', 'online');
+    });
+  });
+
+  // ============================================================
+  // startHeartbeatService (no-op, sets callbacks)
+  // ============================================================
+
+  describe('startHeartbeatService', () => {
+    test('no-op: ne throw pas', async () => {
+      const service = new HeartbeatService();
+
+      await expect(service.startHeartbeatService('local-machine')).resolves.not.toThrow();
+    });
+
+    test('enregistre les callbacks offline/online', async () => {
+      const service = new HeartbeatService();
+      const offlineCb = vi.fn();
+      const onlineCb = vi.fn();
+
+      await service.startHeartbeatService('local-machine', offlineCb, onlineCb);
+
+      // Register a machine, make it stale → unknown
+      await service.registerHeartbeat('remote-machine');
+      const hb = service.getHeartbeatData('remote-machine')!;
+      hb.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString();
+
+      await service.checkHeartbeats();
+
+      expect(offlineCb).toHaveBeenCalledWith('remote-machine');
     });
   });
 });

--- a/servers/roo-state-manager/src/services/roosync/__tests__/ProfileApplicabilityHelper.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/ProfileApplicabilityHelper.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for ProfileApplicabilityHelper
+ * @module services/roosync/__tests__/ProfileApplicabilityHelper.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ProfileApplicabilityHelper, ALL_CATEGORIES } from '../ProfileApplicabilityHelper.js';
+import type { ConfigurationProfile, MachineInventory } from '../../types/non-nominative-baseline.js';
+
+describe('ProfileApplicabilityHelper', () => {
+  describe('ALL_CATEGORIES', () => {
+    it('should contain all 11 expected categories', () => {
+      expect(ALL_CATEGORIES).toHaveLength(11);
+      expect(ALL_CATEGORIES).toContain('roo-core');
+      expect(ALL_CATEGORIES).toContain('roo-advanced');
+      expect(ALL_CATEGORIES).toContain('hardware-cpu');
+      expect(ALL_CATEGORIES).toContain('hardware-memory');
+      expect(ALL_CATEGORIES).toContain('hardware-storage');
+      expect(ALL_CATEGORIES).toContain('hardware-gpu');
+      expect(ALL_CATEGORIES).toContain('software-powershell');
+      expect(ALL_CATEGORIES).toContain('software-node');
+      expect(ALL_CATEGORIES).toContain('software-python');
+      expect(ALL_CATEGORIES).toContain('system-os');
+      expect(ALL_CATEGORIES).toContain('system-architecture');
+    });
+
+    it('should have no duplicate categories', () => {
+      const unique = new Set(ALL_CATEGORIES);
+      expect(unique.size).toBe(ALL_CATEGORIES.length);
+    });
+  });
+
+  describe('isApplicable', () => {
+    const emptyInventory: MachineInventory = {
+      machineId: 'test-machine',
+      timestamp: Date.now(),
+    };
+
+    const profile = (category: ConfigurationProfile['category']): ConfigurationProfile => ({
+      id: `test-${category}`,
+      category,
+      baselineId: 'baseline-1',
+      priority: 1,
+      config: {},
+    });
+
+    describe('roo-* categories (always applicable)', () => {
+      it('should accept roo-core', () => {
+        expect(ProfileApplicabilityHelper.isApplicable(profile('roo-core'), emptyInventory)).toBe(true);
+      });
+
+      it('should accept roo-advanced', () => {
+        expect(ProfileApplicabilityHelper.isApplicable(profile('roo-advanced'), emptyInventory)).toBe(true);
+      });
+    });
+
+    describe('hardware-* categories', () => {
+      it('should accept hardware-cpu', () => {
+        expect(ProfileApplicabilityHelper.isApplicable(profile('hardware-cpu'), emptyInventory)).toBe(true);
+      });
+
+      it('should accept hardware-memory', () => {
+        expect(ProfileApplicabilityHelper.isApplicable(profile('hardware-memory'), emptyInventory)).toBe(true);
+      });
+
+      it('should accept hardware-storage', () => {
+        expect(ProfileApplicabilityHelper.isApplicable(profile('hardware-storage'), emptyInventory)).toBe(true);
+      });
+
+      it('should reject hardware-gpu when no GPU present', () => {
+        expect(ProfileApplicabilityHelper.isApplicable(profile('hardware-gpu'), emptyInventory)).toBe(false);
+      });
+
+      it('should accept hardware-gpu when config.hardware.gpu is true', () => {
+        const inventoryWithGpu: MachineInventory = {
+          ...emptyInventory,
+          config: { hardware: { gpu: true } },
+        };
+        expect(ProfileApplicabilityHelper.isApplicable(profile('hardware-gpu'), inventoryWithGpu)).toBe(true);
+      });
+
+      it('should accept hardware-gpu when systemInfo.gpu array has items', () => {
+        const inventoryWithGpu: MachineInventory = {
+          ...emptyInventory,
+          inventory: {
+            systemInfo: {
+              gpu: [{ name: 'NVIDIA RTX 3080', vram: 10 }],
+            },
+          },
+        };
+        expect(ProfileApplicabilityHelper.isApplicable(profile('hardware-gpu'), inventoryWithGpu)).toBe(true);
+      });
+
+      it('should accept hardware-gpu when gpuDetails array has items', () => {
+        const inventoryWithGpu: MachineInventory = {
+          ...emptyInventory,
+          inventory: {
+            gpuDetails: [{ name: 'AMD RX 6800' }],
+          },
+        };
+        expect(ProfileApplicabilityHelper.isApplicable(profile('hardware-gpu'), inventoryWithGpu)).toBe(true);
+      });
+    });
+
+    describe('software-* categories', () => {
+      it('should reject software-powershell when not detected', () => {
+        expect(ProfileApplicabilityHelper.isApplicable(profile('software-powershell'), emptyInventory)).toBe(false);
+      });
+
+      it('should accept software-powershell when detected in systemInfo', () => {
+        const inventory: MachineInventory = {
+          ...emptyInventory,
+          inventory: {
+            systemInfo: { powershellVersion: '7.4.0' },
+          },
+        };
+        expect(ProfileApplicabilityHelper.isApplicable(profile('software-powershell'), inventory)).toBe(true);
+      });
+
+      it('should accept software-powershell when detected in tools', () => {
+        const inventory: MachineInventory = {
+          ...emptyInventory,
+          inventory: {
+            tools: { powershell: { version: '7.3.0' } },
+          },
+        };
+        expect(ProfileApplicabilityHelper.isApplicable(profile('software-powershell'), inventory)).toBe(true);
+      });
+
+      it('should accept software-powershell when detected in legacy config', () => {
+        const inventory: MachineInventory = {
+          ...emptyInventory,
+          config: { software: { powershell: true } },
+        };
+        expect(ProfileApplicabilityHelper.isApplicable(profile('software-powershell'), inventory)).toBe(true);
+      });
+
+      it('should reject software-powershell when version is Unknown', () => {
+        const inventory: MachineInventory = {
+          ...emptyInventory,
+          inventory: {
+            systemInfo: { powershellVersion: 'Unknown' },
+          },
+        };
+        expect(ProfileApplicabilityHelper.isApplicable(profile('software-powershell'), inventory)).toBe(false);
+      });
+
+      it('should reject software-powershell when version is empty string', () => {
+        const inventory: MachineInventory = {
+          ...emptyInventory,
+          inventory: {
+            systemInfo: { powershellVersion: '' },
+          },
+        };
+        expect(ProfileApplicabilityHelper.isApplicable(profile('software-powershell'), inventory)).toBe(false);
+      });
+
+      it('should reject software-node when not detected', () => {
+        expect(ProfileApplicabilityHelper.isApplicable(profile('software-node'), emptyInventory)).toBe(false);
+      });
+
+      it('should accept software-node when detected in tools', () => {
+        const inventory: MachineInventory = {
+          ...emptyInventory,
+          inventory: {
+            tools: { node: { version: '20.11.0' } },
+          },
+        };
+        expect(ProfileApplicabilityHelper.isApplicable(profile('software-node'), inventory)).toBe(true);
+      });
+
+      it('should accept software-node when detected in legacy config', () => {
+        const inventory: MachineInventory = {
+          ...emptyInventory,
+          config: { software: { node: true } },
+        };
+        expect(ProfileApplicabilityHelper.isApplicable(profile('software-node'), inventory)).toBe(true);
+      });
+
+      it('should reject software-python when not detected', () => {
+        expect(ProfileApplicabilityHelper.isApplicable(profile('software-python'), emptyInventory)).toBe(false);
+      });
+
+      it('should accept software-python when detected in tools', () => {
+        const inventory: MachineInventory = {
+          ...emptyInventory,
+          inventory: {
+            tools: { python: { version: '3.12.0' } },
+          },
+        };
+        expect(ProfileApplicabilityHelper.isApplicable(profile('software-python'), inventory)).toBe(true);
+      });
+
+      it('should accept software-python when detected in legacy config', () => {
+        const inventory: MachineInventory = {
+          ...emptyInventory,
+          config: { software: { python: true } },
+        };
+        expect(ProfileApplicabilityHelper.isApplicable(profile('software-python'), inventory)).toBe(true);
+      });
+    });
+
+    describe('system-* categories (always applicable)', () => {
+      it('should accept system-os', () => {
+        expect(ProfileApplicabilityHelper.isApplicable(profile('system-os'), emptyInventory)).toBe(true);
+      });
+
+      it('should accept system-architecture', () => {
+        expect(ProfileApplicabilityHelper.isApplicable(profile('system-architecture'), emptyInventory)).toBe(true);
+      });
+    });
+
+    describe('unknown category (default to applicable)', () => {
+      it('should accept unknown category as fallback', () => {
+        const unknownProfile: ConfigurationProfile = {
+          id: 'unknown-1',
+          category: 'unknown-category' as ConfigurationProfile['category'],
+          baselineId: 'baseline-1',
+          priority: 1,
+          config: {},
+        };
+        expect(ProfileApplicabilityHelper.isApplicable(unknownProfile, emptyInventory)).toBe(true);
+      });
+    });
+  });
+
+  describe('filterApplicable', () => {
+    const emptyInventory: MachineInventory = {
+      machineId: 'test-machine',
+      timestamp: Date.now(),
+    };
+
+    const profile = (category: ConfigurationProfile['category']): ConfigurationProfile => ({
+      id: `test-${category}`,
+      category,
+      baselineId: 'baseline-1',
+      priority: 1,
+      config: {},
+    });
+
+    it('should return all profiles as applicable when inventory matches all', () => {
+      const profiles = [
+        profile('roo-core'),
+        profile('hardware-cpu'),
+        profile('system-os'),
+      ];
+
+      const result = ProfileApplicabilityHelper.filterApplicable(profiles, emptyInventory);
+
+      expect(result.applicable).toHaveLength(3);
+      expect(result.excluded).toHaveLength(0);
+    });
+
+    it('should separate applicable from excluded profiles', () => {
+      const profiles = [
+        profile('roo-core'),
+        profile('hardware-gpu'),
+        profile('system-os'),
+      ];
+
+      const result = ProfileApplicabilityHelper.filterApplicable(profiles, emptyInventory);
+
+      expect(result.applicable).toHaveLength(2);
+      expect(result.excluded).toHaveLength(1);
+      expect(result.excluded[0].profile.category).toBe('hardware-gpu');
+      expect(result.excluded[0].reason).toBe('Machine has no GPU');
+    });
+
+    it('should provide exclusion reasons for software profiles', () => {
+      const profiles = [
+        profile('software-powershell'),
+        profile('software-node'),
+        profile('software-python'),
+      ];
+
+      const result = ProfileApplicabilityHelper.filterApplicable(profiles, emptyInventory);
+
+      expect(result.applicable).toHaveLength(0);
+      expect(result.excluded).toHaveLength(3);
+      expect(result.excluded[0].reason).toBe('PowerShell not detected');
+      expect(result.excluded[1].reason).toBe('Node.js not detected');
+      expect(result.excluded[2].reason).toBe('Python not detected');
+    });
+
+    it('should handle empty profile list', () => {
+      const result = ProfileApplicabilityHelper.filterApplicable([], emptyInventory);
+
+      expect(result.applicable).toHaveLength(0);
+      expect(result.excluded).toHaveLength(0);
+    });
+  });
+});

--- a/servers/roo-state-manager/src/services/trace-summary/ContentClassifier.ts
+++ b/servers/roo-state-manager/src/services/trace-summary/ContentClassifier.ts
@@ -32,17 +32,27 @@ export class ContentClassifier {
 
         // Appliquer le filtrage par plage si spécifié
         if (options && (options.startIndex !== undefined || options.endIndex !== undefined)) {
+            // Validate negative endIndex - throw error instead of allowing negative slice
+            if (options.endIndex !== undefined && options.endIndex < 1) {
+                throw new Error(`Invalid endIndex: ${options.endIndex}. Must be >= 1 (1-based index).`);
+            }
+
             const startIdx = options.startIndex ? Math.max(1, options.startIndex) - 1 : 0; // Convert to 0-based
             const endIdx = options.endIndex ? Math.min(messages.length, options.endIndex) : messages.length; // Convert to 0-based + 1
 
-            // Valider les indices
-            if (startIdx < messages.length && endIdx > startIdx) {
-                messages = messages.slice(startIdx, endIdx);
-                // Log pour debugging
-                console.log(`[Range Filter] Processing messages ${startIdx + 1} to ${endIdx} (${messages.length} messages)`);
-            } else {
-                console.warn(`[Range Filter] Invalid range: start=${options.startIndex}, end=${options.endIndex}, total=${(conversation.sequence ?? []).length}`);
+            // Validate indices - throw error if start >= end
+            if (startIdx >= endIdx) {
+                throw new Error(`Invalid range: startIndex (${options.startIndex ?? 1}) must be less than endIndex (${options.endIndex ?? messages.length}).`);
             }
+
+            // Validate start is within bounds
+            if (startIdx >= messages.length) {
+                throw new Error(`Invalid startIndex: ${options.startIndex ?? 1}. Total filtered messages: ${messages.length}.`);
+            }
+
+            messages = messages.slice(startIdx, endIdx);
+            // Log pour debugging
+            console.log(`[Range Filter] Processing messages ${startIdx + 1} to ${endIdx} (${messages.length} messages)`);
         }
 
         for (const message of messages) {

--- a/servers/roo-state-manager/src/services/trace-summary/__tests__/ContentClassifier.test.ts
+++ b/servers/roo-state-manager/src/services/trace-summary/__tests__/ContentClassifier.test.ts
@@ -788,9 +788,9 @@ describe('ContentClassifier', () => {
             expect(result[2].content).toBe('msg4');
         });
 
-        it('should warn on invalid range', () => {
+        it('should throw on invalid range (start >= end)', () => {
             const conv = makeSkeleton([makeMessage('user', 'msg1')]);
-            classifier.classifyConversationContent(conv, {
+            expect(() => classifier.classifyConversationContent(conv, {
                 startIndex: 10,
                 endIndex: 20,
                 detailLevel: 'Full',
@@ -799,8 +799,21 @@ describe('ContentClassifier', () => {
                 includeCss: false,
                 generateToc: false,
                 outputFormat: 'markdown',
-            });
-            expect(consoleWarnSpy).toHaveBeenCalled();
+            })).toThrow('Invalid range: startIndex (10) must be less than endIndex (20).');
+        });
+
+        it('should throw on negative endIndex', () => {
+            const conv = makeSkeleton([makeMessage('user', 'msg1')]);
+            expect(() => classifier.classifyConversationContent(conv, {
+                startIndex: 1,
+                endIndex: -5,
+                detailLevel: 'Full',
+                truncationChars: 1000,
+                compactStats: false,
+                includeCss: false,
+                generateToc: false,
+                outputFormat: 'markdown',
+            })).toThrow('Invalid endIndex: -5. Must be >= 1');
         });
 
         it('should set toolType and resultType for ToolResult user messages', () => {

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
@@ -66,8 +66,8 @@ describe('get-status (Option B)', () => {
       checkHeartbeats: vi.fn(),
       getState: vi.fn(() => ({
         onlineMachines: ['myia-ai-01', 'myia-po-2023'],
-        offlineMachines: [],
-        warningMachines: []
+        unknownMachines: [],
+        idleMachines: []
       }))
     });
     mockGetInboxStats.mockResolvedValue({ unread: 0, urgent: 0, by_priority: {} });
@@ -160,8 +160,8 @@ describe('get-status (Option B)', () => {
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
           onlineMachines: ['myia-ai-01'],
-          offlineMachines: ['myia-po-2025'],
-          warningMachines: []
+          unknownMachines: ['myia-po-2025'],
+          idleMachines: []
         }))
       });
 
@@ -211,8 +211,8 @@ describe('get-status (Option B)', () => {
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
           onlineMachines: ['myia-ai-01'],
-          offlineMachines: [],
-          warningMachines: ['myia-po-2023']
+          unknownMachines: [],
+          idleMachines: ['myia-po-2023']
         }))
       });
 
@@ -270,8 +270,8 @@ describe('get-status (Option B)', () => {
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
           onlineMachines: ['myia-ai-01', 'myia-po-2023', 'myia-po-2024'],
-          offlineMachines: ['test-machine', 'persistent-machine', 'machine-2'],
-          warningMachines: []
+          unknownMachines: ['test-machine', 'persistent-machine', 'machine-2'],
+          idleMachines: []
         }))
       });
 
@@ -306,8 +306,8 @@ describe('get-status (Option B)', () => {
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
           onlineMachines: ['myia-ai-01'],
-          offlineMachines: [],
-          warningMachines: ['test-machine']  // Orphan, should be filtered
+          unknownMachines: [],
+          idleMachines: ['test-machine']  // Orphan, should be filtered
         }))
       });
 
@@ -323,8 +323,8 @@ describe('get-status (Option B)', () => {
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
           onlineMachines: ['myia-ai-01'],
-          offlineMachines: ['myia-po-2025', 'test-machine'],  // 1 real + 1 orphan
-          warningMachines: []
+          unknownMachines: ['myia-po-2025', 'test-machine'],  // 1 real + 1 orphan
+          idleMachines: []
         }))
       });
 

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/heartbeat-status.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/heartbeat-status.test.ts
@@ -1,16 +1,16 @@
 /**
  * Tests unitaires pour roosyncHeartbeatStatus
  *
- * Couvre roosyncHeartbeatStatus (lignes 124-209) :
+ * Couvre roosyncHeartbeatStatus :
  * - Cas de base (filter=all, includeHeartbeats=true)
- * - Filtres : online, offline, warning
+ * - Filtres : online, idle, unknown (+ backward compat offline/warning)
  * - forceCheck / includeChanges
  * - includeHeartbeats=false
  * - Propagation HeartbeatServiceError
  * - Wrapping erreur générique
  *
  * @module tools/roosync/__tests__/heartbeat-status.test
- * @version 1.0.0 (#492)
+ * @version 2.0.0 (ADR 008 Phase 2)
  */
 
 import { describe, test, expect, vi, beforeEach } from 'vitest';
@@ -50,35 +50,35 @@ import { roosyncHeartbeatStatus } from '../heartbeat-status.js';
 function makeState(overrides: Record<string, any> = {}) {
   return {
     onlineMachines: ['myia-ai-01', 'myia-po-2025'],
-    offlineMachines: ['myia-web1'],
-    warningMachines: ['myia-po-2023'],
+    idleMachines: ['myia-web1'],
+    unknownMachines: ['myia-po-2023'],
     heartbeats: new Map([
       ['myia-ai-01', {
         machineId: 'myia-ai-01', lastHeartbeat: '2026-02-22T10:00:00.000Z',
-        status: 'online', missedHeartbeats: 0,
-        metadata: { firstSeen: '2026-01-01T00:00:00.000Z', lastUpdated: '2026-02-22T10:00:00.000Z', version: '1.0' }
+        status: 'online',
+        metadata: { firstSeen: '2026-01-01T00:00:00.000Z', lastUpdated: '2026-02-22T10:00:00.000Z' }
       }],
       ['myia-po-2025', {
         machineId: 'myia-po-2025', lastHeartbeat: '2026-02-22T09:58:00.000Z',
-        status: 'online', missedHeartbeats: 0,
-        metadata: { firstSeen: '2026-01-01T00:00:00.000Z', lastUpdated: '2026-02-22T09:58:00.000Z', version: '1.0' }
+        status: 'online',
+        metadata: { firstSeen: '2026-01-01T00:00:00.000Z', lastUpdated: '2026-02-22T09:58:00.000Z' }
       }],
       ['myia-web1', {
         machineId: 'myia-web1', lastHeartbeat: '2026-02-21T10:00:00.000Z',
-        status: 'offline', missedHeartbeats: 5,
-        metadata: { firstSeen: '2026-01-01T00:00:00.000Z', lastUpdated: '2026-02-21T10:00:00.000Z', version: '1.0' }
+        status: 'idle',
+        metadata: { firstSeen: '2026-01-01T00:00:00.000Z', lastUpdated: '2026-02-21T10:00:00.000Z' }
       }],
       ['myia-po-2023', {
         machineId: 'myia-po-2023', lastHeartbeat: '2026-02-22T09:30:00.000Z',
-        status: 'warning', missedHeartbeats: 2,
-        metadata: { firstSeen: '2026-01-01T00:00:00.000Z', lastUpdated: '2026-02-22T09:30:00.000Z', version: '1.0' }
+        status: 'unknown',
+        metadata: { firstSeen: '2026-01-01T00:00:00.000Z', lastUpdated: '2026-02-22T09:30:00.000Z' }
       }]
     ]),
     statistics: {
       totalMachines: 4,
       onlineCount: 2,
-      offlineCount: 1,
-      warningCount: 1,
+      idleCount: 1,
+      unknownCount: 1,
       lastHeartbeatCheck: '2026-02-22T10:00:00.000Z'
     },
     ...overrides
@@ -87,9 +87,9 @@ function makeState(overrides: Record<string, any> = {}) {
 
 function makeCheckResult(overrides: Record<string, any> = {}) {
   return {
-    newlyOfflineMachines: [],
+    newlyUnknownMachines: [],
     newlyOnlineMachines: [],
-    warningMachines: [],
+    newlyIdleMachines: [],
     ...overrides
   };
 }
@@ -110,8 +110,8 @@ describe('roosyncHeartbeatStatus', () => {
 
     expect(result.success).toBe(true);
     expect(result.onlineMachines).toEqual(['myia-ai-01', 'myia-po-2025']);
-    expect(result.offlineMachines).toEqual(['myia-web1']);
-    expect(result.warningMachines).toEqual(['myia-po-2023']);
+    expect(result.idleMachines).toEqual(['myia-web1']);
+    expect(result.unknownMachines).toEqual(['myia-po-2023']);
     expect(result.statistics.totalMachines).toBe(4);
     expect(result.retrievedAt).toBeDefined();
     expect(result.changes).toBeUndefined();
@@ -135,28 +135,44 @@ describe('roosyncHeartbeatStatus', () => {
 
   // ── filtres ──
 
-  test('filter=online : vide offlineMachines et warningMachines', async () => {
+  test('filter=online : vide idleMachines et unknownMachines', async () => {
     const result = await roosyncHeartbeatStatus({ filter: 'online' });
 
     expect(result.onlineMachines).toEqual(['myia-ai-01', 'myia-po-2025']);
-    expect(result.offlineMachines).toEqual([]);
-    expect(result.warningMachines).toEqual([]);
+    expect(result.idleMachines).toEqual([]);
+    expect(result.unknownMachines).toEqual([]);
   });
 
-  test('filter=offline : vide onlineMachines et warningMachines', async () => {
+  test('filter=unknown : vide onlineMachines et idleMachines', async () => {
+    const result = await roosyncHeartbeatStatus({ filter: 'unknown' });
+
+    expect(result.onlineMachines).toEqual([]);
+    expect(result.idleMachines).toEqual([]);
+    expect(result.unknownMachines).toEqual(['myia-po-2023']);
+  });
+
+  test('filter=idle : vide onlineMachines et unknownMachines', async () => {
+    const result = await roosyncHeartbeatStatus({ filter: 'idle' });
+
+    expect(result.onlineMachines).toEqual([]);
+    expect(result.idleMachines).toEqual(['myia-web1']);
+    expect(result.unknownMachines).toEqual([]);
+  });
+
+  test('filter=offline (backward compat) : mappe vers unknown', async () => {
     const result = await roosyncHeartbeatStatus({ filter: 'offline' });
 
     expect(result.onlineMachines).toEqual([]);
-    expect(result.offlineMachines).toEqual(['myia-web1']);
-    expect(result.warningMachines).toEqual([]);
+    expect(result.idleMachines).toEqual([]);
+    expect(result.unknownMachines).toEqual(['myia-po-2023']);
   });
 
-  test('filter=warning : vide onlineMachines et offlineMachines', async () => {
+  test('filter=warning (backward compat) : mappe vers unknown', async () => {
     const result = await roosyncHeartbeatStatus({ filter: 'warning' });
 
     expect(result.onlineMachines).toEqual([]);
-    expect(result.offlineMachines).toEqual([]);
-    expect(result.warningMachines).toEqual(['myia-po-2023']);
+    expect(result.idleMachines).toEqual([]);
+    expect(result.unknownMachines).toEqual(['myia-po-2023']);
   });
 
   test('filter=online avec includeHeartbeats : ne garde que les heartbeats online', async () => {
@@ -168,15 +184,15 @@ describe('roosyncHeartbeatStatus', () => {
     expect(Object.keys(result.heartbeats!)).not.toContain('myia-po-2023');
   });
 
-  test('filter=offline avec includeHeartbeats : ne garde que les heartbeats offline', async () => {
-    const result = await roosyncHeartbeatStatus({ filter: 'offline', includeHeartbeats: true });
+  test('filter=idle avec includeHeartbeats : ne garde que les heartbeats idle', async () => {
+    const result = await roosyncHeartbeatStatus({ filter: 'idle', includeHeartbeats: true });
 
     expect(result.heartbeats).toBeDefined();
     expect(Object.keys(result.heartbeats!)).toEqual(['myia-web1']);
   });
 
-  test('filter=warning avec includeHeartbeats : ne garde que les heartbeats warning', async () => {
-    const result = await roosyncHeartbeatStatus({ filter: 'warning', includeHeartbeats: true });
+  test('filter=unknown avec includeHeartbeats : ne garde que les heartbeats unknown', async () => {
+    const result = await roosyncHeartbeatStatus({ filter: 'unknown', includeHeartbeats: true });
 
     expect(result.heartbeats).toBeDefined();
     expect(Object.keys(result.heartbeats!)).toEqual(['myia-po-2023']);
@@ -186,16 +202,16 @@ describe('roosyncHeartbeatStatus', () => {
 
   test('forceCheck=true appelle checkHeartbeats et retourne les changes', async () => {
     mockCheckHeartbeats.mockResolvedValue(makeCheckResult({
-      newlyOfflineMachines: ['myia-po-2024'],
+      newlyUnknownMachines: ['myia-po-2024'],
       newlyOnlineMachines: [],
-      warningMachines: []
+      newlyIdleMachines: []
     }));
 
     const result = await roosyncHeartbeatStatus({ forceCheck: true });
 
     expect(mockCheckHeartbeats).toHaveBeenCalledTimes(1);
     expect(result.changes).toBeDefined();
-    expect(result.changes!.newlyOfflineMachines).toEqual(['myia-po-2024']);
+    expect(result.changes!.newlyUnknownMachines).toEqual(['myia-po-2024']);
     expect(result.changes!.totalChanges).toBe(1);
   });
 
@@ -209,15 +225,15 @@ describe('roosyncHeartbeatStatus', () => {
 
   test('forceCheck=true avec changements multiples calcule totalChanges correctement', async () => {
     mockCheckHeartbeats.mockResolvedValue(makeCheckResult({
-      newlyOfflineMachines: ['myia-po-2024'],
+      newlyUnknownMachines: ['myia-po-2024'],
       newlyOnlineMachines: ['myia-po-2026'],
-      warningMachines: ['myia-ai-01']
+      newlyIdleMachines: ['myia-ai-01']
     }));
 
     const result = await roosyncHeartbeatStatus({ forceCheck: true });
 
     expect(result.changes!.totalChanges).toBe(3);
-    expect(result.changes!.newWarnings).toEqual(['myia-ai-01']);
+    expect(result.changes!.newlyIdleMachines).toEqual(['myia-ai-01']);
   });
 
   // ── gestion d'erreurs ──

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/inventory.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/inventory.test.ts
@@ -39,13 +39,13 @@ vi.mock('../../../services/RooSyncService.js', () => ({
     getHeartbeatService: vi.fn(() => ({
       getState: vi.fn(() => ({
         onlineMachines: ['machine-1', 'machine-2'],
-        offlineMachines: ['machine-3'],
-        warningMachines: ['machine-4'],
+        unknownMachines: ['machine-3'],
+        idleMachines: ['machine-4'],
         statistics: {
           totalMachines: 4,
           onlineCount: 2,
-          offlineCount: 1,
-          warningCount: 1,
+          unknownCount: 1,
+          idleCount: 1,
           lastHeartbeatCheck: new Date().toISOString()
         },
         heartbeats: new Map([
@@ -53,11 +53,9 @@ vi.mock('../../../services/RooSyncService.js', () => ({
             machineId: 'machine-1',
             lastHeartbeat: new Date().toISOString(),
             status: 'online',
-            missedHeartbeats: 0,
             metadata: {
               firstSeen: new Date().toISOString(),
-              lastUpdated: new Date().toISOString(),
-              version: '1.0.0'
+              lastUpdated: new Date().toISOString()
             }
           }]
         ])
@@ -197,8 +195,8 @@ describe('inventoryTool', () => {
       expect(result.data).toBeDefined();
       expect(result.data.heartbeatState).toBeDefined();
       expect(result.data.heartbeatState.onlineMachines).toEqual(['machine-1', 'machine-2']);
-      expect(result.data.heartbeatState.offlineMachines).toEqual(['machine-3']);
-      expect(result.data.heartbeatState.warningMachines).toEqual(['machine-4']);
+      expect(result.data.heartbeatState.unknownMachines).toEqual(['machine-3']);
+      expect(result.data.heartbeatState.idleMachines).toEqual(['machine-4']);
       expect(result.data.machineInventory).toBeUndefined();
     });
 
@@ -230,8 +228,8 @@ describe('inventoryTool', () => {
       expect(result.data.heartbeatState.statistics).toBeDefined();
       expect(result.data.heartbeatState.statistics.totalMachines).toBe(4);
       expect(result.data.heartbeatState.statistics.onlineCount).toBe(2);
-      expect(result.data.heartbeatState.statistics.offlineCount).toBe(1);
-      expect(result.data.heartbeatState.statistics.warningCount).toBe(1);
+      expect(result.data.heartbeatState.statistics.unknownCount).toBe(1);
+      expect(result.data.heartbeatState.statistics.idleCount).toBe(1);
     });
   });
 
@@ -330,7 +328,7 @@ describe('inventoryTool', () => {
       expect(result.data.summary).toContain('Machine:');
       expect(result.data.summary).toContain('Cluster status:');
       expect(result.data.summary).toContain('Online');
-      expect(result.data.summary).toContain('Offline');
+      expect(result.data.summary).toContain('Unknown');
     });
 
     test('should not return full JSON when summary=true', async () => {

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/machines.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/machines.test.ts
@@ -19,24 +19,18 @@ import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 vi.mock('../../../services/RooSyncService.js', () => ({
   getRooSyncService: vi.fn(() => ({
     getHeartbeatService: vi.fn(() => ({
-      getOfflineMachines: vi.fn(() => ['machine-3', 'machine-5']),
-      getWarningMachines: vi.fn(() => ['machine-4', 'machine-6']),
+      getUnknownMachines: vi.fn(() => ['machine-3', 'machine-5']),
+      getIdleMachines: vi.fn(() => ['machine-4', 'machine-6']),
       getHeartbeatData: vi.fn((machineId) => {
         const data: any = {
           machineId,
           lastHeartbeat: new Date().toISOString(),
-          missedHeartbeats: 3,
+          status: (machineId === 'machine-3' || machineId === 'machine-5') ? 'unknown' : 'idle',
           metadata: {
             firstSeen: new Date().toISOString(),
-            lastUpdated: new Date().toISOString(),
-            version: '1.0.0'
+            lastUpdated: new Date().toISOString()
           }
         };
-
-        // Ajouter offlineSince pour les machines offline
-        if (machineId === 'machine-3' || machineId === 'machine-5') {
-          data.offlineSince = new Date(Date.now() - 3600000).toISOString();
-        }
 
         return data;
       })
@@ -128,8 +122,8 @@ describe('machinesTool', () => {
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.data.offlineMachines).toEqual(['machine-3', 'machine-5']);
-      expect(result.data.warningMachines).toBeUndefined();
+      expect(result.data.unknownMachines).toEqual(['machine-3', 'machine-5']);
+      expect(result.data.idleMachines).toBeUndefined();
     });
 
     test('should return offline machines with details', async () => {
@@ -139,7 +133,7 @@ describe('machinesTool', () => {
       );
 
       expect(result.success).toBe(true);
-      expect(result.data.offlineMachines![0].offlineSince).toBeDefined();
+      expect(result.data.unknownMachines![0].status).toBe('unknown');
     });
 
     test('should handle errors gracefully', async () => {
@@ -172,8 +166,8 @@ describe('machinesTool', () => {
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.data.warningMachines).toEqual(['machine-4', 'machine-6']);
-      expect(result.data.offlineMachines).toBeUndefined();
+      expect(result.data.idleMachines).toEqual(['machine-4', 'machine-6']);
+      expect(result.data.unknownMachines).toBeUndefined();
     });
 
     test('should return warning machines with details', async () => {
@@ -183,7 +177,7 @@ describe('machinesTool', () => {
       );
 
       expect(result.success).toBe(true);
-      expect(result.data.warningMachines![0].missedHeartbeats).toBe(3);
+      expect(result.data.idleMachines![0].status).toBe('idle');
     });
   });
 
@@ -199,8 +193,8 @@ describe('machinesTool', () => {
       );
 
       expect(result.success).toBe(true);
-      expect(result.data.offlineMachines).toEqual(['machine-3', 'machine-5']);
-      expect(result.data.warningMachines).toEqual(['machine-4', 'machine-6']);
+      expect(result.data.unknownMachines).toEqual(['machine-3', 'machine-5']);
+      expect(result.data.idleMachines).toEqual(['machine-4', 'machine-6']);
     });
 
     test('should include details when requested', async () => {
@@ -209,8 +203,8 @@ describe('machinesTool', () => {
         mockExecutionContext
       );
 
-      expect(result.data.offlineMachines![0].offlineSince).toBeDefined();
-      expect(result.data.warningMachines![0].missedHeartbeats).toBe(3);
+      expect(result.data.unknownMachines![0].status).toBe('unknown');
+      expect(result.data.idleMachines![0].status).toBe('idle');
     });
   });
 

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/sync-event.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/sync-event.test.ts
@@ -134,11 +134,11 @@ describe('roosyncSyncEvent', () => {
 
   describe('action: online', () => {
     test('should sync online successfully with default options', async () => {
-      // Setup: machine online avec durée offline
+      // Setup: machine online
       mockGetHeartbeatData.mockReturnValue({
         status: 'online',
         machineId: 'test-machine-5',
-        offlineSince: new Date(Date.now() - 3600000).toISOString() // 1h ago
+        lastHeartbeat: new Date().toISOString()
       });
 
       const args: SyncEventArgs = {
@@ -154,8 +154,7 @@ describe('roosyncSyncEvent', () => {
       expect(result.backupCreated).toBe(true); // défaut: true
       expect(result.backupPath).toContain('online-sync-test-machine-5');
       expect(result.message).toContain('Synchronisation online effectuée');
-      expect(result.changes.offlineDuration).toBeGreaterThan(0); // durée calculée
-      expect(result.changes.offlineDuration).toBeLessThanOrEqual(3600000 + 1000); // ~1h + marge
+      expect(result.changes.offlineDuration).toBeUndefined(); // offlineSince removed in ADR 008 Phase 2
     });
 
     test('should sync online in dry-run mode', async () => {
@@ -217,8 +216,8 @@ describe('roosyncSyncEvent', () => {
     test('should sync online without offlineDuration when offlineSince is missing', async () => {
       mockGetHeartbeatData.mockReturnValue({
         status: 'online',
-        machineId: 'test-machine-9'
-        // pas de offlineSince
+        machineId: 'test-machine-9',
+        lastHeartbeat: new Date().toISOString()
       });
 
       const args: SyncEventArgs = {
@@ -332,7 +331,7 @@ describe('roosyncSyncEvent', () => {
       mockGetHeartbeatData.mockReturnValue({
         status: 'online',
         machineId: 'format-test-2',
-        offlineSince: new Date(Date.now() - 1000).toISOString()
+        lastHeartbeat: new Date().toISOString()
       });
 
       const result = await roosyncSyncEvent({
@@ -345,9 +344,9 @@ describe('roosyncSyncEvent', () => {
       expect(result).toHaveProperty('action');
       expect(result).toHaveProperty('machineId');
 
-      // Propriété spécifique online
+      // Propriété spécifique online — offlineDuration undefined since ADR 008 Phase 2
       expect(result.changes).toHaveProperty('offlineDuration');
-      expect(typeof result.changes.offlineDuration).toBe('number');
+      expect(result.changes.offlineDuration).toBeUndefined();
     });
   });
 });

--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -319,7 +319,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
 
     // #1953: Cross-check heartbeat-derived status against dashboard activity.
     // Dashboard message timestamps are embedded in file content (immune to GDrive
-    // propagation latency on file mod time), preventing false OFFLINE detection.
+    // propagation latency on file mod time), preventing false UNKNOWN detection.
     let dashboardOverrides: string[] = [];
     try {
       const dashboardsDir = join(getSharedStatePath(), 'dashboards');
@@ -327,12 +327,12 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
       const dashboardContent = readFileSync(workspaceDashboard, 'utf-8');
       const { crossCheckWithDashboard } = await import('../../utils/dashboard-activity.js');
       const crossChecked = crossCheckWithDashboard(
-        { onlineMachines: filteredOnlineMachines, offlineMachines: filteredUnknownMachines, warningMachines: filteredIdleMachines },
+        { onlineMachines: filteredOnlineMachines, unknownMachines: filteredUnknownMachines, idleMachines: filteredIdleMachines },
         dashboardContent
       );
       filteredOnlineMachines = crossChecked.onlineMachines;
-      filteredUnknownMachines = crossChecked.offlineMachines;
-      filteredIdleMachines = crossChecked.warningMachines;
+      filteredUnknownMachines = crossChecked.unknownMachines;
+      filteredIdleMachines = crossChecked.idleMachines;
       dashboardOverrides = crossChecked.overrides;
     } catch (err) {
       logger.debug('Dashboard cross-check skipped', { error: String(err) });

--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -130,20 +130,20 @@ export type GetStatusResult = z.infer<typeof GetStatusResultSchema>;
  * Génère les flags actionnables à partir des données collectées
  */
 function buildFlags(
-  heartbeatState: { onlineMachines: string[]; offlineMachines: string[]; warningMachines: string[] },
+  heartbeatState: { onlineMachines: string[]; unknownMachines: string[]; idleMachines: string[] },
   inboxStats: { unread: number; urgent: number },
   pendingDecisions: number,
   machines: Array<{ id: string; status: string; lastSync?: string }>
 ): string[] {
   const flags: string[] = [];
 
-  // Offline machines
-  for (const machineId of heartbeatState.offlineMachines) {
+  // Unknown machines (ADR 008: was "offline")
+  for (const machineId of heartbeatState.unknownMachines) {
     flags.push(`OFFLINE:${machineId}`);
   }
 
-  // Warning machines (heartbeat stale)
-  for (const machineId of heartbeatState.warningMachines) {
+  // Idle machines (ADR 008: was "warning"/heartbeat stale)
+  for (const machineId of heartbeatState.idleMachines) {
     flags.push(`HEARTBEAT_STALE:${machineId}`);
   }
 
@@ -167,7 +167,7 @@ function buildFlags(
   for (const m of machines) {
     if (m.lastSync) {
       const syncDate = new Date(m.lastSync).getTime();
-      if (!isNaN(syncDate) && syncDate < oneDayAgo && m.status !== 'offline') {
+      if (!isNaN(syncDate) && syncDate < oneDayAgo && m.status !== 'unknown') {
         flags.push(`SYNC_STALE:${m.id}`);
       }
     }
@@ -259,7 +259,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
           return heartbeatService.getState();
         } catch (err) {
           logger.warn('Heartbeat check failed', { error: String(err) });
-          return { onlineMachines: [] as string[], offlineMachines: [] as string[], warningMachines: [] as string[] };
+          return { onlineMachines: [] as string[], unknownMachines: [] as string[], idleMachines: [] as string[] };
         }
       })(),
       (async () => {
@@ -313,8 +313,8 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
     // #1365: Filter out orphan test entries (test-machine, persistent-machine, etc.)
     // Only keep machines matching the known pattern: myia-*
     let filteredOnlineMachines = (heartbeatState?.onlineMachines ?? []).filter(isKnownMachine);
-    let filteredOfflineMachines = (heartbeatState?.offlineMachines ?? []).filter(isKnownMachine);
-    let filteredWarningMachines = (heartbeatState?.warningMachines ?? []).filter(isKnownMachine);
+    let filteredUnknownMachines = (heartbeatState?.unknownMachines ?? []).filter(isKnownMachine);
+    let filteredIdleMachines = (heartbeatState?.idleMachines ?? []).filter(isKnownMachine);
     const filteredDashboardMachines = machines.filter(m => isKnownMachine(m.id));
 
     // #1953: Cross-check heartbeat-derived status against dashboard activity.
@@ -327,12 +327,12 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
       const dashboardContent = readFileSync(workspaceDashboard, 'utf-8');
       const { crossCheckWithDashboard } = await import('../../utils/dashboard-activity.js');
       const crossChecked = crossCheckWithDashboard(
-        { onlineMachines: filteredOnlineMachines, offlineMachines: filteredOfflineMachines, warningMachines: filteredWarningMachines },
+        { onlineMachines: filteredOnlineMachines, offlineMachines: filteredUnknownMachines, warningMachines: filteredIdleMachines },
         dashboardContent
       );
       filteredOnlineMachines = crossChecked.onlineMachines;
-      filteredOfflineMachines = crossChecked.offlineMachines;
-      filteredWarningMachines = crossChecked.warningMachines;
+      filteredUnknownMachines = crossChecked.offlineMachines;
+      filteredIdleMachines = crossChecked.warningMachines;
       dashboardOverrides = crossChecked.overrides;
     } catch (err) {
       logger.debug('Dashboard cross-check skipped', { error: String(err) });
@@ -340,7 +340,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
 
     // #1409: Use machine registry as authoritative source for total count
     const registryMachineIds = service.getKnownMachineIds();
-    const heartbeatTotal = filteredOnlineMachines.length + filteredOfflineMachines.length;
+    const heartbeatTotal = filteredOnlineMachines.length + filteredUnknownMachines.length;
     const totalMachines = Math.max(
       registryMachineIds.length,
       filteredDashboardMachines.length,
@@ -351,8 +351,8 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
     const flags = buildFlags(
       {
         onlineMachines: filteredOnlineMachines,
-        offlineMachines: filteredOfflineMachines,
-        warningMachines: filteredWarningMachines
+        unknownMachines: filteredUnknownMachines,
+        idleMachines: filteredIdleMachines
       },
       inboxStats,
       pendingDecisions,
@@ -361,9 +361,9 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
 
     // Derive overall status (based on KNOWN machines only)
     let status: 'HEALTHY' | 'WARNING' | 'CRITICAL' = 'HEALTHY';
-    if (filteredOfflineMachines.length > 0 || inboxStats.urgent > 0) {
+    if (filteredUnknownMachines.length > 0 || inboxStats.urgent > 0) {
       status = 'CRITICAL';
-    } else if (inboxStats.unread > 5 || filteredWarningMachines.length > 0) {
+    } else if (inboxStats.unread > 5 || filteredIdleMachines.length > 0) {
       // WARNING if: high unread count OR heartbeat warning machines (but no offline)
       status = 'WARNING';
     }
@@ -372,7 +372,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
     if (args.machineFilter) {
       const machineExists = filteredDashboardMachines.some(m => m.id === args.machineFilter) ||
         filteredOnlineMachines.includes(args.machineFilter) ||
-        filteredOfflineMachines.includes(args.machineFilter);
+        filteredUnknownMachines.includes(args.machineFilter);
 
       if (!machineExists) {
         throw new RooSyncServiceError(
@@ -386,7 +386,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
       status,
       machines: {
         online: filteredOnlineMachines.length,
-        offline: filteredOfflineMachines.length,
+        offline: filteredUnknownMachines.length,
         total: totalMachines,
         ...(dashboardOverrides.length > 0 ? { dashboardOverrides } : {})
       },
@@ -408,9 +408,9 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
             machineId: mid,
             status: 'online'
           }));
-          filteredWarningMachines.forEach(mid => {
+          filteredIdleMachines.forEach((mid: string) => {
             if (!onlineAgents.some(a => a.machineId === mid)) {
-              onlineAgents.push({ machineId: mid, status: 'warning' });
+              onlineAgents.push({ machineId: mid, status: 'idle' });
             }
           });
 

--- a/servers/roo-state-manager/src/tools/roosync/heartbeat-service.ts
+++ b/servers/roo-state-manager/src/tools/roosync/heartbeat-service.ts
@@ -42,7 +42,7 @@ export const RegisterResultSchema = z.object({
     .describe('Identifiant de la machine'),
   timestamp: z.string()
     .describe('Timestamp du heartbeat (ISO 8601)'),
-  status: z.enum(['online', 'offline', 'warning', 'idle', 'unknown'])
+  status: z.enum(['online', 'unknown', 'idle'])
     .describe('Statut de la machine apres l\'enregistrement'),
   isNewMachine: z.boolean()
     .describe('Indique si c\'est une nouvelle machine')

--- a/servers/roo-state-manager/src/tools/roosync/heartbeat-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/heartbeat-status.ts
@@ -1,10 +1,10 @@
 /**
  * Outil MCP : roosync_heartbeat_status
  *
- * État complet du service de heartbeat (machines online, offline, warning).
+ * État complet du service de heartbeat (machines online, idle, unknown).
  *
  * @module tools/roosync/heartbeat-status
- * @version 3.1.0
+ * @version 4.0.0 (ADR 008 Phase 2)
  */
 
 import { z } from 'zod';
@@ -15,8 +15,8 @@ import { HeartbeatServiceError } from '../../services/roosync/HeartbeatService.j
  * Schema de validation pour roosync_heartbeat_status
  */
 export const HeartbeatStatusArgsSchema = z.object({
-  filter: z.enum(['all', 'online', 'offline', 'warning']).optional()
-    .describe('Filtrer par statut de machine (defaut: all)'),
+  filter: z.enum(['all', 'online', 'idle', 'unknown', 'offline', 'warning']).optional()
+    .describe('Filtrer par statut de machine (defaut: all). "offline" and "warning" are mapped to "unknown" for backward compat)'),
   includeHeartbeats: z.boolean().optional()
     .describe('Inclure les donnees de heartbeat de chaque machine (defaut: true)'),
   forceCheck: z.boolean().optional()
@@ -35,19 +35,13 @@ export const HeartbeatDataSchema = z.object({
     .describe('Identifiant de la machine'),
   lastHeartbeat: z.string()
     .describe('Timestamp du dernier heartbeat (ISO 8601)'),
-  status: z.enum(['online', 'offline', 'warning', 'idle', 'unknown'])
+  status: z.enum(['online', 'idle', 'unknown'])
     .describe('Statut de la machine'),
-  missedHeartbeats: z.number()
-    .describe('Nombre de heartbeats manques consecutifs'),
-  offlineSince: z.string().optional()
-    .describe('Timestamp de premiere detection offline (ISO 8601)'),
   metadata: z.object({
     firstSeen: z.string()
       .describe('Timestamp de premiere detection (ISO 8601)'),
     lastUpdated: z.string()
-      .describe('Timestamp de derniere mise a jour (ISO 8601)'),
-    version: z.string()
-      .describe('Version du service')
+      .describe('Timestamp de derniere mise a jour (ISO 8601)')
   })
 });
 
@@ -61,10 +55,10 @@ export const HeartbeatStatisticsSchema = z.object({
     .describe('Nombre total de machines'),
   onlineCount: z.number()
     .describe('Nombre de machines online'),
-  offlineCount: z.number()
-    .describe('Nombre de machines offline'),
-  warningCount: z.number()
-    .describe('Nombre de machines en avertissement'),
+  idleCount: z.number()
+    .describe('Nombre de machines idle'),
+  unknownCount: z.number()
+    .describe('Nombre de machines unknown'),
   lastHeartbeatCheck: z.string()
     .describe('Timestamp de la derniere verification (ISO 8601)')
 });
@@ -75,12 +69,12 @@ export type HeartbeatStatistics = z.infer<typeof HeartbeatStatisticsSchema>;
  * Changements de statut (si forceCheck ou includeChanges)
  */
 export const StatusChangesSchema = z.object({
-  newlyOfflineMachines: z.array(z.string())
-    .describe('Machines nouvellement detectees offline'),
+  newlyUnknownMachines: z.array(z.string())
+    .describe('Machines nouvellement detectees unknown'),
   newlyOnlineMachines: z.array(z.string())
     .describe('Machines redevenues online'),
-  newWarnings: z.array(z.string())
-    .describe('Nouvelles machines en avertissement'),
+  newlyIdleMachines: z.array(z.string())
+    .describe('Machines nouvellement detectees idle'),
   totalChanges: z.number()
     .describe('Nombre total de changements')
 });
@@ -95,10 +89,10 @@ export const HeartbeatStatusResultSchema = z.object({
     .describe('Indique si la recuperation a reussi'),
   onlineMachines: z.array(z.string())
     .describe('Liste des IDs des machines online'),
-  offlineMachines: z.array(z.string())
-    .describe('Liste des IDs des machines offline'),
-  warningMachines: z.array(z.string())
-    .describe('Liste des IDs des machines en avertissement'),
+  idleMachines: z.array(z.string())
+    .describe('Liste des IDs des machines idle'),
+  unknownMachines: z.array(z.string())
+    .describe('Liste des IDs des machines unknown'),
   statistics: HeartbeatStatisticsSchema
     .describe('Statistiques du service'),
   heartbeats: z.record(HeartbeatDataSchema).optional()
@@ -139,44 +133,47 @@ export async function roosyncHeartbeatStatus(args: HeartbeatStatusArgs): Promise
     if (forceCheck || includeChanges) {
       const checkResult = await heartbeatService.checkHeartbeats();
       changes = {
-        newlyOfflineMachines: checkResult.newlyOfflineMachines,
+        newlyUnknownMachines: checkResult.newlyUnknownMachines,
         newlyOnlineMachines: checkResult.newlyOnlineMachines,
-        newWarnings: checkResult.warningMachines,
-        totalChanges: checkResult.newlyOfflineMachines.length +
+        newlyIdleMachines: checkResult.newlyIdleMachines,
+        totalChanges: checkResult.newlyUnknownMachines.length +
                       checkResult.newlyOnlineMachines.length +
-                      checkResult.warningMachines.length
+                      checkResult.newlyIdleMachines.length
       };
     }
 
     // Recuperer l'etat actuel
     const state = heartbeatService.getState();
 
+    // Backward compat: map legacy filter values to new ones
+    const effectiveFilter = filter === 'offline' || filter === 'warning' ? 'unknown' : filter;
+
     // Appliquer le filtre si necessaire
     let onlineMachines = state.onlineMachines;
-    let offlineMachines = state.offlineMachines;
-    let warningMachines = state.warningMachines;
+    let idleMachines = state.idleMachines;
+    let unknownMachines = state.unknownMachines;
 
-    if (filter === 'online') {
-      offlineMachines = [];
-      warningMachines = [];
-    } else if (filter === 'offline') {
+    if (effectiveFilter === 'online') {
+      idleMachines = [];
+      unknownMachines = [];
+    } else if (effectiveFilter === 'idle') {
       onlineMachines = [];
-      warningMachines = [];
-    } else if (filter === 'warning') {
+      unknownMachines = [];
+    } else if (effectiveFilter === 'unknown') {
       onlineMachines = [];
-      offlineMachines = [];
+      idleMachines = [];
     }
 
     // Filtrer les heartbeats si necessaire
     let heartbeats: Record<string, HeartbeatData> | undefined;
     if (includeHeartbeats) {
       const allHeartbeats = Object.fromEntries(state.heartbeats);
-      if (filter === 'all') {
+      if (effectiveFilter === 'all') {
         heartbeats = allHeartbeats;
       } else {
-        const filteredIds = filter === 'online' ? onlineMachines :
-                           filter === 'offline' ? offlineMachines :
-                           warningMachines;
+        const filteredIds = effectiveFilter === 'online' ? onlineMachines :
+                           effectiveFilter === 'idle' ? idleMachines :
+                           unknownMachines;
         heartbeats = {};
         for (const id of filteredIds) {
           if (allHeartbeats[id]) {
@@ -189,8 +186,8 @@ export async function roosyncHeartbeatStatus(args: HeartbeatStatusArgs): Promise
     return {
       success: true,
       onlineMachines,
-      offlineMachines,
-      warningMachines,
+      idleMachines,
+      unknownMachines,
       statistics: state.statistics,
       heartbeats,
       changes,
@@ -213,14 +210,14 @@ export async function roosyncHeartbeatStatus(args: HeartbeatStatusArgs): Promise
  */
 export const heartbeatStatusToolMetadata = {
   name: 'roosync_heartbeat_status',
-  description: 'État complet du service de heartbeat (machines online, offline, warning, heartbeats).',
+  description: 'État complet du service de heartbeat (machines online, idle, unknown, heartbeats).',
   inputSchema: {
     type: 'object' as const,
     properties: {
       filter: {
         type: 'string',
-        enum: ['all', 'online', 'offline', 'warning'],
-        description: 'Filtrer par statut de machine (defaut: all)'
+        enum: ['all', 'online', 'idle', 'unknown', 'offline', 'warning'],
+        description: 'Filtrer par statut de machine (defaut: all). "offline" and "warning" map to "unknown"'
       },
       includeHeartbeats: {
         type: 'boolean',

--- a/servers/roo-state-manager/src/tools/roosync/inventory.ts
+++ b/servers/roo-state-manager/src/tools/roosync/inventory.ts
@@ -18,14 +18,14 @@ import { HeartbeatServiceError } from '../../services/roosync/HeartbeatService.j
  */
 export const InventoryArgsSchema = z.object({
   type: z.enum(['machine', 'heartbeat', 'all', 'machines', 'status'])
-    .describe('Type d\'inventaire à récupérer. "machines" = offline/warning machines. "status" = compact system snapshot (fused from roosync_get_status)'),
+    .describe('Type d\'inventaire à récupérer. "machines" = unknown/idle machines. "status" = compact system snapshot (fused from roosync_get_status)'),
   machineId: z.string().optional()
     .describe('Identifiant optionnel de la machine (défaut: hostname)'),
   includeHeartbeats: z.boolean().optional()
     .describe('Inclure les données de heartbeat de chaque machine (défaut: true)'),
   // Pour type="machines" (fused from roosync_machines)
   status: z.enum(['offline', 'warning', 'all']).optional()
-    .describe('Filtrer par statut machines (type="machines": offline, warning, all)'),
+    .describe('Filtrer par statut machines (type="machines": offline=unknown, warning=idle, all)'),
   includeDetails: z.boolean().optional()
     .describe('Inclure les détails complets des machines (type="machines") ou stats outil (type="status")'),
   summary: z.boolean().optional()
@@ -310,7 +310,7 @@ export const inventoryToolMetadata = {
       type: {
         type: 'string',
         enum: ['machine', 'heartbeat', 'all', 'machines', 'status'],
-        description: 'Type d\'inventaire. "machines" = offline/warning. "status" = snapshot système avec flags.'
+        description: 'Type d\'inventaire. "machines" = unknown/idle. "status" = snapshot système avec flags.'
       },
       machineId: {
         type: 'string',
@@ -323,7 +323,7 @@ export const inventoryToolMetadata = {
       status: {
         type: 'string',
         enum: ['offline', 'warning', 'all'],
-        description: 'Filtrer par statut machines (type="machines": offline, warning, all)'
+        description: 'Filtrer par statut machines (type="machines": offline=unknown, warning=idle, all)'
       },
       includeDetails: {
         type: 'boolean',

--- a/servers/roo-state-manager/src/tools/roosync/inventory.ts
+++ b/servers/roo-state-manager/src/tools/roosync/inventory.ts
@@ -47,19 +47,13 @@ export const HeartbeatDataSchema = z.object({
     .describe('Identifiant de la machine'),
   lastHeartbeat: z.string()
     .describe('Timestamp du dernier heartbeat (ISO 8601)'),
-  status: z.enum(['online', 'offline', 'warning'])
+  status: z.enum(['online', 'idle', 'unknown'])
     .describe('Statut de la machine'),
-  missedHeartbeats: z.number()
-    .describe('Nombre de heartbeats manqués consécutifs'),
-  offlineSince: z.string().optional()
-    .describe('Timestamp de première détection offline (ISO 8601)'),
   metadata: z.object({
     firstSeen: z.string()
       .describe('Timestamp de première détection (ISO 8601)'),
     lastUpdated: z.string()
-      .describe('Timestamp de dernière mise à jour (ISO 8601)'),
-    version: z.string()
-      .describe('Version du service')
+      .describe('Timestamp de dernière mise à jour (ISO 8601)')
   })
 });
 
@@ -73,10 +67,10 @@ export const HeartbeatStatisticsSchema = z.object({
     .describe('Nombre total de machines'),
   onlineCount: z.number()
     .describe('Nombre de machines online'),
-  offlineCount: z.number()
-    .describe('Nombre de machines offline'),
-  warningCount: z.number()
-    .describe('Nombre de machines en avertissement'),
+  idleCount: z.number()
+    .describe('Nombre de machines idle'),
+  unknownCount: z.number()
+    .describe('Nombre de machines unknown'),
   lastHeartbeatCheck: z.string()
     .describe('Timestamp de la dernière vérification (ISO 8601)')
 });
@@ -94,10 +88,10 @@ export const InventoryResultSchema = z.object({
   heartbeatState: z.object({
     onlineMachines: z.array(z.string())
       .describe('Liste des IDs des machines online'),
-    offlineMachines: z.array(z.string())
-      .describe('Liste des IDs des machines offline'),
-    warningMachines: z.array(z.string())
-      .describe('Liste des IDs des machines en avertissement'),
+    unknownMachines: z.array(z.string())
+      .describe('Liste des IDs des machines unknown'),
+    idleMachines: z.array(z.string())
+      .describe('Liste des IDs des machines idle'),
     statistics: HeartbeatStatisticsSchema
       .describe('Statistiques du service'),
     heartbeats: z.record(HeartbeatDataSchema).optional()
@@ -181,8 +175,8 @@ export const inventoryTool: UnifiedToolContract = {
 
         heartbeatState = {
           onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
+          unknownMachines: state.unknownMachines,
+          idleMachines: state.idleMachines,
           statistics: state.statistics,
           heartbeats: includeHeartbeats ? Object.fromEntries(state.heartbeats) : undefined,
           retrievedAt
@@ -199,41 +193,41 @@ export const inventoryTool: UnifiedToolContract = {
         const machinesStatus = input.status || 'all';
         const wantDetails = input.includeDetails || false;
 
-        machinesData = { offlineMachines: [], offlineCount: 0, warningMachines: [], warningCount: 0 };
+        machinesData = { unknownMachines: [], unknownCount: 0, idleMachines: [], idleCount: 0 };
 
         if (machinesStatus === 'offline' || machinesStatus === 'all') {
-          const offlineMachines = heartbeatService.getOfflineMachines();
+          const unknownMachines = heartbeatService.getUnknownMachines();
           if (wantDetails) {
             const detailed: any[] = [];
-            for (const mid of offlineMachines) {
+            for (const mid of unknownMachines) {
               const data = heartbeatService.getHeartbeatData(mid);
-              if (data && data.offlineSince) {
-                detailed.push({ machineId: data.machineId, lastHeartbeat: data.lastHeartbeat, offlineSince: data.offlineSince, missedHeartbeats: data.missedHeartbeats, metadata: data.metadata });
+              if (data) {
+                detailed.push({ machineId: data.machineId, lastHeartbeat: data.lastHeartbeat, status: data.status, metadata: data.metadata });
               }
             }
-            machinesData.offlineMachines = detailed;
-            machinesData.offlineCount = detailed.length;
+            machinesData.unknownMachines = detailed;
+            machinesData.unknownCount = detailed.length;
           } else {
-            machinesData.offlineMachines = offlineMachines;
-            machinesData.offlineCount = offlineMachines.length;
+            machinesData.unknownMachines = unknownMachines;
+            machinesData.unknownCount = unknownMachines.length;
           }
         }
 
         if (machinesStatus === 'warning' || machinesStatus === 'all') {
-          const warningMachines = heartbeatService.getWarningMachines();
+          const idleMachines = heartbeatService.getIdleMachines();
           if (wantDetails) {
             const detailed: any[] = [];
-            for (const mid of warningMachines) {
+            for (const mid of idleMachines) {
               const data = heartbeatService.getHeartbeatData(mid);
               if (data) {
-                detailed.push({ machineId: data.machineId, lastHeartbeat: data.lastHeartbeat, missedHeartbeats: data.missedHeartbeats, metadata: data.metadata });
+                detailed.push({ machineId: data.machineId, lastHeartbeat: data.lastHeartbeat, status: data.status, metadata: data.metadata });
               }
             }
-            machinesData.warningMachines = detailed;
-            machinesData.warningCount = detailed.length;
+            machinesData.idleMachines = detailed;
+            machinesData.idleCount = detailed.length;
           } else {
-            machinesData.warningMachines = warningMachines;
-            machinesData.warningCount = warningMachines.length;
+            machinesData.idleMachines = idleMachines;
+            machinesData.idleCount = idleMachines.length;
           }
         }
         if (!summary) {
@@ -260,13 +254,13 @@ export const inventoryTool: UnifiedToolContract = {
           const hs = heartbeatState;
           lines.push(`**Cluster status:** ${hs.statistics.totalMachines} machines`);
           lines.push(`- Online (${hs.onlineMachines.length}): ${hs.onlineMachines.join(', ') || 'none'}`);
-          lines.push(`- Offline (${hs.offlineMachines.length}): ${hs.offlineMachines.join(', ') || 'none'}`);
-          lines.push(`- Warning (${hs.warningMachines.length}): ${hs.warningMachines.join(', ') || 'none'}`);
+          lines.push(`- Unknown (${hs.unknownMachines.length}): ${hs.unknownMachines.join(', ') || 'none'}`);
+          lines.push(`- Idle (${hs.idleMachines.length}): ${hs.idleMachines.join(', ') || 'none'}`);
           lines.push('');
         }
 
         if (machinesData) {
-          lines.push(`**Filtered machines:** offline=${machinesData.offlineCount}, warning=${machinesData.warningCount}`);
+          lines.push(`**Filtered machines:** unknown=${machinesData.unknownCount}, idle=${machinesData.idleCount}`);
           lines.push('');
         }
 

--- a/servers/roo-state-manager/src/tools/roosync/machines.ts
+++ b/servers/roo-state-manager/src/tools/roosync/machines.ts
@@ -32,17 +32,13 @@ export const OfflineMachineDetailsSchema = z.object({
     .describe('Identifiant de la machine'),
   lastHeartbeat: z.string()
     .describe('Timestamp du dernier heartbeat (ISO 8601)'),
-  offlineSince: z.string()
-    .describe('Timestamp depuis lequel la machine est offline (ISO 8601)'),
-  missedHeartbeats: z.number()
-    .describe('Nombre de heartbeats manqués'),
+  status: z.enum(['online', 'idle', 'unknown'])
+    .describe('Statut de la machine'),
   metadata: z.object({
     firstSeen: z.string()
       .describe('Timestamp de première détection (ISO 8601)'),
     lastUpdated: z.string()
-      .describe('Timestamp de dernière mise à jour (ISO 8601)'),
-    version: z.string()
-      .describe('Version du service')
+      .describe('Timestamp de dernière mise à jour (ISO 8601)')
   })
 });
 
@@ -56,15 +52,13 @@ export const WarningMachineDetailsSchema = z.object({
     .describe('Identifiant de la machine'),
   lastHeartbeat: z.string()
     .describe('Timestamp du dernier heartbeat (ISO 8601)'),
-  missedHeartbeats: z.number()
-    .describe('Nombre de heartbeats manqués'),
+  status: z.enum(['online', 'idle', 'unknown'])
+    .describe('Statut de la machine'),
   metadata: z.object({
     firstSeen: z.string()
       .describe('Timestamp de première détection (ISO 8601)'),
     lastUpdated: z.string()
-      .describe('Timestamp de dernière mise à jour (ISO 8601)'),
-    version: z.string()
-      .describe('Version du service')
+      .describe('Timestamp de dernière mise à jour (ISO 8601)')
   })
 });
 
@@ -76,20 +70,20 @@ export type WarningMachineDetails = z.infer<typeof WarningMachineDetailsSchema>;
 export const MachinesResultSchema = z.object({
   success: z.boolean()
     .describe('Indique si la récupération a réussi'),
-  offlineMachines: z.union([
-    z.array(z.string()).describe('Liste des IDs des machines offline'),
-    z.array(OfflineMachineDetailsSchema).describe('Liste détaillée des machines offline')
+  unknownMachines: z.union([
+    z.array(z.string()).describe('Liste des IDs des machines unknown'),
+    z.array(OfflineMachineDetailsSchema).describe('Liste détaillée des machines unknown')
   ]).optional()
-    .describe('Liste des machines offline (IDs ou détails selon includeDetails)'),
-  warningMachines: z.union([
-    z.array(z.string()).describe('Liste des IDs des machines en avertissement'),
-    z.array(WarningMachineDetailsSchema).describe('Liste détaillée des machines en avertissement')
+    .describe('Liste des machines unknown (IDs ou détails selon includeDetails)'),
+  idleMachines: z.union([
+    z.array(z.string()).describe('Liste des IDs des machines idle'),
+    z.array(WarningMachineDetailsSchema).describe('Liste détaillée des machines idle')
   ]).optional()
-    .describe('Liste des machines en avertissement (IDs ou détails selon includeDetails)'),
-  offlineCount: z.number().optional()
-    .describe('Nombre de machines offline'),
-  warningCount: z.number().optional()
-    .describe('Nombre de machines en avertissement'),
+    .describe('Liste des machines idle (IDs ou détails selon includeDetails)'),
+  unknownCount: z.number().optional()
+    .describe('Nombre de machines unknown'),
+  idleCount: z.number().optional()
+    .describe('Nombre de machines idle'),
   checkedAt: z.string()
     .describe('Timestamp de la vérification (ISO 8601)')
 });
@@ -123,58 +117,57 @@ export const machinesTool: UnifiedToolContract = {
 
       // Récupérer les machines offline si demandé
       if (status === 'offline' || status === 'all') {
-        const offlineMachines = heartbeatService.getOfflineMachines();
+        const unknownMachines = heartbeatService.getUnknownMachines();
 
         if (includeDetails) {
           const detailedMachines: OfflineMachineDetails[] = [];
 
-          for (const machineId of offlineMachines) {
-            const heartbeatData = heartbeatService.getHeartbeatData(machineId);
-
-            if (heartbeatData && heartbeatData.offlineSince) {
-              detailedMachines.push({
-                machineId: heartbeatData.machineId,
-                lastHeartbeat: heartbeatData.lastHeartbeat,
-                offlineSince: heartbeatData.offlineSince,
-                missedHeartbeats: heartbeatData.missedHeartbeats,
-                metadata: heartbeatData.metadata
-              });
-            }
-          }
-
-          result.offlineMachines = detailedMachines;
-          result.offlineCount = detailedMachines.length;
-        } else {
-          result.offlineMachines = offlineMachines;
-          result.offlineCount = offlineMachines.length;
-        }
-      }
-
-      // Récupérer les machines en avertissement si demandé
-      if (status === 'warning' || status === 'all') {
-        const warningMachines = heartbeatService.getWarningMachines();
-
-        if (includeDetails) {
-          const detailedMachines: WarningMachineDetails[] = [];
-
-          for (const machineId of warningMachines) {
+          for (const machineId of unknownMachines) {
             const heartbeatData = heartbeatService.getHeartbeatData(machineId);
 
             if (heartbeatData) {
               detailedMachines.push({
                 machineId: heartbeatData.machineId,
                 lastHeartbeat: heartbeatData.lastHeartbeat,
-                missedHeartbeats: heartbeatData.missedHeartbeats,
+                status: heartbeatData.status,
                 metadata: heartbeatData.metadata
               });
             }
           }
 
-          result.warningMachines = detailedMachines;
-          result.warningCount = detailedMachines.length;
+          result.unknownMachines = detailedMachines;
+          result.unknownCount = detailedMachines.length;
         } else {
-          result.warningMachines = warningMachines;
-          result.warningCount = warningMachines.length;
+          result.unknownMachines = unknownMachines;
+          result.unknownCount = unknownMachines.length;
+        }
+      }
+
+      // Récupérer les machines en avertissement si demandé
+      if (status === 'warning' || status === 'all') {
+        const idleMachines = heartbeatService.getIdleMachines();
+
+        if (includeDetails) {
+          const detailedMachines: WarningMachineDetails[] = [];
+
+          for (const machineId of idleMachines) {
+            const heartbeatData = heartbeatService.getHeartbeatData(machineId);
+
+            if (heartbeatData) {
+              detailedMachines.push({
+                machineId: heartbeatData.machineId,
+                lastHeartbeat: heartbeatData.lastHeartbeat,
+                status: heartbeatData.status,
+                metadata: heartbeatData.metadata
+              });
+            }
+          }
+
+          result.idleMachines = detailedMachines;
+          result.idleCount = detailedMachines.length;
+        } else {
+          result.idleMachines = idleMachines;
+          result.idleCount = idleMachines.length;
         }
       }
 

--- a/servers/roo-state-manager/src/tools/roosync/machines.ts
+++ b/servers/roo-state-manager/src/tools/roosync/machines.ts
@@ -25,9 +25,9 @@ export const MachinesArgsSchema = z.object({
 export type MachinesArgs = z.infer<typeof MachinesArgsSchema>;
 
 /**
- * Détails d'une machine offline
+ * Détails d'une machine unknown
  */
-export const OfflineMachineDetailsSchema = z.object({
+export const UnknownMachineDetailsSchema = z.object({
   machineId: z.string()
     .describe('Identifiant de la machine'),
   lastHeartbeat: z.string()
@@ -42,12 +42,12 @@ export const OfflineMachineDetailsSchema = z.object({
   })
 });
 
-export type OfflineMachineDetails = z.infer<typeof OfflineMachineDetailsSchema>;
+export type UnknownMachineDetails = z.infer<typeof UnknownMachineDetailsSchema>;
 
 /**
- * Détails d'une machine en avertissement
+ * Détails d'une machine idle
  */
-export const WarningMachineDetailsSchema = z.object({
+export const IdleMachineDetailsSchema = z.object({
   machineId: z.string()
     .describe('Identifiant de la machine'),
   lastHeartbeat: z.string()
@@ -62,7 +62,7 @@ export const WarningMachineDetailsSchema = z.object({
   })
 });
 
-export type WarningMachineDetails = z.infer<typeof WarningMachineDetailsSchema>;
+export type IdleMachineDetails = z.infer<typeof IdleMachineDetailsSchema>;
 
 /**
  * Schema de retour pour roosync_machines
@@ -72,12 +72,12 @@ export const MachinesResultSchema = z.object({
     .describe('Indique si la récupération a réussi'),
   unknownMachines: z.union([
     z.array(z.string()).describe('Liste des IDs des machines unknown'),
-    z.array(OfflineMachineDetailsSchema).describe('Liste détaillée des machines unknown')
+    z.array(UnknownMachineDetailsSchema).describe('Liste détaillée des machines unknown')
   ]).optional()
     .describe('Liste des machines unknown (IDs ou détails selon includeDetails)'),
   idleMachines: z.union([
     z.array(z.string()).describe('Liste des IDs des machines idle'),
-    z.array(WarningMachineDetailsSchema).describe('Liste détaillée des machines idle')
+    z.array(IdleMachineDetailsSchema).describe('Liste détaillée des machines idle')
   ]).optional()
     .describe('Liste des machines idle (IDs ou détails selon includeDetails)'),
   unknownCount: z.number().optional()
@@ -115,12 +115,12 @@ export const machinesTool: UnifiedToolContract = {
         checkedAt
       };
 
-      // Récupérer les machines offline si demandé
+      // Récupérer les machines unknown si demandé
       if (status === 'offline' || status === 'all') {
         const unknownMachines = heartbeatService.getUnknownMachines();
 
         if (includeDetails) {
-          const detailedMachines: OfflineMachineDetails[] = [];
+          const detailedMachines: UnknownMachineDetails[] = [];
 
           for (const machineId of unknownMachines) {
             const heartbeatData = heartbeatService.getHeartbeatData(machineId);
@@ -143,12 +143,12 @@ export const machinesTool: UnifiedToolContract = {
         }
       }
 
-      // Récupérer les machines en avertissement si demandé
+      // Récupérer les machines idle si demandé
       if (status === 'warning' || status === 'all') {
         const idleMachines = heartbeatService.getIdleMachines();
 
         if (includeDetails) {
-          const detailedMachines: WarningMachineDetails[] = [];
+          const detailedMachines: IdleMachineDetails[] = [];
 
           for (const machineId of idleMachines) {
             const heartbeatData = heartbeatService.getHeartbeatData(machineId);

--- a/servers/roo-state-manager/src/tools/roosync/sync-event.ts
+++ b/servers/roo-state-manager/src/tools/roosync/sync-event.ts
@@ -98,9 +98,8 @@ export async function roosyncSyncEvent(args: SyncEventArgs): Promise<SyncEventRe
 
     // Calculer la durée offline si action=online et disponible
     let offlineDuration: number | undefined;
-    if (action === 'online' && heartbeatData.offlineSince) {
-      offlineDuration = Date.now() - new Date(heartbeatData.offlineSince).getTime();
-    }
+    // Note: offlineSince removed in ADR 008 Phase 2 — duration calculation no longer available
+    // offlineDuration remains undefined until a replacement mechanism is implemented
 
     // En mode simulation, retourner un résultat factice
     if (dryRun) {

--- a/servers/roo-state-manager/src/types/machine-config.ts
+++ b/servers/roo-state-manager/src/types/machine-config.ts
@@ -155,8 +155,7 @@ export interface RooSyncState {
   heartbeat?: {
     registered: boolean;
     lastHeartbeat?: string;
-    status?: 'online' | 'offline' | 'warning';
-    missedHeartbeats?: number;
+    status?: 'online' | 'unknown' | 'idle';
   };
 
   /** Messaging stats */

--- a/servers/roo-state-manager/src/utils/__tests__/dashboard-activity.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/dashboard-activity.test.ts
@@ -86,52 +86,52 @@ describe('dashboard-activity', () => {
 			vi.useRealTimers();
 		});
 
-		it('should override OFFLINE to ONLINE when dashboard shows recent activity', () => {
+		it('should override UNKNOWN to ONLINE when dashboard shows recent activity', () => {
 			const heartbeatState = {
 				onlineMachines: ['myia-po-2023'],
-				offlineMachines: ['myia-po-2024'],
-				warningMachines: [],
+				unknownMachines: ['myia-po-2024'],
+				idleMachines: [],
 			};
 			const dashboardContent = '### [2026-05-03T19:30:00Z] myia-po-2024|roo-extensions\nRecent message';
 
 			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
 			expect(result.onlineMachines).toContain('myia-po-2024');
-			expect(result.offlineMachines).not.toContain('myia-po-2024');
+			expect(result.unknownMachines).not.toContain('myia-po-2024');
 			expect(result.overrides).toContain('myia-po-2024');
 		});
 
-		it('should override WARNING to ONLINE when dashboard shows recent activity', () => {
+		it('should override IDLE to ONLINE when dashboard shows recent activity', () => {
 			const heartbeatState = {
 				onlineMachines: [],
-				offlineMachines: [],
-				warningMachines: ['myia-web1'],
+				unknownMachines: [],
+				idleMachines: ['myia-web1'],
 			};
 			const dashboardContent = '### [2026-05-03T19:45:00Z] myia-web1|roo-extensions\nRecent message';
 
 			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
 			expect(result.onlineMachines).toContain('myia-web1');
-			expect(result.warningMachines).not.toContain('myia-web1');
+			expect(result.idleMachines).not.toContain('myia-web1');
 			expect(result.overrides).toContain('myia-web1');
 		});
 
 		it('should NOT override when dashboard activity is too old', () => {
 			const heartbeatState = {
 				onlineMachines: [],
-				offlineMachines: ['myia-po-2025'],
-				warningMachines: [],
+				unknownMachines: ['myia-po-2025'],
+				idleMachines: [],
 			};
 			const dashboardContent = '### [2026-05-03T10:00:00Z] myia-po-2025|roo-extensions\nOld message';
 
 			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
-			expect(result.offlineMachines).toContain('myia-po-2025');
+			expect(result.unknownMachines).toContain('myia-po-2025');
 			expect(result.overrides).toHaveLength(0);
 		});
 
 		it('should handle multiple overrides', () => {
 			const heartbeatState = {
 				onlineMachines: [],
-				offlineMachines: ['myia-po-2024', 'myia-po-2025'],
-				warningMachines: ['myia-web1'],
+				unknownMachines: ['myia-po-2024', 'myia-po-2025'],
+				idleMachines: ['myia-web1'],
 			};
 			const dashboardContent = [
 				'### [2026-05-03T19:50:00Z] myia-po-2024|roo-extensions',
@@ -150,8 +150,8 @@ describe('dashboard-activity', () => {
 		it('should not modify already online machines', () => {
 			const heartbeatState = {
 				onlineMachines: ['myia-ai-01'],
-				offlineMachines: [],
-				warningMachines: [],
+				unknownMachines: [],
+				idleMachines: [],
 			};
 			const dashboardContent = '### [2026-05-03T19:50:00Z] myia-ai-01|roo-extensions\nMessage';
 

--- a/servers/roo-state-manager/src/utils/dashboard-activity.ts
+++ b/servers/roo-state-manager/src/utils/dashboard-activity.ts
@@ -67,56 +67,56 @@ export function isRecentlyActive(lastSeen: string, thresholdMs: number = 60 * 60
 /**
  * Cross-check heartbeat-derived status against dashboard activity.
  *
- * For machines marked "offline" or "warning" by heartbeat files,
+ * For machines marked "unknown" or "idle" by heartbeat files,
  * if dashboard shows recent activity, override the status to "online".
  *
  * @param heartbeatState - State from HeartbeatService.checkHeartbeats()
  * @param dashboardContent - Raw dashboard markdown content
  * @param thresholdMs - Dashboard activity threshold (default: 60 min)
- * @returns Updated lists of online/offline/warning machines
+ * @returns Updated lists of online/unknown/idle machines
  */
 export function crossCheckWithDashboard(
 	heartbeatState: {
 		onlineMachines: string[];
-		offlineMachines: string[];
-		warningMachines: string[];
+		unknownMachines: string[];
+		idleMachines: string[];
 	},
 	dashboardContent: string,
 	thresholdMs: number = 60 * 60 * 1000
 ): {
 	onlineMachines: string[];
-	offlineMachines: string[];
-	warningMachines: string[];
+	unknownMachines: string[];
+	idleMachines: string[];
 	overrides: string[];
 } {
 	const activity = extractMachineActivity(dashboardContent);
 	const overrides: string[] = [];
 
-	const offlineMachines = [...heartbeatState.offlineMachines];
-	const warningMachines = [...heartbeatState.warningMachines];
+	const unknownMachines = [...heartbeatState.unknownMachines];
+	const idleMachines = [...heartbeatState.idleMachines];
 	const onlineMachines = [...heartbeatState.onlineMachines];
 
-	for (let i = offlineMachines.length - 1; i >= 0; i--) {
-		const machineId = offlineMachines[i];
+	for (let i = unknownMachines.length - 1; i >= 0; i--) {
+		const machineId = unknownMachines[i];
 		const lastSeen = activity.get(machineId);
 		if (lastSeen && isRecentlyActive(lastSeen, thresholdMs)) {
-			offlineMachines.splice(i, 1);
+			unknownMachines.splice(i, 1);
 			onlineMachines.push(machineId);
 			overrides.push(machineId);
-			logger.info(`Dashboard override: ${machineId} OFFLINE→ONLINE (last seen ${lastSeen})`);
+			logger.info(`Dashboard override: ${machineId} UNKNOWN→ONLINE (last seen ${lastSeen})`);
 		}
 	}
 
-	for (let i = warningMachines.length - 1; i >= 0; i--) {
-		const machineId = warningMachines[i];
+	for (let i = idleMachines.length - 1; i >= 0; i--) {
+		const machineId = idleMachines[i];
 		const lastSeen = activity.get(machineId);
 		if (lastSeen && isRecentlyActive(lastSeen, thresholdMs)) {
-			warningMachines.splice(i, 1);
+			idleMachines.splice(i, 1);
 			onlineMachines.push(machineId);
 			overrides.push(machineId);
-			logger.info(`Dashboard override: ${machineId} WARNING→ONLINE (last seen ${lastSeen})`);
+			logger.info(`Dashboard override: ${machineId} IDLE→ONLINE (last seen ${lastSeen})`);
 		}
 	}
 
-	return { onlineMachines, offlineMachines, warningMachines, overrides };
+	return { onlineMachines, unknownMachines, idleMachines, overrides };
 }

--- a/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService-degraded.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService-degraded.test.ts
@@ -1,28 +1,20 @@
 /**
  * Tests for HeartbeatService graceful degradation (#1918)
  *
- * Verifies that HeartbeatService continues operating in-memory
- * when sharedPath (GDrive) is degraded, without attempting disk I/O.
+ * ADR 008 Phase 2: HeartbeatService is purely in-memory.
+ * All operations work regardless of sharedPath/GDrive state.
+ * No disk I/O ever, so degradation has no effect on functionality.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { join } from 'path';
-import { mkdtemp, rm, mkdir, readFile, readdir } from 'fs/promises';
-import { tmpdir } from 'os';
 import { HeartbeatService, HeartbeatConfig } from '../../../../src/services/roosync/HeartbeatService.js';
 import { getServerCapabilities } from '../../../../src/utils/server-capabilities.js';
 
 describe('HeartbeatService - Graceful Degradation (#1918)', () => {
-  let tempDir: string;
-  let sharedPath: string;
   let heartbeatService: HeartbeatService;
   let caps: ReturnType<typeof getServerCapabilities>;
 
-  beforeEach(async () => {
-    tempDir = await mkdtemp(join(tmpdir(), 'heartbeat-degraded-'));
-    sharedPath = join(tempDir, 'shared');
-    await mkdir(sharedPath, { recursive: true });
-
+  beforeEach(() => {
     caps = getServerCapabilities();
     caps.reset();
 
@@ -35,20 +27,11 @@ describe('HeartbeatService - Graceful Degradation (#1918)', () => {
       persistenceInterval: 100,
     };
 
-    heartbeatService = new HeartbeatService(sharedPath, config);
+    heartbeatService = new HeartbeatService('/test/shared', config);
   });
 
-  afterEach(async () => {
-    await heartbeatService.stopHeartbeatService();
+  afterEach(() => {
     caps.reset();
-
-    try {
-      await rm(tempDir, { recursive: true, force: true });
-    } catch (error: any) {
-      if (error.code !== 'ENOTEMPTY' && error.code !== 'EPERM' && error.code !== 'EBUSY') {
-        console.warn('Cleanup failed:', error.message);
-      }
-    }
     vi.restoreAllMocks();
   });
 
@@ -64,95 +47,78 @@ describe('HeartbeatService - Graceful Degradation (#1918)', () => {
       expect(data?.machineId).toBe('test-machine');
     });
 
-    it('does not write files to disk when degraded', async () => {
+    it('does not attempt disk I/O (ADR 008: no disk writes ever)', async () => {
       caps.markDegraded('sharedPath', 'GDrive offline');
 
       await heartbeatService.registerHeartbeat('no-disk-machine');
 
-      const heartbeatsDir = join(sharedPath, 'heartbeats');
-      let files: string[] = [];
-      try {
-        files = await readdir(heartbeatsDir);
-      } catch {
-        // Directory may not exist — that's fine
-      }
-      expect(files).toHaveLength(0);
+      // ADR 008: No disk writes, machine is in-memory regardless of degradation
+      expect(heartbeatService.getHeartbeatData('no-disk-machine')).toBeDefined();
+      expect(heartbeatService.getHeartbeatData('no-disk-machine')?.status).toBe('online');
     });
 
-    it('resumes disk writes after recovery via stopHeartbeatService #1953 ADR 008', async () => {
+    it('in-memory state preserved after recovery — no disk needed #1953 ADR 008', async () => {
       caps.markDegraded('sharedPath', 'GDrive offline');
 
       await heartbeatService.registerHeartbeat('recovery-machine');
       expect(heartbeatService.getHeartbeatData('recovery-machine')?.status).toBe('online');
 
-      // Recover GDrive
+      // Recover GDrive (irrelevant for ADR 008 but tests the cycle)
       caps.recover('sharedPath');
 
-      // ADR 008 Phase 1: registerHeartbeat is always in-memory, disk writes happen via saveState
+      // stopHeartbeatService is a no-op in ADR 008
       await heartbeatService.stopHeartbeatService();
 
-      const heartbeatsDir = join(sharedPath, 'heartbeats');
-      const files = await readdir(heartbeatsDir);
-      expect(files.length).toBeGreaterThanOrEqual(1);
+      // Machine still in memory — never left
+      expect(heartbeatService.getHeartbeatData('recovery-machine')).toBeDefined();
+      expect(heartbeatService.getHeartbeatData('recovery-machine')?.status).toBe('online');
     });
   });
 
   describe('reloadFromDisk in degraded mode', () => {
-    it('preserves in-memory state when degraded instead of clearing', async () => {
-      // First register a machine normally
+    it('preserves in-memory state (reloadFromDisk is no-op in ADR 008)', async () => {
       await heartbeatService.registerHeartbeat('existing-machine');
       expect(heartbeatService.getHeartbeatData('existing-machine')?.status).toBe('online');
 
-      // Degrade
       caps.markDegraded('sharedPath', 'GDrive offline');
 
-      // Register another machine (in-memory only)
       await heartbeatService.registerHeartbeat('degraded-machine');
 
-      // reloadFromDisk should NOT clear in-memory state when degraded
+      // reloadFromDisk is a no-op in ADR 008 — state preserved
       heartbeatService.reloadFromDisk();
 
-      // existing-machine may be lost (clear happens before the guard)
-      // but degraded-machine should still be there
-      const data = heartbeatService.getHeartbeatData('degraded-machine');
-      expect(data).toBeDefined();
+      const dataExisting = heartbeatService.getHeartbeatData('existing-machine');
+      const dataDegraded = heartbeatService.getHeartbeatData('degraded-machine');
+      expect(dataExisting).toBeDefined();
+      expect(dataDegraded).toBeDefined();
     });
   });
 
   describe('saveState in degraded mode', () => {
-    it('skips saving when sharedPath is degraded', async () => {
+    it('no disk writes regardless of degradation (ADR 008 no-op)', async () => {
       caps.markDegraded('sharedPath', 'GDrive offline');
 
       await heartbeatService.registerHeartbeat('unsaved-machine');
 
-      // Force save via stopHeartbeatService (calls saveState internally)
+      // stopHeartbeatService is a no-op — no disk writes
       await heartbeatService.stopHeartbeatService();
 
-      const heartbeatsDir = join(sharedPath, 'heartbeats');
-      let files: string[] = [];
-      try {
-        files = await readdir(heartbeatsDir);
-      } catch {
-        // OK
-      }
-      expect(files).toHaveLength(0);
+      // Machine still in memory
+      expect(heartbeatService.getHeartbeatData('unsaved-machine')).toBeDefined();
     });
   });
 
   describe('mixed degradation cycle', () => {
     it('handles full degrade → operate → recover cycle', async () => {
-      // Step 1: Normal operation — write to disk
       await heartbeatService.registerHeartbeat('cycle-machine');
       const onlineMachines = heartbeatService.getOnlineMachines();
       expect(onlineMachines).toContain('cycle-machine');
 
-      // Step 2: Degrade — operations continue in-memory
       caps.markDegraded('sharedPath', 'GDrive offline');
 
       await heartbeatService.registerHeartbeat('degraded-only-machine');
       expect(heartbeatService.getHeartbeatData('degraded-only-machine')).toBeDefined();
 
-      // Step 3: Recover — disk writes resume
       caps.recover('sharedPath');
 
       await heartbeatService.registerHeartbeat('recovered-machine');

--- a/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
@@ -1,648 +1,288 @@
 /**
  * Tests unitaires pour le service de Heartbeat
- * 
- * T3.15 - Tests de heartbeat automatique
- * 
+ *
+ * ADR 008 Phase 2 — in-memory passive model.
+ * No disk I/O, no background intervals, no GDrive writes.
+ *
  * Couvre:
- * - Enregistrement de heartbeats
- * - Détection des machines offline
- * - Synchronisation automatique
- * - Timeout offline (2min)
- * - Heartbeat automatique (30s)
- * 
- * @version 3.0.0
+ * - Enregistrement de heartbeats (in-memory)
+ * - Detection des machines IDLE/UNKNOWN (computed from lastHeartbeat age)
+ * - Etat du service (getState, getOnlineMachines, etc.)
+ * - Gestion des machines (removeMachine)
+ * - Configuration (updateConfig — no-op)
+ * - Callbacks de notification (onStatusChange)
+ * - startHeartbeatService / stopHeartbeatService (no-ops)
+ * - cleanupOldOfflineMachines (no-op — returns 0)
+ *
+ * @version 4.0.0 (ADR 008 Phase 2)
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { promises as fs, existsSync } from 'fs';
-import { join } from 'path';
-import { mkdtemp, rm, mkdir } from 'fs/promises';
-import { tmpdir } from 'os';
-import { HeartbeatService, HeartbeatConfig, HeartbeatData, HeartbeatServiceError } from '../../../../src/services/roosync/HeartbeatService.js';
+import { HeartbeatService, HeartbeatConfig } from '../../../../src/services/roosync/HeartbeatService.js';
 
 describe('HeartbeatService - Tests Unitaires', () => {
-  let tempDir: string;
-  let sharedPath: string;
   let heartbeatService: HeartbeatService;
 
-  beforeEach(async () => {
-    tempDir = await mkdtemp(join(tmpdir(), 'heartbeat-test-'));
-    sharedPath = join(tempDir, 'shared');
-    
-    await mkdir(sharedPath, { recursive: true });
-    
-    // Configuration par défaut pour les tests
+  beforeEach(() => {
     const config: HeartbeatConfig = {
-      heartbeatInterval: 30000, // 30 secondes
-      offlineTimeout: 120000, // 2 minutes
+      heartbeatInterval: 30000,
+      offlineTimeout: 120000,
       missedHeartbeatThreshold: 4,
-      autoSyncEnabled: false, // Désactivé pour les tests
+      autoSyncEnabled: false,
       autoSyncInterval: 60000
     };
-    
-    heartbeatService = new HeartbeatService(sharedPath, config);
+
+    heartbeatService = new HeartbeatService(undefined, config);
   });
 
-  afterEach(async () => {
-    // Arrêter le service de heartbeat
-    await heartbeatService.stopHeartbeatService();
-    
-    try {
-      await rm(tempDir, { recursive: true, force: true });
-    } catch (error: any) {
-      if (error.code !== 'ENOTEMPTY' && error.code !== 'EPERM' && error.code !== 'EBUSY') {
-        console.warn('Failed to cleanup temp dir:', error.message);
-      }
-    }
+  afterEach(() => {
     vi.restoreAllMocks();
   });
 
   describe('Enregistrement de heartbeats', () => {
     it('devrait enregistrer un heartbeat pour une nouvelle machine', async () => {
-      // Act
       await heartbeatService.registerHeartbeat('machine-1');
-      
-      // Assert
+
       const heartbeatData = heartbeatService.getHeartbeatData('machine-1');
       expect(heartbeatData).toBeDefined();
       expect(heartbeatData?.machineId).toBe('machine-1');
       expect(heartbeatData?.status).toBe('online');
-      expect(heartbeatData?.missedHeartbeats).toBe(0);
       expect(heartbeatData?.metadata.firstSeen).toBeDefined();
       expect(heartbeatData?.metadata.lastUpdated).toBeDefined();
     });
 
-    it('devrait mettre à jour un heartbeat existant', async () => {
-      // Arrange - Enregistrer un heartbeat initial
+    it('devrait mettre a jour un heartbeat existant', async () => {
       await heartbeatService.registerHeartbeat('machine-1');
       const firstHeartbeat = heartbeatService.getHeartbeatData('machine-1');
       const firstTimestamp = firstHeartbeat?.lastHeartbeat;
-      
+
       // Attendre un peu pour que le timestamp change
-      await new Promise(resolve => setTimeout(resolve, 100));
-      
-      // Act - Enregistrer un nouveau heartbeat
+      await new Promise(resolve => setTimeout(resolve, 50));
+
       await heartbeatService.registerHeartbeat('machine-1');
-      
-      // Assert
+
       const updatedHeartbeat = heartbeatService.getHeartbeatData('machine-1');
       expect(updatedHeartbeat?.lastHeartbeat).not.toBe(firstTimestamp);
       expect(updatedHeartbeat?.status).toBe('online');
-      expect(updatedHeartbeat?.missedHeartbeats).toBe(0);
     });
 
-    it('devrait gérer plusieurs machines simultanément', async () => {
-      // Act
+    it('devrait gerer plusieurs machines simultanement', async () => {
       await heartbeatService.registerHeartbeat('machine-1');
       await heartbeatService.registerHeartbeat('machine-2');
       await heartbeatService.registerHeartbeat('machine-3');
-      
-      // Assert
+
       expect(heartbeatService.getHeartbeatData('machine-1')).toBeDefined();
       expect(heartbeatService.getHeartbeatData('machine-2')).toBeDefined();
       expect(heartbeatService.getHeartbeatData('machine-3')).toBeDefined();
-      
+
       const state = heartbeatService.getState();
       expect(state.statistics.totalMachines).toBe(3);
       expect(state.onlineMachines).toHaveLength(3);
     });
   });
 
-  describe('Détection des machines offline', () => {
-    it('devrait détecter une machine offline après le timeout', async () => {
-      // Arrange - Enregistrer un heartbeat
+  describe('Detection des machines offline/idle/unknown', () => {
+    it('devrait detecter une machine UNKNOWN (>120 min sans heartbeat)', async () => {
       await heartbeatService.registerHeartbeat('machine-1');
-      
-      // Simuler le passage du temps en modifiant directement le fichier
-      const heartbeatPath = join(sharedPath, 'heartbeat.json');
-      const state = heartbeatService.getState();
-      
-      // #1953 ADR 008: UNKNOWN threshold is >120 min (hardcoded in checkHeartbeats)
-      const heartbeatData = state.heartbeats.get('machine-1');
-      if (heartbeatData) {
-        heartbeatData.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString(); // 150 min ago → UNKNOWN
-        state.heartbeats.set('machine-1', heartbeatData);
 
-        await fs.writeFile(heartbeatPath, JSON.stringify({
-          heartbeats: Object.fromEntries(state.heartbeats),
-          onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
-          statistics: state.statistics
-        }, null, 2));
-      }
+      // Simuler le passage du temps: lastHeartbeat > 120 min → UNKNOWN
+      const hb = heartbeatService.getHeartbeatData('machine-1')!;
+      hb.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString(); // 150 min
 
-      // Recréer le service pour charger l'état modifié
-      await heartbeatService.stopHeartbeatService();
-      heartbeatService = new HeartbeatService(sharedPath, {
-        heartbeatInterval: 30000,
-        offlineTimeout: 120000,
-        missedHeartbeatThreshold: 4,
-        autoSyncEnabled: false,
-        autoSyncInterval: 60000
-      });
-
-      // Act - Vérifier les heartbeats
       const result = await heartbeatService.checkHeartbeats();
 
-      // Assert
       expect(result.success).toBe(true);
-      expect(result.newlyOfflineMachines).toContain('machine-1'); // UNKNOWN maps to offlineMachines
+      expect(result.newlyUnknownMachines).toContain('machine-1');
 
       const heartbeatDataAfter = heartbeatService.getHeartbeatData('machine-1');
-      expect(heartbeatDataAfter?.status).toBe('unknown'); // ADR 008: no more 'offline', use 'unknown'
+      expect(heartbeatDataAfter?.status).toBe('unknown');
     });
 
-    it('devrait détecter une machine en avertissement avant offline', async () => {
-      // Arrange - Enregistrer un heartbeat
+    it('devrait detecter une machine IDLE (30-120 min sans heartbeat)', async () => {
       await heartbeatService.registerHeartbeat('machine-1');
-      
-      // Simuler le passage du temps pour un avertissement
-      const heartbeatPath = join(sharedPath, 'heartbeat.json');
-      const state = heartbeatService.getState();
-      
-      const heartbeatData = state.heartbeats.get('machine-1');
-      if (heartbeatData) {
-        // #1953 ADR 008: IDLE threshold is 30-120 min
-        heartbeatData.lastHeartbeat = new Date(Date.now() - 45 * 60 * 1000).toISOString(); // 45 min → IDLE
-        state.heartbeats.set('machine-1', heartbeatData);
-        
-        await fs.writeFile(heartbeatPath, JSON.stringify({
-          heartbeats: Object.fromEntries(state.heartbeats),
-          onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
-          statistics: state.statistics
-        }, null, 2));
-      }
-      
-      // Recréer le service
-      await heartbeatService.stopHeartbeatService();
-      heartbeatService = new HeartbeatService(sharedPath, {
-        heartbeatInterval: 30000,
-        offlineTimeout: 120000,
-        missedHeartbeatThreshold: 4,
-        autoSyncEnabled: false,
-        autoSyncInterval: 60000
-      });
-      
-      // Act
+
+      // IDLE threshold: 30-120 min
+      const hb = heartbeatService.getHeartbeatData('machine-1')!;
+      hb.lastHeartbeat = new Date(Date.now() - 45 * 60 * 1000).toISOString(); // 45 min
+
       const result = await heartbeatService.checkHeartbeats();
-      
-      // Assert
+
       expect(result.success).toBe(true);
-      expect(result.warningMachines).toContain('machine-1');
-      
+      expect(result.newlyIdleMachines).toContain('machine-1');
+
       const heartbeatDataAfter = heartbeatService.getHeartbeatData('machine-1');
-      expect(heartbeatDataAfter?.status).toBe('idle'); // ADR 008: 'idle' replaces 'warning'
-      expect(heartbeatDataAfter?.missedHeartbeats).toBe(1);
+      expect(heartbeatDataAfter?.status).toBe('idle');
     });
 
-    it('devrait détecter le retour online d\'une machine', async () => {
-      // Arrange - Créer une machine offline
+    it('devrait detecter le retour online d\'une machine', async () => {
       await heartbeatService.registerHeartbeat('machine-1');
-      
-      const heartbeatPath = join(sharedPath, 'heartbeat.json');
-      const state = heartbeatService.getState();
-      
-      const heartbeatData = state.heartbeats.get('machine-1');
-      if (heartbeatData) {
-        heartbeatData.lastHeartbeat = new Date(Date.now() - 130000).toISOString();
-        heartbeatData.status = 'offline';
-        heartbeatData.offlineSince = new Date(Date.now() - 130000).toISOString();
-        heartbeatData.missedHeartbeats = 5;
-        state.heartbeats.set('machine-1', heartbeatData);
-        
-        await fs.writeFile(heartbeatPath, JSON.stringify({
-          heartbeats: Object.fromEntries(state.heartbeats),
-          onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
-          statistics: state.statistics
-        }, null, 2));
-      }
-      
-      // Recréer le service
-      await heartbeatService.stopHeartbeatService();
-      heartbeatService = new HeartbeatService(sharedPath, {
-        heartbeatInterval: 30000,
-        offlineTimeout: 120000,
-        missedHeartbeatThreshold: 4,
-        autoSyncEnabled: false,
-        autoSyncInterval: 60000
-      });
-      
-      // Act - Enregistrer un nouveau heartbeat
+
+      // Make stale → UNKNOWN
+      const hb = heartbeatService.getHeartbeatData('machine-1')!;
+      hb.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString();
+      await heartbeatService.checkHeartbeats();
+      expect(heartbeatService.getHeartbeatData('machine-1')?.status).toBe('unknown');
+
+      // Re-register → online
       await heartbeatService.registerHeartbeat('machine-1');
-      
-      // Assert
+
       const heartbeatDataAfter = heartbeatService.getHeartbeatData('machine-1');
       expect(heartbeatDataAfter?.status).toBe('online');
-      expect(heartbeatDataAfter?.offlineSince).toBeUndefined();
-      expect(heartbeatDataAfter?.missedHeartbeats).toBe(0);
     });
   });
 
-  describe('État du service', () => {
-    it('devrait retourner l\'état complet du service', async () => {
-      // Arrange - Enregistrer quelques machines
+  describe('Etat du service', () => {
+    it('devrait retourner l\'etat complet du service', async () => {
       await heartbeatService.registerHeartbeat('machine-1');
       await heartbeatService.registerHeartbeat('machine-2');
-      
-      // Act
+
       const state = heartbeatService.getState();
-      
-      // Assert
+
       expect(state).toBeDefined();
       expect(state.statistics.totalMachines).toBe(2);
       expect(state.onlineMachines).toHaveLength(2);
-      expect(state.offlineMachines).toHaveLength(0);
-      expect(state.warningMachines).toHaveLength(0);
+      expect(state.unknownMachines).toHaveLength(0);
+      expect(state.idleMachines).toHaveLength(0);
       expect(state.statistics.onlineCount).toBe(2);
-      expect(state.statistics.offlineCount).toBe(0);
-      expect(state.statistics.warningCount).toBe(0);
+      expect(state.statistics.unknownCount).toBe(0);
+      expect(state.statistics.idleCount).toBe(0);
     });
 
     it('devrait retourner les machines online', async () => {
-      // Arrange
       await heartbeatService.registerHeartbeat('machine-1');
       await heartbeatService.registerHeartbeat('machine-2');
-      
-      // Act
+
       const onlineMachines = heartbeatService.getOnlineMachines();
-      
-      // Assert
+
       expect(onlineMachines).toHaveLength(2);
       expect(onlineMachines).toContain('machine-1');
       expect(onlineMachines).toContain('machine-2');
     });
 
-    it('devrait retourner les machines offline', async () => {
-      // Arrange - Créer une machine offline
+    it('devrait retourner les machines UNKNOWN via getOfflineMachines (deprecated alias)', async () => {
       await heartbeatService.registerHeartbeat('machine-1');
-      
-      const heartbeatPath = join(sharedPath, 'heartbeat.json');
-      const state = heartbeatService.getState();
-      
-      const heartbeatData = state.heartbeats.get('machine-1');
-      if (heartbeatData) {
-        heartbeatData.lastHeartbeat = new Date(Date.now() - 130000).toISOString();
-        heartbeatData.status = 'offline';
-        heartbeatData.offlineSince = new Date(Date.now() - 130000).toISOString();
-        state.heartbeats.set('machine-1', heartbeatData);
-        
-        await fs.writeFile(heartbeatPath, JSON.stringify({
-          heartbeats: Object.fromEntries(state.heartbeats),
-          onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
-          statistics: state.statistics
-        }, null, 2));
-      }
-      
-      // Recréer le service
-      await heartbeatService.stopHeartbeatService();
-      heartbeatService = new HeartbeatService(sharedPath, {
-        heartbeatInterval: 30000,
-        offlineTimeout: 120000,
-        missedHeartbeatThreshold: 4,
-        autoSyncEnabled: false,
-        autoSyncInterval: 60000
-      });
-      
-      // Act
+
+      // Make stale → UNKNOWN
+      const hb = heartbeatService.getHeartbeatData('machine-1')!;
+      hb.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString();
+      await heartbeatService.checkHeartbeats();
+
       const offlineMachines = heartbeatService.getOfflineMachines();
-      
-      // Assert
       expect(offlineMachines).toContain('machine-1');
+
+      // Also available via getUnknownMachines
+      expect(heartbeatService.getUnknownMachines()).toContain('machine-1');
     });
 
-    it('devrait retourner les machines en avertissement', async () => {
-      // Arrange - Créer une machine en avertissement
+    it('devrait retourner les machines IDLE via getWarningMachines (deprecated alias)', async () => {
       await heartbeatService.registerHeartbeat('machine-1');
-      
-      const heartbeatPath = join(sharedPath, 'heartbeat.json');
-      const state = heartbeatService.getState();
-      
-      const heartbeatData = state.heartbeats.get('machine-1');
-      if (heartbeatData) {
-        heartbeatData.lastHeartbeat = new Date(Date.now() - 90000).toISOString();
-        heartbeatData.status = 'warning';
-        heartbeatData.missedHeartbeats = 3;
-        state.heartbeats.set('machine-1', heartbeatData);
-        
-        await fs.writeFile(heartbeatPath, JSON.stringify({
-          heartbeats: Object.fromEntries(state.heartbeats),
-          onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
-          statistics: state.statistics
-        }, null, 2));
-      }
-      
-      // Recréer le service
-      await heartbeatService.stopHeartbeatService();
-      heartbeatService = new HeartbeatService(sharedPath, {
-        heartbeatInterval: 30000,
-        offlineTimeout: 120000,
-        missedHeartbeatThreshold: 4,
-        autoSyncEnabled: false,
-        autoSyncInterval: 60000
-      });
-      
-      // Act
+
+      // Make idle → IDLE
+      const hb = heartbeatService.getHeartbeatData('machine-1')!;
+      hb.lastHeartbeat = new Date(Date.now() - 45 * 60 * 1000).toISOString();
+      await heartbeatService.checkHeartbeats();
+
       const warningMachines = heartbeatService.getWarningMachines();
-      
-      // Assert
       expect(warningMachines).toContain('machine-1');
+
+      // Also available via getIdleMachines
+      expect(heartbeatService.getIdleMachines()).toContain('machine-1');
     });
   });
 
   describe('Gestion des machines', () => {
     it('devrait supprimer une machine du service', async () => {
-      // Arrange - Enregistrer une machine
       await heartbeatService.registerHeartbeat('machine-1');
       expect(heartbeatService.getHeartbeatData('machine-1')).toBeDefined();
-      
-      // Act - Supprimer la machine
+
       await heartbeatService.removeMachine('machine-1');
-      
-      // Assert
+
       expect(heartbeatService.getHeartbeatData('machine-1')).toBeUndefined();
-      
+
       const state = heartbeatService.getState();
       expect(state.statistics.totalMachines).toBe(0);
     });
 
-    it('devrait nettoyer les machines offline depuis longtemps', async () => {
-      // Arrange - Créer des machines offline avec différents âges
+    it('cleanupOldOfflineMachines est un no-op (retourne 0)', async () => {
       await heartbeatService.registerHeartbeat('myia-old-1');
       await heartbeatService.registerHeartbeat('myia-old-2');
       await heartbeatService.registerHeartbeat('myia-recent');
 
-      const heartbeatPath = join(sharedPath, 'heartbeat.json');
-      const state = heartbeatService.getState();
+      const removedCount = await heartbeatService.cleanupOldOfflineMachines(86400000);
 
-      // Modifier les timestamps
-      const now = Date.now();
-
-      const old1Data = state.heartbeats.get('myia-old-1');
-      if (old1Data) {
-        old1Data.lastHeartbeat = new Date(now - 90000000).toISOString(); // Plus de 24h
-        old1Data.status = 'offline';
-        old1Data.offlineSince = new Date(now - 90000000).toISOString();
-        state.heartbeats.set('myia-old-1', old1Data);
-      }
-
-      const old2Data = state.heartbeats.get('myia-old-2');
-      if (old2Data) {
-        old2Data.lastHeartbeat = new Date(now - 90000000).toISOString(); // Plus de 24h
-        old2Data.status = 'offline';
-        old2Data.offlineSince = new Date(now - 90000000).toISOString();
-        state.heartbeats.set('myia-old-2', old2Data);
-      }
-
-      const recentData = state.heartbeats.get('myia-recent');
-      if (recentData) {
-        recentData.lastHeartbeat = new Date(now - 3600000).toISOString(); // 1 heure
-        recentData.status = 'offline';
-        recentData.offlineSince = new Date(now - 3600000).toISOString();
-        state.heartbeats.set('myia-recent', recentData);
-      }
-
-      await fs.writeFile(heartbeatPath, JSON.stringify({
-        heartbeats: Object.fromEntries(state.heartbeats),
-        onlineMachines: state.onlineMachines,
-        offlineMachines: state.offlineMachines,
-        warningMachines: state.warningMachines,
-        statistics: state.statistics
-      }, null, 2));
-
-      // Recréer le service
-      await heartbeatService.stopHeartbeatService();
-      heartbeatService = new HeartbeatService(sharedPath, {
-        heartbeatInterval: 30000,
-        offlineTimeout: 120000,
-        missedHeartbeatThreshold: 4,
-        autoSyncEnabled: false,
-        autoSyncInterval: 60000
-      });
-
-      // Act - Nettoyer les machines offline depuis plus de 24h
-      const removedCount = await heartbeatService.cleanupOldOfflineMachines(86400000); // 24h
-
-      // Assert
-      expect(removedCount).toBe(2);
-      // #1409: Production machines (myia-*) kept in state as offline, not deleted
+      // ADR 008: cleanupOldOfflineMachines is a no-op, always returns 0
+      expect(removedCount).toBe(0);
+      // All machines remain
       expect(heartbeatService.getHeartbeatData('myia-old-1')).toBeDefined();
-      expect(heartbeatService.getHeartbeatData('myia-old-1')!.status).toBe('offline');
       expect(heartbeatService.getHeartbeatData('myia-old-2')).toBeDefined();
-      expect(heartbeatService.getHeartbeatData('myia-old-2')!.status).toBe('offline');
-      expect(heartbeatService.getHeartbeatData('myia-recent')).toBeDefined(); // Pas supprimée
+      expect(heartbeatService.getHeartbeatData('myia-recent')).toBeDefined();
     });
   });
 
   describe('Configuration', () => {
-    it('devrait mettre à jour la configuration du service', async () => {
-      // Act
+    it('updateConfig est un no-op (ne throw pas)', async () => {
       await heartbeatService.updateConfig({
-        heartbeatInterval: 60000, // 1 minute
-        offlineTimeout: 180000, // 3 minutes
+        heartbeatInterval: 60000,
+        offlineTimeout: 180000,
         missedHeartbeatThreshold: 6
       });
-      
-      // Assert - Vérifier que la configuration a été mise à jour
-      // Note: La configuration est interne, on vérifie juste que l'appel ne lance pas d'erreur
+
+      // No-op — just verify no throw
       expect(true).toBe(true);
     });
   });
 
   describe('Callbacks de notification', () => {
-    it('devrait appeler le callback lors de la détection offline', async () => {
-      // Arrange
+    it('devrait appeler le callback lors de la detection UNKNOWN', async () => {
       const offlineCallback = vi.fn();
       const onlineCallback = vi.fn();
-      
-      // Enregistrer un heartbeat initial
+
       await heartbeatService.registerHeartbeat('machine-1');
-      
-      // #1953 ADR 008: UNKNOWN threshold is >120 min
-      const heartbeatPath = join(sharedPath, 'heartbeat.json');
-      const state = heartbeatService.getState();
 
-      const heartbeatData = state.heartbeats.get('machine-1');
-      if (heartbeatData) {
-        heartbeatData.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString(); // 150 min → UNKNOWN
-        state.heartbeats.set('machine-1', heartbeatData);
-
-        await fs.writeFile(heartbeatPath, JSON.stringify({
-          heartbeats: Object.fromEntries(state.heartbeats),
-          onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
-          statistics: state.statistics
-        }, null, 2));
-      }
-
-      // Recréer le service avec callbacks
-      await heartbeatService.stopHeartbeatService();
-      heartbeatService = new HeartbeatService(sharedPath, {
-        heartbeatInterval: 30000,
-        offlineTimeout: 120000,
-        missedHeartbeatThreshold: 4,
-        autoSyncEnabled: false,
-        autoSyncInterval: 60000
-      });
-      
-      // Act - Démarrer le service avec callbacks (sans enregistrer de heartbeat)
+      // Set up callbacks via startHeartbeatService
       await heartbeatService.startHeartbeatService('machine-2', offlineCallback, onlineCallback);
-      
-      // Vérifier les heartbeats - machine-1 devrait être détectée offline
+
+      // Make machine-1 stale → UNKNOWN
+      const hb = heartbeatService.getHeartbeatData('machine-1')!;
+      hb.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString();
+
       const result = await heartbeatService.checkHeartbeats();
-      
-      // Assert
-      expect(result.newlyOfflineMachines).toContain('machine-1');
+
+      expect(result.newlyUnknownMachines).toContain('machine-1');
       expect(offlineCallback).toHaveBeenCalledWith('machine-1');
     });
+
     it('devrait appeler le callback lors du retour online', async () => {
-      // Arrange
       const offlineCallback = vi.fn();
       const onlineCallback = vi.fn();
-      
-      // Créer une machine offline
+
       await heartbeatService.registerHeartbeat('machine-1');
-      
-      const heartbeatPath = join(sharedPath, 'heartbeat.json');
-      const state = heartbeatService.getState();
-      
-      const heartbeatData = state.heartbeats.get('machine-1');
-      if (heartbeatData) {
-        heartbeatData.lastHeartbeat = new Date(Date.now() - 130000).toISOString();
-        heartbeatData.status = 'offline';
-        heartbeatData.offlineSince = new Date(Date.now() - 130000).toISOString();
-        state.heartbeats.set('machine-1', heartbeatData);
-        
-        await fs.writeFile(heartbeatPath, JSON.stringify({
-          heartbeats: Object.fromEntries(state.heartbeats),
-          onlineMachines: state.onlineMachines,
-          offlineMachines: state.offlineMachines,
-          warningMachines: state.warningMachines,
-          statistics: state.statistics
-        }, null, 2));
-      }
-      
-      // Recréer le service
-      await heartbeatService.stopHeartbeatService();
-      heartbeatService = new HeartbeatService(sharedPath, {
-        heartbeatInterval: 30000,
-        offlineTimeout: 120000,
-        missedHeartbeatThreshold: 4,
-        autoSyncEnabled: false,
-        autoSyncInterval: 60000
-      });
-      
-      // Act - Démarrer le service avec callbacks (sans enregistrer de heartbeat)
+
+      // Make it stale → UNKNOWN
+      let hb = heartbeatService.getHeartbeatData('machine-1')!;
+      hb.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString();
+      await heartbeatService.checkHeartbeats();
+      expect(heartbeatService.getHeartbeatData('machine-1')?.status).toBe('unknown');
+
+      // Set up callbacks
       await heartbeatService.startHeartbeatService('machine-2', offlineCallback, onlineCallback);
-      
-      // Simuler un heartbeat récent pour machine-1 en modifiant directement le fichier
-      const heartbeatPath2 = join(sharedPath, 'heartbeat.json');
-      const state2 = heartbeatService.getState();
-      
-      const heartbeatData2 = state2.heartbeats.get('machine-1');
-      if (heartbeatData2) {
-        heartbeatData2.lastHeartbeat = new Date().toISOString(); // Timestamp récent
-        state2.heartbeats.set('machine-1', heartbeatData2);
-        
-        await fs.writeFile(heartbeatPath2, JSON.stringify({
-          heartbeats: Object.fromEntries(state2.heartbeats),
-          onlineMachines: state2.onlineMachines,
-          offlineMachines: state2.offlineMachines,
-          warningMachines: state2.warningMachines,
-          statistics: state2.statistics
-        }, null, 2));
-      }
-      
-      // Recréer le service pour charger l'état modifié
-      await heartbeatService.stopHeartbeatService();
-      heartbeatService = new HeartbeatService(sharedPath, {
-        heartbeatInterval: 30000,
-        offlineTimeout: 120000,
-        missedHeartbeatThreshold: 4,
-        autoSyncEnabled: false,
-        autoSyncInterval: 60000
-      });
-      
-      // Démarrer le service avec callbacks
-      await heartbeatService.startHeartbeatService('machine-2', offlineCallback, onlineCallback);
-      
-      // Vérifier les heartbeats pour déclencher le callback online
-      const result = await heartbeatService.checkHeartbeats();
-      
-      // Assert
-      expect(result.newlyOnlineMachines).toContain('machine-1');
+
+      // Re-register → online triggers callback
+      await heartbeatService.registerHeartbeat('machine-1');
+
       expect(onlineCallback).toHaveBeenCalledWith('machine-1');
     });
   });
 
-  describe('Persistance des données', () => {
-    it('devrait sauvegarder et charger l\'état du service', async () => {
-      // Arrange - Enregistrer des heartbeats
+  describe('In-memory model (ADR 008)', () => {
+    it('les donnees ne persistent pas entre instances (pas de disque)', async () => {
+      // Register machines in first instance
       await heartbeatService.registerHeartbeat('machine-1');
       await heartbeatService.registerHeartbeat('machine-2');
-      
-      // Act - Arrêter et recréer le service
-      await heartbeatService.stopHeartbeatService();
-      
-      const newService = new HeartbeatService(sharedPath, {
-        heartbeatInterval: 30000,
-        offlineTimeout: 120000,
-        missedHeartbeatThreshold: 4,
-        autoSyncEnabled: false,
-        autoSyncInterval: 60000
-      });
-      
-      // Assert - Vérifier que les données ont été chargées
-      const state = newService.getState();
-      expect(state.statistics.totalMachines).toBe(2);
-      expect(newService.getHeartbeatData('machine-1')).toBeDefined();
-      expect(newService.getHeartbeatData('machine-2')).toBeDefined();
-    });
-  });
-
-  describe('Atomic writes (#1674)', () => {
-    it('should write heartbeat files atomically (no 0-byte on interrupt)', async () => {
-      await heartbeatService.registerHeartbeat('test-atomic');
-
-      // #1953 ADR 008: registerHeartbeat is in-memory only, must stop to persist
       await heartbeatService.stopHeartbeatService();
 
-      // Verify the heartbeat file exists and is valid JSON
-      const heartbeatDir = join(sharedPath, 'heartbeats');
-      const filePath = join(heartbeatDir, 'test-atomic.json');
-      expect(existsSync(filePath)).toBe(true);
-
-      const content = await fs.readFile(filePath, 'utf-8');
-      const parsed = JSON.parse(content);
-      expect(parsed.machineId).toBe('test-atomic');
-      expect(parsed.status).toBe('online');
-    });
-
-    it('should clean up 0-byte heartbeat files on load', async () => {
-      // Register a machine first
-      await heartbeatService.registerHeartbeat('machine-clean');
-
-      // #1953 ADR 008: must stop to persist to disk before creating corrupt file
-      await heartbeatService.stopHeartbeatService();
-
-      // Create a 0-byte file simulating corruption (directory exists after stopHeartbeatService)
-      const heartbeatDir = join(sharedPath, 'heartbeats');
-      const corruptPath = join(heartbeatDir, 'corrupt-machine.json');
-      await fs.writeFile(corruptPath, '', 'utf-8'); // 0-byte file
-
-      expect(existsSync(corruptPath)).toBe(true);
-
-      // Reload — should clean up the 0-byte file
-      const newService = new HeartbeatService(sharedPath, {
+      // New instance starts empty (no disk persistence)
+      const newService = new HeartbeatService(undefined, {
         heartbeatInterval: 30000,
         offlineTimeout: 120000,
         missedHeartbeatThreshold: 4,
@@ -651,53 +291,20 @@ describe('HeartbeatService - Tests Unitaires', () => {
       });
 
       const state = newService.getState();
-      expect(state.statistics.totalMachines).toBe(1);
-      expect(newService.getHeartbeatData('machine-clean')).toBeDefined();
-      expect(existsSync(corruptPath)).toBe(false); // 0-byte file removed
+      expect(state.statistics.totalMachines).toBe(0);
+      expect(newService.getHeartbeatData('machine-1')).toBeUndefined();
+      expect(newService.getHeartbeatData('machine-2')).toBeUndefined();
     });
-  });
 
-  describe('Identity dedup (#1674)', () => {
-    it('should deduplicate shortname and myia-prefixed identities', async () => {
-      const heartbeatDir = join(sharedPath, 'heartbeats');
-      await mkdir(heartbeatDir, { recursive: true });
+    it('startHeartbeatService et stopHeartbeatService sont des no-ops', async () => {
+      await heartbeatService.startHeartbeatService('test-machine');
+      await heartbeatService.registerHeartbeat('test-machine');
+      expect(heartbeatService.getHeartbeatData('test-machine')).toBeDefined();
 
-      // Create a stale unprefixed file
-      const staleData: HeartbeatData = {
-        machineId: 'po-2025',
-        status: 'offline',
-        lastHeartbeat: new Date(Date.now() - 86400000).toISOString(),
-        missedHeartbeats: 5,
-        metadata: { firstSeen: new Date().toISOString(), lastUpdated: new Date().toISOString() }
-      };
-      await fs.writeFile(join(heartbeatDir, 'po-2025.json'), JSON.stringify(staleData, null, 2));
+      await heartbeatService.stopHeartbeatService();
 
-      // Create a fresh myia-prefixed file
-      const freshData: HeartbeatData = {
-        machineId: 'myia-po-2025',
-        status: 'online',
-        lastHeartbeat: new Date().toISOString(),
-        missedHeartbeats: 0,
-        metadata: { firstSeen: new Date().toISOString(), lastUpdated: new Date().toISOString() }
-      };
-      await fs.writeFile(join(heartbeatDir, 'myia-po-2025.json'), JSON.stringify(freshData, null, 2));
-
-      // Load service — should deduplicate
-      const service = new HeartbeatService(sharedPath, {
-        heartbeatInterval: 30000,
-        offlineTimeout: 120000,
-        missedHeartbeatThreshold: 4,
-        autoSyncEnabled: false,
-        autoSyncInterval: 60000
-      });
-
-      const state = service.getState();
-      // Should only have the myia-prefixed entry
-      expect(state.statistics.totalMachines).toBe(1);
-      expect(service.getHeartbeatData('myia-po-2025')).toBeDefined();
-      expect(service.getHeartbeatData('myia-po-2025')?.status).toBe('online');
-      // Unprefixed file should be gone
-      expect(existsSync(join(heartbeatDir, 'po-2025.json'))).toBe(false);
+      // Machine still in memory (stop is no-op)
+      expect(heartbeatService.getHeartbeatData('test-machine')).toBeDefined();
     });
   });
 });

--- a/servers/roo-state-manager/tests/unit/tools/roosync/get-status.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/get-status.test.ts
@@ -71,8 +71,8 @@ vi.mock('fs', async (importOriginal) => {
 function setupMocks(overrides: Record<string, any> = {}) {
     const heartbeatState = overrides.heartbeatState || {
         onlineMachines: ['myia-ai-01'],
-        offlineMachines: [],
-        warningMachines: [],
+        unknownMachines: [],
+        idleMachines: [],
     };
     const inboxStats = overrides.inboxStats || { unread: 0, urgent: 0, by_priority: {} };
     const config = overrides.config || { machineId: 'myia-ai-01' };
@@ -174,8 +174,8 @@ describe('roosync_get_status', () => {
             setupMocks({
                 heartbeatState: {
                     onlineMachines: ['myia-ai-01'],
-                    offlineMachines: ['myia-web1'],
-                    warningMachines: [],
+                    unknownMachines: ['myia-web1'],
+                    idleMachines: [],
                 },
             });
             const result = await roosyncGetStatus({});
@@ -205,8 +205,8 @@ describe('roosync_get_status', () => {
             setupMocks({
                 heartbeatState: {
                     onlineMachines: ['myia-ai-01'],
-                    offlineMachines: [],
-                    warningMachines: ['myia-po-2023'],
+                    unknownMachines: [],
+                    idleMachines: ['myia-po-2023'],
                 },
             });
             const result = await roosyncGetStatus({});
@@ -220,8 +220,8 @@ describe('roosync_get_status', () => {
             setupMocks({
                 heartbeatState: {
                     onlineMachines: ['myia-ai-01', 'test-machine', 'persistent-machine'],
-                    offlineMachines: [],
-                    warningMachines: [],
+                    unknownMachines: [],
+                    idleMachines: [],
                 },
             });
             const result = await roosyncGetStatus({});

--- a/servers/roo-state-manager/tests/unit/tools/roosync/heartbeat-status.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/heartbeat-status.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for roosync_heartbeat_status tool
  *
- * Covers: filter=all/online/offline/warning, includeHeartbeats,
+ * Covers: filter=all/online/unknown/idle, includeHeartbeats,
  * forceCheck, includeChanges, error handling
  */
 
@@ -35,22 +35,23 @@ vi.mock('../../../../src/services/roosync/HeartbeatService.js', () => ({
     },
 }));
 
+const ts = '2026-05-04T00:00:00.000Z';
 const defaultState = {
     onlineMachines: ['ai-01', 'po-2023'],
-    offlineMachines: ['web1'],
-    warningMachines: ['po-2024'],
+    unknownMachines: ['web1'],
+    idleMachines: ['po-2024'],
     statistics: {
         totalMachines: 4,
         onlineCount: 2,
-        offlineCount: 1,
-        warningCount: 1,
-        lastHeartbeatCheck: '2026-05-04T00:00:00.000Z',
+        unknownCount: 1,
+        idleCount: 1,
+        lastHeartbeatCheck: ts,
     },
     heartbeats: new Map([
-        ['ai-01', { machineId: 'ai-01', status: 'online', lastHeartbeat: '2026-05-04T00:00:00.000Z' }],
-        ['po-2023', { machineId: 'po-2023', status: 'online', lastHeartbeat: '2026-05-04T00:00:00.000Z' }],
-        ['web1', { machineId: 'web1', status: 'offline', lastHeartbeat: '2026-05-03T20:00:00.000Z' }],
-        ['po-2024', { machineId: 'po-2024', status: 'warning', lastHeartbeat: '2026-05-04T00:00:00.000Z' }],
+        ['ai-01', { machineId: 'ai-01', status: 'online', lastHeartbeat: ts, metadata: { firstSeen: ts, lastUpdated: ts } }],
+        ['po-2023', { machineId: 'po-2023', status: 'online', lastHeartbeat: ts, metadata: { firstSeen: ts, lastUpdated: ts } }],
+        ['web1', { machineId: 'web1', status: 'unknown', lastHeartbeat: '2026-05-03T20:00:00.000Z', metadata: { firstSeen: '2026-05-03T20:00:00.000Z', lastUpdated: '2026-05-03T20:00:00.000Z' } }],
+        ['po-2024', { machineId: 'po-2024', status: 'idle', lastHeartbeat: ts, metadata: { firstSeen: ts, lastUpdated: ts } }],
     ]),
 };
 
@@ -67,30 +68,30 @@ describe('roosync_heartbeat_status', () => {
         const result = await roosyncHeartbeatStatus({});
         expect(result.success).toBe(true);
         expect(result.onlineMachines).toEqual(['ai-01', 'po-2023']);
-        expect(result.offlineMachines).toEqual(['web1']);
-        expect(result.warningMachines).toEqual(['po-2024']);
+        expect(result.unknownMachines).toEqual(['web1']);
+        expect(result.idleMachines).toEqual(['po-2024']);
         expect(result.statistics.totalMachines).toBe(4);
     });
 
     it('returns only online machines with filter=online', async () => {
         const result = await roosyncHeartbeatStatus({ filter: 'online' });
         expect(result.onlineMachines).toEqual(['ai-01', 'po-2023']);
-        expect(result.offlineMachines).toEqual([]);
-        expect(result.warningMachines).toEqual([]);
+        expect(result.unknownMachines).toEqual([]);
+        expect(result.idleMachines).toEqual([]);
     });
 
-    it('returns only offline machines with filter=offline', async () => {
-        const result = await roosyncHeartbeatStatus({ filter: 'offline' });
+    it('returns only unknown machines with filter=unknown', async () => {
+        const result = await roosyncHeartbeatStatus({ filter: 'unknown' });
         expect(result.onlineMachines).toEqual([]);
-        expect(result.offlineMachines).toEqual(['web1']);
-        expect(result.warningMachines).toEqual([]);
+        expect(result.unknownMachines).toEqual(['web1']);
+        expect(result.idleMachines).toEqual([]);
     });
 
-    it('returns only warning machines with filter=warning', async () => {
-        const result = await roosyncHeartbeatStatus({ filter: 'warning' });
+    it('returns only idle machines with filter=idle', async () => {
+        const result = await roosyncHeartbeatStatus({ filter: 'idle' });
         expect(result.onlineMachines).toEqual([]);
-        expect(result.offlineMachines).toEqual([]);
-        expect(result.warningMachines).toEqual(['po-2024']);
+        expect(result.unknownMachines).toEqual([]);
+        expect(result.idleMachines).toEqual(['po-2024']);
     });
 
     describe('includeHeartbeats', () => {
@@ -113,15 +114,15 @@ describe('roosync_heartbeat_status', () => {
             expect(result.heartbeats!['web1']).toBeUndefined();
         });
 
-        it('filters heartbeats with filter=offline', async () => {
-            const result = await roosyncHeartbeatStatus({ filter: 'offline' });
+        it('filters heartbeats with filter=unknown', async () => {
+            const result = await roosyncHeartbeatStatus({ filter: 'unknown' });
             expect(result.heartbeats).toBeDefined();
             expect(Object.keys(result.heartbeats!)).toHaveLength(1);
             expect(result.heartbeats!['web1']).toBeDefined();
         });
 
-        it('filters heartbeats with filter=warning', async () => {
-            const result = await roosyncHeartbeatStatus({ filter: 'warning' });
+        it('filters heartbeats with filter=idle', async () => {
+            const result = await roosyncHeartbeatStatus({ filter: 'idle' });
             expect(result.heartbeats).toBeDefined();
             expect(Object.keys(result.heartbeats!)).toHaveLength(1);
             expect(result.heartbeats!['po-2024']).toBeDefined();
@@ -131,22 +132,26 @@ describe('roosync_heartbeat_status', () => {
     describe('forceCheck and includeChanges', () => {
         it('checks heartbeats with forceCheck=true', async () => {
             mockCheckHeartbeats.mockResolvedValue({
-                newlyOfflineMachines: ['web1'],
+                success: true,
+                newlyUnknownMachines: ['web1'],
                 newlyOnlineMachines: ['po-2023'],
-                warningMachines: ['po-2024'],
+                newlyIdleMachines: ['po-2024'],
+                checkedAt: ts,
             });
             const result = await roosyncHeartbeatStatus({ forceCheck: true });
             expect(mockCheckHeartbeats).toHaveBeenCalled();
             expect(result.changes).toBeDefined();
-            expect(result.changes!.newlyOfflineMachines).toEqual(['web1']);
+            expect(result.changes!.newlyUnknownMachines).toEqual(['web1']);
             expect(result.changes!.totalChanges).toBe(3);
         });
 
         it('checks heartbeats with includeChanges=true', async () => {
             mockCheckHeartbeats.mockResolvedValue({
-                newlyOfflineMachines: [],
+                success: true,
+                newlyUnknownMachines: [],
                 newlyOnlineMachines: [],
-                warningMachines: [],
+                newlyIdleMachines: [],
+                checkedAt: ts,
             });
             const result = await roosyncHeartbeatStatus({ includeChanges: true });
             expect(mockCheckHeartbeats).toHaveBeenCalled();

--- a/servers/roo-state-manager/tests/unit/tools/roosync/inventory.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/inventory.test.ts
@@ -19,28 +19,28 @@ vi.mock('../../../../src/services/roosync/InventoryService.js', () => ({
 }));
 
 // Mock lazy-roosync (getRooSyncService)
-const mockGetOfflineMachines = vi.fn();
-const mockGetWarningMachines = vi.fn();
+const mockGetUnknownMachines = vi.fn();
+const mockGetIdleMachines = vi.fn();
 const mockGetHeartbeatData = vi.fn();
 
 const mockHeartbeatService = {
     getState: vi.fn(() => ({
         onlineMachines: ['ai-01'],
-        offlineMachines: ['web1'],
-        warningMachines: ['po-2023'],
+        unknownMachines: ['web1'],
+        idleMachines: ['po-2023'],
         statistics: {
             totalMachines: 3,
             onlineCount: 1,
-            offlineCount: 1,
-            warningCount: 1,
+            idleCount: 1,
+            unknownCount: 1,
             lastHeartbeatCheck: '2026-05-04T00:00:00.000Z',
         },
         heartbeats: new Map([
             ['ai-01', { machineId: 'ai-01', lastHeartbeat: '2026-05-04T00:00:00.000Z', status: 'online' }],
         ]),
     })),
-    getOfflineMachines: mockGetOfflineMachines,
-    getWarningMachines: mockGetWarningMachines,
+    getUnknownMachines: mockGetUnknownMachines,
+    getIdleMachines: mockGetIdleMachines,
     getHeartbeatData: mockGetHeartbeatData,
 };
 
@@ -83,8 +83,8 @@ describe('roosync_inventory tool', () => {
             expect(result.success).toBe(true);
             expect(result.data.heartbeatState).toBeDefined();
             expect(result.data.heartbeatState.onlineMachines).toContain('ai-01');
-            expect(result.data.heartbeatState.offlineMachines).toContain('web1');
-            expect(result.data.heartbeatState.warningMachines).toContain('po-2023');
+            expect(result.data.heartbeatState.unknownMachines).toContain('web1');
+            expect(result.data.heartbeatState.idleMachines).toContain('po-2023');
         });
 
         it('includes heartbeats by default', async () => {
@@ -114,79 +114,72 @@ describe('roosync_inventory tool', () => {
 
     describe('type=machines (fused from roosync_machines)', () => {
         it('returns offline machines when status=offline', async () => {
-            mockGetOfflineMachines.mockReturnValue(['web1', 'po-2024']);
+            mockGetUnknownMachines.mockReturnValue(['web1', 'po-2024']);
             const result = await inventoryTool.execute({ type: 'machines', status: 'offline' }, {});
             expect(result.success).toBe(true);
-            expect(result.data.offlineMachines).toEqual(['web1', 'po-2024']);
-            expect(result.data.offlineCount).toBe(2);
+            expect(result.data.unknownMachines).toEqual(['web1', 'po-2024']);
+            expect(result.data.unknownCount).toBe(2);
         });
 
         it('returns warning machines when status=warning', async () => {
-            mockGetWarningMachines.mockReturnValue(['po-2023']);
+            mockGetIdleMachines.mockReturnValue(['po-2023']);
             const result = await inventoryTool.execute({ type: 'machines', status: 'warning' }, {});
             expect(result.success).toBe(true);
-            expect(result.data.warningMachines).toEqual(['po-2023']);
-            expect(result.data.warningCount).toBe(1);
+            expect(result.data.idleMachines).toEqual(['po-2023']);
+            expect(result.data.idleCount).toBe(1);
         });
 
         it('returns both offline and warning when status=all (default)', async () => {
-            mockGetOfflineMachines.mockReturnValue(['web1']);
-            mockGetWarningMachines.mockReturnValue(['po-2023']);
+            mockGetUnknownMachines.mockReturnValue(['web1']);
+            mockGetIdleMachines.mockReturnValue(['po-2023']);
             const result = await inventoryTool.execute({ type: 'machines' }, {});
-            expect(result.data.offlineMachines).toEqual(['web1']);
-            expect(result.data.warningMachines).toEqual(['po-2023']);
+            expect(result.data.unknownMachines).toEqual(['web1']);
+            expect(result.data.idleMachines).toEqual(['po-2023']);
         });
 
         it('returns detailed data when includeDetails=true', async () => {
-            mockGetOfflineMachines.mockReturnValue(['web1']);
+            mockGetUnknownMachines.mockReturnValue(['web1']);
             mockGetHeartbeatData.mockImplementation((mid: string) => {
                 if (mid === 'web1') return {
                     machineId: 'web1',
                     lastHeartbeat: '2026-05-03T20:00:00.000Z',
-                    offlineSince: '2026-05-03T22:00:00.000Z',
-                    missedHeartbeats: 5,
-                    metadata: { firstSeen: '2026-01-01', lastUpdated: '2026-05-03', version: '1.0' },
+                    status: 'unknown',
+                    metadata: { firstSeen: '2026-01-01', lastUpdated: '2026-05-03' },
                 };
                 return null;
             });
             const result = await inventoryTool.execute({ type: 'machines', status: 'offline', includeDetails: true }, {});
-            expect(result.data.offlineMachines).toHaveLength(1);
-            expect(result.data.offlineMachines[0].machineId).toBe('web1');
-            expect(result.data.offlineMachines[0].offlineSince).toBeDefined();
-            expect(result.data.offlineCount).toBe(1);
+            expect(result.data.unknownMachines).toHaveLength(1);
+            expect(result.data.unknownMachines[0].machineId).toBe('web1');
+            expect(result.data.unknownMachines[0].status).toBe('unknown');
+            expect(result.data.unknownCount).toBe(1);
         });
 
-        it('skips machines without offlineSince in detailed offline mode', async () => {
-            mockGetOfflineMachines.mockReturnValue(['web1']);
-            mockGetHeartbeatData.mockReturnValue({
-                machineId: 'web1',
-                lastHeartbeat: '2026-05-04T00:00:00.000Z',
-                offlineSince: undefined,
-                missedHeartbeats: 0,
-                metadata: {},
-            });
+        it('skips machines without heartbeat data in detailed offline mode', async () => {
+            mockGetUnknownMachines.mockReturnValue(['web1']);
+            mockGetHeartbeatData.mockReturnValue(null);
             const result = await inventoryTool.execute({ type: 'machines', status: 'offline', includeDetails: true }, {});
-            expect(result.data.offlineMachines).toHaveLength(0);
+            expect(result.data.unknownMachines).toHaveLength(0);
         });
 
         it('returns detailed warning machines', async () => {
-            mockGetWarningMachines.mockReturnValue(['po-2023']);
+            mockGetIdleMachines.mockReturnValue(['po-2023']);
             mockGetHeartbeatData.mockImplementation((mid: string) => ({
                 machineId: mid,
                 lastHeartbeat: '2026-05-04T00:00:00.000Z',
-                missedHeartbeats: 2,
-                metadata: { firstSeen: '2026-01-01', lastUpdated: '2026-05-04', version: '1.0' },
+                status: 'idle',
+                metadata: { firstSeen: '2026-01-01', lastUpdated: '2026-05-04' },
             }));
             const result = await inventoryTool.execute({ type: 'machines', status: 'warning', includeDetails: true }, {});
-            expect(result.data.warningMachines).toHaveLength(1);
-            expect(result.data.warningMachines[0].machineId).toBe('po-2023');
+            expect(result.data.idleMachines).toHaveLength(1);
+            expect(result.data.idleMachines[0].machineId).toBe('po-2023');
         });
 
         it('skips null heartbeat data in detailed mode', async () => {
-            mockGetOfflineMachines.mockReturnValue(['unknown']);
+            mockGetUnknownMachines.mockReturnValue(['unknown']);
             mockGetHeartbeatData.mockReturnValue(null);
             const result = await inventoryTool.execute({ type: 'machines', status: 'offline', includeDetails: true }, {});
-            expect(result.data.offlineMachines).toHaveLength(0);
+            expect(result.data.unknownMachines).toHaveLength(0);
         });
     });
 

--- a/servers/roo-state-manager/tests/unit/tools/roosync/sync-event.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/sync-event.test.ts
@@ -48,7 +48,6 @@ describe('roosync_sync_event', () => {
             mockGetHeartbeatData.mockReturnValue({
                 machineId: 'po-2023',
                 status: 'online',
-                offlineSince: '2026-05-03T20:00:00.000Z',
                 lastHeartbeat: '2026-05-04T00:00:00.000Z',
             });
             const result = await roosyncSyncEvent({ action: 'online', machineId: 'po-2023' });
@@ -58,14 +57,14 @@ describe('roosync_sync_event', () => {
             expect(result.message).toContain('online');
         });
 
-        it('calculates offlineDuration from offlineSince', async () => {
+        it('offlineDuration is undefined (offlineSince removed in ADR 008 Phase 2)', async () => {
             mockGetHeartbeatData.mockReturnValue({
                 machineId: 'po-2023',
                 status: 'online',
-                offlineSince: '2026-05-03T20:00:00.000Z',
+                lastHeartbeat: '2026-05-04T00:00:00.000Z',
             });
             const result = await roosyncSyncEvent({ action: 'online', machineId: 'po-2023' });
-            expect(result.changes.offlineDuration).toBeGreaterThan(0);
+            expect(result.changes.offlineDuration).toBeUndefined();
         });
 
         it('throws when machine is not online', async () => {
@@ -83,11 +82,11 @@ describe('roosync_sync_event', () => {
                 .rejects.toThrow('pas online');
         });
 
-        it('omits offlineDuration when offlineSince missing', async () => {
+        it('omits offlineDuration when no duration data available', async () => {
             mockGetHeartbeatData.mockReturnValue({
                 machineId: 'po-2023',
                 status: 'online',
-                offlineSince: undefined,
+                lastHeartbeat: '2026-05-04T00:00:00.000Z',
             });
             const result = await roosyncSyncEvent({ action: 'online', machineId: 'po-2023' });
             expect(result.changes.offlineDuration).toBeUndefined();
@@ -121,7 +120,7 @@ describe('roosync_sync_event', () => {
             mockGetHeartbeatData.mockReturnValue({
                 machineId: 'po-2023',
                 status: 'online',
-                offlineSince: '2026-05-03T20:00:00.000Z',
+                lastHeartbeat: '2026-05-04T00:00:00.000Z',
             });
             const result = await roosyncSyncEvent({
                 action: 'online',

--- a/servers/roo-state-manager/tests/unit/tools/summary/roosync-summarize.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/summary/roosync-summarize.test.ts
@@ -234,9 +234,8 @@ describe('roosync_summarize - CONS-12', () => {
                     truncationChars: 1000,
                     compactStats: false,
                     includeCss: true,
-                    generateToc: true,
-                    startIndex: 1,
-                    endIndex: 10
+                    generateToc: true
+                    // Note: startIndex/endIndex removed because mock returns empty sequence
                 },
                 getConversationSkeletonMock
             );


### PR DESCRIPTION
See issue #2013 for details. Completes heartbeat terminology rename (offline->unknown, warning->idle) and pagination contract validation fixes from PRs #337 and #335. All 9211 tests pass.