### PR TITLE
feat(#1987 Phase 3a): noise filter for Qdrant indexation

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/noise-filter.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/noise-filter.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NoiseFilter } from '../noise-filter.js';
+import { SkeletonHeader } from '../../types/conversation.js';
+
+function makeSkeleton(overrides: Partial<SkeletonHeader['metadata']> & { taskId?: string; parentTaskId?: string }): SkeletonHeader {
+    const taskId = overrides.taskId || 'test-task-001';
+    return {
+        taskId,
+        parentTaskId: overrides.parentTaskId,
+        metadata: {
+            lastActivity: overrides.lastActivity || new Date().toISOString(),
+            createdAt: overrides.createdAt || new Date().toISOString(),
+            messageCount: overrides.messageCount ?? 50,
+            actionCount: overrides.actionCount ?? 20,
+            totalSize: overrides.totalSize ?? 10000,
+            mode: overrides.mode,
+            workspace: overrides.workspace,
+            machineId: overrides.machineId,
+            source: overrides.source,
+        },
+    };
+}
+
+function makeOldDate(daysAgo: number): string {
+    return new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+}
+
+describe('NoiseFilter', () => {
+    let filter: NoiseFilter;
+
+    beforeEach(() => {
+        filter = new NoiseFilter();
+    });
+
+    describe('blacklist', () => {
+        it('matches blacklisted task IDs', () => {
+            filter.loadBlacklist(['bad-task-1', 'bad-task-2']);
+            const skeleton = makeSkeleton({ taskId: 'bad-task-1' });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(true);
+            expect(result.pattern).toBe('blacklist');
+        });
+
+        it('does not match non-blacklisted tasks', () => {
+            filter.loadBlacklist(['bad-task-1']);
+            const skeleton = makeSkeleton({ taskId: 'good-task-1' });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(false);
+        });
+
+        it('reports blacklist size', () => {
+            filter.loadBlacklist(['a', 'b', 'c']);
+            expect(filter.blacklistSize).toBe(3);
+        });
+    });
+
+    describe('scheduled-repetitive pattern', () => {
+        it('matches scheduled mode with age + volume', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'test-task',
+                mode: 'scheduled',
+                lastActivity: makeOldDate(60),
+                messageCount: 500,
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(true);
+            expect(result.pattern).toBe('scheduled-repetitive');
+        });
+
+        it('matches automated taskId pattern with age + volume', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'worker-build-check-001',
+                lastActivity: makeOldDate(45),
+                messageCount: 300,
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(true);
+            expect(result.pattern).toBe('scheduled-repetitive');
+        });
+
+        it('does not match recent scheduled tasks', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'test-task',
+                mode: 'scheduled',
+                lastActivity: makeOldDate(5),
+                messageCount: 500,
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(false);
+        });
+
+        it('does not match small scheduled tasks', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'test-task',
+                mode: 'scheduled',
+                lastActivity: makeOldDate(60),
+                messageCount: 10,
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(false);
+        });
+    });
+
+    describe('runaway-spiral pattern', () => {
+        it('matches huge task with tool-dominated content', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'test-task',
+                messageCount: 15000,
+                actionCount: 14500,
+                totalSize: 200 * 1024 * 1024,
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(true);
+            expect(result.pattern).toBe('runaway-spiral');
+        });
+
+        it('matches massive size with tool dominance', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'test-task',
+                messageCount: 5000,
+                actionCount: 4800,
+                totalSize: 500 * 1024 * 1024,
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(true);
+            expect(result.pattern).toBe('runaway-spiral');
+        });
+
+        it('does not match huge task with balanced conversation', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'test-task',
+                messageCount: 15000,
+                actionCount: 5000, // ratio = 0.33, well below 0.85
+                totalSize: 200 * 1024 * 1024,
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(false);
+        });
+
+        it('does not match small tool-dominated tasks', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'test-task',
+                messageCount: 100,
+                actionCount: 95,
+                totalSize: 50000,
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(false);
+        });
+    });
+
+    describe('cold-orphan pattern', () => {
+        it('matches old tiny orphan tasks', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'test-task',
+                lastActivity: makeOldDate(200),
+                messageCount: 2,
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(true);
+            expect(result.pattern).toBe('cold-orphan');
+        });
+
+        it('does not match old tasks with parent', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'test-task',
+                parentTaskId: 'parent-task-001',
+                lastActivity: makeOldDate(200),
+                messageCount: 2,
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(false);
+        });
+
+        it('does not match recent orphan tasks', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'test-task',
+                lastActivity: makeOldDate(30),
+                messageCount: 2,
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(false);
+        });
+
+        it('does not match old tasks with substantial content', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'test-task',
+                lastActivity: makeOldDate(200),
+                messageCount: 50,
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(false);
+        });
+    });
+
+    describe('normal tasks (not noise)', () => {
+        it('passes typical interactive task', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'test-task',
+                mode: 'code',
+                messageCount: 100,
+                actionCount: 40,
+                totalSize: 50000,
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(false);
+        });
+
+        it('passes recent scheduled task with few messages', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'test-task',
+                mode: 'scheduled',
+                messageCount: 20,
+                lastActivity: makeOldDate(5),
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(false);
+        });
+
+        it('passes large interactive conversation', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'test-task',
+                mode: 'code',
+                messageCount: 8000,
+                actionCount: 3000, // ratio = 0.375
+                totalSize: 80 * 1024 * 1024,
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(false);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('handles skeleton with no metadata gracefully', () => {
+            const skeleton: SkeletonHeader = {
+                taskId: 'test-task',
+                metadata: undefined as any,
+            };
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(false);
+        });
+
+        it('handles zero messageCount', () => {
+            const skeleton = makeSkeleton({
+                taskId: 'test-task',
+                messageCount: 0,
+                actionCount: 0,
+            });
+            const result = filter.isNoiseTask(skeleton);
+            expect(result.isNoise).toBe(false);
+        });
+
+        it('FORCE_REINDEX bypasses noise filter via IndexingDecisionService', async () => {
+            // Import dynamically to avoid env pollution
+            const orig = process.env.ROO_INDEX_FORCE;
+            process.env.ROO_INDEX_FORCE = '1';
+            const { IndexingDecisionService } = await import('../indexing-decision.js');
+            const service = new IndexingDecisionService();
+            service.noiseFilter.loadBlacklist(['test-task']);
+
+            const skeleton = makeSkeleton({ taskId: 'test-task', mode: 'scheduled', lastActivity: makeOldDate(60), messageCount: 500 });
+            const decision = service.shouldIndex(skeleton);
+            expect(decision.shouldIndex).toBe(true);
+            expect(decision.reason).toContain('FORCE_REINDEX');
+
+            process.env.ROO_INDEX_FORCE = orig;
+        });
+    });
+});

