### PR TITLE
perf(#809): parallel inbox reads + cache TTL 5min + non-blocking heartbeat

### DIFF
--- a/servers/roo-state-manager/src/services/MessageManager.ts
+++ b/servers/roo-state-manager/src/services/MessageManager.ts
@@ -150,8 +150,10 @@ export class MessageManager {
   private inboxFullCache: Map<string, Message> = new Map();
   /** Timestamp of last cache build */
   private cacheBuiltAt: number = 0;
-  /** Cache TTL in ms (30 seconds - shared filesystem can change) */
-  private static readonly CACHE_TTL_MS = 30_000;
+  /** Cache TTL in ms (5 minutes — file count check detects external changes) */
+  private static readonly CACHE_TTL_MS = 300_000;
+  /** Max concurrent file reads during cache rebuild (GDrive-safe) */
+  private static readonly READ_CONCURRENCY = 50;
   /** Last known file count in inbox dir (cheap invalidation check) */
   private lastInboxFileCount: number = -1;
 
@@ -217,39 +219,56 @@ export class MessageManager {
       return { items: [], full: new Map() };
     }
 
+    // Fast path: return cached data if still within TTL (skip readdir entirely)
     const now = Date.now();
-    const files = (await fs.readdir(this.inboxPath)).filter(f => f.endsWith('.json'));
-
-    // Cache is valid if: within TTL AND file count hasn't changed
     if (
       this.inboxCache !== null &&
-      (now - this.cacheBuiltAt) < MessageManager.CACHE_TTL_MS &&
-      files.length === this.lastInboxFileCount
+      (now - this.cacheBuiltAt) < MessageManager.CACHE_TTL_MS
     ) {
       return { items: this.inboxCache, full: this.inboxFullCache };
     }
 
-    logger.info(`Building inbox cache (${files.length} files)`);
+    // TTL expired — check file count for external changes
+    const files = (await fs.readdir(this.inboxPath)).filter(f => f.endsWith('.json'));
+
+    // If count unchanged and cache exists, refresh TTL without re-reading files
+    if (
+      this.inboxCache !== null &&
+      files.length === this.lastInboxFileCount
+    ) {
+      this.cacheBuiltAt = now;
+      return { items: this.inboxCache, full: this.inboxFullCache };
+    }
+
+    logger.info(`Building inbox cache (${files.length} files, concurrency=${MessageManager.READ_CONCURRENCY})`);
     const items: MessageListItem[] = [];
     const full = new Map<string, Message>();
 
-    for (const file of files) {
-      try {
-        const content = await fs.readFile(join(this.inboxPath, file), 'utf-8');
-        const message: Message = JSON.parse(content);
-        full.set(message.id, message);
-        items.push({
-          id: message.id,
-          from: message.from,
-          to: message.to,
-          subject: message.subject,
-          priority: message.priority,
-          timestamp: message.timestamp,
-          status: message.status,
-          preview: message.body.substring(0, 100) + (message.body.length > 100 ? '...' : '')
-        });
-      } catch (error) {
-        logger.error(`Error reading message ${file}`, error);
+    // Parallel chunked reads — 50 concurrent instead of serial (84s → ~2s on GDrive)
+    for (let i = 0; i < files.length; i += MessageManager.READ_CONCURRENCY) {
+      const chunk = files.slice(i, i + MessageManager.READ_CONCURRENCY);
+      const results = await Promise.allSettled(
+        chunk.map(async file => {
+          const content = await fs.readFile(join(this.inboxPath, file), 'utf-8');
+          const message: Message = JSON.parse(content);
+          return message;
+        })
+      );
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          const message = result.value;
+          full.set(message.id, message);
+          items.push({
+            id: message.id,
+            from: message.from,
+            to: message.to,
+            subject: message.subject,
+            priority: message.priority,
+            timestamp: message.timestamp,
+            status: message.status,
+            preview: message.body.substring(0, 100) + (message.body.length > 100 ? '...' : '')
+          });
+        }
       }
     }
 

--- a/servers/roo-state-manager/src/services/MessageManager.ts
+++ b/servers/roo-state-manager/src/services/MessageManager.ts
@@ -254,7 +254,8 @@ export class MessageManager {
           return message;
         })
       );
-      for (const result of results) {
+      for (let r = 0; r < results.length; r++) {
+        const result = results[r];
         if (result.status === 'fulfilled') {
           const message = result.value;
           full.set(message.id, message);
@@ -268,6 +269,9 @@ export class MessageManager {
             status: message.status,
             preview: message.body.substring(0, 100) + (message.body.length > 100 ? '...' : '')
           });
+        } else {
+          const failedFile = chunk[r] ? join(this.inboxPath, chunk[r]) : 'unknown';
+          logger.error(`Error reading message file during parallel cache build: ${failedFile}`, result.reason);
         }
       }
     }

--- a/servers/roo-state-manager/src/tools/roosync/read.ts
+++ b/servers/roo-state-manager/src/tools/roosync/read.ts
@@ -98,11 +98,11 @@ async function readInboxMode(
     effectiveMachineId, status, limit, effectiveWorkspaceId, page, perPage
   );
 
-  // Fire-and-forget heartbeat update. Always use the REAL local machine, not
-  // the overridden filter — heartbeat is proof-of-life for the local process,
-  // not for the machine whose inbox is being read.
-  (await getRooSyncService()).getHeartbeatService()
-    .registerHeartbeat(getLocalMachineId(), { lastActivity: 'roosync_read_inbox', messageCount: messages.length })
+  // Fire-and-forget heartbeat update. Truly non-blocking — don't await the
+  // lazy service load. Uses .then() to chain without blocking the inbox response.
+  getRooSyncService()
+    .then(svc => svc.getHeartbeatService()
+      .registerHeartbeat(getLocalMachineId(), { lastActivity: 'roosync_read_inbox', messageCount: messages.length }))
     .catch(err => logger.debug('Heartbeat update skipped (non-critical)', { error: String(err) }));
 
   // Throttled fire-and-forget cleanup tasks (run at most once every 5 min)


### PR DESCRIPTION
## Summary

Fixes #809 — `roosync_read(mode: "inbox")` regression taking 1m44s for 38 messages.

**Root cause:** `ensureInboxCache()` reads all inbox files **serially** on GDrive. With 3,689 files × ~23ms I/O latency each = ~84 seconds cold cache.

## Changes (2 files, +46/-27)

| Fix | File | Detail |
|-----|------|--------|
| **Parallel reads** | `MessageManager.ts` | `Promise.allSettled` with chunked concurrency (50) → ~2s vs ~84s |
| **Cache TTL** | `MessageManager.ts` | 30s → 300s (5 min). File count check detects external changes. |
| **Skip readdir** | `MessageManager.ts` | Hot path returns cache without any I/O when TTL fresh |
| **Non-blocking heartbeat** | `read.ts` | `getRooSyncService().then()` instead of `await` (was blocking inbox response) |

## Performance Impact

| Scenario | Before | After |
|----------|--------|-------|
| Cold cache (3,689 files) | ~84s | ~2s (40× faster) |
| Warm cache (within TTL) | ~0.5s (readdir check) | ~0ms (no I/O) |
| Cache expired, count same | ~84s | ~0.5s (readdir only) |
| First call (lazy RooSyncService) | blocked by `await` | non-blocking |

## Test plan

- [x] `npm run build` — 0 errors
- [x] `npx vitest run --config vitest.config.ci.ts` — 453/453 passed, 9143 tests
- [ ] Cross-machine validation: test on 2+ machines after merge
- [ ] Measure `roosync_read(inbox)` timing post-deploy (target: <5s for <100 msgs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)