### PR TITLE
fix(#2013): complete heartbeat terminology — flags, callbacks, comments

### DIFF
--- a/servers/roo-state-manager/src/services/RooSyncService.ts
+++ b/servers/roo-state-manager/src/services/RooSyncService.ts
@@ -1001,7 +1001,7 @@ export class RooSyncService {
   }
 
   /**
-   * Obtient les machines avec statut UNKNOWN (offline)
+   * Obtient les machines avec statut UNKNOWN
    */
   public getUnknownMachines(): string[] {
     return this.heartbeatService.getUnknownMachines();
@@ -1015,7 +1015,7 @@ export class RooSyncService {
   }
 
   /**
-   * Obtient les machines avec statut IDLE (warning)
+   * Obtient les machines avec statut IDLE
    */
   public getIdleMachines(): string[] {
     return this.heartbeatService.getIdleMachines();
@@ -1032,20 +1032,20 @@ export class RooSyncService {
    * Démarre le service de heartbeat automatique
    */
   public async startHeartbeatService(
-    onOfflineDetected?: (machineId: string) => void,
+    onUnknownDetected?: (machineId: string) => void,
     onOnlineRestored?: (machineId: string) => void
   ): Promise<void> {
     console.log(`[RooSyncService] Démarrage du service heartbeat pour: ${this.config.machineId}`);
-    
+
     // Configurer les callbacks pour la synchronisation automatique
-    const offlineCallback = async (machineId: string) => {
-      console.log(`[RooSyncService] Machine offline détectée: ${machineId}`);
-      
+    const unknownCallback = async (machineId: string) => {
+      console.log(`[RooSyncService] Machine unknown détectée: ${machineId}`);
+
       // Appeler le callback utilisateur si fourni
-      if (onOfflineDetected) {
-        onOfflineDetected(machineId);
+      if (onUnknownDetected) {
+        onUnknownDetected(machineId);
       }
-      
+
       // Synchroniser automatiquement les baselines
       await this.syncOnMachineOffline(machineId);
     };
@@ -1064,7 +1064,7 @@ export class RooSyncService {
     
     await this.heartbeatService.startHeartbeatService(
       this.config.machineId,
-      offlineCallback,
+      unknownCallback,
       onlineCallback
     );
   }

--- a/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
+++ b/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
@@ -251,14 +251,14 @@ export class HeartbeatService {
    */
   public async startHeartbeatService(
     _machineId: string,
-    onOfflineDetected?: (machineId: string) => void,
+    onUnknownDetected?: (machineId: string) => void,
     onOnlineRestored?: (machineId: string) => void
   ): Promise<void> {
     logger.info('startHeartbeatService called — no-op (ADR 008 passive model)');
-    // Set up status change callback if callers provide offline/online callbacks
-    if (onOfflineDetected || onOnlineRestored) {
+    // Set up status change callback if callers provide unknown/online callbacks
+    if (onUnknownDetected || onOnlineRestored) {
       this.onStatusChangeCallback = (machineId, oldStatus, newStatus) => {
-        if (newStatus === 'unknown' && onOfflineDetected) onOfflineDetected(machineId);
+        if (newStatus === 'unknown' && onUnknownDetected) onUnknownDetected(machineId);
         if (newStatus === 'online' && onOnlineRestored) onOnlineRestored(machineId);
       };
     }

--- a/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
@@ -8,11 +8,11 @@
  * - Initialisation → état vide (no disk load)
  * - registerHeartbeat : nouvelle machine + machine existante (update)
  * - checkHeartbeats : détection IDLE/UNKNOWN/ONLINE (computed from lastHeartbeat age)
- * - getOnlineMachines / getOfflineMachines (deprecated alias) / getWarningMachines (deprecated alias)
+ * - getOnlineMachines / getUnknownMachines / getIdleMachines (deprecated aliases: getOfflineMachines / getWarningMachines)
  * - getHeartbeatData : défini après register, undefined avant
  * - getState : retourne copie défensive avec nouvelles clés (idleMachines, unknownMachines)
  * - removeMachine : suppression in-memory
- * - cleanupOldOfflineMachines : no-op (returns 0)
+ * - cleanupOldUnknownMachines : no-op (returns 0)
  * - stopHeartbeatService : no-op
  * - updateConfig : no-op
  * - reloadFromDisk : no-op

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
@@ -118,7 +118,7 @@ describe('get-status (Option B)', () => {
         inbox: { unread: 15, urgent: 2 },
         decisions: { pending: 3 },
         dashboards: { active: 1 },
-        flags: ['OFFLINE:myia-po-2025', 'INBOX_URGENT:2', 'DECISIONS_PENDING:3'],
+        flags: ['UNKNOWN:myia-po-2025', 'INBOX_URGENT:2', 'DECISIONS_PENDING:3'],
         lastUpdated: '2026-04-08T00:00:00Z'
       });
       expect(result.status).toBe('CRITICAL');
@@ -169,7 +169,7 @@ describe('get-status (Option B)', () => {
 
       expect(result.status).toBe('CRITICAL');
       expect(result.machines.unknown).toBe(1);
-      expect(result.flags).toContain('OFFLINE:myia-po-2025');
+      expect(result.flags).toContain('UNKNOWN:myia-po-2025');
     });
 
     test('returns CRITICAL when urgent messages', async () => {
@@ -280,8 +280,8 @@ describe('get-status (Option B)', () => {
       // Orphan test machines should NOT trigger CRITICAL
       expect(result.status).toBe('HEALTHY');
       expect(result.machines.unknown).toBe(0);
-      expect(result.flags).not.toContain('OFFLINE:test-machine');
-      expect(result.flags).not.toContain('OFFLINE:persistent-machine');
+      expect(result.flags).not.toContain('UNKNOWN:test-machine');
+      expect(result.flags).not.toContain('UNKNOWN:persistent-machine');
     });
 
     test('excludes orphan test machines from dashboard total', async () => {
@@ -333,8 +333,8 @@ describe('get-status (Option B)', () => {
       // Should be CRITICAL from real offline machine only
       expect(result.status).toBe('CRITICAL');
       expect(result.machines.unknown).toBe(1);  // Only myia-po-2025
-      expect(result.flags).toContain('OFFLINE:myia-po-2025');
-      expect(result.flags).not.toContain('OFFLINE:test-machine');
+      expect(result.flags).toContain('UNKNOWN:myia-po-2025');
+      expect(result.flags).not.toContain('UNKNOWN:test-machine');
     });
   });
 });

--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -25,7 +25,7 @@ const logger = createLogger('GetStatus');
  * Production machines match the pattern: myia-*
  * Test artifacts (test-machine, persistent-machine, machine-2, etc.) are excluded.
  *
- * #1365: Orphan test entries in heartbeat files pollute offline counts.
+ * #1365: Orphan test entries in heartbeat files pollute unknown counts.
  */
 function isKnownMachine(machineId: string): boolean {
 	return machineId.toLowerCase().startsWith('myia-');
@@ -58,7 +58,7 @@ export const GetStatusResultSchema = z.object({
     online: z.number(),
     unknown: z.number(),
     total: z.number()
-  }).describe('Compteurs machines par état (unknown = machines sans heartbeat récent, ADR 008: was "offline")'),
+  }).describe('Compteurs machines par état'),
 
   inbox: z.object({
     unread: z.number(),
@@ -137,12 +137,12 @@ function buildFlags(
 ): string[] {
   const flags: string[] = [];
 
-  // Unknown machines (ADR 008: was "offline")
+  // Unknown machines (ADR 008 terminology)
   for (const machineId of heartbeatState.unknownMachines) {
-    flags.push(`OFFLINE:${machineId}`);
+    flags.push(`UNKNOWN:${machineId}`);
   }
 
-  // Idle machines (ADR 008: was "warning"/heartbeat stale)
+  // Idle machines (ADR 008 terminology)
   for (const machineId of heartbeatState.idleMachines) {
     flags.push(`HEARTBEAT_STALE:${machineId}`);
   }
@@ -373,7 +373,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
     if (filteredUnknownMachines.length > 0 || inboxStats.urgent > 0) {
       status = 'CRITICAL';
     } else if (inboxStats.unread > 5 || filteredIdleMachines.length > 0) {
-      // WARNING if: high unread count OR heartbeat warning machines (but no offline)
+      // WARNING if: high unread count OR heartbeat idle machines (but no unknown)
       status = 'WARNING';
     }
 

--- a/servers/roo-state-manager/tests/unit/tools/roosync/get-status.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/get-status.test.ts
@@ -180,7 +180,7 @@ describe('roosync_get_status', () => {
             });
             const result = await roosyncGetStatus({});
             expect(result.status).toBe('CRITICAL');
-            expect(result.flags).toContain('OFFLINE:myia-web1');
+            expect(result.flags).toContain('UNKNOWN:myia-web1');
         });
 
         it('returns CRITICAL when urgent messages', async () => {


### PR DESCRIPTION
## Summary
- `OFFLINE:` flag → `UNKNOWN:` in `get-status.ts` and all test files
- `onOfflineDetected` → `onUnknownDetected` callback in `HeartbeatService.ts` and `RooSyncService.ts`
- Comment cleanup: remove ADR 008 migration notes, use clean terminology

## Context
Followup to #365 (which renamed schemas and status values). This PR addresses the remaining stale terminology identified in #2013 acceptance criteria.

## Out of scope
- `sync-event.ts` `action: 'offline'` enum value — public API contract, needs separate deprecation plan
- Pagination contract (#335 follow-up) — requires design decision

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 9184 passed, 16 skipped
- [ ] Verify `UNKNOWN:` flags appear in `roosync_get_status` output (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)