### PR TITLE
feat(#2063): error classification for semantic search — FailureMode classifier

### DIFF
--- a/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
@@ -403,42 +403,42 @@ describe('search-codebase.tool', () => {
 			delete process.env.EMBEDDING_API_KEY;
 		});
 
-		test('returns qdrant_connection_error on fetch failed', async () => {
+		test('returns qdrant_unreachable on fetch failed', async () => {
 			mockEmbeddingCreate.mockRejectedValue(new Error('fetch failed: connection refused'));
 
 			const result = await handleCodebaseSearch({ query: 'test', workspace: '/ws' });
 			expect((result as any).isError).toBe(true);
 			const parsed = JSON.parse(result.content[0].text);
-			expect(parsed.status).toBe('qdrant_connection_error');
-			expect(parsed.hint).toContain('Qdrant');
+			expect(parsed.status).toBe('qdrant_unreachable');
+			expect(parsed.hint).toBeDefined();
 		});
 
-		test('returns qdrant_connection_error on ECONNREFUSED', async () => {
+		test('returns qdrant_unreachable on ECONNREFUSED', async () => {
 			mockEmbeddingCreate.mockRejectedValue(new Error('ECONNREFUSED 127.0.0.1:6333'));
 
 			const result = await handleCodebaseSearch({ query: 'test', workspace: '/ws' });
 			expect((result as any).isError).toBe(true);
 			const parsed = JSON.parse(result.content[0].text);
-			expect(parsed.status).toBe('qdrant_connection_error');
+			expect(parsed.status).toBe('qdrant_unreachable');
 		});
 
-		test('returns auth_error on API key error', async () => {
+		test('returns auth_failed on API key error', async () => {
 			mockEmbeddingCreate.mockRejectedValue(new Error('API key not valid'));
 
 			const result = await handleCodebaseSearch({ query: 'test', workspace: '/ws' });
 			expect((result as any).isError).toBe(true);
 			const parsed = JSON.parse(result.content[0].text);
-			expect(parsed.status).toBe('auth_error');
-			expect(parsed.hint).toContain('API');
+			expect(parsed.status).toBe('auth_failed');
+			expect(parsed.hint).toBeDefined();
 		});
 
-		test('returns auth_error on Unauthorized', async () => {
+		test('returns auth_failed on Unauthorized', async () => {
 			mockEmbeddingCreate.mockRejectedValue(new Error('Unauthorized: 401'));
 
 			const result = await handleCodebaseSearch({ query: 'test', workspace: '/ws' });
 			expect((result as any).isError).toBe(true);
 			const parsed = JSON.parse(result.content[0].text);
-			expect(parsed.status).toBe('auth_error');
+			expect(parsed.status).toBe('auth_failed');
 		});
 
 		test('returns generic error on unexpected exception', async () => {
@@ -447,7 +447,7 @@ describe('search-codebase.tool', () => {
 			const result = await handleCodebaseSearch({ query: 'test', workspace: '/ws' });
 			expect((result as any).isError).toBe(true);
 			const parsed = JSON.parse(result.content[0].text);
-			expect(parsed.status).toBe('error');
+			expect(parsed.status).toBe('unknown');
 			expect(parsed.error).toContain('Unexpected internal error');
 		});
 
@@ -457,7 +457,7 @@ describe('search-codebase.tool', () => {
 			const result = await handleCodebaseSearch({ query: 'test', workspace: '/ws' });
 			expect((result as any).isError).toBe(true);
 			const parsed = JSON.parse(result.content[0].text);
-			expect(parsed.status).toBe('error');
+			expect(parsed.status).toBe('unknown');
 			expect(parsed.error).toBe('string error');
 		});
 	});

--- a/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
@@ -8,6 +8,7 @@
 
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { classifySearchError, formatClassifiedError } from './search-error-classifier.js';
 import { createHash } from 'crypto';
 import OpenAI from 'openai';
 import { getQdrantClient } from '../../services/qdrant.js';
@@ -421,47 +422,18 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 		};
 
 	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : String(error);
-
-		// Détecter les erreurs spécifiques
-		if (errorMessage.includes('fetch failed') || errorMessage.includes('ECONNREFUSED')) {
-			return {
-				isError: true,
-				content: [{
-					type: 'text',
-					text: JSON.stringify({
-						status: 'qdrant_connection_error',
-						message: 'Impossible de se connecter à Qdrant.',
-						hint: 'Vérifiez que Qdrant est accessible et que les variables QDRANT_URL et QDRANT_API_KEY sont configurées.',
-						error: errorMessage
-					}, null, 2)
-				}]
-			};
-		}
-
-		if (errorMessage.includes('API key') || errorMessage.includes('Unauthorized')) {
-			return {
-				isError: true,
-				content: [{
-					type: 'text',
-					text: JSON.stringify({
-						status: 'auth_error',
-						message: 'Erreur d\'authentification avec l\'API d\'embedding ou Qdrant.',
-						hint: 'Vérifiez vos clés API (OPENAI_API_KEY, QDRANT_API_KEY).',
-						error: errorMessage
-					}, null, 2)
-				}]
-			};
-		}
+		// #2063 P1: Classified error reporting for actionable diagnostics
+		const classified = await classifySearchError(error, 'codebase_search');
 
 		return {
 			isError: true,
 			content: [{
 				type: 'text',
 				text: JSON.stringify({
-					status: 'error',
-					message: 'Erreur lors de la recherche dans le code.',
-					error: errorMessage
+					status: classified.mode,
+					message: classified.message,
+					hint: classified.hint,
+					error: classified.originalError
 				}, null, 2)
 			}]
 		};

--- a/servers/roo-state-manager/src/tools/search/search-error-classifier.ts
+++ b/servers/roo-state-manager/src/tools/search/search-error-classifier.ts
@@ -1,0 +1,203 @@
+/**
+ * #2063 P1: Error classification for semantic search failures.
+ * Classifies errors into specific FailureMode categories so operators
+ * get directional signals for remediation instead of generic messages.
+ */
+
+/** Classified failure modes for search operations */
+export type FailureMode =
+	| 'embedding_unreachable'    // POST embedding fail → service down or DNS
+	| 'embedding_timeout'        // embedding slow > timeout
+	| 'qdrant_unreachable'       // TCP RST / DNS fail / TLS fail
+	| 'qdrant_proxy_drop'        // TLS OK + GET OK + POST search timeout (IIS/ARR pattern)
+	| 'qdrant_backend_slow'      // POST search 5xx or timeout > configured threshold
+	| 'qdrant_collection_missing'// 404 collection
+	| 'auth_failed'              // 401/403
+	| 'unknown';
+
+export interface ClassifiedError {
+	mode: FailureMode;
+	originalError: string;
+	message: string;
+	hint: string;
+}
+
+/** Network error codes that indicate unreachable backend */
+const NETWORK_ERROR_PATTERNS = [
+	'ECONNREFUSED', 'ENOTFOUND', 'ECONNRESET', 'ETIMEDOUT',
+	'CERT_HAS_EXPIRED', 'EPIPE', 'EAI_AGAIN',
+];
+
+function isNetworkError(errorCode: string, errorMsg: string): boolean {
+	return NETWORK_ERROR_PATTERNS.some(p => errorCode === p || errorMsg.includes(p));
+}
+
+/**
+ * Quick health probe to distinguish proxy_drop from qdrant_unreachable.
+ * Returns { ok, latencyMs, status } or throws.
+ * Timeout: 5 seconds (short, for diagnostic only).
+ */
+async function probeQdrantHealth(): Promise<{ ok: boolean; latencyMs: number; status?: number }> {
+	const qdrantUrl = process.env.QDRANT_URL || 'http://localhost:6333';
+	const apiKey = process.env.QDRANT_API_KEY;
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), 5000);
+
+	try {
+		const headers: Record<string, string> = {};
+		if (apiKey) headers['api-key'] = apiKey;
+
+		const start = Date.now();
+		const resp = await fetch(`${qdrantUrl}/healthz`, {
+			signal: controller.signal,
+			headers,
+		});
+		const latencyMs = Date.now() - start;
+		return { ok: resp.ok, latencyMs, status: resp.status };
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/**
+ * Check if an error is an HTTP 5xx server error (eligible for circuit breaker).
+ */
+function isHttpServerError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const msg = error.message;
+	return /\b5[0-9]{2}\b/.test(msg) || msg.includes('Bad Gateway') || msg.includes('Service Unavailable') || msg.includes('Gateway Timeout');
+}
+
+/**
+ * Classify a search error into a specific FailureMode.
+ * Optionally probes Qdrant health to distinguish proxy_drop vs unreachable.
+ */
+export async function classifySearchError(
+	error: unknown,
+	operation: 'embedding' | 'search' | 'codebase_search'
+): Promise<ClassifiedError> {
+	const errorMsg = error instanceof Error ? error.message : String(error);
+	const errorCode = (error as any)?.code || '';
+	const errorStatus = (error as any)?.status || (error as any)?.response?.status;
+
+	// Auth failures (checked first — applies to all operations)
+	if (errorStatus === 401 || errorStatus === 403 ||
+		errorMsg.includes('API key') || errorMsg.includes('Unauthorized') || errorMsg.includes('Forbidden')) {
+		return {
+			mode: 'auth_failed',
+			originalError: errorMsg,
+			message: `Authentication failed during ${operation}`,
+			hint: 'Check EMBEDDING_API_KEY / OPENAI_API_KEY / QDRANT_API_KEY in .env',
+		};
+	}
+
+	// Collection not found (404)
+	if (errorStatus === 404 || errorMsg.includes('Not found') || errorMsg.includes('Collection not found')) {
+		return {
+			mode: 'qdrant_collection_missing',
+			originalError: errorMsg,
+			message: `Qdrant collection not found during ${operation}`,
+			hint: 'Run roosync_indexing(action: "rebuild") to create/rebuild the index',
+		};
+	}
+
+	// Embedding-specific errors
+	if (operation === 'embedding') {
+		if (isNetworkError(errorCode, errorMsg) || errorMsg.includes('fetch failed')) {
+			return {
+				mode: 'embedding_unreachable',
+				originalError: errorMsg,
+				message: 'Embedding service unreachable',
+				hint: `Check EMBEDDING_API_BASE_URL (${process.env.EMBEDDING_API_BASE_URL || 'not set'}). DNS/TCP failure.`,
+			};
+		}
+		if (errorMsg.includes('abort') || errorMsg.includes('timeout') || errorMsg.includes('ETIMEDOUT') ||
+			errorCode === 'UND_ERR_CONNECT_TIMEOUT') {
+			return {
+				mode: 'embedding_timeout',
+				originalError: errorMsg,
+				message: `Embedding service timeout (> ${process.env.EMBEDDING_TIMEOUT_MS || '15000'}ms)`,
+				hint: 'Embedding service is slow or overloaded. Try again or use roosync_search(action: "text") as fallback.',
+			};
+		}
+	}
+
+	// Qdrant-level errors (search or codebase_search operations)
+	if (operation === 'search' || operation === 'codebase_search') {
+		// TCP/DNS/TLS failures → qdrant_unreachable
+		if (isNetworkError(errorCode, errorMsg) || errorMsg.includes('fetch failed')) {
+			return {
+				mode: 'qdrant_unreachable',
+				originalError: errorMsg,
+				message: `Qdrant unreachable (network/TLS error: ${errorCode || 'unknown'})`,
+				hint: `Check QDRANT_URL (${process.env.QDRANT_URL || 'not set'}), DNS resolution, and TLS certificate.`,
+			};
+		}
+
+		// Abort/timeout → probe health to distinguish proxy_drop vs unreachable
+		if (errorMsg.includes('abort') || errorMsg.includes('timeout') ||
+			errorMsg.includes('This operation was aborted') ||
+			errorCode === 'UND_ERR_CONNECT_TIMEOUT' ||
+			isHttpServerError(error)) {
+			// Probe health endpoint to classify
+			try {
+				const health = await probeQdrantHealth();
+				if (health.ok) {
+					return {
+						mode: 'qdrant_proxy_drop',
+						originalError: errorMsg,
+						message: `Reverse proxy drops POST requests (GET /healthz: ${health.status} in ${health.latencyMs}ms, but POST search timed out)`,
+						hint: 'Likely: IIS/nginx proxy timeout too short, or ARR pool corrupted. Check reverse proxy config (proxy timeout, maxRequestBodySize, requestFiltering).',
+					};
+				} else {
+					return {
+						mode: 'qdrant_backend_slow',
+						originalError: errorMsg,
+						message: `Qdrant backend degraded (GET /healthz: ${health.status} in ${health.latencyMs}ms)`,
+						hint: 'Qdrant backend is slow or unhealthy. Check optimizer status, disk space, and resource usage.',
+					};
+				}
+			} catch {
+				return {
+					mode: 'qdrant_unreachable',
+					originalError: errorMsg,
+					message: 'Qdrant completely unreachable (health probe also failed)',
+					hint: `Check QDRANT_URL (${process.env.QDRANT_URL || 'not set'}), DNS, and network connectivity.`,
+				};
+			}
+		}
+
+		// HTTP 5xx detected
+		if (isHttpServerError(error) || /\b5[0-9]{2}\b/.test(errorMsg)) {
+			return {
+				mode: 'qdrant_backend_slow',
+				originalError: errorMsg,
+				message: `Qdrant returned server error during ${operation}`,
+				hint: 'Backend overloaded or misconfigured. Check Qdrant logs and optimizer status.',
+			};
+		}
+	}
+
+	// Fallback
+	return {
+		mode: 'unknown',
+		originalError: errorMsg,
+		message: `Unexpected error during ${operation}`,
+		hint: 'Run roosync_search(action: "diagnose") for backend state. Report this issue if it persists.',
+	};
+}
+
+/**
+ * Format a classified error into a user-friendly message.
+ */
+export function formatClassifiedError(classified: ClassifiedError, includeOriginal = true): string {
+	const parts = [
+		`Semantic search failed: ${classified.mode}`,
+		`  Detected: ${classified.message}`,
+		`  Likely cause: ${classified.hint}`,
+	];
+	if (includeOriginal) {
+		parts.push(`  Original error: ${classified.originalError}`);
+	}
+	return parts.join('\n');
+}

--- a/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
@@ -10,6 +10,7 @@ import getOpenAIClient, { getEmbeddingModel } from '../../services/openai.js';
 import { handleSearchTasksSemanticFallback } from './search-fallback.tool.js';
 import { getHostIdentifier } from '../../services/task-indexer/ChunkExtractor.js';
 import { parseFilterDate, isWithinDateRange } from '../../utils/date-filters.js';
+import { classifySearchError, formatClassifiedError } from './search-error-classifier.js';
 
 // #1232: Circuit breaker for embedding API failures
 // When the embedding API returns 502/503, skip semantic search and go directly to text fallback
@@ -25,6 +26,18 @@ function isHttpServerError(error: unknown): boolean {
     if (!(error instanceof Error)) return false;
     const msg = error.message;
     return /\b5[0-9]{2}\b/.test(msg) || msg.includes('Bad Gateway') || msg.includes('Service Unavailable') || msg.includes('Gateway Timeout');
+}
+
+/**
+ * #2063: Check if an error is an AbortError/timeout (not HTTP 5xx but still
+ * eligible for circuit breaker — prevents repeated 30s timeouts).
+ */
+function isAbortOrTimeout(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const msg = error.message;
+    const code = (error as any)?.code || '';
+    return msg.includes('abort') || msg.includes('timeout') || msg.includes('ETIMEDOUT') ||
+        msg.includes('This operation was aborted') || code === 'UND_ERR_CONNECT_TIMEOUT';
 }
 
 /**
@@ -652,44 +665,43 @@ export const searchTasksByContentTool = {
             };
 
         } catch (semanticError) {
-            // #1232: Activate circuit breaker ONLY on HTTP 5xx server errors
-            if (isHttpServerError(semanticError)) {
+            // #1232: Activate circuit breaker on HTTP 5xx OR AbortError/timeout
+            if (isHttpServerError(semanticError) || isAbortOrTimeout(semanticError)) {
                 lastEmbeddingFailureTime = Date.now();
-                console.warn(`[WARN] #1232: Embedding circuit breaker activated for ${EMBEDDING_CIRCUIT_BREAKER_TTL_MS / 1000}s (HTTP 5xx detected)`);
+                console.warn(`[WARN] #1232: Embedding circuit breaker activated for ${EMBEDDING_CIRCUIT_BREAKER_TTL_MS / 1000}s`);
             }
 
             const semanticErrorMsg = semanticError instanceof Error ? semanticError.message : String(semanticError);
 
-            // #1496: Strict mode — propagate the semantic error instead of silently
+            // #2063 P1: Classify the error for actionable diagnostics
+            const classified = await classifySearchError(semanticError, 'search');
+
+            // #1496: Strict mode — propagate the classified error instead of silently
             // falling back to text. Callers that explicitly requested semantic
             // (like `roosync_search(action: "semantic")`) need to know when the
             // embedding backend is down, otherwise they treat text results as
             // semantic and real regressions go unnoticed for days (cf #1407, #1451).
             if (args.strict_mode) {
-                console.warn(`[WARN] Semantic search failed in strict_mode (no fallback): ${semanticErrorMsg}`);
+                console.warn(`[WARN] Semantic search failed in strict_mode (${classified.mode}): ${semanticErrorMsg}`);
                 return {
                     isError: true,
                     content: [{
                         type: 'text',
-                        text: `Semantic search failed: ${semanticErrorMsg}\n\n` +
-                              `Diagnostic: run roosync_search(action: "diagnose") to check backend state.\n` +
-                              `Hint: if you want text fallback, use roosync_search(action: "text") explicitly.`
+                        text: formatClassifiedError(classified) +
+                              `\n\n  Fallback: use roosync_search(action: "text") for text-based search.`
                     }]
                 };
             }
 
-            console.warn(`[WARN] Semantic search failed, falling back to text search: ${semanticErrorMsg}`);
+            console.warn(`[WARN] Semantic search failed (${classified.mode}), falling back to text: ${semanticErrorMsg}`);
 
             // Fallback vers la recherche textuelle simple (legacy — default path)
             try {
-                // Fix: mapper search_query → query pour le fallback
                 const fallbackResult = await fallbackHandler(
                     { query: args.search_query, workspace: args.workspace },
                     conversationCache
                 );
 
-                // Le fallback handler retourne déjà le bon format : content: [objets avec taskId, score, match, etc.]
-                // Pas besoin de transformation, retourner directement le résultat
                 return fallbackResult;
             } catch (fallbackError) {
                 console.log(`[ERROR] Fallback handler a échoué: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`);
@@ -697,7 +709,8 @@ export const searchTasksByContentTool = {
                     isError: false,
                     content: [{
                         type: 'text',
-                        text: `Erreur lors du fallback: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`
+                        text: `Semantic search failed (${classified.mode}), fallback also failed: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}\n\n` +
+                              `Diagnostics: ${classified.message}\nHint: ${classified.hint}`
                     }] as any
                 };
             }

--- a/servers/roo-state-manager/tests/unit/tools/repair/repair-conversation-bom.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/repair/repair-conversation-bom.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests unitaires pour repair_conversation_bom
+ * Répare les fichiers de conversation corrompus par un BOM UTF-8
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock RooStorageDetector avec vi.hoisted
+const { mockDetectStorageLocations } = vi.hoisted(() => ({
+    mockDetectStorageLocations: vi.fn()
+}));
+
+vi.mock('../../../../src/utils/roo-storage-detector.js', () => ({
+    RooStorageDetector: {
+        detectStorageLocations: mockDetectStorageLocations
+    }
+}));
+
+// Mock fs avec vi.hoisted
+const { mockReaddir, mockAccess, mockReadFile, mockWriteFile } = vi.hoisted(() => ({
+    mockReaddir: vi.fn(),
+    mockAccess: vi.fn(),
+    mockReadFile: vi.fn(),
+    mockWriteFile: vi.fn()
+}));
+
+vi.mock('fs', () => ({
+    promises: {
+        readdir: mockReaddir,
+        access: mockAccess,
+        readFile: mockReadFile,
+        writeFile: mockWriteFile
+    }
+}));
+
+import { repairConversationBomTool } from '../../../../src/tools/repair/repair-conversation-bom.tool.js';
+
+// Helper: create a Buffer with BOM prefix
+function createBomBuffer(content: string): Buffer {
+    const bom = Buffer.from([0xEF, 0xBB, 0xBF]);
+    return Buffer.concat([bom, Buffer.from(content, 'utf-8')]);
+}
+
+describe('repair_conversation_bom', () => {
+    const handler = repairConversationBomTool.handler;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should have correct tool definition', () => {
+        expect(repairConversationBomTool.definition.name).toBe('repair_conversation_bom');
+        expect(repairConversationBomTool.definition.inputSchema.properties).toHaveProperty('dry_run');
+        expect(repairConversationBomTool.definition.inputSchema.properties.dry_run.type).toBe('boolean');
+    });
+
+    it('should return message when no storage locations found', async () => {
+        mockDetectStorageLocations.mockResolvedValue([]);
+
+        const result = await handler({});
+        const text = (result.content[0] as any).text;
+
+        expect(text).toContain('Aucun emplacement');
+    });
+
+    it('should scan files and report no corruption in dry_run mode', async () => {
+        mockDetectStorageLocations.mockResolvedValue(['/mock/storage']);
+        mockReaddir.mockResolvedValue([
+            { name: 'conv-001', isDirectory: () => true }
+        ]);
+        mockAccess.mockResolvedValue(undefined);
+        // Clean file without BOM
+        mockReadFile.mockResolvedValue(Buffer.from('[{"role":"user"}]', 'utf-8'));
+
+        const result = await handler({ dry_run: true });
+        const text = (result.content[0] as any).text;
+
+        expect(text).toContain('Simulation (dry-run)');
+        expect(text).toContain('Fichiers analysés:** 1');
+        expect(text).toContain('Fichiers corrompus (BOM):** 0');
+        expect(mockWriteFile).not.toHaveBeenCalled();
+    });
+
+    it('should detect BOM-corrupted files in dry_run mode', async () => {
+        mockDetectStorageLocations.mockResolvedValue(['/mock/storage']);
+        mockReaddir.mockResolvedValue([
+            { name: 'conv-001', isDirectory: () => true }
+        ]);
+        mockAccess.mockResolvedValue(undefined);
+        // File with BOM prefix
+        mockReadFile.mockResolvedValue(createBomBuffer('[{"role":"user"}]'));
+
+        const result = await handler({ dry_run: true });
+        const text = (result.content[0] as any).text;
+
+        expect(text).toContain('Simulation (dry-run)');
+        expect(text).toContain('Fichiers corrompus (BOM):** 1');
+        expect(text).toContain('seraient réparés');
+        expect(text).toContain('🔍'); // Icon for SERAIT_REPARE
+        expect(mockWriteFile).not.toHaveBeenCalled();
+    });
+
+    it('should repair BOM-corrupted files in real mode', async () => {
+        mockDetectStorageLocations.mockResolvedValue(['/mock/storage']);
+        mockReaddir.mockResolvedValue([
+            { name: 'conv-001', isDirectory: () => true }
+        ]);
+        mockAccess.mockResolvedValue(undefined);
+        // File with BOM prefix
+        mockReadFile.mockResolvedValue(createBomBuffer('[{"role":"user"}]'));
+        mockWriteFile.mockResolvedValue(undefined);
+
+        const result = await handler({ dry_run: false });
+        const text = (result.content[0] as any).text;
+
+        expect(text).toContain('Réparation réelle');
+        expect(text).toContain('Fichiers réparés:** 1');
+        expect(text).toContain('✅ 1 fichier(s) réparé(s)');
+        expect(text).toContain('✅'); // Icon for REPARE
+        expect(mockWriteFile).toHaveBeenCalledTimes(1);
+        // Verify that BOM was removed (buffer should start after 3 bytes)
+        const writtenContent = mockWriteFile.mock.calls[0][1] as string;
+        expect(writtenContent).toBe('[{"role":"user"}]');
+    });
+
+    it('should handle multiple corrupted files', async () => {
+        mockDetectStorageLocations.mockResolvedValue(['/mock/storage']);
+        mockReaddir.mockResolvedValue([
+            { name: 'conv-001', isDirectory: () => true },
+            { name: 'conv-002', isDirectory: () => true },
+            { name: 'conv-003', isDirectory: () => true }
+        ]);
+        mockAccess.mockResolvedValue(undefined);
+        // Mix of clean and corrupted files
+        mockReadFile.mockImplementation((path: string) => {
+            if (path.includes('conv-001')) return Promise.resolve(createBomBuffer('[{"role":"user"}]'));
+            if (path.includes('conv-002')) return Promise.resolve(createBomBuffer('[{"role":"assistant"}]'));
+            return Promise.resolve(Buffer.from('[{"role":"system"}]', 'utf-8'));
+        });
+        mockWriteFile.mockResolvedValue(undefined);
+
+        const result = await handler({ dry_run: false });
+        const text = (result.content[0] as any).text;
+
+        expect(text).toContain('Fichiers analysés:** 3');
+        expect(text).toContain('Fichiers corrompus (BOM):** 2');
+        expect(text).toContain('Fichiers réparés:** 2');
+        expect(mockWriteFile).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle repair failure when JSON is invalid', async () => {
+        mockDetectStorageLocations.mockResolvedValue(['/mock/storage']);
+        mockReaddir.mockResolvedValue([
+            { name: 'conv-001', isDirectory: () => true }
+        ]);
+        mockAccess.mockResolvedValue(undefined);
+        // File with BOM but invalid JSON after BOM removal
+        mockReadFile.mockResolvedValue(createBomBuffer('not valid json'));
+
+        const result = await handler({ dry_run: false });
+        const text = (result.content[0] as any).text;
+
+        expect(text).toContain('Fichiers corrompus (BOM):** 1');
+        expect(text).toContain('Échecs de réparation:** 1');
+        expect(text).toContain('❌ 1 échec(s)');
+        expect(text).toContain('❌'); // Icon for ECHEC
+        expect(text).toContain('Erreur:'); // Error details
+        expect(mockWriteFile).not.toHaveBeenCalled();
+    });
+
+    it('should truncate results when more than 30 files', async () => {
+        const dirs = Array.from({ length: 35 }, (_, i) => ({
+            name: `conv-${String(i).padStart(3, '0')}`,
+            isDirectory: () => true
+        }));
+
+        mockDetectStorageLocations.mockResolvedValue(['/mock/storage']);
+        mockReaddir.mockResolvedValue(dirs);
+        mockAccess.mockResolvedValue(undefined);
+        mockReadFile.mockResolvedValue(createBomBuffer('[{"role":"user"}]'));
+        mockWriteFile.mockResolvedValue(undefined);
+
+        const result = await handler({ dry_run: false });
+        const text = (result.content[0] as any).text;
+
+        expect(text).toContain('30 premiers résultats');
+        expect(text).toContain('et 5 autres résultats');
+    });
+
+    it('should ignore missing files gracefully', async () => {
+        mockDetectStorageLocations.mockResolvedValue(['/mock/storage']);
+        mockReaddir.mockResolvedValue([
+            { name: 'conv-001', isDirectory: () => true },
+            { name: 'conv-002', isDirectory: () => true }
+        ]);
+        // First file exists, second doesn't
+        mockAccess.mockImplementation((path: string) => {
+            if (path.includes('conv-001')) return Promise.resolve(undefined);
+            throw new Error('ENOENT');
+        });
+        mockReadFile.mockResolvedValue(createBomBuffer('[{"role":"user"}]'));
+        mockWriteFile.mockResolvedValue(undefined);
+
+        const result = await handler({ dry_run: false });
+        const text = (result.content[0] as any).text;
+
+        expect(text).toContain('Fichiers analysés:** 1');
+        expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle directory read errors', async () => {
+        mockDetectStorageLocations.mockResolvedValue(['/mock/storage']);
+        mockReaddir.mockRejectedValue(new Error('Permission denied'));
+
+        const result = await handler({ dry_run: false });
+        const text = (result.content[0] as any).text;
+
+        expect(text).toContain('Fichiers analysés:** 0');
+        expect(text).toContain('Fichiers corrompus (BOM):** 0');
+    });
+
+    it('should default dry_run to false when not specified', async () => {
+        mockDetectStorageLocations.mockResolvedValue(['/mock/storage']);
+        mockReaddir.mockResolvedValue([
+            { name: 'conv-001', isDirectory: () => true }
+        ]);
+        mockAccess.mockResolvedValue(undefined);
+        mockReadFile.mockResolvedValue(Buffer.from('[{"role":"user"}]', 'utf-8'));
+
+        const result = await handler({});
+        const text = (result.content[0] as any).text;
+
+        expect(text).toContain('Réparation réelle');
+        expect(text).not.toContain('Simulation (dry-run)');
+    });
+});

--- a/servers/roo-state-manager/tests/unit/tools/roosync/baseline.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/baseline.test.ts
@@ -277,7 +277,7 @@ describe('roosync_baseline - Metadata', () => {
     expect(metadata.inputSchema.type).toBe('object');
     expect(metadata.inputSchema.properties).toBeDefined();
     expect(metadata.inputSchema.properties.action).toBeDefined();
-    expect(metadata.inputSchema.properties.action.enum).toEqual(['update', 'version', 'restore', 'export', 'list_versions']);
+    expect(metadata.inputSchema.properties.action.enum).toEqual(['update', 'version', 'restore', 'export', 'list_versions', 'current_version']);
     expect(metadata.inputSchema.required).toEqual(['action']);
   });
 

--- a/servers/roo-state-manager/tests/unit/tools/search/codebase-search-errors.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/search/codebase-search-errors.test.ts
@@ -1,11 +1,12 @@
 /**
  * Tests de couverture des chemins d'erreur pour search-codebase.tool.ts
  * Issue #733 — Couverture module search > 70%
+ * Issue #2063 P1 — Updated to match classified error modes
  *
- * Couvre le catch block (lignes 333-377) :
- * - fetch failed / ECONNREFUSED → qdrant_connection_error
- * - API key / Unauthorized → auth_error
- * - Erreur générique → error
+ * Couvre le catch block avec FailureMode classification:
+ * - fetch failed / ECONNREFUSED → qdrant_unreachable
+ * - API key / Unauthorized → auth_failed
+ * - Erreur inattendue → unknown
  *
  * @module search/codebase-search-errors.test
  */
@@ -80,60 +81,57 @@ describe('codebase_search - handleCodebaseSearch - Error paths', () => {
 		process.env = { ...originalEnv };
 	});
 
-	it('retourne qdrant_connection_error quand fetch failed', async () => {
+	it('retourne qdrant_unreachable quand fetch failed', async () => {
 		mockQuery.mockRejectedValue(new Error('fetch failed ECONNREFUSED 127.0.0.1:6333'));
 
 		const result = await hcs({ query: 'test connection error', workspace: '/test' });
 
 		expect(result.isError).toBe(true);
 		const response = JSON.parse(result.content[0].text);
-		expect(response.status).toBe('qdrant_connection_error');
-		expect(response.message).toContain('Qdrant');
+		expect(response.status).toBe('qdrant_unreachable');
 		expect(response.hint).toBeDefined();
 		expect(response.error).toContain('fetch failed');
 	});
 
-	it('retourne qdrant_connection_error quand ECONNREFUSED', async () => {
+	it('retourne qdrant_unreachable quand ECONNREFUSED', async () => {
 		mockQuery.mockRejectedValue(new Error('connect ECONNREFUSED ::1:6333'));
 
 		const result = await hcs({ query: 'test econnrefused', workspace: '/test' });
 
 		expect(result.isError).toBe(true);
 		const response = JSON.parse(result.content[0].text);
-		expect(response.status).toBe('qdrant_connection_error');
+		expect(response.status).toBe('qdrant_unreachable');
 	});
 
-	it('retourne auth_error quand API key invalide', async () => {
+	it('retourne auth_failed quand API key invalide', async () => {
 		mockEmbeddingsCreate.mockRejectedValue(new Error('Invalid API key provided'));
 
 		const result = await hcs({ query: 'test auth error', workspace: '/test' });
 
 		expect(result.isError).toBe(true);
 		const response = JSON.parse(result.content[0].text);
-		expect(response.status).toBe('auth_error');
-		expect(response.message).toContain('authentification');
+		expect(response.status).toBe('auth_failed');
 		expect(response.hint).toBeDefined();
 	});
 
-	it('retourne auth_error quand Unauthorized', async () => {
+	it('retourne auth_failed quand Unauthorized', async () => {
 		mockEmbeddingsCreate.mockRejectedValue(new Error('Unauthorized: token expired'));
 
 		const result = await hcs({ query: 'test unauthorized', workspace: '/test' });
 
 		expect(result.isError).toBe(true);
 		const response = JSON.parse(result.content[0].text);
-		expect(response.status).toBe('auth_error');
+		expect(response.status).toBe('auth_failed');
 	});
 
-	it('retourne error générique pour toute autre erreur', async () => {
-		mockQuery.mockRejectedValue(new Error('Unexpected server error: timeout'));
+	it('retourne unknown pour toute autre erreur', async () => {
+		mockQuery.mockRejectedValue(new Error('Something completely unexpected'));
 
 		const result = await hcs({ query: 'test generic error', workspace: '/test' });
 
 		expect(result.isError).toBe(true);
 		const response = JSON.parse(result.content[0].text);
-		expect(response.status).toBe('error');
-		expect(response.message).toContain('recherche');
-		expect(response.error).toContain('Unexpected server error');
+		expect(response.status).toBe('unknown');
+		expect(response.error).toContain('Something completely unexpected');
 	});
 });


### PR DESCRIPTION
## Summary
- New `search-error-classifier.ts` module with 8 `FailureMode` categories replacing generic error messages
- Health probe (`GET /healthz`) distinguishes `qdrant_proxy_drop` (reverse proxy drops POST) from `qdrant_unreachable`
- Circuit breaker extended to cover `AbortError`/timeout (not just HTTP 5xx)
- Both `codebase_search` and `roosync_search(semantic)` now report classified errors with actionable hints
- Fixes `baseline.test.ts` enum assertion (missing `current_version` action)

## Test plan
- [x] CI tests: 454/454 files, 9190 tests pass, 0 failures
- [x] Error path tests updated to match new FailureMode status values
- [x] Build clean (tsc 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)