### PR TITLE
feat(#1836): expose roosync_claim tool in tools/list

### DIFF
--- a/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
@@ -35,6 +35,8 @@ import {
     roosyncMcpManagementDefinition,
     roosyncStorageManagementDefinition,
     roosyncDiagnoseDefinition,
+    // #1836: roosync_claim added — pre-claim enforcement tool
+    roosyncClaimDefinition,
     // #1935 Cluster B: roosyncRefreshDashboardDefinition, roosyncUpdateDashboardDefinition removed from tools/list
     // #1841 Cluster G: roosyncSend/Read/Manage/Attachments removed — fused into roosync_messages
     roosyncSendDefinition,
@@ -45,7 +47,7 @@ import {
     roosyncMessagesDefinition
 } from '../tool-definitions.js';
 
-const EXPECTED_TOOL_COUNT = 18;
+const EXPECTED_TOOL_COUNT = 19; // #1836: 18 → 19 (roosync_claim added)
 
 // Order MUST mirror allToolDefinitions in tool-definitions.ts.
 // #1863: 3 deprecated definitions removed from allToolDefinitions
@@ -75,6 +77,8 @@ const allDefinitions = [
     roosyncMcpManagementDefinition,
     roosyncStorageManagementDefinition,
     roosyncDiagnoseDefinition,
+    // #1836: roosync_claim added — pre-claim enforcement tool
+    roosyncClaimDefinition,
     // [REMOVED #291] roosyncRefreshDashboardDefinition — removed from allToolDefinitions
     // [REMOVED #291] roosyncUpdateDashboardDefinition — removed from allToolDefinitions
     // [REMOVED #1841 Cluster G] roosyncSendDefinition — fused into roosync_messages
@@ -88,7 +92,7 @@ const allDefinitions = [
 describe('tool-definitions.ts — Schema Validation', () => {
 
     describe('allToolDefinitions array', () => {
-        it('should have exactly 18 tool definitions', () => {
+        it('should have exactly 19 tool definitions', () => {
             expect(allToolDefinitions).toHaveLength(EXPECTED_TOOL_COUNT);
         });
 

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -478,6 +478,26 @@ export const roosyncDiagnoseDefinition = {
     }
 };
 
+// #1836 Phase 1: Pre-claim enforcement tool
+export const roosyncClaimDefinition = {
+    name: 'roosync_claim',
+    description: 'Pre-claim enforcement — prevents concurrent agent collisions on the same issue. Actions: claim (reserve issue), release (free claim), extend (prolong), list (active claims), check (verify issue status). Claims auto-expire after eta_minutes * 1.5. Always check before starting work on an issue.',
+    inputSchema: {
+        type: 'object',
+        properties: {
+            action: { type: 'string', enum: ['claim', 'release', 'extend', 'list', 'check'], description: 'Action: "claim" (reserve issue), "release" (free claim), "extend" (prolong), "list" (active claims), "check" (verify issue status)' },
+            issue_number: { type: 'string', description: 'Issue number (e.g., "1836"). Required for claim/check/release/extend.' },
+            agent: { type: 'string', description: 'Agent identifier (machine ID). Defaults to local machine.' },
+            eta_minutes: { type: 'number', description: 'Estimated time in minutes. Required for claim, optional for extend.' },
+            branch: { type: 'string', description: 'Git branch name for the claim (optional).' },
+            claim_id: { type: 'string', description: 'Claim ID. Required for release/extend.' },
+            additional_minutes: { type: 'number', description: 'Additional minutes for extend action.' }
+        },
+        required: ['action'],
+        additionalProperties: false
+    }
+};
+
 // [#1935 Cluster B] DEPRECATED: roosync_refresh_dashboard + roosync_update_dashboard
 // Removed from tools/list. Callers should use roosync_dashboard(action: "refresh"|"update").
 // Backward-compat CallTool handlers remain in registry.ts (redirect to roosyncDashboard).
@@ -665,6 +685,8 @@ export const allToolDefinitions = [
     roosyncMcpManagementDefinition,
     roosyncStorageManagementDefinition,
     roosyncDiagnoseDefinition,
+    // #1836: Pre-claim enforcement
+    roosyncClaimDefinition,
     // [REMOVED #1935 Cluster B] roosyncRefreshDashboardDefinition — fused into roosync_dashboard(action: "refresh"), redirect in registry.ts
     // [REMOVED #1935 Cluster B] roosyncUpdateDashboardDefinition — fused into roosync_dashboard(action: "update"), redirect in registry.ts
     // [REMOVED #1841 Cluster G] roosyncSendDefinition — fused into roosync_messages(action: "send"/"reply"/"amend"), redirect in registry.ts

--- a/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
@@ -299,15 +299,16 @@ describe('#1935 Fusion E: get_status → inventory(type: "status")', () => {
 // Cross-cutting: Definition count and deprecation removal verification
 // ============================================================
 describe('#1863 Cross-cutting: tool count and deprecation markers', () => {
-  it('allToolDefinitions should contain 18 tools (Cluster H fusion removed task_export)', () => {
+  it('allToolDefinitions should contain 19 tools (18 + #1836 roosync_claim)', () => {
     // Before: 32 tools → #1922 Pass 4 removed 3 deprecated → 29
     // #1841 removed 6 low-usage → 23. allToolDefinitions baseline = 24.
     // Cluster D (#1935) fused analyze_roosync_problems → roosync_diagnose: 24 → 23
     // Cluster E (#1935) fused get_status → inventory: 23 → 22
     // Cluster G (#1841) fused send+read+manage+attachments → roosync_messages: 22 → 19
     // Cluster H (#1841) fused task_export → export_data: 19 → 18
+    // #1836 added roosync_claim: 18 → 19
     // Backward compat redirect handlers in registry.ts are preserved
-    expect(allToolDefinitions.length).toBe(18);
+    expect(allToolDefinitions.length).toBe(19);
   });
 
   it('deprecated tools should NOT be in allToolDefinitions', () => {


### PR DESCRIPTION
## Summary
- Expose `roosync_claim` tool in MCP `tools/list` response by adding its definition to `allToolDefinitions`
- The tool handler was fully implemented (`claim.tool.ts`) but was invisible to agents because its schema was missing from `tool-definitions.ts`

## Changes
- Add `roosyncClaimDefinition` with JSON schema (action: claim/release/extend/list/check)
- Add to `allToolDefinitions` array (count: 18 → 19)
- Update `fusions-1863.test.ts` tool count assertion

## Test plan
- [x] 27 claim tool tests pass
- [x] 30 fusions tests pass (updated count)
- [x] Build succeeds
- [ ] Full CI suite passes (known flaky: search-semantic TTL timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>