### PR TITLE
fix(#1953): crossCheckWithDashboard discovers machines absent from heartbeat map

### DIFF
--- a/servers/roo-state-manager/src/utils/__tests__/dashboard-activity.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/dashboard-activity.test.ts
@@ -202,5 +202,62 @@ describe('dashboard-activity', () => {
 			expect(result.overrides).toHaveLength(0);
 			expect(result.onlineMachines).toEqual(['myia-ai-01']);
 		});
+
+		it('should ADD machines from dashboard that are not in any heartbeat list (#1953 Phase 4)', () => {
+			// ADR 008 in-memory model: each MCP server only sees its own tool calls.
+			// Other machines are discovered via shared dashboard messages.
+			const heartbeatState = {
+				onlineMachines: ['myia-po-2026'],
+				unknownMachines: [],
+				idleMachines: [],
+			};
+			const dashboardContent = [
+				'### [2026-05-03T19:50:00Z] myia-po-2023|roo-extensions',
+				'Active machine not in heartbeat map',
+				'### [2026-05-03T19:55:00Z] myia-web1|roo-extensions',
+				'Another active machine',
+			].join('\n');
+
+			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
+			expect(result.onlineMachines).toContain('myia-po-2026'); // self stays
+			expect(result.onlineMachines).toContain('myia-po-2023'); // discovered
+			expect(result.onlineMachines).toContain('myia-web1'); // discovered
+			expect(result.overrides).toContain('myia-po-2023');
+			expect(result.overrides).toContain('myia-web1');
+		});
+
+		it('should NOT add dashboard machines with stale activity', () => {
+			const heartbeatState = {
+				onlineMachines: ['myia-po-2026'],
+				unknownMachines: [],
+				idleMachines: [],
+			};
+			const dashboardContent = '### [2026-05-03T08:00:00Z] myia-po-2023|roo-extensions\nOld message';
+
+			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
+			expect(result.onlineMachines).toEqual(['myia-po-2026']);
+			expect(result.overrides).toHaveLength(0);
+		});
+
+		it('should handle mixed scenario: override existing + discover new', () => {
+			const heartbeatState = {
+				onlineMachines: ['myia-po-2026'],
+				unknownMachines: ['myia-po-2024'],
+				idleMachines: [],
+			};
+			const dashboardContent = [
+				'### [2026-05-03T19:50:00Z] myia-po-2023|roo-extensions',
+				'Discovered machine',
+				'### [2026-05-03T19:55:00Z] myia-po-2024|roo-extensions',
+				'Override UNKNOWN',
+			].join('\n');
+
+			const result = crossCheckWithDashboard(heartbeatState, dashboardContent);
+			expect(result.onlineMachines).toContain('myia-po-2026'); // original
+			expect(result.onlineMachines).toContain('myia-po-2023'); // discovered
+			expect(result.onlineMachines).toContain('myia-po-2024'); // overridden
+			expect(result.unknownMachines).toHaveLength(0);
+			expect(result.overrides).toHaveLength(2);
+		});
 	});
 });

--- a/servers/roo-state-manager/src/utils/dashboard-activity.ts
+++ b/servers/roo-state-manager/src/utils/dashboard-activity.ts
@@ -11,7 +11,7 @@
  * Message format: ### [2026-05-03T20:08:15.436Z] myia-po-2024|roo-extensions
  *
  * @module utils/dashboard-activity
- * @version 2.0.0
+ * @version 3.0.0 (#1953 Phase 4: dashboard discovery of absent machines)
  */
 
 import { createLogger } from './logger.js';
@@ -83,6 +83,11 @@ export function isRecentlyActive(lastSeen: string, thresholdMs: number = DEFAULT
  * For machines marked UNKNOWN (heartbeat stale) or IDLE by HeartbeatService,
  * if any dashboard shows recent activity, override the status to ONLINE.
  *
+ * Additionally, machines discovered from dashboard activity that are NOT in any
+ * heartbeat list (never called this MCP server instance) are added as ONLINE.
+ * This handles the ADR 008 in-memory model where each MCP server only tracks
+ * its own tool calls — other machines are discovered via shared dashboards.
+ *
  * @param heartbeatState - State from HeartbeatService.checkHeartbeats()
  * @param dashboardContent - One or more dashboard contents (string or string[]).
  *                          When passing string[], activity is merged across all.
@@ -110,6 +115,13 @@ export function crossCheckWithDashboard(
 	const idleMachines = [...heartbeatState.idleMachines];
 	const onlineMachines = [...heartbeatState.onlineMachines];
 
+	const knownSet = new Set([
+		...onlineMachines.map(m => m.toLowerCase()),
+		...unknownMachines.map(m => m.toLowerCase()),
+		...idleMachines.map(m => m.toLowerCase()),
+	]);
+
+	// Override existing UNKNOWN → ONLINE
 	for (let i = unknownMachines.length - 1; i >= 0; i--) {
 		const machineId = unknownMachines[i];
 		const lastSeen = activity.get(machineId);
@@ -121,6 +133,7 @@ export function crossCheckWithDashboard(
 		}
 	}
 
+	// Override existing IDLE → ONLINE
 	for (let i = idleMachines.length - 1; i >= 0; i--) {
 		const machineId = idleMachines[i];
 		const lastSeen = activity.get(machineId);
@@ -129,6 +142,18 @@ export function crossCheckWithDashboard(
 			onlineMachines.push(machineId);
 			overrides.push(machineId);
 			logger.info(`Dashboard override: ${machineId} IDLE->ONLINE (last seen ${lastSeen})`);
+		}
+	}
+
+	// #1953 Phase 4: Add machines discovered from dashboard that aren't in any heartbeat list.
+	// Each MCP server instance only tracks its own tool calls (ADR 008 in-memory model).
+	// Other machines are discovered via shared dashboard messages on GDrive.
+	for (const [machineId, lastSeen] of activity.entries()) {
+		if (!knownSet.has(machineId.toLowerCase()) && isRecentlyActive(lastSeen, thresholdMs)) {
+			onlineMachines.push(machineId);
+			overrides.push(machineId);
+			knownSet.add(machineId.toLowerCase());
+			logger.info(`Dashboard discovery: ${machineId} added as ONLINE (last seen ${lastSeen})`);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `crossCheckWithDashboard` now discovers machines from dashboard activity that are NOT in any heartbeat list and adds them as ONLINE
- Fixes the ADR 008 in-memory model blind spot: each MCP server instance only tracks its own tool calls, so other machines (on their own MCP instances) were invisible
- Adds 3 new tests: dashboard discovery, stale discovery rejection, mixed scenario (override + discover)

## Problem
`roosync_inventory(type: "status")` showed only 1 machine online (the calling machine itself) because HeartbeatService v4.0 is in-memory only. The dashboard cross-check (`crossCheckWithDashboard`) only overrode machines already in UNKNOWN/IDLE lists — it never added machines absent from the heartbeat map entirely.

## Fix
After overriding existing UNKNOWN/IDLE machines, iterate over all dashboard-discovered machines and add any that aren't in the known set as ONLINE (if their activity is within the 8h threshold).

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 9206/9223 (1 flaky circuit breaker timeout, 16 skipped)
- [x] New tests: dashboard discovery, stale rejection, mixed override+discover
- [ ] Verify `roosync_inventory(type: "status")` shows all 6 machines after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)