### PR TITLE
fix(jupyter): add hard timeout to execute_on_kernel (#2051)

### DIFF
--- a/servers/jupyter-papermill-mcp-server/papermill_mcp/tools/kernel_tools.py
+++ b/servers/jupyter-papermill-mcp-server/papermill_mcp/tools/kernel_tools.py
@@ -4,6 +4,7 @@ MCP tools for kernel operations.
 Defines all kernel-related MCP tools using FastMCP.
 """
 
+import asyncio
 import logging
 from typing import Any, Dict, Optional, Literal
 
@@ -323,14 +324,33 @@ def register_kernel_tools(app: FastMCP) -> None:
         try:
             logger.info(f"Executing on kernel {kernel_id} in mode: {mode}")
             service = get_kernel_service()
-            result = await service.execute_on_kernel_consolidated(
-                kernel_id=kernel_id,
-                mode=mode,
-                code=code,
-                path=path,
-                cell_index=cell_index,
-                timeout=timeout,
-            )
+            # Hard timeout at MCP level: kernel-level timeout may not fire
+            # if the ZMQ socket thread blocks (#2051). Add 10s margin.
+            hard_timeout = timeout + 10
+            try:
+                result = await asyncio.wait_for(
+                    service.execute_on_kernel_consolidated(
+                        kernel_id=kernel_id,
+                        mode=mode,
+                        code=code,
+                        path=path,
+                        cell_index=cell_index,
+                        timeout=timeout,
+                    ),
+                    timeout=hard_timeout,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "execute_on_kernel timed out after %ds (hard limit, kernel=%s, mode=%s)",
+                    hard_timeout, kernel_id, mode,
+                )
+                return {
+                    "error": f"Execution timed out after {hard_timeout}s (kernel timeout={timeout}s)",
+                    "kernel_id": kernel_id,
+                    "mode": mode,
+                    "status": "timeout",
+                    "success": False,
+                }
             logger.info(f"Successfully executed on kernel {kernel_id} in mode: {mode}")
             return result
         except Exception as e:


### PR DESCRIPTION
## Summary
- Add `asyncio.wait_for()` hard timeout at MCP tool level around `execute_on_kernel_consolidated()`
- Prevents indefinite blocking when ZMQ socket thread hangs (kernel-level deadline may not fire)
- Timeout = `timeout + 10s` margin (kernel gets its own timeout, MCP enforces hard limit)

## Problem
`execute_on_kernel` blocked indefinitely when the `.net-csharp` kernel hung during compilation. The kernel-level timeout (deadline-based loop with `run_in_executor` + `get_iopub_msg(timeout=1.0)`) didn't fire because the ZMQ socket thread was blocked, preventing the event loop from checking the deadline.

## Root Cause
The `run_in_executor` wrapping `kc.get_iopub_msg()` runs in a thread pool. If the ZMQ socket blocks (e.g., kernel process hung during .NET assembly compilation), the thread doesn't return, and the `await` in the asyncio loop never completes — the outer deadline check is never reached.

## Fix
Wrap the entire `service.execute_on_kernel_consolidated()` call with `asyncio.wait_for()`. This cancels the coroutine at the asyncio level regardless of thread state.

## Test plan
- [x] Python syntax check passes (`py_compile`)
- [ ] Manual: execute code on a hung kernel, verify timeout fires
- [ ] Manual: execute code normally, verify no regression

Fixes #2051

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>