### PR TITLE
fix(#1314): remove as-any cast in getSummaryForTask(), use skeleton.metadata.synthesis

### DIFF
--- a/servers/roo-state-manager/src/services/synthesis/NarrativeContextBuilderService.ts
+++ b/servers/roo-state-manager/src/services/synthesis/NarrativeContextBuilderService.ts
@@ -1505,23 +1505,21 @@ export class NarrativeContextBuilderService {
                 return null;
             }
 
-            // Vérifier si skeleton a les métadonnées de synthèse (extension selon synthesis_models.md)
-            const metadata = (skeleton as any).synthesisMetadata;
-            if (!metadata) {
-                return await this.generateOnDemandSummary(skeleton);
+            // Synthesis metadata lives on skeleton.metadata.synthesis (SynthesisMetadata type)
+            const synthesis = skeleton.metadata.synthesis;
+            if (synthesis?.status === 'completed') {
+                // 1. Priorité au lot condensé
+                if (synthesis.condensedBatchPath) {
+                    return await this.readCondensedBatchSummary(synthesis.condensedBatchPath);
+                }
+
+                // 2. Synthèse atomique
+                if (synthesis.analysisFilePath) {
+                    return await this.readAtomicSynthesis(synthesis.analysisFilePath);
+                }
             }
 
-            // 1. Priorité au lot condensé
-            if (metadata.condensedBatchPath) {
-                return await this.readCondensedBatchSummary(metadata.condensedBatchPath);
-            }
-
-            // 2. Synthèse atomique
-            if (metadata.analysisFilePath) {
-                return await this.readAtomicSynthesis(metadata.analysisFilePath);
-            }
-
-            // 3. Génération à la volée
+            // Fallback: generate on-demand summary
             return await this.generateOnDemandSummary(skeleton);
 
         } catch (error) {


### PR DESCRIPTION
## Summary
- Fix type bug: `(skeleton as any).synthesisMetadata` → `skeleton.metadata.synthesis` (proper typed access)
- Add status check: only use synthesis when `status === 'completed'`
- Remove dead branches and `as any` cast
- 12 insertions, 14 deletions (net -2 lines)

## Root cause
The code accessed a non-existent `synthesisMetadata` field via `as any` cast. The correct path is `skeleton.metadata.synthesis`, which is already defined as `SynthesisMetadata?` on `SkeletonMetadata` (see `src/types/conversation.ts:55`).

## Test plan
- [x] Build passes (`npm run build` clean)
- [x] CI tests pass (9200/9216, 16 skipped = baseline)
- [ ] Verify `getSummaryForTask()` returns on-demand summary when no synthesis
- [ ] Verify `getSummaryForTask()` uses cached synthesis when `status === 'completed'`

Closes #1314

🤖 Generated with [Claude Code](https://claude.com/claude-code)