### PR TITLE
fix(#2013): complete heartbeat terminology — response schema + flags

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
@@ -101,7 +101,7 @@ describe('get-status (Option B)', () => {
     test('validates HEALTHY result', () => {
       const result = GetStatusResultSchema.parse({
         status: 'HEALTHY',
-        machines: { online: 6, offline: 0, total: 6 },
+        machines: { online: 6, unknown: 0, total: 6 },
         inbox: { unread: 0, urgent: 0 },
         decisions: { pending: 0 },
         dashboards: { active: 1 },
@@ -114,11 +114,11 @@ describe('get-status (Option B)', () => {
     test('validates CRITICAL result with flags', () => {
       const result = GetStatusResultSchema.parse({
         status: 'CRITICAL',
-        machines: { online: 4, offline: 2, total: 6 },
+        machines: { online: 4, unknown: 2, total: 6 },
         inbox: { unread: 15, urgent: 2 },
         decisions: { pending: 3 },
         dashboards: { active: 1 },
-        flags: ['OFFLINE:myia-po-2025', 'INBOX_URGENT:2', 'DECISIONS_PENDING:3'],
+        flags: ['UNKNOWN:myia-po-2025', 'INBOX_URGENT:2', 'DECISIONS_PENDING:3'],
         lastUpdated: '2026-04-08T00:00:00Z'
       });
       expect(result.status).toBe('CRITICAL');
@@ -128,7 +128,7 @@ describe('get-status (Option B)', () => {
     test('rejects old status values', () => {
       expect(() => GetStatusResultSchema.parse({
         status: 'synced',
-        machines: { online: 6, offline: 0, total: 6 },
+        machines: { online: 6, unknown: 0, total: 6 },
         inbox: { unread: 0, urgent: 0 },
         decisions: { pending: 0 },
         dashboards: { active: 1 },
@@ -155,7 +155,7 @@ describe('get-status (Option B)', () => {
       expect(result.flags).toHaveLength(0);
     });
 
-    test('returns CRITICAL when machines offline', async () => {
+    test('returns CRITICAL when machines unknown', async () => {
       mockGetHeartbeatService.mockReturnValue({
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
@@ -168,8 +168,8 @@ describe('get-status (Option B)', () => {
       const result = await roosyncGetStatus({});
 
       expect(result.status).toBe('CRITICAL');
-      expect(result.machines.offline).toBe(1);
-      expect(result.flags).toContain('OFFLINE:myia-po-2025');
+      expect(result.machines.unknown).toBe(1);
+      expect(result.flags).toContain('UNKNOWN:myia-po-2025');
     });
 
     test('returns CRITICAL when urgent messages', async () => {
@@ -264,8 +264,8 @@ describe('get-status (Option B)', () => {
   });
 
   describe('#1365 orphan test entry filtering', () => {
-    test('excludes orphan test machines from offline count', async () => {
-      // Simulates real scenario: 6 real machines online + 3 test artifacts offline
+    test('excludes orphan test machines from unknown count', async () => {
+      // Simulates real scenario: real machines online + 3 test artifacts unknown
       mockGetHeartbeatService.mockReturnValue({
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
@@ -279,9 +279,9 @@ describe('get-status (Option B)', () => {
 
       // Orphan test machines should NOT trigger CRITICAL
       expect(result.status).toBe('HEALTHY');
-      expect(result.machines.offline).toBe(0);
-      expect(result.flags).not.toContain('OFFLINE:test-machine');
-      expect(result.flags).not.toContain('OFFLINE:persistent-machine');
+      expect(result.machines.unknown).toBe(0);
+      expect(result.flags).not.toContain('UNKNOWN:test-machine');
+      expect(result.flags).not.toContain('UNKNOWN:persistent-machine');
     });
 
     test('excludes orphan test machines from dashboard total', async () => {
@@ -318,7 +318,7 @@ describe('get-status (Option B)', () => {
       expect(result.flags).not.toContain('HEARTBEAT_STALE:test-machine');
     });
 
-    test('still detects real offline machines correctly', async () => {
+    test('still detects real unknown machines correctly', async () => {
       mockGetHeartbeatService.mockReturnValue({
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
@@ -330,11 +330,11 @@ describe('get-status (Option B)', () => {
 
       const result = await roosyncGetStatus({});
 
-      // Should be CRITICAL from real offline machine only
+      // Should be CRITICAL from real unknown machine only
       expect(result.status).toBe('CRITICAL');
-      expect(result.machines.offline).toBe(1);  // Only myia-po-2025
-      expect(result.flags).toContain('OFFLINE:myia-po-2025');
-      expect(result.flags).not.toContain('OFFLINE:test-machine');
+      expect(result.machines.unknown).toBe(1);  // Only myia-po-2025
+      expect(result.flags).toContain('UNKNOWN:myia-po-2025');
+      expect(result.flags).not.toContain('UNKNOWN:test-machine');
     });
   });
 });

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/inventory.integration.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/inventory.integration.test.ts
@@ -122,8 +122,8 @@ describe('roosync_inventory (integration)', () => {
       const shape = HeartbeatStatisticsSchema.shape;
       expect(shape.totalMachines).toBeDefined();
       expect(shape.onlineCount).toBeDefined();
-      expect(shape.offlineCount).toBeDefined();
-      expect(shape.warningCount).toBeDefined();
+      expect(shape.unknownCount).toBeDefined();
+      expect(shape.idleCount).toBeDefined();
       expect(shape.lastHeartbeatCheck).toBeDefined();
     });
   });

--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -25,7 +25,7 @@ const logger = createLogger('GetStatus');
  * Production machines match the pattern: myia-*
  * Test artifacts (test-machine, persistent-machine, machine-2, etc.) are excluded.
  *
- * #1365: Orphan test entries in heartbeat files pollute offline counts.
+ * #1365: Orphan test entries in heartbeat files pollute unknown counts.
  */
 function isKnownMachine(machineId: string): boolean {
 	return machineId.toLowerCase().startsWith('myia-');
@@ -56,7 +56,7 @@ export const GetStatusResultSchema = z.object({
 
   machines: z.object({
     online: z.number(),
-    offline: z.number(),
+    unknown: z.number(),
     total: z.number()
   }).describe('Compteurs machines par état'),
 
@@ -137,9 +137,9 @@ function buildFlags(
 ): string[] {
   const flags: string[] = [];
 
-  // Unknown machines (ADR 008: was "offline")
+  // Unknown machines (ADR 008 terminology)
   for (const machineId of heartbeatState.unknownMachines) {
-    flags.push(`OFFLINE:${machineId}`);
+    flags.push(`UNKNOWN:${machineId}`);
   }
 
   // Idle machines (ADR 008: was "warning"/heartbeat stale)
@@ -373,7 +373,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
     if (filteredUnknownMachines.length > 0 || inboxStats.urgent > 0) {
       status = 'CRITICAL';
     } else if (inboxStats.unread > 5 || filteredIdleMachines.length > 0) {
-      // WARNING if: high unread count OR heartbeat warning machines (but no offline)
+      // WARNING if: high unread count OR heartbeat idle machines (but no unknown)
       status = 'WARNING';
     }
 
@@ -395,7 +395,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
       status,
       machines: {
         online: filteredOnlineMachines.length,
-        offline: filteredUnknownMachines.length,
+        unknown: filteredUnknownMachines.length,
         total: totalMachines,
         ...(dashboardOverrides.length > 0 ? { dashboardOverrides } : {})
       },

--- a/servers/roo-state-manager/src/tools/roosync/machines.ts
+++ b/servers/roo-state-manager/src/tools/roosync/machines.ts
@@ -1,7 +1,7 @@
 /**
  * Outil MCP : roosync_machines
  *
- * Récupération des machines offline et/ou en avertissement.
+ * Récupération des machines unknown et/ou idle.
  *
  * @module tools/roosync/machines
  * @version 3.0.0
@@ -99,7 +99,7 @@ export type MachinesResult = z.infer<typeof MachinesResultSchema>;
 /**
  * Outil roosync_machines (UnifiedToolContract)
  *
- * Récupération des machines offline et/ou en avertissement.
+ * Récupération des machines unknown et/ou idle.
  */
 export const machinesTool: UnifiedToolContract = {
   name: 'roosync_machines',

--- a/servers/roo-state-manager/tests/e2e/roosync-multi-machine-sync.test.ts
+++ b/servers/roo-state-manager/tests/e2e/roosync-multi-machine-sync.test.ts
@@ -514,7 +514,7 @@ describe('RooSync E2E - Synchronisation Multi-Machines', () => {
         console.log('✅ État des heartbeats obtenu');
         console.log(`   Machines enregistrées: ${result.statistics.totalMachines}`);
         console.log(`   Machines online: ${result.statistics.onlineCount}`);
-        console.log(`   Machines offline: ${result.statistics.offlineCount}`);
+        console.log(`   Machines unknown: ${result.statistics.unknownCount}`);
       } catch (error: any) {
         console.error('❌ Erreur lors de l\'obtention de l\'état:', error);
         throw error;

--- a/servers/roo-state-manager/tests/unit/tools/roosync/get-status.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/get-status.test.ts
@@ -180,7 +180,7 @@ describe('roosync_get_status', () => {
             });
             const result = await roosyncGetStatus({});
             expect(result.status).toBe('CRITICAL');
-            expect(result.flags).toContain('OFFLINE:myia-web1');
+            expect(result.flags).toContain('UNKNOWN:myia-web1');
         });
 
         it('returns CRITICAL when urgent messages', async () => {


### PR DESCRIPTION
## Summary
- Rename `machines.offline` → `machines.unknown` in get-status response schema and actual response
- Rename `OFFLINE:` → `UNKNOWN:` flag prefix in buildFlags()
- Update module comments in machines.ts (offline → unknown, avertissement → idle)
- Fix stale `offlineCount`/`warningCount` assertions in inventory integration test
- Update all test assertions to match new field/flag names

Completes the remaining 🔴 Must Fix items from #2013 that PR #358 left:
- `get-status.ts` response key `offline:` → `unknown:`
- `get-status.ts` flag `OFFLINE:` → `UNKNOWN:`
- `machines.ts` stale doc comments

## Test plan
- [x] Build: `npm run build` — 0 errors
- [x] CI tests: `npx vitest run --config vitest.config.ci.ts` — 453 files, 9143 tests passed
- [ ] Verify `roosync_inventory(type="status")` returns `machines.unknown` instead of `machines.offline`
- [ ] Verify flags show `UNKNOWN:myia-*` instead of `OFFLINE:myia-*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)