### PR TITLE
fix(mcp): jupyter-papermill stdout buffering fix #2069

### DIFF
--- a/servers/jupyter-papermill-mcp-server/papermill_mcp/main.py
+++ b/servers/jupyter-papermill-mcp-server/papermill_mcp/main.py
@@ -26,6 +26,14 @@ except ImportError:
     # Silent failure - stdout reserved for MCP protocol
     pass
 
+# CRITICAL FIX: Force line buffering when stdout is piped (not a TTY).
+# MCP servers are launched via piped stdin/stdout — Python buffers stdout
+# in block mode, causing indefinite blocking.
+if not sys.stdout.isatty():
+    sys.stdout.reconfigure(line_buffering=True)
+if not sys.stderr.isatty():
+    sys.stderr.reconfigure(line_buffering=True)
+
 from mcp.server.fastmcp import FastMCP
 
 from .config import get_config, MCPConfig


### PR DESCRIPTION
Fix jupyter-papermill MCP server blocking due to Python stdout buffering when piped (not TTY).

## Problem
The jupyter-papermill MCP server blocks indefinitely because Python buffers stdout when piped (not a TTY). Claude Code launches MCP servers via piped stdin/stdout.

## Fix
Added line buffering configuration when stdout/stderr are not TTY:
```python
if not sys.stdout.isatty():
    sys.stdout.reconfigure(line_buffering=True)
if not sys.stderr.isatty():
    sys.stderr.reconfigure(line_buffering=True)
```

[RESULT] myia-web1: PASS.