### PR TITLE
refactor(adr008-p2): remove legacy offline/warning status terms

### DIFF
--- a/servers/roo-state-manager/src/services/RooSyncService.ts
+++ b/servers/roo-state-manager/src/services/RooSyncService.ts
@@ -994,24 +994,10 @@ export class RooSyncService {
   }
 
   /**
-   * @deprecated Use getUnknownMachines() — terminology rename
-   */
-  public getOfflineMachines(): string[] {
-    return this.heartbeatService.getUnknownMachines();
-  }
-
-  /**
    * Obtient les machines avec statut UNKNOWN
    */
   public getUnknownMachines(): string[] {
     return this.heartbeatService.getUnknownMachines();
-  }
-
-  /**
-   * @deprecated Use getIdleMachines() — terminology rename
-   */
-  public getWarningMachines(): string[] {
-    return this.heartbeatService.getIdleMachines();
   }
 
   /**

--- a/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
+++ b/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
@@ -22,18 +22,8 @@ const IDLE_THRESHOLD = 120 * 60 * 1000;   // 120 min
 export type MachineStatus = 'online' | 'idle' | 'unknown';
 
 export interface HeartbeatConfig {
-  /** @deprecated No longer used — kept for backward compat in tool schemas */
-  heartbeatInterval?: number;
-  /** @deprecated No longer used — kept for backward compat in tool schemas */
-  offlineTimeout?: number;
-  /** @deprecated No longer used */
-  missedHeartbeatThreshold?: number;
-  /** @deprecated No longer used — no disk writes */
-  autoSyncEnabled?: boolean;
-  /** @deprecated No longer used — no disk writes */
-  autoSyncInterval?: number;
-  /** @deprecated No longer used — no disk writes */
-  persistenceInterval?: number;
+  // ADR 008 Phase 2: All config properties removed (no disk I/O, no background intervals).
+  // Interface kept empty for forward compat with callers that pass config objects.
 }
 
 export interface HeartbeatData {
@@ -209,18 +199,8 @@ export class HeartbeatService {
     return [...this.state.onlineMachines];
   }
 
-  /** @deprecated Use getUnknownMachines() — ADR 008 Phase 2 */
-  public getOfflineMachines(): string[] {
-    return this.getUnknownMachines();
-  }
-
   public getUnknownMachines(): string[] {
     return [...this.state.unknownMachines];
-  }
-
-  /** @deprecated Use getIdleMachines() — ADR 008 Phase 2 */
-  public getWarningMachines(): string[] {
-    return this.getIdleMachines();
   }
 
   public getIdleMachines(): string[] {
@@ -243,19 +223,14 @@ export class HeartbeatService {
     logger.info(`Machine removed: ${machineId}`);
   }
 
-  // --- Backward compat methods (no-ops or redirects for ADR 008 Phase 2) ---
+  // --- No-op backward compat methods (callers still reference these) ---
 
-  /**
-   * @deprecated No-op in ADR 008. Background service no longer needed.
-   * Kept for backward compat with callers (background-services.ts, heartbeat-service tool).
-   */
+  /** No-op in ADR 008. Sets up status change callback if provided. */
   public async startHeartbeatService(
     _machineId: string,
     onUnknownDetected?: (machineId: string) => void,
     onOnlineRestored?: (machineId: string) => void
   ): Promise<void> {
-    logger.info('startHeartbeatService called — no-op (ADR 008 passive model)');
-    // Set up status change callback if callers provide unknown/online callbacks
     if (onUnknownDetected || onOnlineRestored) {
       this.onStatusChangeCallback = (machineId, oldStatus, newStatus) => {
         if (newStatus === 'unknown' && onUnknownDetected) onUnknownDetected(machineId);
@@ -264,37 +239,18 @@ export class HeartbeatService {
     }
   }
 
-  /**
-   * @deprecated No-op in ADR 008. No background interval to stop.
-   */
-  public async stopHeartbeatService(): Promise<void> {
-    logger.info('stopHeartbeatService called — no-op (ADR 008 passive model)');
-  }
+  /** No-op in ADR 008. */
+  public async stopHeartbeatService(): Promise<void> {}
 
-  /**
-   * @deprecated No-op in ADR 008.
-   */
-  public async updateConfig(_config: Partial<HeartbeatConfig>): Promise<void> {
-    logger.info('updateConfig called — no-op (ADR 008 passive model)');
-  }
+  /** No-op in ADR 008. */
+  public async updateConfig(_config: Partial<HeartbeatConfig>): Promise<void> {}
 
-  /**
-   * @deprecated No disk state to reload.
-   */
-  public reloadFromDisk(): void {
-    // No-op: ADR 008 in-memory only
-  }
+  /** No-op in ADR 008. */
+  public reloadFromDisk(): void {}
 
-  /**
-   * @deprecated No disk state to clean up. ADR 008: in-memory only.
-   */
+  /** No-op in ADR 008. In-memory only, no cleanup needed. */
   public async cleanupOldUnknownMachines(_maxAge?: number): Promise<number> {
     return 0;
-  }
-
-  /** @deprecated Use cleanupOldUnknownMachines — ADR 008 terminology */
-  public async cleanupOldOfflineMachines(maxAge?: number): Promise<number> {
-    return this.cleanupOldUnknownMachines(maxAge);
   }
 
   // --- Internal ---

--- a/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
@@ -8,7 +8,7 @@
  * - Initialisation → état vide (no disk load)
  * - registerHeartbeat : nouvelle machine + machine existante (update)
  * - checkHeartbeats : détection IDLE/UNKNOWN/ONLINE (computed from lastHeartbeat age)
- * - getOnlineMachines / getUnknownMachines / getIdleMachines (deprecated aliases: getOfflineMachines / getWarningMachines)
+ * - getOnlineMachines / getUnknownMachines / getIdleMachines
  * - getHeartbeatData : défini après register, undefined avant
  * - getState : retourne copie défensive avec nouvelles clés (idleMachines, unknownMachines)
  * - removeMachine : suppression in-memory
@@ -48,8 +48,6 @@ describe('HeartbeatService', () => {
       const service = new HeartbeatService();
 
       expect(service.getOnlineMachines()).toEqual([]);
-      expect(service.getOfflineMachines()).toEqual([]);
-      expect(service.getWarningMachines()).toEqual([]);
       expect(service.getUnknownMachines()).toEqual([]);
       expect(service.getIdleMachines()).toEqual([]);
     });
@@ -60,15 +58,8 @@ describe('HeartbeatService', () => {
       expect(service.getOnlineMachines()).toEqual([]);
     });
 
-    test('accepte une config complète', () => {
-      const service = new HeartbeatService('/path', {
-        heartbeatInterval: 30000,
-        offlineTimeout: 120000,
-        missedHeartbeatThreshold: 4,
-        autoSyncEnabled: false,
-        autoSyncInterval: 60000,
-        persistenceInterval: 100,
-      });
+    test('accepte une config complète (empty in ADR 008 Phase 2)', () => {
+      const service = new HeartbeatService('/path', {});
 
       expect(service).toBeDefined();
       expect(service.getOnlineMachines()).toEqual([]);
@@ -185,7 +176,6 @@ describe('HeartbeatService', () => {
       const result = await service.checkHeartbeats();
 
       expect(result.newlyUnknownMachines).toContain('slow-machine');
-      expect(service.getOfflineMachines()).toContain('slow-machine'); // deprecated alias
       expect(service.getUnknownMachines()).toContain('slow-machine');
       expect(service.getHeartbeatData('slow-machine')!.status).toBe('unknown');
     });
@@ -201,7 +191,6 @@ describe('HeartbeatService', () => {
       const result = await service.checkHeartbeats();
 
       expect(result.newlyIdleMachines).toContain('idle-machine');
-      expect(service.getWarningMachines()).toContain('idle-machine'); // deprecated alias
       expect(service.getIdleMachines()).toContain('idle-machine');
       expect(service.getHeartbeatData('idle-machine')!.status).toBe('idle');
     });
@@ -216,12 +205,12 @@ describe('HeartbeatService', () => {
 
       // First check → detected UNKNOWN
       await service.checkHeartbeats();
-      expect(service.getOfflineMachines()).toContain('recovering-machine');
+      expect(service.getUnknownMachines()).toContain('recovering-machine');
 
       // Re-register → revient online (in-memory update)
       await service.registerHeartbeat('recovering-machine');
       expect(service.getOnlineMachines()).toContain('recovering-machine');
-      expect(service.getOfflineMachines()).not.toContain('recovering-machine');
+      expect(service.getUnknownMachines()).not.toContain('recovering-machine');
     });
 
     test('machine online stable reste online #1953 ADR 008', async () => {
@@ -402,10 +391,12 @@ describe('HeartbeatService', () => {
       expect(service.getHeartbeatData('test-artifact-machine')).toBeDefined();
     });
 
-    test('deprecated cleanupOldOfflineMachines still works (backward compat)', async () => {
+    test('deprecated cleanupOldOfflineMachines removed in Phase 2', async () => {
       const service = new HeartbeatService();
 
-      const removed = await service.cleanupOldOfflineMachines();
+      // cleanupOldOfflineMachines was removed in ADR 008 Phase 2
+      // Use cleanupOldUnknownMachines instead
+      const removed = await service.cleanupOldUnknownMachines();
 
       expect(removed).toBe(0);
     });
@@ -445,11 +436,8 @@ describe('HeartbeatService', () => {
       expect(service).toBeDefined();
     });
 
-    test('accepte une config partielle', () => {
-      const service = new HeartbeatService('/path', {
-        heartbeatInterval: 5_000,
-        offlineTimeout: 30_000,
-      });
+    test('accepte une config partielle (empty in ADR 008 Phase 2)', () => {
+      const service = new HeartbeatService('/path', {});
 
       expect(service).toBeDefined();
     });
@@ -457,7 +445,7 @@ describe('HeartbeatService', () => {
     test('updateConfig est un no-op (ne throw pas)', async () => {
       const service = new HeartbeatService();
 
-      await expect(service.updateConfig({ heartbeatInterval: 10_000 })).resolves.not.toThrow();
+      await expect(service.updateConfig({})).resolves.not.toThrow();
     });
   });
 

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/machines.smoke.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/machines.smoke.test.ts
@@ -1,11 +1,10 @@
 /**
  * Smoke test for roosync_machines
  *
- * Purpose: Validate that roosync_machines returns fresh data after heartbeat state changes
- * Pattern: Issue #564 Phase 2 - Prevent silent bugs from cache staleness (issue #562)
+ * ADR 008 Phase 2: offline/warning removed, only unknown/idle/all.
  *
- * @see docs/testing/issue-564-phase1-audit-report.md (lines 88-95)
- * @see src/services/roosync/HeartbeatService.ts - Per-machine file architecture (v3.1.0)
+ * @module roosync/machines.smoke.test
+ * @version 2.0.0 (ADR 008 Phase 2)
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -15,8 +14,6 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-// Unmock modules that jest.setup.js mocks globally.
-// Smoke tests need real filesystem and real RooSyncService (not mocks).
 vi.unmock('fs');
 vi.unmock('fs/promises');
 vi.unmock('os');
@@ -24,15 +21,10 @@ vi.unmock('../../../services/RooSyncService.js');
 vi.unmock('../../../services/ConfigService.js');
 
 describe('SMOKE: roosync_machines', () => {
-  // Use unique directory per test file to avoid ENOTEMPTY cleanup errors
   const testSharedStatePath = path.join(os.tmpdir(), '.shared-state-test-machines');
   const testHeartbeatsDir = path.join(testSharedStatePath, 'heartbeats');
   let originalEnv: NodeJS.ProcessEnv;
 
-  /**
-   * Helper: Create a HeartbeatData object with proper structure
-   * Matches the format expected by HeartbeatService v3.1.0 per-machine files
-   */
   function makeHeartbeatData(
     machineId: string,
     status: 'online' | 'unknown' | 'idle',
@@ -40,189 +32,110 @@ describe('SMOKE: roosync_machines', () => {
   ): Record<string, any> {
     const now = Date.now();
     const lastHeartbeat = new Date(now - minutesAgo * 60 * 1000).toISOString();
-
-    const data: Record<string, any> = {
+    return {
       machineId,
       lastHeartbeat,
       status,
-      metadata: {
-        firstSeen: lastHeartbeat,
-        lastUpdated: new Date(now).toISOString(),
-        version: '3.1.0',
-      },
+      metadata: { firstSeen: lastHeartbeat, lastUpdated: new Date(now).toISOString(), version: '4.0.0' },
     };
-
-    return data;
   }
 
-  /**
-   * Helper: Write per-machine heartbeat files
-   * HeartbeatService v3.1.0 uses heartbeats/{machineId}.json files instead of heartbeat.json
-   */
   function writeHeartbeatFiles(machines: Record<string, any>): void {
     if (!fs.existsSync(testHeartbeatsDir)) {
       fs.mkdirSync(testHeartbeatsDir, { recursive: true });
     }
-
     for (const [machineId, data] of Object.entries(machines)) {
-      const heartbeatPath = path.join(testHeartbeatsDir, `${machineId}.json`);
-      fs.writeFileSync(heartbeatPath, JSON.stringify(data, null, 2));
+      fs.writeFileSync(path.join(testHeartbeatsDir, `${machineId}.json`), JSON.stringify(data, null, 2));
     }
   }
 
   beforeEach(() => {
-    // Save original environment
     originalEnv = { ...process.env };
-
-    // Setup test environment with required env vars
     process.env.NODE_ENV = 'test';
     process.env.ROOSYNC_SHARED_PATH = testSharedStatePath;
     process.env.ROOSYNC_MACHINE_ID = 'smoke-test-machine';
     process.env.ROOSYNC_WORKSPACE_ID = 'smoke-test-ws';
-
-    // Reset RooSyncService singleton to pick up new env vars
-    // (HeartbeatService inside RooSyncService uses ROOSYNC_SHARED_PATH from constructor)
     RooSyncService.resetInstance();
-
-    // Ensure test directory exists
-    if (!fs.existsSync(testSharedStatePath)) {
-      fs.mkdirSync(testSharedStatePath, { recursive: true });
-    }
+    if (!fs.existsSync(testSharedStatePath)) fs.mkdirSync(testSharedStatePath, { recursive: true });
   });
 
   afterEach(async () => {
-    // Reset RooSyncService singleton FIRST to stop any pending async file writes
     RooSyncService.resetInstance();
-
-    // Wait briefly for any in-flight async operations to complete before cleanup
     await new Promise(resolve => setTimeout(resolve, 50));
-
-    // Cleanup test files
-    if (fs.existsSync(testSharedStatePath)) {
-      fs.rmSync(testSharedStatePath, { recursive: true, force: true });
-    }
-
-    // Restore original environment
+    if (fs.existsSync(testSharedStatePath)) fs.rmSync(testSharedStatePath, { recursive: true, force: true });
     process.env = originalEnv;
   });
 
-  it('should detect offline machines after heartbeat timeout (status: offline)', async () => {
-    // Step 1: Create initial heartbeat state with all machines online
+  it('should detect unknown machines after heartbeat timeout (status: unknown)', async () => {
     const initialMachines = {
       'test-machine-1': makeHeartbeatData('test-machine-1', 'online'),
       'test-machine-2': makeHeartbeatData('test-machine-2', 'online'),
     };
-
     writeHeartbeatFiles(initialMachines);
 
-    // Step 2: Initial call to get baseline (should show no offline machines)
-    const result1 = await roosyncMachines({ status: 'offline', includeDetails: true });
-
+    const result1 = await roosyncMachines({ status: 'unknown', includeDetails: true });
     expect(result1.success).toBe(true);
-    expect(result1.data).toBeDefined();
-    expect(result1.data.unknownMachines).toHaveLength(0); // No offline machines initially
+    expect(result1.data.unknownMachines).toHaveLength(0);
 
-    // Step 3: Modify the underlying state (simulate machine going offline)
     const modifiedMachines = {
       ...initialMachines,
-      'test-machine-1': makeHeartbeatData('test-machine-1', 'offline', 20), // 20 minutes ago
+      'test-machine-1': makeHeartbeatData('test-machine-1', 'unknown', 20),
     };
-
     writeHeartbeatFiles(modifiedMachines);
-
-    // Step 4: Reset singleton so the second call picks up filesystem changes
     RooSyncService.resetInstance();
 
-    // Second call to get offline machines with details
-    const result2 = await roosyncMachines({ status: 'offline', includeDetails: true });
-
-    // Step 5: Verify that result2 reflects the state change (fresh offline list, not cached)
+    const result2 = await roosyncMachines({ status: 'unknown', includeDetails: true });
     expect(result2.success).toBe(true);
     expect(result2.data.unknownMachines).toHaveLength(1);
     expect(result2.data.unknownMachines[0].machineId).toBe('test-machine-1');
-
-    // This validates that offline machines are read fresh from heartbeat state,
-    // not from stale cached data that would show 0 offline machines
   });
 
-  it('should detect warning machines after threshold change (status: warning)', async () => {
-    // Step 1: Create initial heartbeat state with all machines healthy
+  it('should detect idle machines after threshold change (status: idle)', async () => {
     const initialMachines = {
       'test-machine-3': makeHeartbeatData('test-machine-3', 'online'),
     };
-
     writeHeartbeatFiles(initialMachines);
 
-    // Step 2: Initial call to get baseline (should show no warning machines)
-    const result1 = await roosyncMachines({ status: 'warning', includeDetails: true });
-
+    const result1 = await roosyncMachines({ status: 'idle', includeDetails: true });
     expect(result1.success).toBe(true);
-    expect(result1.data.idleMachines).toBeDefined();
-    expect(result1.data.idleMachines).toHaveLength(0); // No warning machines initially
+    expect(result1.data.idleMachines).toHaveLength(0);
 
-    // Step 3: Modify the underlying state (simulate machine entering warning state)
     const modifiedMachines = {
-      'test-machine-3': makeHeartbeatData('test-machine-3', 'warning', 8), // 8 minutes ago
+      'test-machine-3': makeHeartbeatData('test-machine-3', 'idle', 8),
     };
-
     writeHeartbeatFiles(modifiedMachines);
-
-    // Step 4: Reset singleton so the second call picks up filesystem changes
     RooSyncService.resetInstance();
 
-    // Second call to get warning machines with details
-    const result2 = await roosyncMachines({ status: 'warning', includeDetails: true });
-
-    // Step 5: Verify that result2 reflects the state change (fresh warning list, not cached)
+    const result2 = await roosyncMachines({ status: 'idle', includeDetails: true });
     expect(result2.success).toBe(true);
     expect(result2.data.idleMachines).toHaveLength(1);
     expect(result2.data.idleMachines[0].machineId).toBe('test-machine-3');
-
-    // This validates that warning machines are read fresh from heartbeat state,
-    // not returning stale cached results
   });
 
   it('should return all machines with fresh status (status: all)', async () => {
-    // Step 1: Create initial heartbeat state
     const initialMachines = {
       'test-machine-4': makeHeartbeatData('test-machine-4', 'online'),
     };
-
     writeHeartbeatFiles(initialMachines);
 
-    // Step 2: Initial call to get baseline (no offline or warning machines)
     const result1 = await roosyncMachines({ status: 'all', includeDetails: true });
-
     expect(result1.success).toBe(true);
     expect(result1.data.unknownMachines).toHaveLength(0);
     expect(result1.data.idleMachines).toHaveLength(0);
 
-    // Step 3: Modify the underlying state (add more machines with different statuses)
     const modifiedMachines = {
       ...initialMachines,
-      'test-machine-5': makeHeartbeatData('test-machine-5', 'offline', 12),
-      'test-machine-6': makeHeartbeatData('test-machine-6', 'warning', 7),
+      'test-machine-5': makeHeartbeatData('test-machine-5', 'unknown', 12),
+      'test-machine-6': makeHeartbeatData('test-machine-6', 'idle', 7),
     };
-
     writeHeartbeatFiles(modifiedMachines);
-
-    // Step 4: Reset singleton so the second call picks up filesystem changes
     RooSyncService.resetInstance();
 
-    // Second call to get all machines
     const result2 = await roosyncMachines({ status: 'all', includeDetails: true });
-
-    // Step 5: Verify that result2 reflects the state change
     expect(result2.success).toBe(true);
-    // With status: 'all', we get both unknownMachines and idleMachines
     expect(result2.data.unknownMachines).toHaveLength(1);
     expect(result2.data.idleMachines).toHaveLength(1);
-
-    // Verify machine IDs are correct
     expect(result2.data.unknownMachines[0].machineId).toBe('test-machine-5');
     expect(result2.data.idleMachines[0].machineId).toBe('test-machine-6');
-
-    // This validates that the machine list is computed fresh from heartbeat state,
-    // not showing stale list that would only have 1 machine
   });
 });

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/machines.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/machines.test.ts
@@ -1,16 +1,12 @@
 /**
  * Tests unitaires pour roosync_machines
  *
- * Couvre tous les status de l'outil consolidé :
- * - status: 'offline' : Machines offline
- * - status: 'warning' : Machines en avertissement
- * - status: 'all' : Les deux
+ * ADR 008 Phase 2: offline/warning removed, only unknown/idle/all.
  *
  * Framework: Vitest
- * Coverage cible: >80%
  *
  * @module roosync/machines.test
- * @version 1.0.0 (CONS-6)
+ * @version 2.0.0 (ADR 008 Phase 2)
  */
 
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -41,84 +37,32 @@ vi.mock('../../../services/RooSyncService.js', () => ({
 // Mock ExecutionContext complet
 const mockExecutionContext: any = {
   services: {
-    storage: {
-      read: vi.fn(),
-      write: vi.fn(),
-      delete: vi.fn()
-    },
-    cache: {
-      get: vi.fn(),
-      set: vi.fn(),
-      delete: vi.fn()
-    },
-    search: {
-      search: vi.fn(),
-      index: vi.fn()
-    },
-    export: {
-      export: vi.fn(),
-      format: vi.fn()
-    },
-    summary: {
-      summarize: vi.fn(),
-      aggregate: vi.fn()
-    },
-    display: {
-      display: vi.fn(),
-      format: vi.fn()
-    },
-    utility: {
-      validate: vi.fn(),
-      transform: vi.fn()
-    }
+    storage: { read: vi.fn(), write: vi.fn(), delete: vi.fn() },
+    cache: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    search: { search: vi.fn(), index: vi.fn() },
+    export: { export: vi.fn(), format: vi.fn() },
+    summary: { summarize: vi.fn(), aggregate: vi.fn() },
+    display: { display: vi.fn(), format: vi.fn() },
+    utility: { validate: vi.fn(), transform: vi.fn() }
   },
-  security: {
-    validateInput: vi.fn(() => true),
-    sanitizeOutput: vi.fn((x) => x)
-  },
+  security: { validateInput: vi.fn(() => true), sanitizeOutput: vi.fn((x) => x) },
   monitoring: {
-    immediate: {
-      logEvent: vi.fn(),
-      logError: vi.fn()
-    },
-    background: {
-      logEvent: vi.fn(),
-      logError: vi.fn()
-    }
+    immediate: { logEvent: vi.fn(), logError: vi.fn() },
+    background: { logEvent: vi.fn(), logError: vi.fn() }
   },
-  cacheManager: {
-    get: vi.fn(),
-    set: vi.fn(),
-    delete: vi.fn()
-  }
+  cacheManager: { get: vi.fn(), set: vi.fn(), delete: vi.fn() }
 };
 
-// Import après les mocks
-// Fix #636 timeout: Use static import instead of dynamic imports
 import { machinesTool, machinesToolMetadata } from '../machines.js';
 import { getRooSyncService } from '../../../services/RooSyncService.js';
 
 describe('machinesTool', () => {
-  beforeEach(() => {
-    // Reset mocks avant chaque test
-    vi.clearAllMocks();
-  });
+  beforeEach(() => { vi.clearAllMocks(); });
+  afterEach(() => { vi.restoreAllMocks(); });
 
-  afterEach(() => {
-    // Cleanup
-    vi.restoreAllMocks();
-  });
-
-  // ============================================================
-  // Tests pour status: 'offline'
-  // ============================================================
-
-  describe('status: offline', () => {
-    test('should return offline machines', async () => {
-      const result = await machinesTool.execute(
-        { status: 'offline' },
-        mockExecutionContext
-      );
+  describe('status: unknown', () => {
+    test('should return unknown machines', async () => {
+      const result = await machinesTool.execute({ status: 'unknown' }, mockExecutionContext);
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
@@ -126,9 +70,9 @@ describe('machinesTool', () => {
       expect(result.data.idleMachines).toBeUndefined();
     });
 
-    test('should return offline machines with details', async () => {
+    test('should return unknown machines with details', async () => {
       const result = await machinesTool.execute(
-        { status: 'offline', includeDetails: true },
+        { status: 'unknown', includeDetails: true },
         mockExecutionContext
       );
 
@@ -137,15 +81,11 @@ describe('machinesTool', () => {
     });
 
     test('should handle errors gracefully', async () => {
-      // Mock pour simuler une erreur
       vi.mocked(getRooSyncService).mockImplementationOnce(() => {
         throw new Error('Heartbeat service error');
       });
 
-      const result = await machinesTool.execute(
-        { status: 'offline' },
-        mockExecutionContext
-      );
+      const result = await machinesTool.execute({ status: 'unknown' }, mockExecutionContext);
 
       expect(result.success).toBe(false);
       expect(result.error).toBeDefined();
@@ -153,16 +93,9 @@ describe('machinesTool', () => {
     });
   });
 
-  // ============================================================
-  // Tests pour status: 'warning'
-  // ============================================================
-
-  describe('status: warning', () => {
-    test('should return warning machines', async () => {
-      const result = await machinesTool.execute(
-        { status: 'warning' },
-        mockExecutionContext
-      );
+  describe('status: idle', () => {
+    test('should return idle machines', async () => {
+      const result = await machinesTool.execute({ status: 'idle' }, mockExecutionContext);
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
@@ -170,9 +103,9 @@ describe('machinesTool', () => {
       expect(result.data.unknownMachines).toBeUndefined();
     });
 
-    test('should return warning machines with details', async () => {
+    test('should return idle machines with details', async () => {
       const result = await machinesTool.execute(
-        { status: 'warning', includeDetails: true },
+        { status: 'idle', includeDetails: true },
         mockExecutionContext
       );
 
@@ -181,16 +114,9 @@ describe('machinesTool', () => {
     });
   });
 
-  // ============================================================
-  // Tests pour status: 'all'
-  // ============================================================
-
   describe('status: all', () => {
-    test('should return both offline and warning machines', async () => {
-      const result = await machinesTool.execute(
-        { status: 'all' },
-        mockExecutionContext
-      );
+    test('should return both unknown and idle machines', async () => {
+      const result = await machinesTool.execute({ status: 'all' }, mockExecutionContext);
 
       expect(result.success).toBe(true);
       expect(result.data.unknownMachines).toEqual(['machine-3', 'machine-5']);
@@ -208,16 +134,10 @@ describe('machinesTool', () => {
     });
   });
 
-  // ============================================================
-  // Tests de validation
-  // ============================================================
-
   describe('validation', () => {
     test('should have correct metadata', () => {
       expect(machinesToolMetadata.name).toBe('roosync_machines');
-      expect(machinesToolMetadata.description).toContain('machines');
-      expect(machinesToolMetadata.inputSchema.properties.status).toBeDefined();
-      expect(machinesToolMetadata.inputSchema.properties.status.enum).toEqual(['unknown', 'idle', 'all', 'offline', 'warning']);
+      expect(machinesToolMetadata.inputSchema.properties.status.enum).toEqual(['unknown', 'idle', 'all']);
     });
 
     test('should require status parameter', () => {
@@ -225,14 +145,10 @@ describe('machinesTool', () => {
     });
   });
 
-  // ============================================================
-  // Tests d'intégration
-  // ============================================================
-
   describe('integration', () => {
     test('should handle multiple calls with different status', async () => {
-      const r1 = await machinesTool.execute({ status: 'offline' }, mockExecutionContext);
-      const r2 = await machinesTool.execute({ status: 'warning' }, mockExecutionContext);
+      const r1 = await machinesTool.execute({ status: 'unknown' }, mockExecutionContext);
+      const r2 = await machinesTool.execute({ status: 'idle' }, mockExecutionContext);
       const r3 = await machinesTool.execute({ status: 'all' }, mockExecutionContext);
 
       expect(r1.success).toBe(true);
@@ -241,10 +157,7 @@ describe('machinesTool', () => {
     });
 
     test('should return execution time metrics', async () => {
-      const result = await machinesTool.execute(
-        { status: 'offline' },
-        mockExecutionContext
-      );
+      const result = await machinesTool.execute({ status: 'unknown' }, mockExecutionContext);
 
       expect(result.metrics).toBeDefined();
       expect(result.metrics.executionTime).toBeGreaterThanOrEqual(0);

--- a/servers/roo-state-manager/src/tools/roosync/inventory.ts
+++ b/servers/roo-state-manager/src/tools/roosync/inventory.ts
@@ -24,8 +24,8 @@ export const InventoryArgsSchema = z.object({
   includeHeartbeats: z.boolean().optional()
     .describe('Inclure les données de heartbeat de chaque machine (défaut: true)'),
   // Pour type="machines" (fused from roosync_machines)
-  status: z.enum(['unknown', 'idle', 'all', 'offline', 'warning']).optional()
-    .describe('Filtrer par statut machines (type="machines"). "offline"/"warning" map to "unknown"/"idle" (backward compat)'),
+  status: z.enum(['unknown', 'idle', 'all']).optional()
+    .describe('Filtrer par statut machines (type="machines")'),
   includeDetails: z.boolean().optional()
     .describe('Inclure les détails complets des machines (type="machines") ou stats outil (type="status")'),
   summary: z.boolean().optional()
@@ -195,7 +195,7 @@ export const inventoryTool: UnifiedToolContract = {
 
         machinesData = { unknownMachines: [], unknownCount: 0, idleMachines: [], idleCount: 0 };
 
-        if (machinesStatus === 'offline' || machinesStatus === 'unknown' || machinesStatus === 'all') {
+        if (machinesStatus === 'unknown' || machinesStatus === 'all') {
           const unknownMachines = heartbeatService.getUnknownMachines();
           if (wantDetails) {
             const detailed: any[] = [];
@@ -213,7 +213,7 @@ export const inventoryTool: UnifiedToolContract = {
           }
         }
 
-        if (machinesStatus === 'warning' || machinesStatus === 'idle' || machinesStatus === 'all') {
+        if (machinesStatus === 'idle' || machinesStatus === 'all') {
           const idleMachines = heartbeatService.getIdleMachines();
           if (wantDetails) {
             const detailed: any[] = [];
@@ -322,8 +322,8 @@ export const inventoryToolMetadata = {
       },
       status: {
         type: 'string',
-        enum: ['unknown', 'idle', 'all', 'offline', 'warning'],
-        description: 'Filtrer par statut machines. "offline"/"warning" map to "unknown"/"idle" (backward compat)'
+        enum: ['unknown', 'idle', 'all'],
+        description: 'Filtrer par statut machines (type="machines")'
       },
       includeDetails: {
         type: 'boolean',

--- a/servers/roo-state-manager/src/tools/roosync/machines.ts
+++ b/servers/roo-state-manager/src/tools/roosync/machines.ts
@@ -16,8 +16,8 @@ import { HeartbeatServiceError } from '../../services/roosync/HeartbeatService.j
  * Schema de validation pour roosync_machines
  */
 export const MachinesArgsSchema = z.object({
-  status: z.enum(['unknown', 'idle', 'all', 'offline', 'warning'])
-    .describe('Statut des machines à récupérer. "offline" and "warning" map to "unknown" and "idle" respectively (backward compat)'),
+  status: z.enum(['unknown', 'idle', 'all'])
+    .describe('Statut des machines à récupérer'),
   includeDetails: z.boolean().optional()
     .describe('Inclure les détails complets de chaque machine (défaut: false)')
 });
@@ -44,8 +44,7 @@ export const UnknownMachineDetailsSchema = z.object({
 
 export type UnknownMachineDetails = z.infer<typeof UnknownMachineDetailsSchema>;
 
-/** @deprecated Use UnknownMachineDetails */
-export type OfflineMachineDetails = UnknownMachineDetails;
+/** Removed in ADR 008 Phase 2: OfflineMachineDetails → use UnknownMachineDetails */
 
 /**
  * Détails d'une machine idle
@@ -67,8 +66,7 @@ export const IdleMachineDetailsSchema = z.object({
 
 export type IdleMachineDetails = z.infer<typeof IdleMachineDetailsSchema>;
 
-/** @deprecated Use IdleMachineDetails */
-export type WarningMachineDetails = IdleMachineDetails;
+/** Removed in ADR 008 Phase 2: WarningMachineDetails → use IdleMachineDetails */
 
 /**
  * Schema de retour pour roosync_machines
@@ -122,8 +120,7 @@ export const machinesTool: UnifiedToolContract = {
       };
 
       // Récupérer les machines unknown si demandé
-      const effectiveStatus = status === 'offline' ? 'unknown' : status === 'warning' ? 'idle' : status;
-      if (effectiveStatus === 'unknown' || effectiveStatus === 'all') {
+      if (status === 'unknown' || status === 'all') {
         const unknownMachines = heartbeatService.getUnknownMachines();
 
         if (includeDetails) {
@@ -151,7 +148,7 @@ export const machinesTool: UnifiedToolContract = {
       }
 
       // Récupérer les machines idle si demandé
-      if (effectiveStatus === 'idle' || effectiveStatus === 'all') {
+      if (status === 'idle' || status === 'all') {
         const idleMachines = heartbeatService.getIdleMachines();
 
         if (includeDetails) {
@@ -220,8 +217,8 @@ export const machinesToolMetadata = {
     properties: {
       status: {
         type: 'string',
-        enum: ['unknown', 'idle', 'all', 'offline', 'warning'],
-        description: 'Statut des machines à récupérer. "offline"/"warning" map to "unknown"/"idle"'
+        enum: ['unknown', 'idle', 'all'],
+        description: 'Statut des machines à récupérer'
       },
       includeDetails: {
         type: 'boolean',

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -402,10 +402,10 @@ export const roosyncInventoryDefinition = {
     inputSchema: {
         type: 'object',
         properties: {
-            type: { type: 'string', enum: ['machine', 'heartbeat', 'all', 'machines', 'status'], description: 'Inventory type. "machines" = offline/warning only. "status" = compact system snapshot with flags.' },
+            type: { type: 'string', enum: ['machine', 'heartbeat', 'all', 'machines', 'status'], description: 'Inventory type. "machines" = unknown/idle machines. "status" = compact system snapshot with flags.' },
             machineId: { type: 'string', description: 'Machine ID (default: hostname). For type="status", acts as machineFilter.' },
             includeHeartbeats: { type: 'boolean', description: 'Include heartbeat data (default: true, type=heartbeat|all)' },
-            status: { type: 'string', enum: ['unknown', 'idle', 'all', 'offline', 'warning'], description: 'Filter by status (type="machines")' },
+            status: { type: 'string', enum: ['unknown', 'idle', 'all'], description: 'Filter by status (type="machines")' },
             includeDetails: { type: 'boolean', description: 'Full machine details (type="machines") or tool usage stats (type="status")' },
             detail: { type: 'string', enum: ['compact', 'full'], description: 'Detail level for type="status". "full" adds claims + pipeline stages (#1855 HUD)' },
             resetCache: { type: 'boolean', description: 'Force service cache reset (type="status" only, default: false)' }

--- a/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/roosync/HeartbeatService.test.ts
@@ -159,7 +159,7 @@ describe('HeartbeatService - Tests Unitaires', () => {
       expect(onlineMachines).toContain('machine-2');
     });
 
-    it('devrait retourner les machines UNKNOWN via getOfflineMachines (deprecated alias)', async () => {
+    it('devrait retourner les machines UNKNOWN via getUnknownMachines', async () => {
       await heartbeatService.registerHeartbeat('machine-1');
 
       // Make stale → UNKNOWN
@@ -167,14 +167,10 @@ describe('HeartbeatService - Tests Unitaires', () => {
       hb.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString();
       await heartbeatService.checkHeartbeats();
 
-      const offlineMachines = heartbeatService.getOfflineMachines();
-      expect(offlineMachines).toContain('machine-1');
-
-      // Also available via getUnknownMachines
       expect(heartbeatService.getUnknownMachines()).toContain('machine-1');
     });
 
-    it('devrait retourner les machines IDLE via getWarningMachines (deprecated alias)', async () => {
+    it('devrait retourner les machines IDLE via getIdleMachines', async () => {
       await heartbeatService.registerHeartbeat('machine-1');
 
       // Make idle → IDLE
@@ -182,10 +178,6 @@ describe('HeartbeatService - Tests Unitaires', () => {
       hb.lastHeartbeat = new Date(Date.now() - 45 * 60 * 1000).toISOString();
       await heartbeatService.checkHeartbeats();
 
-      const warningMachines = heartbeatService.getWarningMachines();
-      expect(warningMachines).toContain('machine-1');
-
-      // Also available via getIdleMachines
       expect(heartbeatService.getIdleMachines()).toContain('machine-1');
     });
   });
@@ -218,19 +210,15 @@ describe('HeartbeatService - Tests Unitaires', () => {
       expect(heartbeatService.getHeartbeatData('myia-recent')).toBeDefined();
     });
 
-    it('cleanupOldOfflineMachines (deprecated) still works via backward compat', async () => {
-      const removedCount = await heartbeatService.cleanupOldOfflineMachines(86400000);
+    it('cleanupOldUnknownMachines returns 0 (no-op ADR 008)', async () => {
+      const removedCount = await heartbeatService.cleanupOldUnknownMachines(86400000);
       expect(removedCount).toBe(0);
     });
   });
 
   describe('Configuration', () => {
     it('updateConfig est un no-op (ne throw pas)', async () => {
-      await heartbeatService.updateConfig({
-        heartbeatInterval: 60000,
-        offlineTimeout: 180000,
-        missedHeartbeatThreshold: 6
-      });
+      await heartbeatService.updateConfig({});
 
       // No-op — just verify no throw
       expect(true).toBe(true);

--- a/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
@@ -110,14 +110,14 @@ describe('#1863 Fusion A2: machines → inventory(type: "machines")', () => {
       }
     });
 
-    it('should validate type="machines" with status="offline"', () => {
+    it('should validate type="machines" with status="unknown"', () => {
       const result = InventoryArgsSchema.safeParse({
         type: 'machines',
-        status: 'offline'
+        status: 'unknown'
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.status).toBe('offline');
+        expect(result.data.status).toBe('unknown');
       }
     });
 

--- a/servers/roo-state-manager/tests/unit/tools/roosync/inventory.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/inventory.test.ts
@@ -113,23 +113,23 @@ describe('roosync_inventory tool', () => {
     });
 
     describe('type=machines (fused from roosync_machines)', () => {
-        it('returns offline machines when status=offline', async () => {
+        it('returns unknown machines when status=unknown', async () => {
             mockGetUnknownMachines.mockReturnValue(['web1', 'po-2024']);
-            const result = await inventoryTool.execute({ type: 'machines', status: 'offline' }, {});
+            const result = await inventoryTool.execute({ type: 'machines', status: 'unknown' }, {});
             expect(result.success).toBe(true);
             expect(result.data.unknownMachines).toEqual(['web1', 'po-2024']);
             expect(result.data.unknownCount).toBe(2);
         });
 
-        it('returns warning machines when status=warning', async () => {
+        it('returns idle machines when status=idle', async () => {
             mockGetIdleMachines.mockReturnValue(['po-2023']);
-            const result = await inventoryTool.execute({ type: 'machines', status: 'warning' }, {});
+            const result = await inventoryTool.execute({ type: 'machines', status: 'idle' }, {});
             expect(result.success).toBe(true);
             expect(result.data.idleMachines).toEqual(['po-2023']);
             expect(result.data.idleCount).toBe(1);
         });
 
-        it('returns both offline and warning when status=all (default)', async () => {
+        it('returns both unknown and idle when status=all (default)', async () => {
             mockGetUnknownMachines.mockReturnValue(['web1']);
             mockGetIdleMachines.mockReturnValue(['po-2023']);
             const result = await inventoryTool.execute({ type: 'machines' }, {});
@@ -148,21 +148,21 @@ describe('roosync_inventory tool', () => {
                 };
                 return null;
             });
-            const result = await inventoryTool.execute({ type: 'machines', status: 'offline', includeDetails: true }, {});
+            const result = await inventoryTool.execute({ type: 'machines', status: 'unknown', includeDetails: true }, {});
             expect(result.data.unknownMachines).toHaveLength(1);
             expect(result.data.unknownMachines[0].machineId).toBe('web1');
             expect(result.data.unknownMachines[0].status).toBe('unknown');
             expect(result.data.unknownCount).toBe(1);
         });
 
-        it('skips machines without heartbeat data in detailed offline mode', async () => {
+        it('skips machines without heartbeat data in detailed unknown mode', async () => {
             mockGetUnknownMachines.mockReturnValue(['web1']);
             mockGetHeartbeatData.mockReturnValue(null);
-            const result = await inventoryTool.execute({ type: 'machines', status: 'offline', includeDetails: true }, {});
+            const result = await inventoryTool.execute({ type: 'machines', status: 'unknown', includeDetails: true }, {});
             expect(result.data.unknownMachines).toHaveLength(0);
         });
 
-        it('returns detailed warning machines', async () => {
+        it('returns detailed idle machines', async () => {
             mockGetIdleMachines.mockReturnValue(['po-2023']);
             mockGetHeartbeatData.mockImplementation((mid: string) => ({
                 machineId: mid,
@@ -170,7 +170,7 @@ describe('roosync_inventory tool', () => {
                 status: 'idle',
                 metadata: { firstSeen: '2026-01-01', lastUpdated: '2026-05-04' },
             }));
-            const result = await inventoryTool.execute({ type: 'machines', status: 'warning', includeDetails: true }, {});
+            const result = await inventoryTool.execute({ type: 'machines', status: 'idle', includeDetails: true }, {});
             expect(result.data.idleMachines).toHaveLength(1);
             expect(result.data.idleMachines[0].machineId).toBe('po-2023');
         });
@@ -178,7 +178,7 @@ describe('roosync_inventory tool', () => {
         it('skips null heartbeat data in detailed mode', async () => {
             mockGetUnknownMachines.mockReturnValue(['unknown']);
             mockGetHeartbeatData.mockReturnValue(null);
-            const result = await inventoryTool.execute({ type: 'machines', status: 'offline', includeDetails: true }, {});
+            const result = await inventoryTool.execute({ type: 'machines', status: 'unknown', includeDetails: true }, {});
             expect(result.data.unknownMachines).toHaveLength(0);
         });
     });


### PR DESCRIPTION
## Summary

- **ADR 008 Phase 2**: Remove all backward-compat `offline`/`warning` status overlay terms
- Status model is now strictly: `online` | `idle` | `unknown`
- Removed deprecated methods from HeartbeatService and RooSyncService: `getOfflineMachines()`, `getWarningMachines()`, `cleanupOldOfflineMachines()`
- Removed deprecated HeartbeatConfig properties (no disk I/O, no background intervals in ADR 008 passive model)
- Updated Zod schemas and tool-definitions enums: `['unknown', 'idle', 'all']`

## Changes

### Production code
- `HeartbeatService.ts` — removed deprecated methods and config props, cleaned no-op logging
- `RooSyncService.ts` — removed forwarding deprecated methods
- `inventory.ts` — removed `offline`/`warning` from Zod enum and execute mapping
- `machines.ts` — removed backward-compat status mapping, deprecated type aliases
- `tool-definitions.ts` — updated inventory schema enums

### Tests (11 files updated)
- All test files updated to use `unknown`/`idle` instead of `offline`/`warning`
- `HeartbeatService.test.ts` (both locations) — updated deprecated method calls
- `machines.test.ts`, `machines.smoke.test.ts` — complete rewrite for Phase 2 enums
- `inventory.test.ts`, `fusions-1863.test.ts` — status mapping updates

## Test plan
- [x] Build: `npm run build` — clean
- [x] Tests: `npx vitest run --config vitest.config.ci.ts` — 9185 passed, 0 failed (454 files)
- [x] Net reduction: -259 lines (11 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)