### PR TITLE
feat(#1841): Cluster H — merge task_export into export_data

### DIFF
--- a/servers/roo-state-manager/src/tools/__tests__/mcp-tools-audit.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/mcp-tools-audit.test.ts
@@ -34,7 +34,7 @@ const TOOL_MAPPINGS: Record<string, string> = {
   // Conversation tools
   'conversation_browser': 'conversation/conversation-browser.ts',
   'task_browse': 'conversation/conversation-browser.ts', // deprecated
-  'task_export': 'conversation/conversation-browser.ts',
+  'task_export': 'export/export-data.ts', // CONS-14 Cluster H: redirect to export_data,
   'view_conversation_tree': 'conversation/view-details.tool.ts',
   'view_task_details': 'conversation/view-details.tool.ts',
   // 'list_conversations': removed - file no longer exists

--- a/servers/roo-state-manager/src/tools/__tests__/registry.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/registry.test.ts
@@ -844,7 +844,6 @@ describe('registry.ts - Tool Registration', () => {
             roosync_storage_management: ['sharedPath'],
             conversation_browser: ['sharedPath'],
             export_data: ['sharedPath'],
-            task_export: ['sharedPath'],
             maintenance: ['sharedPath'],
             storage_info: ['sharedPath'],
 
@@ -881,12 +880,11 @@ describe('registry.ts - Tool Registration', () => {
                 'roosync_storage_management',
                 'conversation_browser',
                 'export_data',
-                'task_export',
                 'maintenance',
                 'storage_info'
             ];
 
-            expect(Object.keys(TOOL_CAPABILITIES)).toHaveLength(29);
+            expect(Object.keys(TOOL_CAPABILITIES)).toHaveLength(28);
             sharedPathTools.forEach(toolName => {
                 expect(TOOL_CAPABILITIES[toolName]).toContain('sharedPath');
             });

--- a/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
@@ -12,7 +12,6 @@ import { describe, it, expect } from 'vitest';
 import {
     allToolDefinitions,
     conversationBrowserDefinition,
-    taskExportDefinition,
     roosyncSearchDefinition,
     roosyncIndexingDefinition,
     codebaseSearchDefinition,
@@ -46,7 +45,7 @@ import {
     roosyncMessagesDefinition
 } from '../tool-definitions.js';
 
-const EXPECTED_TOOL_COUNT = 19;
+const EXPECTED_TOOL_COUNT = 18;
 
 // Order MUST mirror allToolDefinitions in tool-definitions.ts.
 // #1863: 3 deprecated definitions removed from allToolDefinitions
@@ -54,7 +53,6 @@ const EXPECTED_TOOL_COUNT = 19;
 // #1935 Cluster E: get_status removed — fused into roosync_inventory(type: "status")
 const allDefinitions = [
     conversationBrowserDefinition,
-    taskExportDefinition,
     roosyncSearchDefinition,
     roosyncIndexingDefinition,
     codebaseSearchDefinition,
@@ -90,7 +88,7 @@ const allDefinitions = [
 describe('tool-definitions.ts — Schema Validation', () => {
 
     describe('allToolDefinitions array', () => {
-        it('should have exactly 19 tool definitions', () => {
+        it('should have exactly 18 tool definitions', () => {
             expect(allToolDefinitions).toHaveLength(EXPECTED_TOOL_COUNT);
         });
 
@@ -332,9 +330,6 @@ describe('tool-definitions.ts — Schema Validation', () => {
             expect(exportConfigDefinition.inputSchema.required).toContain('action');
         });
 
-        it('task_export should require action', () => {
-            expect(taskExportDefinition.inputSchema.required).toContain('action');
-        });
 
         it('roosync_list_diffs should have filterType enum', () => {
             const filterTypes = (roosyncListDiffsDefinition.inputSchema.properties.filterType as Record<string, unknown>).enum as string[];

--- a/servers/roo-state-manager/src/tools/__tests__/tool-discoverability.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-discoverability.test.ts
@@ -270,10 +270,6 @@ describe('Category 3: Consolidated Tool Action Completeness', () => {
         },
         // B4: maintenance removed from ListTools — covered by roosync_storage_management(action: 'maintenance')
         // CallTool handler preserved for backward compat
-        'task_export': {
-            field: 'action',
-            actions: ['markdown', 'debug'],
-        },
         'roosync_search': {
             field: 'action',
             actions: ['semantic', 'text', 'diagnose'],
@@ -425,8 +421,7 @@ describe('Category 4: Essential Tools for Agent Workflows', () => {
         'roosync_indexing',      // index management
 
         // Export
-        'export_data',           // export conversations/tasks
-        'task_export',           // export task trees
+        'export_data',           // export conversations/tasks (CONS-14: absorbed task_export)
     ];
 
     it('all essential tools must be present in ListTools', async () => {
@@ -485,7 +480,6 @@ describe('Category 5: Description Discoverability', () => {
         'roosync_indexing': ['index'],                   // "index sémantique"
         'export_data': ['export'],                       // "exporter des données"
         // [REMOVED #291] export_config removed from allToolDefinitions
-        'task_export': ['export', 'tâche'],              // "exporter/diagnostiquer les tâches"
         // B4: maintenance removed from ListTools — covered by roosync_storage_management(action: 'maintenance')
         // B4: storage_info removed from ListTools — covered by roosync_storage_management(action: 'storage')
         'codebase_search': ['recherche', 'code'],        // "Recherche sémantique dans le code"
@@ -555,8 +549,8 @@ describe('Category 6: Backward Compatibility Routes', () => {
         'diagnose_conversation_bom': 'roosync_storage_management',
         'repair_conversation_bom': 'roosync_storage_management',
         // [REMOVED #625] build_skeleton_cache — handler removed
-        // CLEANUP-3: debug → task_export
-        'debug_analyze_conversation': 'task_export',
+        // CLEANUP-3: debug → export_data (via task_export redirect, Cluster H)
+        'debug_analyze_conversation': 'export_data',
         // [REMOVED #625] 6 legacy messaging handlers removed
         // [REMOVED Phase B #1863] Legacy decision/baseline/config/inventory backward-compat handlers removed
         // roosync_get_decision_details, approve/reject/apply/rollback_decision,

--- a/servers/roo-state-manager/src/tools/export/__tests__/export-data.integration.test.ts
+++ b/servers/roo-state-manager/src/tools/export/__tests__/export-data.integration.test.ts
@@ -191,7 +191,7 @@ describe('export_data (integration)', () => {
       // Vérifier que la propriété format est définie
       expect(exportDataTool.inputSchema.properties).toHaveProperty('format');
       expect(exportDataTool.inputSchema.properties.format.type).toBe('string');
-      expect(exportDataTool.inputSchema.properties.format.enum).toEqual(['xml', 'json', 'csv']);
+      expect(exportDataTool.inputSchema.properties.format.enum).toEqual(['xml', 'json', 'csv', 'markdown', 'debug']);
     });
 
     test('should include taskId property in schema', async () => {

--- a/servers/roo-state-manager/src/tools/export/__tests__/export-data.test.ts
+++ b/servers/roo-state-manager/src/tools/export/__tests__/export-data.test.ts
@@ -420,7 +420,7 @@ describe('export_data - CONS-10', () => {
 
         test('should have correct format enum values', () => {
             const props = exportDataTool.inputSchema.properties as any;
-            expect(props.format.enum).toEqual(['xml', 'json', 'csv']);
+            expect(props.format.enum).toEqual(['xml', 'json', 'csv', 'markdown', 'debug']);
         });
 
         test('should include all expected parameters', () => {
@@ -431,6 +431,12 @@ describe('export_data - CONS-10', () => {
             expect(props.filePath).toBeDefined();
             expect(props.jsonVariant).toBeDefined();
             expect(props.csvVariant).toBeDefined();
+            // CONS-14 Cluster H: new params for markdown/debug formats
+            expect(props.outputFormat).toBeDefined();
+            expect(props.includeSiblings).toBeDefined();
+            expect(props.currentTaskId).toBeDefined();
+            expect(props.truncateInstruction).toBeDefined();
+            expect(props.showMetadata).toBeDefined();
         });
     });
 });

--- a/servers/roo-state-manager/src/tools/export/export-data.ts
+++ b/servers/roo-state-manager/src/tools/export/export-data.ts
@@ -2,16 +2,18 @@
  * Outil MCP consolidé : export_data
  *
  * CONS-10: Consolide 5 outils d'export en 1 outil unifié.
+ * CONS-14 (#1841 Cluster H): Absorbe task_export (markdown + debug).
  * Remplace:
  *   - export_tasks_xml
  *   - export_conversation_xml
  *   - export_project_xml
  *   - export_conversation_json
  *   - export_conversation_csv
+ *   - task_export (markdown tree export + debug parsing)
  *
  * @module tools/export/export-data
- * @version 1.0.0
- * @since CONS-10
+ * @version 2.0.0
+ * @since CONS-10, CONS-14
  */
 
 import { Tool, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
@@ -21,6 +23,9 @@ import { XmlExporterService } from '../../services/XmlExporterService.js';
 import { TraceSummaryService, SummaryOptions } from '../../services/TraceSummaryService.js';
 import { ExportConfigManager } from '../../services/ExportConfigManager.js';
 import { normalizePath } from '../../utils/path-normalizer.js';
+import { handleExportTaskTreeMarkdown, ExportTaskTreeMarkdownArgs } from '../task/export-tree-md.tool.js';
+import { handleDebugTaskParsing, DebugTaskParsingArgs } from '../task/debug-parsing.tool.js';
+import { handleGetTaskTree } from '../task/get-tree.tool.js';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -28,7 +33,7 @@ import path from 'path';
  * Types d'export supportés
  */
 export type ExportTarget = 'task' | 'conversation' | 'project';
-export type ExportFormat = 'xml' | 'json' | 'csv';
+export type ExportFormat = 'xml' | 'json' | 'csv' | 'markdown' | 'debug';
 
 /**
  * Arguments consolidés du tool export_data
@@ -74,6 +79,18 @@ export interface ExportDataArgs {
     startIndex?: number;
     /** Index de fin (1-based) pour plage de messages */
     endIndex?: number;
+
+    // Options markdown (CONS-14, from task_export)
+    /** Format de sortie pour markdown: ascii-tree, markdown, hierarchical, json */
+    outputFormat?: 'ascii-tree' | 'markdown' | 'hierarchical' | 'json';
+    /** Inclure les tâches sœurs (même parent) dans l'arbre */
+    includeSiblings?: boolean;
+    /** ID de la tâche en cours d'exécution pour marquage */
+    currentTaskId?: string;
+    /** Longueur max de l'instruction affichée (défaut: 80) */
+    truncateInstruction?: number;
+    /** Afficher les métadonnées détaillées */
+    showMetadata?: boolean;
 }
 
 /**
@@ -81,7 +98,7 @@ export interface ExportDataArgs {
  */
 export const exportDataTool: Tool = {
     name: 'export_data',
-    description: 'Export data as XML, JSON or CSV. Targets: task (XML), conversation (all formats), project (XML). JSON variants: light/full. CSV variants: conversations/messages/tools.',
+    description: 'Export data as XML, JSON, CSV, or Markdown. Debug task parsing. Targets: task (XML, debug), conversation (all formats), project (XML). CONS-10 + CONS-14 (absorbs task_export).',
     inputSchema: {
         type: 'object',
         properties: {
@@ -92,16 +109,16 @@ export const exportDataTool: Tool = {
             },
             format: {
                 type: 'string',
-                enum: ['xml', 'json', 'csv'],
-                description: 'Output format: xml, json, or csv'
+                enum: ['xml', 'json', 'csv', 'markdown', 'debug'],
+                description: 'Output format: xml, json, csv, markdown (conversation tree), or debug (task parsing diagnostic)'
             },
             taskId: {
                 type: 'string',
-                description: 'Task ID (required for target=task, or conversation with json/csv)'
+                description: 'Task ID (required for target=task, or conversation with json/csv/debug)'
             },
             conversationId: {
                 type: 'string',
-                description: 'Root conversation ID (required for target=conversation with xml)'
+                description: 'Root conversation ID (required for target=conversation with xml/markdown)'
             },
             projectPath: {
                 type: 'string',
@@ -122,7 +139,7 @@ export const exportDataTool: Tool = {
             },
             maxDepth: {
                 type: 'integer',
-                description: 'Max tree depth (XML conversation)'
+                description: 'Max tree depth (XML/markdown)'
             },
             startDate: {
                 type: 'string',
@@ -156,6 +173,28 @@ export const exportDataTool: Tool = {
             endIndex: {
                 type: 'number',
                 description: 'End index (1-based) for message range'
+            },
+            // Options markdown (CONS-14, from task_export)
+            outputFormat: {
+                type: 'string',
+                enum: ['ascii-tree', 'markdown', 'hierarchical', 'json'],
+                description: '[markdown] Sub-format: ascii-tree (default), markdown, hierarchical, or json'
+            },
+            includeSiblings: {
+                type: 'boolean',
+                description: '[markdown] Include sibling tasks (default: true)'
+            },
+            currentTaskId: {
+                type: 'string',
+                description: '[markdown] Mark this task as current in the tree'
+            },
+            truncateInstruction: {
+                type: 'number',
+                description: '[markdown] Max instruction display length (default: 80)'
+            },
+            showMetadata: {
+                type: 'boolean',
+                description: '[markdown] Show detailed metadata (default: false)'
             }
         },
         required: ['target', 'format']
@@ -167,8 +206,8 @@ export const exportDataTool: Tool = {
  */
 function validateTargetFormat(target: ExportTarget, format: ExportFormat): void {
     const validCombinations: Record<ExportTarget, ExportFormat[]> = {
-        task: ['xml'],
-        conversation: ['xml', 'json', 'csv'],
+        task: ['xml', 'debug'],
+        conversation: ['xml', 'json', 'csv', 'markdown'],
         project: ['xml']
     };
 
@@ -189,13 +228,23 @@ function validateTargetFormat(target: ExportTarget, format: ExportFormat): void 
 function validateRequiredParams(args: ExportDataArgs): void {
     const { target, format, taskId, conversationId, projectPath } = args;
 
-    if (target === 'task' && !taskId) {
-        throw new StateManagerError(
-            'taskId est requis pour target=task',
-            'MISSING_REQUIRED_PARAM',
-            'ExportDataTool',
-            { target, missingParam: 'taskId' }
-        );
+    if (target === 'task') {
+        if (format === 'xml' && !taskId) {
+            throw new StateManagerError(
+                'taskId est requis pour target=task format=xml',
+                'MISSING_REQUIRED_PARAM',
+                'ExportDataTool',
+                { target, format, missingParam: 'taskId' }
+            );
+        }
+        if (format === 'debug' && !taskId) {
+            throw new StateManagerError(
+                'taskId est requis pour target=task format=debug',
+                'MISSING_REQUIRED_PARAM',
+                'ExportDataTool',
+                { target, format, missingParam: 'taskId' }
+            );
+        }
     }
 
     if (target === 'conversation') {
@@ -213,6 +262,14 @@ function validateRequiredParams(args: ExportDataArgs): void {
                 'MISSING_REQUIRED_PARAM',
                 'ExportDataTool',
                 { target, format, missingParam: 'taskId' }
+            );
+        }
+        if (format === 'markdown' && !conversationId) {
+            throw new StateManagerError(
+                'conversationId est requis pour target=conversation format=markdown',
+                'MISSING_REQUIRED_PARAM',
+                'ExportDataTool',
+                { target, format, missingParam: 'conversationId' }
             );
         }
     }
@@ -539,6 +596,49 @@ async function handleConversationCsv(
 }
 
 /**
+ * Handler pour export markdown d'une conversation (task tree)
+ * CONS-14: Absorbed from task_export action='markdown'
+ */
+async function handleConversationMarkdown(
+    args: ExportDataArgs,
+    conversationCache: Map<string, ConversationSkeleton>,
+    ensureSkeletonCacheIsFresh: () => Promise<void>
+): Promise<CallToolResult> {
+    const exportArgs: ExportTaskTreeMarkdownArgs = {
+        conversation_id: args.conversationId!,
+        filePath: args.filePath,
+        max_depth: args.maxDepth,
+        include_siblings: args.includeSiblings,
+        current_task_id: args.currentTaskId,
+        output_format: args.outputFormat || 'ascii-tree',
+        truncate_instruction: args.truncateInstruction,
+        show_metadata: args.showMetadata
+    };
+
+    const wrappedHandleGetTaskTree = async (treeArgs: any) => {
+        return await handleGetTaskTree(treeArgs, conversationCache, ensureSkeletonCacheIsFresh);
+    };
+
+    return await handleExportTaskTreeMarkdown(
+        exportArgs,
+        wrappedHandleGetTaskTree,
+        ensureSkeletonCacheIsFresh,
+        conversationCache
+    );
+}
+
+/**
+ * Handler pour diagnostic de parsing d'une tâche
+ * CONS-14: Absorbed from task_export action='debug'
+ */
+async function handleTaskDebug(args: ExportDataArgs): Promise<CallToolResult> {
+    const debugArgs: DebugTaskParsingArgs = {
+        task_id: args.taskId!
+    };
+    return await handleDebugTaskParsing(debugArgs);
+}
+
+/**
  * Handler principal consolidé pour export_data
  */
 export async function handleExportData(
@@ -565,7 +665,7 @@ export async function handleExportData(
                 isError: true,
                 content: [{
                     type: 'text',
-                    text: 'Paramètre "format" requis. Valeurs: xml, json, csv'
+                    text: 'Paramètre "format" requis. Valeurs: xml, json, csv, markdown, debug'
                 }]
             };
         }
@@ -579,8 +679,13 @@ export async function handleExportData(
         // Router vers le handler approprié
         const { target, format } = args;
 
-        if (target === 'task' && format === 'xml') {
-            return await handleTaskXml(args, conversationCache, xmlExporterService, ensureSkeletonCacheIsFresh);
+        if (target === 'task') {
+            if (format === 'xml') {
+                return await handleTaskXml(args, conversationCache, xmlExporterService, ensureSkeletonCacheIsFresh);
+            }
+            if (format === 'debug') {
+                return await handleTaskDebug(args);
+            }
         }
 
         if (target === 'conversation') {
@@ -592,6 +697,9 @@ export async function handleExportData(
             }
             if (format === 'csv') {
                 return await handleConversationCsv(args, getConversationSkeleton);
+            }
+            if (format === 'markdown') {
+                return await handleConversationMarkdown(args, conversationCache, ensureSkeletonCacheIsFresh);
             }
         }
 

--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -77,7 +77,6 @@ export const TOOL_CAPABILITIES: Record<string, Capability[]> = {
 	roosync_storage_management: ['sharedPath'],
 	conversation_browser: ['sharedPath'],
 	export_data: ['sharedPath'],
-	task_export: ['sharedPath'],
 	maintenance: ['sharedPath'],
 	storage_info: ['sharedPath'],
 	// Qdrant-dependent tools
@@ -252,12 +251,41 @@ export function registerCallToolHandler(
                 );
                 break;
             }
+            // #1841 Cluster H: task_export deprecated — redirects to export_data(format: "markdown"/"debug")
             case 'task_export': {
-                const m = await import('./task/export.js');
-                result = await m.handleTaskExport(
-                    args as any,
+                const taskArgs = args as any;
+                // Map task_export action → export_data target/format
+                const mappedArgs: any = {
+                    ...taskArgs,
+                    target: taskArgs.action === 'debug' ? 'task' : 'conversation',
+                    format: taskArgs.action || 'markdown',
+                    // Map snake_case params to camelCase
+                    conversationId: taskArgs.conversation_id,
+                    maxDepth: taskArgs.max_depth,
+                    includeSiblings: taskArgs.include_siblings,
+                    currentTaskId: taskArgs.current_task_id,
+                    truncateInstruction: taskArgs.truncate_instruction,
+                    showMetadata: taskArgs.show_metadata,
+                    outputFormat: taskArgs.output_format,
+                    taskId: taskArgs.task_id,
+                };
+                delete mappedArgs.action;
+                delete mappedArgs.conversation_id;
+                delete mappedArgs.max_depth;
+                delete mappedArgs.include_siblings;
+                delete mappedArgs.current_task_id;
+                delete mappedArgs.truncate_instruction;
+                delete mappedArgs.show_metadata;
+                delete mappedArgs.output_format;
+                delete mappedArgs.task_id;
+
+                const m = await import('./export/export-data.js');
+                result = await m.handleExportData(
+                    mappedArgs,
                     cache,
-                    async () => { await ensureSkeletonCacheIsFresh(); }
+                    state.xmlExporterService,
+                    async (options?: { workspace?: string }) => { await ensureSkeletonCacheIsFresh(options); },
+                    async (id: string) => cache.get(id) || null
                 );
                 break;
             }

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -195,26 +195,31 @@ export const readVscodeLogsDefinition = {
 // ============================================================
 export const exportDataDefinition = {
     name: 'export_data',
-    description: `Outil consolidé pour exporter des données au format XML, JSON ou CSV.\n\nCibles supportées:\n- task: Export d'une tâche individuelle (XML uniquement)\n- conversation: Export d'une conversation complète (tous formats)\n- project: Export d'un projet entier (XML uniquement)\n\nFormats supportés:\n- xml: Format XML structuré\n- json: Format JSON avec variantes light/full\n- csv: Format CSV avec variantes conversations/messages/tools\n\nCONS-10: Remplace export_tasks_xml, export_conversation_xml, export_project_xml, export_conversation_json, export_conversation_csv`,
+    description: `Outil consolidé pour exporter des données au format XML, JSON, CSV, Markdown, ou diagnostiquer le parsing.\n\nCibles supportées:\n- task: Export d'une tâche individuelle (XML, debug parsing)\n- conversation: Export d'une conversation complète (tous formats, incluant markdown tree)\n- project: Export d'un projet entier (XML uniquement)\n\nFormats supportés:\n- xml: Format XML structuré\n- json: Format JSON avec variantes light/full\n- csv: Format CSV avec variantes conversations/messages/tools\n- markdown: Export arbre de tâches (ascii-tree/markdown/hierarchical/json)\n- debug: Diagnostic parsing d'une tâche\n\nCONS-10: Remplace export_tasks_xml, export_conversation_xml, export_project_xml, export_conversation_json, export_conversation_csv\nCONS-14 (#1841 Cluster H): Absorbe task_export (markdown + debug)`,
     inputSchema: {
         type: 'object',
         properties: {
             target: { type: 'string', enum: ['task', 'conversation', 'project'], description: "Cible de l'export: task, conversation, ou project" },
-            format: { type: 'string', enum: ['xml', 'json', 'csv'], description: 'Format de sortie: xml, json, ou csv' },
-            taskId: { type: 'string', description: 'ID de la tâche (requis pour target=task, ou conversation avec json/csv)' },
-            conversationId: { type: 'string', description: 'ID de la conversation racine (requis pour target=conversation avec xml)' },
+            format: { type: 'string', enum: ['xml', 'json', 'csv', 'markdown', 'debug'], description: 'Format de sortie: xml, json, csv, markdown (arbre tâches), ou debug (diagnostic parsing)' },
+            taskId: { type: 'string', description: 'ID de la tâche (requis pour target=task, ou conversation avec json/csv/debug)' },
+            conversationId: { type: 'string', description: 'ID de la conversation racine (requis pour target=conversation avec xml/markdown)' },
             projectPath: { type: 'string', description: 'Chemin du projet (requis pour target=project)' },
             filePath: { type: 'string', description: 'Chemin de sortie pour le fichier. Si non fourni, retourne le contenu.' },
             includeContent: { type: 'boolean', description: 'Inclure le contenu complet des messages (XML, défaut: false)' },
             prettyPrint: { type: 'boolean', description: 'Indenter pour lisibilité (XML, défaut: true)' },
-            maxDepth: { type: 'integer', description: "Profondeur max de l'arbre de tâches (XML conversation)" },
+            maxDepth: { type: 'integer', description: "Profondeur max de l'arbre de tâches (XML/markdown)" },
             startDate: { type: 'string', description: 'Date de début ISO 8601 pour filtrer (XML project)' },
             endDate: { type: 'string', description: 'Date de fin ISO 8601 pour filtrer (XML project)' },
             jsonVariant: { type: 'string', enum: ['light', 'full'], description: 'Variante JSON: light (squelette) ou full (détail complet)' },
             csvVariant: { type: 'string', enum: ['conversations', 'messages', 'tools'], description: 'Variante CSV: conversations, messages, ou tools' },
             truncationChars: { type: 'number', description: 'Max caractères avant troncature (0 = pas de troncature)' },
             startIndex: { type: 'number', description: 'Index de début (1-based) pour plage de messages' },
-            endIndex: { type: 'number', description: 'Index de fin (1-based) pour plage de messages' }
+            endIndex: { type: 'number', description: 'Index de fin (1-based) pour plage de messages' },
+            outputFormat: { type: 'string', enum: ['ascii-tree', 'markdown', 'hierarchical', 'json'], description: '[markdown] Sous-format: ascii-tree (défaut), markdown, hierarchical, ou json' },
+            includeSiblings: { type: 'boolean', description: '[markdown] Inclure les tâches sœurs (défaut: true)' },
+            currentTaskId: { type: 'string', description: '[markdown] Marquer cette tâche comme active dans l\'arbre' },
+            truncateInstruction: { type: 'number', description: '[markdown] Longueur max instruction affichée (défaut: 80)' },
+            showMetadata: { type: 'boolean', description: '[markdown] Afficher métadonnées détaillées (défaut: false)' }
         },
         required: ['target', 'format']
     }
@@ -632,7 +637,7 @@ export const roosyncDashboardDefinition = dashboardToolMetadata;
 export const allToolDefinitions = [
     // CONS-X (#457): conversation_browser
     conversationBrowserDefinition,
-    taskExportDefinition,
+    // [REMOVED #1841 Cluster H] taskExportDefinition — fused into export_data(format: "markdown"/"debug"), redirect in registry.ts
     // CONS-11: Search/Indexing
     roosyncSearchDefinition,
     roosyncIndexingDefinition,

--- a/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
@@ -299,16 +299,15 @@ describe('#1935 Fusion E: get_status → inventory(type: "status")', () => {
 // Cross-cutting: Definition count and deprecation removal verification
 // ============================================================
 describe('#1863 Cross-cutting: tool count and deprecation markers', () => {
-  it('allToolDefinitions should contain 22 tools (3 deprecated #1863 + 6 low-usage #1841 + 1 Cluster D fusion + 1 Cluster E fusion removed)', () => {
+  it('allToolDefinitions should contain 18 tools (Cluster H fusion removed task_export)', () => {
     // Before: 32 tools → #1922 Pass 4 removed 3 deprecated → 29
-    // #1841 removed 6 low-usage (get_mcp_best_practices, export_config, view_task_details,
-    //   get_raw_conversation, refresh_dashboard, update_dashboard) → 23 (wait: 29-6=23)
-    // Actually #297 consolidated to 24 active in ListTools (less low-usage). allToolDefinitions baseline = 24.
-    // Cluster D (#1935) fused analyze_roosync_problems → roosync_diagnose(action: "analyze"): 24 → 23
-    // Cluster E (#1935) fused get_status → inventory(type: "status"): 23 → 22
+    // #1841 removed 6 low-usage → 23. allToolDefinitions baseline = 24.
+    // Cluster D (#1935) fused analyze_roosync_problems → roosync_diagnose: 24 → 23
+    // Cluster E (#1935) fused get_status → inventory: 23 → 22
     // Cluster G (#1841) fused send+read+manage+attachments → roosync_messages: 22 → 19
+    // Cluster H (#1841) fused task_export → export_data: 19 → 18
     // Backward compat redirect handlers in registry.ts are preserved
-    expect(allToolDefinitions.length).toBe(19);
+    expect(allToolDefinitions.length).toBe(18);
   });
 
   it('deprecated tools should NOT be in allToolDefinitions', () => {


### PR DESCRIPTION
## Summary
- Merges `task_export` tool (markdown tree export + debug parsing) into `export_data` via new `format: "markdown"` and `format: "debug"` options
- Removes `taskExportDefinition` from `allToolDefinitions` (19→18 tools exposed to agents)
- Adds backward-compat redirect handler in registry.ts with snake_case→camelCase param mapping
- Tool count: 19→18 active tools in ListTools

## Changes
- `export-data.ts`: Added `handleConversationMarkdown` and `handleTaskDebug` handlers, new params (outputFormat, includeSiblings, currentTaskId, truncateInstruction, showMetadata)
- `tool-definitions.ts`: Removed `taskExportDefinition`, updated `exportDataDefinition` with new formats/params
- `registry.ts`: `task_export` case maps params and delegates to `handleExportData`
- Tests updated: fusions-1863, tool-definitions, tool-discoverability, registry, mcp-tools-audit, export-data unit/integration

## Test plan
- [x] `npm run build` passes (0 errors)
- [x] 7 affected test files: 241 passed, 0 failed
- [x] Tool count assertion: 18 tools in allToolDefinitions
- [x] Backward compat: `task_export` calls redirect to `export_data`
- [x] Format enum: `['xml', 'json', 'csv', 'markdown', 'debug']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)