### PR TITLE
fix: MCP stdio buffering + continue_on_error config

### DIFF
--- a/servers/jupyter-papermill-mcp-server/papermill_mcp/config.py
+++ b/servers/jupyter-papermill-mcp-server/papermill_mcp/config.py
@@ -74,6 +74,10 @@ class MCPConfig(BaseModel):
     skip_connection_check: bool = Field(
         default=False, description="Skip Jupyter server connection check"
     )
+    continue_on_error: bool = Field(
+        default=False,
+        description="Continue notebook execution when a cell errors (instead of stopping)",
+    )
 
     class Config:
         validate_assignment = True

--- a/servers/jupyter-papermill-mcp-server/papermill_mcp/main.py
+++ b/servers/jupyter-papermill-mcp-server/papermill_mcp/main.py
@@ -16,6 +16,13 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+# Force unbuffered stdout/stderr for MCP stdio compatibility
+# When stdout is piped (not TTY), Python uses block-buffering which delays
+# MCP JSON-RPC messages and causes timeouts in Claude Code / VS Code hosts.
+if not sys.stdout.isatty():
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+
 # Import nest_asyncio at the top to handle nested event loops
 try:
     import nest_asyncio


### PR DESCRIPTION
## Summary

- **Fix stdout buffering**: Force `line_buffering=True` on stdout/stderr when not TTY (piped mode). Python defaults to block-buffering when piped, delaying MCP JSON-RPC responses and causing timeouts in Claude Code / VS Code hosts.
- **Fix API mismatch**: Add missing `continue_on_error: bool` field to `MCPConfig`. `kernel_service.py` references `self.config.continue_on_error` (lines 291, 309) but the field was never defined in the Pydantic model, causing `AttributeError` at runtime.

## Root Cause

Traced in jsboige/roo-extensions#2069 — MCP calls from Claude Code on po-2023 returned `AttributeError: 'MCPConfig' object has no attribute 'continue_on_error'` and the subprocess was silently buffering responses until its buffer filled (4-8KB), causing apparent hangs.

## Test Plan

- [ ] `python -m papermill_mcp.main --offline` starts without error
- [ ] MCP tool `execute_on_kernel` with `.net-csharp` kernel completes without `AttributeError`
- [ ] MCP responses arrive promptly (< 2s) when called from Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)