--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -603,11 +603,47 @@ export async function initializeBackgroundServices(state: ServerState): Promise<
 }
 
 /**
+ * #1987 Phase 3a: Load noise filter blacklist from shared state.
+ * File: $ROOSYNC_SHARED_STATE_PATH/qdrant-blacklist.json
+ * Format: { "version": 1, "blacklistedTaskIds": ["id1", "id2", ...] }
+ * Non-blocking: if file missing or malformed, proceeds with empty blacklist.
+ */
+async function loadNoiseFilterBlacklist(state: ServerState): Promise<void> {
+    try {
+        const sharedPath = process.env.ROOSYNC_SHARED_PATH;
+        if (!sharedPath) {
+            console.log('[NoiseFilter] No ROOSYNC_SHARED_PATH, blacklist disabled');
+            return;
+        }
+
+        const blacklistPath = path.join(sharedPath, '.shared-state', 'qdrant-blacklist.json');
+        const content = await fs.readFile(blacklistPath, 'utf8');
+
+        const cleaned = content.charCodeAt(0) === 0xFEFF ? content.slice(1) : content;
+        const data = JSON.parse(cleaned);
+
+        if (data.blacklistedTaskIds && Array.isArray(data.blacklistedTaskIds)) {
+            state.indexingDecisionService.noiseFilter.loadBlacklist(data.blacklistedTaskIds);
+            console.log(`[NoiseFilter] Loaded ${data.blacklistedTaskIds.length} blacklisted task IDs`);
+        }
+    } catch (error: any) {
+        if (error?.code === 'ENOENT') {
+            console.log('[NoiseFilter] No blacklist file found, proceeding without blacklist');
+        } else {
+            console.warn(`[NoiseFilter] Failed to load blacklist: ${error?.message || error}`);
+        }
+    }
+}
+
+/**
  * Initialise le service d'indexation Qdrant asynchrone
  */
 async function initializeQdrantIndexingService(state: ServerState): Promise<void> {
     try {
         console.log('🔍 Initialisation du service d\'indexation Qdrant...');
+
+        // #1987 Phase 3a: Load blacklist from shared state
+        await loadNoiseFilterBlacklist(state);
 
         // FIX #1199: Split verification and scanning into separate phases with defensive error handling
         // Phase 1: Verify consistency (non-critical, safe to skip if Qdrant is down)

--- a/servers/roo-state-manager/src/services/indexing-decision.ts
+++ b/servers/roo-state-manager/src/services/indexing-decision.ts
@@ -4,22 +4,25 @@
  */
 
 import { SkeletonHeader } from '../types/conversation.js';
-import { 
-    IndexingDecision, 
-    IndexingState, 
-    INDEX_VERSION_CURRENT, 
+import {
+    IndexingDecision,
+    IndexingState,
+    INDEX_VERSION_CURRENT,
     DEFAULT_REINDEX_TTL_HOURS,
     MAX_RETRY_ATTEMPTS,
     RETRY_BACKOFF_BASE_MS
 } from '../types/indexing.js';
+import { NoiseFilter } from './noise-filter.js';
 
 export class IndexingDecisionService {
     private readonly forceReindex: boolean;
     private readonly indexVersion: string;
+    readonly noiseFilter: NoiseFilter;
 
     constructor() {
         this.forceReindex = process.env.ROO_INDEX_FORCE === '1' || process.env.ROO_INDEX_FORCE === 'true';
         this.indexVersion = process.env.ROO_INDEX_VERSION || INDEX_VERSION_CURRENT;
+        this.noiseFilter = new NoiseFilter();
     }
 
     /**
@@ -40,6 +43,16 @@ export class IndexingDecisionService {
                 shouldIndex: true,
                 reason: `FORCE_REINDEX mode activé (ROO_INDEX_FORCE=${process.env.ROO_INDEX_FORCE})`,
                 action: 'index'
+            };
+        }
+
+        // #1987 Phase 3a: Noise filtering — skip low-value semantic tasks
+        const noiseResult = this.noiseFilter.isNoiseTask(skeleton);
+        if (noiseResult.isNoise) {
+            return {
+                shouldIndex: false,
+                reason: `Noise filter: ${noiseResult.reason}`,
+                action: 'skip',
             };
         }
 

--- a/servers/roo-state-manager/src/services/noise-filter.ts
+++ b/servers/roo-state-manager/src/services/noise-filter.ts
@@ -1,0 +1,148 @@
+/**
+ * Noise filtering for Qdrant indexation (#1987 Phase 3a)
+ *
+ * Multi-criteria heuristic to identify low-value semantic tasks.
+ * Sanctuary (.jsonl source) is NEVER touched — this only controls Qdrant indexation.
+ *
+ * Design principle: conservative combinations, not single indicators.
+ * Size alone is NOT a noise criterion (user condition #1987 comment).
+ */
+
+import { SkeletonHeader } from '../types/conversation.js';
+
+export interface NoiseFilterResult {
+    isNoise: boolean;
+    reason: string;
+    /** Which criteria pattern matched */
+    pattern?: 'blacklist' | 'scheduled-repetitive' | 'runaway-spiral' | 'cold-orphan';
+}
+
+/**
+ * Recognized scheduled/automated mode names.
+ * Tasks with these modes are typically repetitive with low semantic variability.
+ */
+const SCHEDULED_MODES = [
+    'scheduled',
+    'cron',
+    'worker',
+    'scheduler',
+    'patrol',
+    'meta-audit',
+    'meta-analyst',
+];
+
+/**
+ * TaskId prefixes that indicate automated/scheduled origin.
+ */
+const AUTOMATED_TASK_ID_PATTERNS = [
+    /^worker-/i,
+    /^scheduled-/i,
+    /^patrol-/i,
+    /^meta-audit-/i,
+    /^meta-analyst-/i,
+    /^auto-/i,
+];
+
+export class NoiseFilter {
+    private blacklistedTaskIds: Set<string> = new Set();
+    private blacklistLoaded = false;
+
+    // Configurable thresholds via env vars
+    private readonly scheduledAgeDays: number;
+    private readonly scheduledMinMessages: number;
+    private readonly runawayMessageThreshold: number;
+    private readonly runawaySizeBytes: number;
+    private readonly toolDominanceRatio: number;
+    private readonly coldOrphanDays: number;
+    private readonly coldOrphanMaxMessages: number;
+
+    constructor() {
+        this.scheduledAgeDays = parseInt(process.env.NOISE_FILTER_SCHEDULED_AGE_DAYS || '30', 10);
+        this.scheduledMinMessages = parseInt(process.env.NOISE_FILTER_SCHEDULED_MIN_MESSAGES || '200', 10);
+        this.runawayMessageThreshold = parseInt(process.env.NOISE_FILTER_RUNAWAY_MESSAGES || '10000', 10);
+        this.runawaySizeBytes = parseInt(process.env.NOISE_FILTER_RUNAWAY_SIZE_MB || '100', 10) * 1024 * 1024;
+        this.toolDominanceRatio = parseFloat(process.env.NOISE_FILTER_TOOL_RATIO || '0.85');
+        this.coldOrphanDays = parseInt(process.env.NOISE_FILTER_COLD_ORPHAN_DAYS || '180', 10);
+        this.coldOrphanMaxMessages = parseInt(process.env.NOISE_FILTER_COLD_ORPHAN_MAX_MSG || '5', 10);
+    }
+
+    /**
+     * Load blacklisted task IDs from an array (typically loaded from shared state JSON).
+     */
+    loadBlacklist(taskIds: string[]): void {
+        this.blacklistedTaskIds = new Set(taskIds);
+        this.blacklistLoaded = true;
+    }
+
+    /**
+     * Returns the current blacklist size (for diagnostics).
+     */
+    get blacklistSize(): number {
+        return this.blacklistedTaskIds.size;
+    }
+
+    /**
+     * Check if a task matches any noise pattern.
+     * Returns result with reason and pattern name for audit logging.
+     */
+    isNoiseTask(skeleton: SkeletonHeader): NoiseFilterResult {
+        if (!skeleton.metadata) {
+            return { isNoise: false, reason: 'No metadata available for noise check' };
+        }
+
+        // Pattern 0: Blacklist (manual override, highest priority)
+        if (this.blacklistedTaskIds.has(skeleton.taskId)) {
+            return {
+                isNoise: true,
+                reason: `Task blacklisted (${this.blacklistedTaskIds.size} entries loaded)`,
+                pattern: 'blacklist',
+            };
+        }
+
+        const now = Date.now();
+        const lastActivity = new Date(skeleton.metadata.lastActivity).getTime();
+        const ageDays = (now - lastActivity) / (1000 * 60 * 60 * 24);
+        const messageCount = skeleton.metadata.messageCount || 0;
+        const actionCount = skeleton.metadata.actionCount || 0;
+        const totalSize = skeleton.metadata.totalSize || 0;
+        const mode = (skeleton.metadata.mode || '').toLowerCase();
+
+        // Pattern 1: Scheduled repetitive
+        // Must match BOTH: (mode OR taskId pattern) AND (age > threshold) AND (volume > threshold)
+        const isScheduledMode = SCHEDULED_MODES.some(m => mode.includes(m));
+        const isAutomatedId = AUTOMATED_TASK_ID_PATTERNS.some(p => p.test(skeleton.taskId));
+        if ((isScheduledMode || isAutomatedId) && ageDays > this.scheduledAgeDays && messageCount > this.scheduledMinMessages) {
+            return {
+                isNoise: true,
+                reason: `Scheduled repetitive: mode='${mode}', age=${Math.round(ageDays)}d, msgs=${messageCount}`,
+                pattern: 'scheduled-repetitive',
+            };
+        }
+
+        // Pattern 2: Runaway/error spiral
+        // Must match BOTH: (huge volume) AND (tool-dominated content)
+        const toolRatio = messageCount > 0 ? actionCount / messageCount : 0;
+        const isHugeVolume = messageCount > this.runawayMessageThreshold || totalSize > this.runawaySizeBytes;
+        if (isHugeVolume && toolRatio > this.toolDominanceRatio) {
+            return {
+                isNoise: true,
+                reason: `Runaway spiral: msgs=${messageCount}, size=${Math.round(totalSize / 1024 / 1024)}MB, toolRatio=${toolRatio.toFixed(2)}`,
+                pattern: 'runaway-spiral',
+            };
+        }
+
+        // Pattern 3: Cold orphan (abandoned stubs)
+        // Must match ALL: old + tiny + no parent
+        if (ageDays > this.coldOrphanDays
+            && messageCount < this.coldOrphanMaxMessages
+            && !skeleton.parentTaskId) {
+            return {
+                isNoise: true,
+                reason: `Cold orphan: age=${Math.round(ageDays)}d, msgs=${messageCount}, no parent`,
+                pattern: 'cold-orphan',
+            };
+        }
+
+        return { isNoise: false, reason: 'No noise pattern matched' };
+    }
+}


### PR DESCRIPTION
## Summary

Implements multi-criteria noise filtering (#1987 Phase 3a) to prevent low-value semantic tasks from being indexed in Qdrant. This addresses disk saturation (611 GB / 866 GB) by preventing re-indexation of identified noise patterns.

### Mechanism A — Skip Pattern in IndexingDecisionService

4 noise patterns, all requiring **multi-criteria combinations** (never single indicator):

| Pattern | Criteria | Rationale |
|---------|----------|-----------|
| **Scheduled repetitive** | mode/ID pattern + age >30d + msgs >200 | Low semantic variability, minimal search value |
| **Runaway spiral** | msgs >10K OR size >100MB + tool ratio >0.85 | Almost all tool calls, no real conversation |
| **Cold orphan** | age >180d + msgs <5 + no parent | Abandoned stubs |
| **Blacklist** | Manual task_id in shared state file | Override for any reason |

All thresholds configurable via `NOISE_FILTER_*` env vars. `FORCE_REINDEX` bypasses noise filter.

### Mechanism B — Persistent Blacklist

Blacklist loaded from `$ROOSYNC_SHARED_PATH/.shared-state/qdrant-blacklist.json` at startup. Format:
```json
{ "version": 1, "blacklistedTaskIds": ["task1", "task2"] }
```

Non-blocking: missing/malformed file = proceed with empty blacklist.

### Files Changed

| File | Change |
|------|--------|
| `noise-filter.ts` | NEW — NoiseFilter class with 4 patterns |
| `indexing-decision.ts` | MODIFIED — Integrate noise check in shouldIndex() |
| `background-services.ts` | MODIFIED — Load blacklist at Qdrant service init |
| `noise-filter.test.ts` | NEW — 21 tests covering all patterns + edge cases |

### Test Results

- 21 new tests (noise-filter.test.ts): all pass
- 454 total CI test files: all pass (9164 tests)
- 0 regressions

## Test plan

- [x] Build clean (`npm run build`)
- [x] CI tests pass (`npx vitest run --config vitest.config.ci.ts`)
- [x] Existing indexing-decision tests still pass (24/24)
- [x] FORCE_REINDEX bypasses noise filter (verified in test)
- [ ] Deploy: create `qdrant-blacklist.json` on ai-01 with sampled task_ids
- [ ] Validate: run `roosync_indexing status` to see noise filter skips
- [ ] Sample 100 task_ids matching criteria for human review (Phase 3b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)