### PR TITLE
feat(#2089): add .env.template + ensure-env script for .env protection

### DIFF
--- a/servers/roo-state-manager/.env.template
+++ b/servers/roo-state-manager/.env.template
@@ -1,0 +1,93 @@
+# ====================================================================
+# .env.template — roo-state-manager MCP server
+# ====================================================================
+# This file is VERSIONED (committed to git). The actual .env is gitignored.
+# Source of truth for required environment variables.
+#
+# Recovery procedure (#2089):
+#   If .env is missing (e.g. after `git submodule update --init --recursive`):
+#     PowerShell: pwsh ./scripts/ensure-env.ps1
+#     Bash:       bash ./scripts/ensure-env.sh
+#   The scripts copy this template to .env and warn about placeholders to fill.
+#
+# DO NOT commit real secret values to this file. Use placeholders.
+# ====================================================================
+
+# Configuration Qdrant (base de données vectorielle)
+QDRANT_URL=https://qdrant.myia.io
+QDRANT_API_KEY=__FILL_ME__
+QDRANT_COLLECTION_NAME=roo_tasks_semantic_index
+
+# Configuration LLM Chat/Synthesis (vLLM local — Qwen3.6-35B-A3B)
+# Endpoint et clé pour le pipeline synthesis (LLMService)
+# Le SDK OpenAI lit automatiquement OPENAI_BASE_URL
+OPENAI_BASE_URL=https://api.medium.text-generation-webui.myia.io/v1
+OPENAI_API_KEY=__FILL_ME__
+OPENAI_CHAT_MODEL_ID=qwen3.6-35b-a3b
+
+# Configuration Embeddings pour codebase_search (Qwen3-4B AWQ self-hosted on po-2026)
+# Must match Roo Code's indexing config to produce compatible vectors
+# HTTPS endpoint confirmed working by po-2026 (score 0.76) - HTTP:11436 is DOWN
+EMBEDDING_MODEL=qwen3-4b-awq-embedding
+EMBEDDING_DIMENSIONS=2560
+EMBEDDING_API_BASE_URL=https://embeddings.myia.io/v1
+EMBEDDING_API_KEY=__FILL_ME__
+
+# =============================================================================
+# QDRANT TIMEOUT CONFIGURATION
+# =============================================================================
+# #2009: Increased timeouts for 60M+ vector collection (defaults: 15s/30s)
+# Reference: migration script uses 120s for large collection operations
+QDRANT_TIMEOUT_MS=60000
+QDRANT_SEARCH_TIMEOUT_MS=120000
+
+# =============================================================================
+# ROOSYNC CONFIGURATION
+# =============================================================================
+# Configuration pour l'intégration RooSync - Synchronisation multi-machines
+# Documentation: docs/integration/02-points-integration-roosync.md
+# Version: 2.0.0
+
+# Chemin absolu vers le répertoire Google Drive partagé pour RooSync
+# Ce répertoire contient les fichiers de synchronisation (.shared-state)
+# Exemple Windows: G:/Mon Drive/Synchronisation/RooSync/.shared-state
+# Exemple Mac/Linux: ~/Google Drive/Synchronisation/RooSync/.shared-state
+ROOSYNC_SHARED_PATH=G:/Mon Drive/Synchronisation/RooSync/.shared-state
+
+# Identifiant unique de cette machine (utilisé pour différencier les configurations)
+# Format recommandé: NOM-MACHINE
+# Valeurs valides: myia-ai-01, myia-po-2023, myia-po-2024, myia-po-2025, myia-po-2026, myia-web1
+ROOSYNC_MACHINE_ID=__FILL_ME__
+
+# Active/désactive la synchronisation automatique RooSync
+# Si true, le système vérifie automatiquement les changements
+# Si false, les synchronisations sont déclenchées manuellement via outils MCP
+# Valeurs: true | false
+ROOSYNC_AUTO_SYNC=false
+
+# Stratégie de résolution des conflits de synchronisation
+# - manual: L'utilisateur doit approuver manuellement chaque décision
+# - auto-local: Préférence automatique pour les changements locaux
+# - auto-remote: Préférence automatique pour les changements distants
+# Valeurs: manual | auto-local | auto-remote
+ROOSYNC_CONFLICT_STRATEGY=manual
+
+# Niveau de verbosité des logs RooSync
+# - debug: Tous les détails (développement)
+# - info: Informations importantes (recommandé)
+# - warn: Avertissements uniquement
+# - error: Erreurs uniquement
+# Valeurs: debug | info | warn | error
+ROOSYNC_LOG_LEVEL=info
+
+# =============================================================================
+# SK-AGENT / VLLM API KEYS (self-hosted models on myia.io)
+# =============================================================================
+# Clés pour les modèles self-hosted accessibles via sk-agent
+# Documentation: mcps/internal/servers/sk-agent/README.md
+
+# zwz-8b vision model (api.mini.text-generation-webui.myia.io)
+VLLM_API_KEY_MINI=__FILL_ME__
+
+# glm-4.7-flash text model (api.medium.text-generation-webui.myia.io)
+VLLM_API_KEY_MEDIUM=__FILL_ME__

--- a/servers/roo-state-manager/scripts/ensure-env.ps1
+++ b/servers/roo-state-manager/scripts/ensure-env.ps1
@@ -1,0 +1,120 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Ensure .env exists for roo-state-manager — restores from .env.template if missing,
+    detects placeholder values, validates required keys.
+
+.DESCRIPTION
+    Issue #2089 — Protects .env from being lost after `git submodule update --init --recursive`
+    or other agressive git operations. Idempotent: safe to run repeatedly.
+
+    Behaviour:
+    - If .env missing AND .env.template exists: copies template -> .env, warns user.
+    - If .env exists: validates all keys from template are present, adds missing keys.
+    - Detects __FILL_ME__ placeholders and warns user to fill them.
+
+.EXAMPLE
+    pwsh ./scripts/ensure-env.ps1
+    pwsh ./scripts/ensure-env.ps1 -Quiet
+
+.NOTES
+    Run from mcps/internal/servers/roo-state-manager/ directory.
+    Exit codes: 0 = OK, 1 = missing template, 2 = placeholders detected
+#>
+[CmdletBinding()]
+param(
+    [switch]$Quiet
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$rsmDir = Split-Path -Parent $scriptDir
+$envFile = Join-Path $rsmDir '.env'
+$templateFile = Join-Path $rsmDir '.env.template'
+
+function Write-Info {
+    param([string]$Message)
+    if (-not $Quiet) { Write-Host "[ensure-env] $Message" -ForegroundColor Cyan }
+}
+
+function Write-Warning2 {
+    param([string]$Message)
+    Write-Host "[ensure-env] WARN: $Message" -ForegroundColor Yellow
+}
+
+function Write-Err {
+    param([string]$Message)
+    Write-Host "[ensure-env] ERROR: $Message" -ForegroundColor Red
+}
+
+if (-not (Test-Path $templateFile)) {
+    Write-Err ".env.template missing at $templateFile — cannot validate or restore .env"
+    exit 1
+}
+
+function Read-EnvKeys {
+    param([string]$Path)
+    $keys = @()
+    foreach ($line in (Get-Content $Path -ErrorAction SilentlyContinue)) {
+        $trimmed = $line.Trim()
+        if ($trimmed -and -not $trimmed.StartsWith('#') -and $trimmed.Contains('=')) {
+            $key = $trimmed.Split('=', 2)[0].Trim()
+            if ($key) { $keys += $key }
+        }
+    }
+    return $keys
+}
+
+$templateKeys = Read-EnvKeys -Path $templateFile
+
+if (-not (Test-Path $envFile)) {
+    Write-Warning2 ".env missing — restoring from .env.template"
+    Copy-Item -Path $templateFile -Destination $envFile -Force
+    Write-Warning2 "Restored .env contains __FILL_ME__ placeholders for secrets:"
+    foreach ($line in (Get-Content $envFile)) {
+        if ($line -match '^([^#=]+)=__FILL_ME__') {
+            Write-Warning2 "  - $($matches[1].Trim())"
+        }
+    }
+    Write-Warning2 "Edit .env and replace __FILL_ME__ with real values before starting MCP server."
+    exit 2
+}
+
+# .env exists — validate keys
+$envKeys = Read-EnvKeys -Path $envFile
+$missingKeys = $templateKeys | Where-Object { $_ -notin $envKeys }
+
+if ($missingKeys.Count -gt 0) {
+    Write-Warning2 "$($missingKeys.Count) keys missing from .env (present in template):"
+    foreach ($key in $missingKeys) {
+        Write-Warning2 "  - $key"
+    }
+    Write-Warning2 "Appending missing keys from template (with placeholders)..."
+    $appendLines = @('', "# === Added by ensure-env.ps1 on $(Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ') ===")
+    foreach ($key in $missingKeys) {
+        $templateLine = (Get-Content $templateFile) | Where-Object { $_ -match "^$([regex]::Escape($key))=" } | Select-Object -First 1
+        if ($templateLine) { $appendLines += $templateLine }
+    }
+    Add-Content -Path $envFile -Value $appendLines -Encoding UTF8
+    Write-Warning2 "Missing keys appended. Edit .env to fill placeholders."
+}
+
+# Detect placeholders
+$placeholderKeys = @()
+foreach ($line in (Get-Content $envFile)) {
+    if ($line -match '^([^#=]+)=__FILL_ME__') {
+        $placeholderKeys += $matches[1].Trim()
+    }
+}
+
+if ($placeholderKeys.Count -gt 0) {
+    Write-Warning2 "$($placeholderKeys.Count) keys still contain __FILL_ME__ placeholders:"
+    foreach ($key in $placeholderKeys) {
+        Write-Warning2 "  - $key"
+    }
+    exit 2
+}
+
+Write-Info ".env OK — all $($templateKeys.Count) keys present, no placeholders detected."
+exit 0

--- a/servers/roo-state-manager/scripts/ensure-env.sh
+++ b/servers/roo-state-manager/scripts/ensure-env.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Ensure .env exists for roo-state-manager — restores from .env.template if missing.
+# Issue #2089 — Bash equivalent of ensure-env.ps1
+# Exit codes: 0 = OK, 1 = missing template, 2 = placeholders detected
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RSM_DIR="$(dirname "$SCRIPT_DIR")"
+ENV_FILE="$RSM_DIR/.env"
+TEMPLATE_FILE="$RSM_DIR/.env.template"
+
+QUIET=0
+[[ "${1:-}" == "--quiet" ]] && QUIET=1
+
+log_info()  { [[ $QUIET -eq 0 ]] && echo "[ensure-env] $*"; }
+log_warn()  { echo "[ensure-env] WARN: $*" >&2; }
+log_error() { echo "[ensure-env] ERROR: $*" >&2; }
+
+if [[ ! -f "$TEMPLATE_FILE" ]]; then
+    log_error ".env.template missing at $TEMPLATE_FILE"
+    exit 1
+fi
+
+# Read keys (lines like KEY=value, ignoring comments and blank lines)
+read_keys() {
+    grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$1" | cut -d= -f1
+}
+
+template_keys=$(read_keys "$TEMPLATE_FILE")
+
+if [[ ! -f "$ENV_FILE" ]]; then
+    log_warn ".env missing — restoring from .env.template"
+    cp "$TEMPLATE_FILE" "$ENV_FILE"
+    log_warn "Restored .env contains __FILL_ME__ placeholders for secrets:"
+    grep -E '^[^#=]+=__FILL_ME__' "$ENV_FILE" | cut -d= -f1 | sed 's/^/  - /' >&2
+    log_warn "Edit .env and replace __FILL_ME__ with real values before starting MCP server."
+    exit 2
+fi
+
+env_keys=$(read_keys "$ENV_FILE")
+missing_keys=$(comm -23 <(echo "$template_keys" | sort -u) <(echo "$env_keys" | sort -u))
+
+if [[ -n "$missing_keys" ]]; then
+    missing_count=$(echo "$missing_keys" | grep -c .)
+    log_warn "$missing_count keys missing from .env (present in template):"
+    echo "$missing_keys" | sed 's/^/  - /' >&2
+    log_warn "Appending missing keys from template..."
+    {
+        echo ""
+        echo "# === Added by ensure-env.sh on $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+        for key in $missing_keys; do
+            grep -E "^$key=" "$TEMPLATE_FILE" || true
+        done
+    } >> "$ENV_FILE"
+    log_warn "Missing keys appended. Edit .env to fill placeholders."
+fi
+
+placeholder_keys=$(grep -E '^[^#=]+=__FILL_ME__' "$ENV_FILE" | cut -d= -f1 || true)
+if [[ -n "$placeholder_keys" ]]; then
+    placeholder_count=$(echo "$placeholder_keys" | grep -c .)
+    log_warn "$placeholder_count keys still contain __FILL_ME__ placeholders:"
+    echo "$placeholder_keys" | sed 's/^/  - /' >&2
+    exit 2
+fi
+
+template_count=$(echo "$template_keys" | grep -c .)
+log_info ".env OK — all $template_count keys present, no placeholders detected."
+exit 0


### PR DESCRIPTION
## Summary

Implements **Option B** from [issue #2089](https://github.com/jsboige/roo-extensions/issues/2089) (`.env` protection meta) — protects `roo-state-manager` `.env` from being lost after `git submodule update --init --recursive`. 3rd recurrence on po-2026 2026-05-10T10:12Z (post pointer-bump 94f656f1).

## Changes

| File | Purpose |
|------|---------|
| `servers/roo-state-manager/.env.template` | Versioned source of truth, uses `__FILL_ME__` placeholders for secrets |
| `servers/roo-state-manager/scripts/ensure-env.ps1` | PowerShell idempotent restore script |
| `servers/roo-state-manager/scripts/ensure-env.sh` | Bash equivalent |

## Behaviour

```
pwsh ./scripts/ensure-env.ps1     # If .env missing: restores from template, warns placeholders
                                   # If .env exists: validates keys, appends missing
                                   # Exit 0 = OK, 2 = placeholders detected (user action needed)
```

## Tested

Local ai-01 worktree:
- Script restores `.env` correctly from template
- Detects 6 placeholder keys (QDRANT_API_KEY, OPENAI_API_KEY, EMBEDDING_API_KEY, ROOSYNC_MACHINE_ID, VLLM_API_KEY_MINI, VLLM_API_KEY_MEDIUM)
- Exits 2 (expected — signals user to fill secrets before MCP startup)

## Recovery procedure (documented in `.env.template` header)

After submodule update accidentally deletes `.env`:

```powershell
cd mcps/internal/servers/roo-state-manager
pwsh ./scripts/ensure-env.ps1
# Edit .env to fill __FILL_ME__ placeholders with real secrets
```

## Test plan

- [x] Script runs without errors when `.env` missing → creates `.env` from template
- [x] Script detects placeholder values and warns user
- [x] `.env.template` is NOT gitignored (verified: `.gitignore` has `.env`, `.env.test`, `.env.local`, `.env.*.local` — `.env.template` doesn't match any)
- [x] No real secrets committed (all secret values use `__FILL_ME__`)
- [ ] Multi-machine deployment validation (next pointer-bump cycle)

## Related

- Issue #2089 (parent repo): `.env` protection meta
- Original incident report: dashboard `workspace-roo-extensions` 2026-05-10T10:16:58Z

## Notes

- This is **Option B** (template + script). Option A (migrate to `~/.claude.json` env section) requires per-machine config sync and is deferred.
- Future enhancement: integrate `ensure-env.ps1` into `npm prebuild` script for automatic pre-flight check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)