### PR TITLE
fix(#2013): terminology comment cleanup in machines.ts

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/machines.ts
+++ b/servers/roo-state-manager/src/tools/roosync/machines.ts
@@ -1,7 +1,7 @@
 /**
  * Outil MCP : roosync_machines
  *
- * Récupération des machines offline et/ou en avertissement.
+ * Récupération des machines unknown (heartbeat stale) et/ou idle.
  *
  * @module tools/roosync/machines
  * @version 3.0.0
@@ -99,7 +99,7 @@ export type MachinesResult = z.infer<typeof MachinesResultSchema>;
 /**
  * Outil roosync_machines (UnifiedToolContract)
  *
- * Récupération des machines offline et/ou en avertissement.
+ * Récupération des machines unknown (heartbeat stale) et/ou idle.
  */
 export const machinesTool: UnifiedToolContract = {
   name: 'roosync_machines',


### PR DESCRIPTION
## Summary
- Updates 2 stale file-level comments in `machines.ts` that still referenced "offline et/ou en avertissement" instead of "unknown (heartbeat stale) et/ou idle" per ADR 008
- No functional changes — comment-only

## Context
Completes the #2013 terminology followup. The prior PR #364 renamed the response key and method names. This PR fixes the remaining stale comments.

### Verification from this session
- `dashboard-activity.ts` — already uses `unknownMachines`/`idleMachines` (clean)
- `machine-config.ts` — already uses `'unknown' | 'idle'` (clean)
- `machines.ts` — schemas already renamed (`UnknownMachineDetailsSchema`, `IdleMachineDetailsSchema`), deprecated aliases preserved
- Backward-compat enum values (`'offline'`, `'warning'` in z.enum) are INTENTIONAL and should remain

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 9143 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>