### PR TITLE
docs(#250): document format=json in roosync_dashboard tool description

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/dashboard-schemas.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard-schemas.ts
@@ -213,6 +213,6 @@ export type DashboardArgs = z.infer<typeof DashboardArgsSchema> & Record<string,
 
 export const dashboardToolMetadata = {
   name: 'roosync_dashboard',
-  description: 'Shared dashboards (global/machine/workspace). Actions: read, write, append, condense, list, delete, read_archive, read_overview, refresh, update. Team stages supported.',
+  description: 'Shared dashboards (global/machine/workspace). Actions: read, write, append, condense, list, delete, read_archive, read_overview, refresh, update. Team stages supported. For agent-parseable output, use format="json" on read/read_overview actions. Default is human-readable markdown.',
   inputSchema: zodToJsonSchema(DashboardArgsSchema as any, { target: 'openApi3' })
 };


### PR DESCRIPTION
## Summary
- Add `format="json"` guidance to `roosync_dashboard` tool description, matching the pattern already used by `roosync_messages`
- This completes the **Option A** fix recommended in the #250 investigation: update tool descriptions to document the `format` parameter for agent-parseable output

## Context
Issue #250 reported inconsistent return formats. The consolidation work (#1841) already added `format` parameter support to `roosync_dashboard` (read/read_overview actions) and `roosync_messages` (inbox/stats). However, the dashboard tool description didn't mention this parameter, while `roosync_messages` did.

## What changed
- `dashboard-schemas.ts:216`: Added `"For agent-parseable output, use format="json" on read/read_overview actions. Default is human-readable markdown."` to tool description

## Test plan
- [x] Build: `npm run build` — clean
- [x] CI tests: 9204/9204 passed (0 failures)
- [ ] Verify `roosync_dashboard(action: "read", type: "workspace", format: "json")` returns structured JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)