### PR TITLE
chore(test): align get-status tests with ADR 008 terminology (offline→unknown)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/get-status.test.ts
@@ -155,7 +155,7 @@ describe('get-status (Option B)', () => {
       expect(result.flags).toHaveLength(0);
     });
 
-    test('returns CRITICAL when machines offline', async () => {
+    test('returns CRITICAL when machines unknown', async () => {
       mockGetHeartbeatService.mockReturnValue({
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
@@ -264,8 +264,8 @@ describe('get-status (Option B)', () => {
   });
 
   describe('#1365 orphan test entry filtering', () => {
-    test('excludes orphan test machines from offline count', async () => {
-      // Simulates real scenario: 6 real machines online + 3 test artifacts offline
+    test('excludes orphan test machines from unknown count', async () => {
+      // Simulates real scenario: real machines online + 3 test artifacts unknown
       mockGetHeartbeatService.mockReturnValue({
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
@@ -291,7 +291,7 @@ describe('get-status (Option B)', () => {
         machines: {
           'myia-ai-01': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 },
           'myia-po-2023': { status: 'online', lastSync: new Date().toISOString(), pendingDecisions: 0, diffsCount: 0 },
-          'test-machine': { status: 'offline', lastSync: '2025-01-01', pendingDecisions: 0, diffsCount: 0 }
+          'test-machine': { status: 'unknown', lastSync: '2025-01-01', pendingDecisions: 0, diffsCount: 0 }
         }
       });
 
@@ -318,7 +318,7 @@ describe('get-status (Option B)', () => {
       expect(result.flags).not.toContain('HEARTBEAT_STALE:test-machine');
     });
 
-    test('still detects real offline machines correctly', async () => {
+    test('still detects real unknown machines correctly', async () => {
       mockGetHeartbeatService.mockReturnValue({
         checkHeartbeats: vi.fn(),
         getState: vi.fn(() => ({
@@ -330,7 +330,7 @@ describe('get-status (Option B)', () => {
 
       const result = await roosyncGetStatus({});
 
-      // Should be CRITICAL from real offline machine only
+      // Should be CRITICAL from real unknown machine only
       expect(result.status).toBe('CRITICAL');
       expect(result.machines.unknown).toBe(1);  // Only myia-po-2025
       expect(result.flags).toContain('UNKNOWN:myia-po-2025');

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/inventory.integration.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/inventory.integration.test.ts
@@ -122,7 +122,7 @@ describe('roosync_inventory (integration)', () => {
       const shape = HeartbeatStatisticsSchema.shape;
       expect(shape.totalMachines).toBeDefined();
       expect(shape.onlineCount).toBeDefined();
-      expect(shape.offlineCount).toBeDefined();
+      expect(shape.offlineCount).toBeDefined(); // Kept for backward compat — ADR 008 maps to unknownCount
       expect(shape.warningCount).toBeDefined();
       expect(shape.lastHeartbeatCheck).toBeDefined();
     });


### PR DESCRIPTION
## Summary
- Fix lingering `offline` references in `get-status.test.ts` test names, comments, and mock data
- The test assertions already used `unknown` (correct), but 5 descriptive references still said `offline`
- Also clarify `offlineCount` in `inventory.integration.test.ts` with backward compat comment

## Test plan
- [x] `npx vitest run get-status.test.ts` — 22/22 pass
- [x] `npx vitest run --config vitest.config.ci.ts` — 9203/9204 (1 pre-existing circuit breaker timeout, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)