### PR TITLE
docs(#250) + fix(#253): format guidance + Claude Code tool_use extraction

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/messages.ts
+++ b/servers/roo-state-manager/src/tools/roosync/messages.ts
@@ -214,6 +214,8 @@ export const messagesToolMetadata = {
 - cleanup : nettoyage automatique, stats : statistiques inbox
 - attachments_list, attachments_get, attachments_delete : gestion des pièces jointes
 
+IMPORTANT: For agent-parseable output, use format="json" on inbox/stats actions. Default is human-readable markdown with emojis.
+
 Remplace : roosync_send + roosync_read + roosync_manage + roosync_attachments (4→1, #1841 Cluster G)`,
   inputSchema: {
     type: 'object' as const,

--- a/servers/roo-state-manager/src/utils/claude-storage-detector.ts
+++ b/servers/roo-state-manager/src/utils/claude-storage-detector.ts
@@ -276,6 +276,21 @@ export class ClaudeStorageDetector {
                         timestamp,
                         isTruncated,
                     });
+
+                    // #253: Extract tool_use blocks from assistant message content
+                    if (entry.type === 'assistant' && Array.isArray(entry.message.content)) {
+                        for (const block of entry.message.content) {
+                            if (block.type === 'tool_use' && block.toolUse) {
+                                sequence.push({
+                                    type: 'tool',
+                                    name: block.toolUse.name,
+                                    status: 'success',
+                                    parameters: block.toolUse.input,
+                                    timestamp,
+                                });
+                            }
+                        }
+                    }
                 }
             }
             // Résultats de commande


### PR DESCRIPTION
## Summary
Two fixes for agent-facing tool reliability:

1. **#250** (P1): Added explicit `format="json"` guidance to `roosync_messages` tool description so LLM agents discover the parameter without reading source code.
2. **#253** (P3): Fixed `view_task_details` returning "Aucune action technique trouvée" for Claude Code sessions — `claude-storage-detector.ts` now extracts `tool_use` content blocks from assistant messages as `ActionMetadata` items.

## Changes
- `src/tools/roosync/messages.ts` — Added format=json mention in tool description
- `src/utils/claude-storage-detector.ts` — Added tool_use block extraction from assistant message content (lines 283-295)

## Root cause (#253)
Claude Code JSONL stores tool_use blocks as nested content items inside assistant messages (not as top-level entries). The skeleton builder only checked top-level types, so tool invocations were invisible. Roo sessions worked because `roo-storage-detector.ts` handles tool_use at the API level.

## Test plan
- [x] Build passes (`npm run build`)
- [x] CI tests pass (454 files, 9185 tests, 0 failures)
- [ ] Manual: `view_task_details` on a Claude Code session with tool_use blocks should now show actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>