### PR TITLE
fix(#2046): add timeout to call_agent MCP tool

### DIFF
--- a/servers/sk-agent/sk_agent.py
+++ b/servers/sk-agent/sk_agent.py
@@ -1437,6 +1437,7 @@ async def call_agent(
     options: str = "",
     conversation_id: str = "",
     include_steps: bool = False,
+    timeout: int = 120,
 ) -> str:
     """Send a prompt to an AI agent.
 
@@ -1451,6 +1452,7 @@ async def call_agent(
         options: JSON string with type-specific params (region, mode, max_pages, page_range, num_frames).
         conversation_id: Continue previous conversation.
         include_steps: Show intermediate tool/reasoning steps.
+        timeout: Maximum execution time in seconds (default: 120). 0 = no timeout.
 
     Returns:
         JSON string with: response, conversation_id, agent_used, model_used, and type-specific fields.
@@ -1485,7 +1487,7 @@ async def call_agent(
         except json.JSONDecodeError:
             return json.dumps({"error": "Invalid options JSON"}, ensure_ascii=False)
 
-    result = await manager.call_agent(
+    coro = manager.call_agent(
         prompt=prompt,
         agent_id=agent if agent else None,
         attachment=attachments_list if attachments_list else None,
@@ -1493,6 +1495,20 @@ async def call_agent(
         conversation_id=conversation_id if conversation_id else None,
         include_steps=include_steps,
     )
+
+    effective_timeout = opts.get("timeout", timeout) if opts else timeout
+    if effective_timeout and effective_timeout > 0:
+        try:
+            result = await asyncio.wait_for(coro, timeout=effective_timeout)
+        except asyncio.TimeoutError:
+            result = {
+                "error": f"call_agent timed out after {effective_timeout}s",
+                "timeout": effective_timeout,
+                "agent_used": agent or "auto",
+            }
+    else:
+        result = await coro
+
     return json.dumps(result, ensure_ascii=False)
 
 


### PR DESCRIPTION
## Summary
- Add configurable timeout (default: 120s) to `call_agent` MCP tool to prevent session hangs
- Wrap `manager.call_agent()` with `asyncio.wait_for()` — returns structured error on timeout
- Allow per-call timeout override via `options.timeout` JSON field
- `timeout=0` disables timeout (backward compat)

## Problem
When the underlying LLM or HTTP request hung, `call_agent` blocked the entire Claude Code session indefinitely with no way to cancel. User had to manually restart the session.

## Test plan
- [x] Python syntax check passes (`py_compile`)
- [ ] Manual: invoke `call_agent` with a known-slow endpoint, verify timeout fires
- [ ] Manual: invoke `call_agent` with `timeout: 0`, verify no timeout enforcement
- [ ] CI: existing sk-agent tests pass

Fixes: #2046, #2051

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>