### PR TITLE
fix(#2013): heartbeat terminology rename + pagination contract

### DIFF
--- a/servers/roo-state-manager/src/services/RooSyncService.ts
+++ b/servers/roo-state-manager/src/services/RooSyncService.ts
@@ -994,17 +994,31 @@ export class RooSyncService {
   }
 
   /**
-   * Obtient les machines actuellement offline
+   * @deprecated Use getUnknownMachines() — terminology rename
    */
   public getOfflineMachines(): string[] {
-    return this.heartbeatService.getOfflineMachines();
+    return this.heartbeatService.getUnknownMachines();
   }
 
   /**
-   * Obtient les machines en avertissement
+   * Obtient les machines avec statut UNKNOWN (offline)
+   */
+  public getUnknownMachines(): string[] {
+    return this.heartbeatService.getUnknownMachines();
+  }
+
+  /**
+   * @deprecated Use getIdleMachines() — terminology rename
    */
   public getWarningMachines(): string[] {
-    return this.heartbeatService.getWarningMachines();
+    return this.heartbeatService.getIdleMachines();
+  }
+
+  /**
+   * Obtient les machines avec statut IDLE (warning)
+   */
+  public getIdleMachines(): string[] {
+    return this.heartbeatService.getIdleMachines();
   }
 
   /**

--- a/servers/roo-state-manager/src/services/trace-summary/ContentClassifier.ts
+++ b/servers/roo-state-manager/src/services/trace-summary/ContentClassifier.ts
@@ -32,16 +32,27 @@ export class ContentClassifier {
 
         // Appliquer le filtrage par plage si spécifié
         if (options && (options.startIndex !== undefined || options.endIndex !== undefined)) {
-            const startIdx = options.startIndex ? Math.max(1, options.startIndex) - 1 : 0; // Convert to 0-based
-            const endIdx = options.endIndex ? Math.min(messages.length, options.endIndex) : messages.length; // Convert to 0-based + 1
+            const rawStart = options.startIndex ?? 1;
+            const rawEnd = options.endIndex ?? (conversation.sequence ?? []).length;
 
-            // Valider les indices
-            if (startIdx < messages.length && endIdx > startIdx) {
-                messages = messages.slice(startIdx, endIdx);
-                // Log pour debugging
-                console.log(`[Range Filter] Processing messages ${startIdx + 1} to ${endIdx} (${messages.length} messages)`);
+            if (rawEnd < 0) {
+                throw new Error(`Invalid endIndex: ${rawEnd}. endIndex must be >= 0.`);
+            }
+            if (rawStart < 0) {
+                throw new Error(`Invalid startIndex: ${rawStart}. startIndex must be >= 0.`);
+            }
+            if (rawStart >= rawEnd) {
+                throw new Error(`Invalid range: startIndex (${rawStart}) >= endIndex (${rawEnd}).`);
+            }
+
+            const startIdx = Math.max(0, rawStart - 1); // Convert to 0-based
+            const endIdx = Math.min(messages.length, rawEnd);
+
+            // Graceful: out-of-range returns empty instead of throwing
+            if (startIdx >= messages.length) {
+                messages = [];
             } else {
-                console.warn(`[Range Filter] Invalid range: start=${options.startIndex}, end=${options.endIndex}, total=${(conversation.sequence ?? []).length}`);
+                messages = messages.slice(startIdx, endIdx);
             }
         }
 

--- a/servers/roo-state-manager/src/services/trace-summary/__tests__/ContentClassifier.test.ts
+++ b/servers/roo-state-manager/src/services/trace-summary/__tests__/ContentClassifier.test.ts
@@ -788,9 +788,9 @@ describe('ContentClassifier', () => {
             expect(result[2].content).toBe('msg4');
         });
 
-        it('should warn on invalid range', () => {
+        it('should return empty on startIndex exceeding message count', () => {
             const conv = makeSkeleton([makeMessage('user', 'msg1')]);
-            classifier.classifyConversationContent(conv, {
+            const result = classifier.classifyConversationContent(conv, {
                 startIndex: 10,
                 endIndex: 20,
                 detailLevel: 'Full',
@@ -800,7 +800,34 @@ describe('ContentClassifier', () => {
                 generateToc: false,
                 outputFormat: 'markdown',
             });
-            expect(consoleWarnSpy).toHaveBeenCalled();
+            expect(result).toHaveLength(0);
+        });
+
+        it('should throw on negative endIndex', () => {
+            const conv = makeSkeleton([makeMessage('user', 'msg1')]);
+            expect(() => classifier.classifyConversationContent(conv, {
+                endIndex: -5,
+                detailLevel: 'Full',
+                truncationChars: 1000,
+                compactStats: false,
+                includeCss: false,
+                generateToc: false,
+                outputFormat: 'markdown',
+            })).toThrow(/endIndex.*must be >= 0/);
+        });
+
+        it('should throw on startIndex >= endIndex', () => {
+            const conv = makeSkeleton([makeMessage('user', 'msg1')]);
+            expect(() => classifier.classifyConversationContent(conv, {
+                startIndex: 5,
+                endIndex: 3,
+                detailLevel: 'Full',
+                truncationChars: 1000,
+                compactStats: false,
+                includeCss: false,
+                generateToc: false,
+                outputFormat: 'markdown',
+            })).toThrow(/startIndex.*>=.*endIndex/);
         });
 
         it('should set toolType and resultType for ToolResult user messages', () => {

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/inventory.integration.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/inventory.integration.test.ts
@@ -113,7 +113,6 @@ describe('roosync_inventory (integration)', () => {
       expect(shape.machineId).toBeDefined();
       expect(shape.lastHeartbeat).toBeDefined();
       expect(shape.status).toBeDefined();
-      expect(shape.missedHeartbeats).toBeDefined();
       expect(shape.metadata).toBeDefined();
     });
 

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/machines.smoke.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/machines.smoke.test.ts
@@ -35,7 +35,7 @@ describe('SMOKE: roosync_machines', () => {
    */
   function makeHeartbeatData(
     machineId: string,
-    status: 'online' | 'offline' | 'warning',
+    status: 'online' | 'unknown' | 'idle',
     minutesAgo: number = 0
   ): Record<string, any> {
     const now = Date.now();
@@ -45,20 +45,12 @@ describe('SMOKE: roosync_machines', () => {
       machineId,
       lastHeartbeat,
       status,
-      missedHeartbeats: 0,
       metadata: {
         firstSeen: lastHeartbeat,
         lastUpdated: new Date(now).toISOString(),
         version: '3.1.0',
       },
     };
-
-    // For offline machines, include offlineSince timestamp
-    // (HeartbeatService sets this when marking a machine as offline)
-    if (status === 'offline') {
-      data.offlineSince = lastHeartbeat;
-      data.missedHeartbeats = Math.floor(minutesAgo / 5); // ~5 min heartbeat interval
-    }
 
     return data;
   }
@@ -128,7 +120,7 @@ describe('SMOKE: roosync_machines', () => {
 
     expect(result1.success).toBe(true);
     expect(result1.data).toBeDefined();
-    expect(result1.data.offlineMachines).toHaveLength(0); // No offline machines initially
+    expect(result1.data.unknownMachines).toHaveLength(0); // No offline machines initially
 
     // Step 3: Modify the underlying state (simulate machine going offline)
     const modifiedMachines = {
@@ -146,8 +138,8 @@ describe('SMOKE: roosync_machines', () => {
 
     // Step 5: Verify that result2 reflects the state change (fresh offline list, not cached)
     expect(result2.success).toBe(true);
-    expect(result2.data.offlineMachines).toHaveLength(1);
-    expect(result2.data.offlineMachines[0].machineId).toBe('test-machine-1');
+    expect(result2.data.unknownMachines).toHaveLength(1);
+    expect(result2.data.unknownMachines[0].machineId).toBe('test-machine-1');
 
     // This validates that offline machines are read fresh from heartbeat state,
     // not from stale cached data that would show 0 offline machines
@@ -165,8 +157,8 @@ describe('SMOKE: roosync_machines', () => {
     const result1 = await roosyncMachines({ status: 'warning', includeDetails: true });
 
     expect(result1.success).toBe(true);
-    expect(result1.data.warningMachines).toBeDefined();
-    expect(result1.data.warningMachines).toHaveLength(0); // No warning machines initially
+    expect(result1.data.idleMachines).toBeDefined();
+    expect(result1.data.idleMachines).toHaveLength(0); // No warning machines initially
 
     // Step 3: Modify the underlying state (simulate machine entering warning state)
     const modifiedMachines = {
@@ -183,8 +175,8 @@ describe('SMOKE: roosync_machines', () => {
 
     // Step 5: Verify that result2 reflects the state change (fresh warning list, not cached)
     expect(result2.success).toBe(true);
-    expect(result2.data.warningMachines).toHaveLength(1);
-    expect(result2.data.warningMachines[0].machineId).toBe('test-machine-3');
+    expect(result2.data.idleMachines).toHaveLength(1);
+    expect(result2.data.idleMachines[0].machineId).toBe('test-machine-3');
 
     // This validates that warning machines are read fresh from heartbeat state,
     // not returning stale cached results
@@ -202,8 +194,8 @@ describe('SMOKE: roosync_machines', () => {
     const result1 = await roosyncMachines({ status: 'all', includeDetails: true });
 
     expect(result1.success).toBe(true);
-    expect(result1.data.offlineMachines).toHaveLength(0);
-    expect(result1.data.warningMachines).toHaveLength(0);
+    expect(result1.data.unknownMachines).toHaveLength(0);
+    expect(result1.data.idleMachines).toHaveLength(0);
 
     // Step 3: Modify the underlying state (add more machines with different statuses)
     const modifiedMachines = {
@@ -222,13 +214,13 @@ describe('SMOKE: roosync_machines', () => {
 
     // Step 5: Verify that result2 reflects the state change
     expect(result2.success).toBe(true);
-    // With status: 'all', we get both offlineMachines and warningMachines
-    expect(result2.data.offlineMachines).toHaveLength(1);
-    expect(result2.data.warningMachines).toHaveLength(1);
+    // With status: 'all', we get both unknownMachines and idleMachines
+    expect(result2.data.unknownMachines).toHaveLength(1);
+    expect(result2.data.idleMachines).toHaveLength(1);
 
     // Verify machine IDs are correct
-    expect(result2.data.offlineMachines[0].machineId).toBe('test-machine-5');
-    expect(result2.data.warningMachines[0].machineId).toBe('test-machine-6');
+    expect(result2.data.unknownMachines[0].machineId).toBe('test-machine-5');
+    expect(result2.data.idleMachines[0].machineId).toBe('test-machine-6');
 
     // This validates that the machine list is computed fresh from heartbeat state,
     // not showing stale list that would only have 1 machine

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -400,7 +400,7 @@ export const roosyncInventoryDefinition = {
             type: { type: 'string', enum: ['machine', 'heartbeat', 'all', 'machines', 'status'], description: 'Inventory type. "machines" = offline/warning only. "status" = compact system snapshot with flags.' },
             machineId: { type: 'string', description: 'Machine ID (default: hostname). For type="status", acts as machineFilter.' },
             includeHeartbeats: { type: 'boolean', description: 'Include heartbeat data (default: true, type=heartbeat|all)' },
-            status: { type: 'string', enum: ['offline', 'warning', 'all'], description: 'Filter by status (type="machines")' },
+            status: { type: 'string', enum: ['unknown', 'idle', 'all', 'offline', 'warning'], description: 'Filter by status (type="machines")' },
             includeDetails: { type: 'boolean', description: 'Full machine details (type="machines") or tool usage stats (type="status")' },
             detail: { type: 'string', enum: ['compact', 'full'], description: 'Detail level for type="status". "full" adds claims + pipeline stages (#1855 HUD)' },
             resetCache: { type: 'boolean', description: 'Force service cache reset (type="status" only, default: false)' }

--- a/servers/roo-state-manager/src/types/machine-config.ts
+++ b/servers/roo-state-manager/src/types/machine-config.ts
@@ -155,8 +155,7 @@ export interface RooSyncState {
   heartbeat?: {
     registered: boolean;
     lastHeartbeat?: string;
-    status?: 'online' | 'offline' | 'warning';
-    missedHeartbeats?: number;
+    status?: 'online' | 'unknown' | 'idle';
   };
 
   /** Messaging stats */

--- a/servers/roo-state-manager/tests/e2e/roosync-multi-machine-sync.test.ts
+++ b/servers/roo-state-manager/tests/e2e/roosync-multi-machine-sync.test.ts
@@ -508,7 +508,7 @@ describe('RooSync E2E - Synchronisation Multi-Machines', () => {
         expect(result).toBeDefined();
         expect(result.success).toBe(true);
         expect(result.onlineMachines).toBeDefined();
-        expect(result.offlineMachines).toBeDefined();
+        expect(result.unknownMachines).toBeDefined();
         expect(result.statistics).toBeDefined();
 
         console.log('✅ État des heartbeats obtenu');

--- a/servers/roo-state-manager/tests/unit/services/RooSyncService.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/RooSyncService.test.ts
@@ -346,8 +346,8 @@ describe('RooSyncService', () => {
       });
     });
 
-    describe('getOfflineMachines', () => {
-      it('devrait retourner la liste des machines offline', async () => {
+    describe('getUnknownMachines', () => {
+      it('devrait retourner la liste des machines unknown', async () => {
         // Arrange
         const service = getRooSyncService();
         const heartbeatService = service.getHeartbeatService();
@@ -362,8 +362,7 @@ describe('RooSyncService', () => {
         const machineData = {
           machineId: 'test-machine-1',
           lastHeartbeat: new Date(Date.now() - 300000).toISOString(), // 5 minutes avant
-          status: 'offline',
-          missedHeartbeats: 10,
+          status: 'unknown',
           metadata: {
             firstSeen: new Date().toISOString(),
             lastUpdated: new Date().toISOString(),
@@ -379,15 +378,15 @@ describe('RooSyncService', () => {
         const newService = getRooSyncService();
 
         // Act
-        const offlineMachines = newService.getOfflineMachines();
+        const unknownMachines = newService.getUnknownMachines();
 
         // Assert
-        expect(offlineMachines).toContain('test-machine-1');
+        expect(unknownMachines).toContain('test-machine-1');
       });
     });
 
-    describe('getWarningMachines', () => {
-      it('devrait retourner la liste des machines en avertissement', async () => {
+    describe('getIdleMachines', () => {
+      it('devrait retourner la liste des machines idle', async () => {
         // Arrange
         const service = getRooSyncService();
         const heartbeatService = service.getHeartbeatService();
@@ -402,8 +401,7 @@ describe('RooSyncService', () => {
         const machineData = {
           machineId: 'test-machine-2',
           lastHeartbeat: new Date(Date.now() - 90000).toISOString(), // 90 secondes avant
-          status: 'warning',
-          missedHeartbeats: 3,
+          status: 'idle',
           metadata: {
             firstSeen: new Date().toISOString(),
             lastUpdated: new Date().toISOString(),
@@ -417,10 +415,10 @@ describe('RooSyncService', () => {
         const newService = getRooSyncService();
 
         // Act
-        const warningMachines = newService.getWarningMachines();
+        const idleMachines = newService.getIdleMachines();
 
         // Assert
-        expect(warningMachines).toContain('test-machine-2');
+        expect(idleMachines).toContain('test-machine-2');
       });
     });
 
@@ -441,8 +439,8 @@ describe('RooSyncService', () => {
         expect(state).toBeDefined();
         expect(state.heartbeats).toBeInstanceOf(Map);
         expect(state.onlineMachines).toBeInstanceOf(Array);
-        expect(state.offlineMachines).toBeInstanceOf(Array);
-        expect(state.warningMachines).toBeInstanceOf(Array);
+        expect(state.unknownMachines).toBeInstanceOf(Array);
+        expect(state.idleMachines).toBeInstanceOf(Array);
         expect(state.statistics).toBeDefined();
         expect(state.statistics.totalMachines).toBeGreaterThanOrEqual(2);
       });
@@ -530,9 +528,9 @@ describe('RooSyncService', () => {
         expect(result).toBeDefined();
         expect(result.success).toBe(true);
         expect(result.checkedAt).toBeDefined();
-        expect(Array.isArray(result.newlyOfflineMachines)).toBe(true);
+        expect(Array.isArray(result.newlyUnknownMachines)).toBe(true);
         expect(Array.isArray(result.newlyOnlineMachines)).toBe(true);
-        expect(Array.isArray(result.warningMachines)).toBe(true);
+        expect(Array.isArray(result.newlyIdleMachines)).toBe(true);
       });
     });
   });


### PR DESCRIPTION
## Summary
- Rename heartbeat status enum: `offline` → `unknown`, `warning` → `idle` in `machine-config.ts`
- Remove unused `missedHeartbeats` field from heartbeat config type
- Fix ContentClassifier pagination: throw on negative/invalid ranges, graceful empty return when startIndex exceeds message count

## Test plan
- [x] Build passes clean (`npm run build`)
- [x] CI test suite: 457 passed, 0 failed (`npx vitest run --config vitest.config.ci.ts`)
- [x] `machines.smoke.test.ts` updated for new status values
- [x] `ContentClassifier.test.ts` updated with 3 new validation edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)