### PR TITLE
fix(roo-state-manager): make embedding rate limit env-configurable, default 30/min

### DIFF
--- a/servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts
@@ -28,7 +28,10 @@ let lastFailureTime = 0;
 const embeddingCache = new Map<string, { vector: number[], timestamp: number }>();
 const EMBEDDING_CACHE_TTL = 7 * 24 * 60 * 60 * 1000; // 7 jours cache pour embeddings (FIX: augmenté de 24h)
 const RATE_LIMIT_WINDOW = 60 * 1000; // 1 minute
-const MAX_OPERATIONS_PER_WINDOW = 200; // Max 200 operations/minute (FIX #1123: augmenté de 100 pour éviter storm rate-limiting)
+// Embedding ops per minute per instance. Default 30 sized for fleet (12 MCP instances × 30 = 360/min ≈ 6 emb/s),
+// matching the qwen3-4b-awq embedder capacity on po-2026 (~5-10 req/s). Override via env to accelerate
+// once the cache is warm (steady-state sees high cache hits and the embedder is barely touched).
+const MAX_OPERATIONS_PER_WINDOW = parseInt(process.env.EMBEDDING_OPS_PER_MINUTE || '30', 10);
 let operationTimestamps: number[] = [];
 
 const MAX_CHUNK_SIZE = 800; // Approx. 200-400 tokens, ultra-conservative safety margin below 8192 limit for text-embedding-3-small


### PR DESCRIPTION
## Summary

- Replaces hardcoded `MAX_OPERATIONS_PER_WINDOW = 200` with env-configurable `EMBEDDING_OPS_PER_MINUTE` (default **30**).
- Sized for fleet-wide protection: 12 MCP instances × 30/min ≈ 6 emb/s, matching the qwen3-4b-awq embedder capacity on po-2026 (~5–10 req/s).
- Override via env to accelerate once the embedding cache is warm — steady-state runs hot on cache hits and the embedder is barely touched.

## Why now

This is the **safety pre-condition** for the upcoming nuclear drop+recreate of `roo_tasks_semantic_index` (53M points, 1139 segments stuck). With the previous hardcoded 200/min:

- 12 instances × 200/min = **40 emb/s** vs embedder ~5–10 req/s → **4–8× overload**
- A cold rebuild storm would saturate the embedder and stall re-indexing for weeks

With 30/min/instance default, the fleet stays within the embedder envelope during the multi-week re-indexing window.

## File changed

- [VectorIndexer.ts:31](servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts#L31)

## Test plan

- [x] `npm run build` passes (verified locally)
- [ ] Deploy on the 12 fleet MCP instances before executing drop+recreate
- [ ] Monitor embedder load on po-2026 stays < 10 req/s during cold rebuild