### PR TITLE
fix(heartbeat): ADR 008 terminology followup (#2013)

### DIFF
--- a/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
+++ b/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
@@ -286,10 +286,15 @@ export class HeartbeatService {
   }
 
   /**
-   * @deprecated No disk state to clean up.
+   * @deprecated No disk state to clean up. ADR 008: in-memory only.
    */
-  public async cleanupOldOfflineMachines(_maxAge?: number): Promise<number> {
+  public async cleanupOldUnknownMachines(_maxAge?: number): Promise<number> {
     return 0;
+  }
+
+  /** @deprecated Use cleanupOldUnknownMachines — ADR 008 terminology */
+  public async cleanupOldOfflineMachines(maxAge?: number): Promise<number> {
+    return this.cleanupOldUnknownMachines(maxAge);
   }
 
   // --- Internal ---

--- a/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
@@ -377,16 +377,16 @@ describe('HeartbeatService', () => {
   });
 
   // ============================================================
-  // cleanupOldOfflineMachines (no-op in ADR 008)
+  // cleanupOldUnknownMachines (no-op in ADR 008)
   // ============================================================
 
-  describe('cleanupOldOfflineMachines', () => {
+  describe('cleanupOldUnknownMachines', () => {
     test('retourne toujours 0 (no-op ADR 008)', async () => {
       const service = new HeartbeatService();
 
       await service.registerHeartbeat('active-machine');
 
-      const removed = await service.cleanupOldOfflineMachines();
+      const removed = await service.cleanupOldUnknownMachines();
 
       expect(removed).toBe(0);
     });
@@ -396,10 +396,18 @@ describe('HeartbeatService', () => {
 
       await service.registerHeartbeat('test-artifact-machine');
 
-      const removed = await service.cleanupOldOfflineMachines(0);
+      const removed = await service.cleanupOldUnknownMachines(0);
 
       expect(removed).toBe(0);
       expect(service.getHeartbeatData('test-artifact-machine')).toBeDefined();
+    });
+
+    test('deprecated cleanupOldOfflineMachines still works (backward compat)', async () => {
+      const service = new HeartbeatService();
+
+      const removed = await service.cleanupOldOfflineMachines();
+
+      expect(removed).toBe(0);
     });
   });
 

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
@@ -101,7 +101,7 @@ describe('get-status (Option B)', () => {
     test('validates HEALTHY result', () => {
       const result = GetStatusResultSchema.parse({
         status: 'HEALTHY',
-        machines: { online: 6, offline: 0, total: 6 },
+        machines: { online: 6, unknown: 0, total: 6 },
         inbox: { unread: 0, urgent: 0 },
         decisions: { pending: 0 },
         dashboards: { active: 1 },
@@ -114,7 +114,7 @@ describe('get-status (Option B)', () => {
     test('validates CRITICAL result with flags', () => {
       const result = GetStatusResultSchema.parse({
         status: 'CRITICAL',
-        machines: { online: 4, offline: 2, total: 6 },
+        machines: { online: 4, unknown: 2, total: 6 },
         inbox: { unread: 15, urgent: 2 },
         decisions: { pending: 3 },
         dashboards: { active: 1 },
@@ -128,7 +128,7 @@ describe('get-status (Option B)', () => {
     test('rejects old status values', () => {
       expect(() => GetStatusResultSchema.parse({
         status: 'synced',
-        machines: { online: 6, offline: 0, total: 6 },
+        machines: { online: 6, unknown: 0, total: 6 },
         inbox: { unread: 0, urgent: 0 },
         decisions: { pending: 0 },
         dashboards: { active: 1 },
@@ -168,7 +168,7 @@ describe('get-status (Option B)', () => {
       const result = await roosyncGetStatus({});
 
       expect(result.status).toBe('CRITICAL');
-      expect(result.machines.offline).toBe(1);
+      expect(result.machines.unknown).toBe(1);
       expect(result.flags).toContain('OFFLINE:myia-po-2025');
     });
 
@@ -279,7 +279,7 @@ describe('get-status (Option B)', () => {
 
       // Orphan test machines should NOT trigger CRITICAL
       expect(result.status).toBe('HEALTHY');
-      expect(result.machines.offline).toBe(0);
+      expect(result.machines.unknown).toBe(0);
       expect(result.flags).not.toContain('OFFLINE:test-machine');
       expect(result.flags).not.toContain('OFFLINE:persistent-machine');
     });
@@ -332,7 +332,7 @@ describe('get-status (Option B)', () => {
 
       // Should be CRITICAL from real offline machine only
       expect(result.status).toBe('CRITICAL');
-      expect(result.machines.offline).toBe(1);  // Only myia-po-2025
+      expect(result.machines.unknown).toBe(1);  // Only myia-po-2025
       expect(result.flags).toContain('OFFLINE:myia-po-2025');
       expect(result.flags).not.toContain('OFFLINE:test-machine');
     });

--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -56,9 +56,9 @@ export const GetStatusResultSchema = z.object({
 
   machines: z.object({
     online: z.number(),
-    offline: z.number(),
+    unknown: z.number(),
     total: z.number()
-  }).describe('Compteurs machines par état'),
+  }).describe('Compteurs machines par état (unknown = machines sans heartbeat récent, ADR 008: was "offline")'),
 
   inbox: z.object({
     unread: z.number(),
@@ -395,7 +395,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
       status,
       machines: {
         online: filteredOnlineMachines.length,
-        offline: filteredUnknownMachines.length,
+        unknown: filteredUnknownMachines.length,
         total: totalMachines,
         ...(dashboardOverrides.length > 0 ? { dashboardOverrides } : {})
       },

--- a/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
@@ -203,19 +203,24 @@ describe('HeartbeatService - Tests Unitaires', () => {
       expect(state.statistics.totalMachines).toBe(0);
     });
 
-    it('cleanupOldOfflineMachines est un no-op (retourne 0)', async () => {
+    it('cleanupOldUnknownMachines est un no-op (retourne 0)', async () => {
       await heartbeatService.registerHeartbeat('myia-old-1');
       await heartbeatService.registerHeartbeat('myia-old-2');
       await heartbeatService.registerHeartbeat('myia-recent');
 
-      const removedCount = await heartbeatService.cleanupOldOfflineMachines(86400000);
+      const removedCount = await heartbeatService.cleanupOldUnknownMachines(86400000);
 
-      // ADR 008: cleanupOldOfflineMachines is a no-op, always returns 0
+      // ADR 008: cleanupOldUnknownMachines is a no-op, always returns 0
       expect(removedCount).toBe(0);
       // All machines remain
       expect(heartbeatService.getHeartbeatData('myia-old-1')).toBeDefined();
       expect(heartbeatService.getHeartbeatData('myia-old-2')).toBeDefined();
       expect(heartbeatService.getHeartbeatData('myia-recent')).toBeDefined();
+    });
+
+    it('cleanupOldOfflineMachines (deprecated) still works via backward compat', async () => {
+      const removedCount = await heartbeatService.cleanupOldOfflineMachines(86400000);
+      expect(removedCount).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- Rename response key `offline` → `unknown` in `get-status` result schema (ADR 008 Phase 2)
- Rename `cleanupOldOfflineMachines` → `cleanupOldUnknownMachines` with backward-compat deprecated wrapper
- Update all tests to match new terminology

## Test plan
- [x] `npx vitest run --config vitest.config.ci.ts` — 9145 tests passing, 0 failures
- [x] Backward compatibility verified: `cleanupOldOfflineMachines` still works via deprecated wrapper

Closes #2013 (terminology followup items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)