### PR TITLE
fix(mcp): conversation_browser summarize projectName filter #2041

### DIFF
--- a/servers/roo-state-manager/src/tools/summary/roosync-summarize.tool.ts
+++ b/servers/roo-state-manager/src/tools/summary/roosync-summarize.tool.ts
@@ -235,6 +235,23 @@ export const roosyncSummarizeTool: Tool = {
 };
 
 /**
+ * Extrait le projectName d'un taskId Claude Code.
+ * Format taskId: claude-{projectName}--{sessionUuid}
+ * Ex: "claude-d--dev-roo-extensions--1026d78b-2c6c-441d-be96-33f11a258bae"
+ * → projectName: "d--dev-roo-extensions"
+ */
+function extractClaudeProjectName(taskId: string): string {
+    const withoutPrefix = taskId.startsWith('claude-') ? taskId.slice(7) : taskId;
+    // lastIndexOf pour trouver le séparateur projectName--sessionUuid
+    // (projectName peut contenir des '--', ex: "d--dev-roo-extensions")
+    const doubleDashIndex = withoutPrefix.lastIndexOf('--');
+    if (doubleDashIndex > 0) {
+        return withoutPrefix.slice(0, doubleDashIndex);
+    }
+    return withoutPrefix;
+}
+
+/**
  * Crée le bon getter de conversation selon la source
  * @param source 'roo' ou 'claude'
  * @param options Options de parsing (maxContentLength pour contrôler la troncature)
@@ -245,10 +262,12 @@ function createConversationGetter(
 ): (taskId: string) => Promise<ConversationSkeleton | null> {
     return async (taskId: string) => {
         if (source === 'claude') {
-            // Pour Claude, on cherche dans les projets Claude
-            const locations = await ClaudeStorageDetector.detectStorageLocations();
+            const allLocations = await ClaudeStorageDetector.detectStorageLocations();
+            const projectName = extractClaudeProjectName(taskId);
+            const locations = allLocations.filter(loc => loc.projectName === projectName);
+            const searchLocations = locations.length > 0 ? locations : allLocations;
 
-            for (const location of locations) {
+            for (const location of searchLocations) {
                 const skeleton = await ClaudeStorageDetector.analyzeConversation(
                     taskId,
                     location.projectPath,


### PR DESCRIPTION
## Summary

Fixes #2041: conversation_browser `summarize` returned identical stale data for different Claude Code session taskIds.

## Root Cause

`createConversationGetter()` iterated over ALL Claude project locations, returning the first skeleton found regardless of the requested taskId.

## Fix

- Added `extractClaudeProjectName()` to parse taskId format `claude-{projectName}--{sessionUuid}`
- Filter locations by projectName before iterating (fallback to all locations if no match)
- Uses `lastIndexOf('--')` to correctly handle projectNames containing `--` (e.g. `d--dev-roo-extensions`)

## Testing

- Build: PASS
- Tests: 24/24 passed (roosync-summarize.test.ts)

## Note

This replaces the previous fix attempt (commit `1f523285`) which used `indexOf('--')` instead of `lastIndexOf('--')`, making the fix a no-op. Reviews on PR jsboige/roo-extensions#2042 identified this critical bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)