### PR TITLE
feat(#1391): UnifiedTask schema — unified Roo + Claude Code task types

### DIFF
--- a/servers/roo-state-manager/src/__tests__/types/unified-task.test.ts
+++ b/servers/roo-state-manager/src/__tests__/types/unified-task.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Tests for UnifiedTask schema — #1391
+ */
+
+import { describe, test, expect } from 'vitest';
+import {
+  UnifiedTaskSchema,
+  toUnifiedTask,
+  computeStorageTier,
+  parseUnifiedTask,
+  safeParseUnifiedTask,
+  TaskSource,
+  TaskStatus,
+  TaskOutcome,
+  StorageTier,
+} from '../../types/unified-task.js';
+import type { UnifiedTask } from '../../types/unified-task.js';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const validRooTask: UnifiedTask = {
+  id: 'task-001',
+  source: 'roo',
+  parentId: 'parent-001',
+  title: 'Fix authentication bug',
+  instruction: 'Fix the login flow bug in auth.ts',
+  createdAt: '2026-05-10T10:00:00Z',
+  lastActivity: '2026-05-10T11:30:00Z',
+  completedAt: '2026-05-10T11:30:00Z',
+  messageCount: 42,
+  actionCount: 15,
+  totalSizeBytes: 8192,
+  workspace: '/dev/roo-extensions',
+  machineId: 'myia-po-2025',
+  mode: 'code-simple',
+  status: 'completed',
+  outcome: 'success',
+  indexedAt: '2026-05-10T12:00:00Z',
+};
+
+const validClaudeTask: UnifiedTask = {
+  id: 'session-abc123',
+  source: 'claude-code',
+  createdAt: '2026-05-11T08:00:00Z',
+  lastActivity: '2026-05-11T08:05:00Z',
+  messageCount: 10,
+  actionCount: 3,
+  totalSizeBytes: 4096,
+  status: 'active',
+};
+
+// ─── Schema validation ────────────────────────────────────────────────────────
+
+describe('UnifiedTaskSchema', () => {
+  test('validates a complete Roo task', () => {
+    const result = UnifiedTaskSchema.safeParse(validRooTask);
+    expect(result.success).toBe(true);
+  });
+
+  test('validates a minimal Claude task', () => {
+    const result = UnifiedTaskSchema.safeParse(validClaudeTask);
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects missing required fields', () => {
+    const result = UnifiedTaskSchema.safeParse({
+      id: 'test',
+      // missing: source, createdAt, lastActivity, messageCount, actionCount, totalSizeBytes, status
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects invalid source', () => {
+    const result = UnifiedTaskSchema.safeParse({
+      ...validClaudeTask,
+      source: 'unknown-agent',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects invalid status', () => {
+    const result = UnifiedTaskSchema.safeParse({
+      ...validClaudeTask,
+      status: 'pending',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects negative messageCount', () => {
+    const result = UnifiedTaskSchema.safeParse({
+      ...validClaudeTask,
+      messageCount: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('accepts optional fields as undefined', () => {
+    const minimal: UnifiedTask = {
+      id: 't1',
+      source: 'roo',
+      createdAt: '2026-05-11T00:00:00Z',
+      lastActivity: '2026-05-11T00:00:00Z',
+      messageCount: 0,
+      actionCount: 0,
+      totalSizeBytes: 0,
+      status: 'unknown',
+    };
+    const result = UnifiedTaskSchema.safeParse(minimal);
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts sourceMetadata as opaque record', () => {
+    const task = {
+      ...validClaudeTask,
+      sourceMetadata: { customField: 'value', nested: { deep: true } },
+    };
+    const result = UnifiedTaskSchema.safeParse(task);
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts storageTier hot/warm/cold', () => {
+    for (const tier of ['hot', 'warm', 'cold'] as const) {
+      const result = UnifiedTaskSchema.safeParse({ ...validClaudeTask, storageTier: tier });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test('rejects invalid datetime format', () => {
+    const result = UnifiedTaskSchema.safeParse({
+      ...validClaudeTask,
+      createdAt: 'not-a-date',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── Enums ────────────────────────────────────────────────────────────────────
+
+describe('Task enums', () => {
+  test('TaskSource has exactly 2 values', () => {
+    expect(TaskSource.options).toEqual(['roo', 'claude-code']);
+  });
+
+  test('TaskStatus has expected values', () => {
+    expect(TaskStatus.options).toContain('active');
+    expect(TaskStatus.options).toContain('completed');
+    expect(TaskStatus.options).toContain('stuck');
+    expect(TaskStatus.options).toContain('unknown');
+  });
+
+  test('TaskOutcome has expected values', () => {
+    expect(TaskOutcome.options).toContain('success');
+    expect(TaskOutcome.options).toContain('failure');
+    expect(TaskOutcome.options).toContain('partial');
+  });
+
+  test('StorageTier has hot/warm/cold', () => {
+    expect(StorageTier.options).toEqual(['hot', 'warm', 'cold']);
+  });
+});
+
+// ─── toUnifiedTask conversion ─────────────────────────────────────────────────
+
+describe('toUnifiedTask', () => {
+  test('converts a Roo SkeletonHeader-like input', () => {
+    const input = {
+      taskId: 'task-roo-42',
+      parentTaskId: 'parent-10',
+      metadata: {
+        title: 'Fix bug in auth',
+        lastActivity: '2026-05-10T15:00:00Z',
+        createdAt: '2026-05-10T14:00:00Z',
+        mode: 'code-simple',
+        messageCount: 25,
+        actionCount: 8,
+        totalSize: 5000,
+        workspace: '/dev/project',
+        machineId: 'myia-po-2025',
+        source: 'roo' as const,
+      },
+      truncatedInstruction: 'Fix the authentication flow in login.ts',
+      isCompleted: false,
+    };
+
+    const result = toUnifiedTask(input);
+
+    expect(result.id).toBe('task-roo-42');
+    expect(result.source).toBe('roo');
+    expect(result.parentId).toBe('parent-10');
+    expect(result.title).toBe('Fix bug in auth');
+    expect(result.instruction).toBe('Fix the authentication flow in login.ts');
+    expect(result.messageCount).toBe(25);
+    expect(result.actionCount).toBe(8);
+    expect(result.totalSizeBytes).toBe(5000);
+    expect(result.workspace).toBe('/dev/project');
+    expect(result.machineId).toBe('myia-po-2025');
+    expect(result.mode).toBe('code-simple');
+  });
+
+  test('defaults source to "roo" when metadata.source is undefined', () => {
+    const input = {
+      taskId: 'task-no-source',
+      metadata: {
+        lastActivity: '2026-05-10T15:00:00Z',
+        createdAt: '2026-05-10T14:00:00Z',
+        messageCount: 1,
+      },
+    };
+
+    const result = toUnifiedTask(input);
+    expect(result.source).toBe('roo');
+  });
+
+  test('sets completed status for isCompleted=true', () => {
+    const input = {
+      taskId: 'task-done',
+      metadata: {
+        lastActivity: '2026-05-10T15:00:00Z',
+        createdAt: '2026-05-10T14:00:00Z',
+        messageCount: 5,
+      },
+      isCompleted: true,
+    };
+
+    const result = toUnifiedTask(input);
+    expect(result.status).toBe('completed');
+    expect(result.outcome).toBe('success');
+    expect(result.completedAt).toBe('2026-05-10T15:00:00Z');
+  });
+
+  test('sets stuck status for tasks inactive > 7 days', () => {
+    const oldDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    const input = {
+      taskId: 'task-old',
+      metadata: {
+        lastActivity: oldDate,
+        createdAt: oldDate,
+        messageCount: 3,
+      },
+      isCompleted: false,
+    };
+
+    const result = toUnifiedTask(input);
+    expect(result.status).toBe('stuck');
+  });
+
+  test('truncates long instructions to 500 chars', () => {
+    const longInstruction = 'A'.repeat(600);
+    const input = {
+      taskId: 'task-long',
+      metadata: {
+        lastActivity: '2026-05-10T15:00:00Z',
+        createdAt: '2026-05-10T14:00:00Z',
+        messageCount: 1,
+      },
+      truncatedInstruction: longInstruction,
+    };
+
+    const result = toUnifiedTask(input);
+    expect(result.instruction).toBeDefined();
+    expect(result.instruction!.length).toBe(503); // 500 + '...'
+    expect(result.instruction!.endsWith('...')).toBe(true);
+  });
+});
+
+// ─── computeStorageTier ───────────────────────────────────────────────────────
+
+describe('computeStorageTier', () => {
+  test('returns hot for recent tasks (<=7 days)', () => {
+    const task = { ...validClaudeTask, lastActivity: new Date().toISOString() };
+    expect(computeStorageTier(task)).toBe('hot');
+  });
+
+  test('returns warm for tasks 8-90 days old', () => {
+    const daysAgo = 30;
+    const date = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+    const task = { ...validClaudeTask, lastActivity: date };
+    expect(computeStorageTier(task)).toBe('warm');
+  });
+
+  test('returns cold for tasks >90 days old', () => {
+    const daysAgo = 120;
+    const date = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+    const task = { ...validClaudeTask, lastActivity: date };
+    expect(computeStorageTier(task)).toBe('cold');
+  });
+
+  test('boundary: exactly 7 days = hot', () => {
+    const date = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+    const task = { ...validClaudeTask, lastActivity: date };
+    expect(computeStorageTier(task)).toBe('hot');
+  });
+
+  test('boundary: exactly 90 days = warm', () => {
+    const date = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+    const task = { ...validClaudeTask, lastActivity: date };
+    expect(computeStorageTier(task)).toBe('warm');
+  });
+});
+
+// ─── parseUnifiedTask / safeParseUnifiedTask ──────────────────────────────────
+
+describe('parseUnifiedTask', () => {
+  test('parses valid data', () => {
+    const result = parseUnifiedTask(validClaudeTask);
+    expect(result.id).toBe('session-abc123');
+  });
+
+  test('throws on invalid data', () => {
+    expect(() => parseUnifiedTask({ bad: true })).toThrow();
+  });
+});
+
+describe('safeParseUnifiedTask', () => {
+  test('returns success for valid data', () => {
+    const result = safeParseUnifiedTask(validRooTask);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe('task-001');
+      expect(result.data.source).toBe('roo');
+    }
+  });
+
+  test('returns failure for invalid data', () => {
+    const result = safeParseUnifiedTask({ id: 123 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors).toBeDefined();
+      expect(result.errors.issues.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/servers/roo-state-manager/src/types/index.ts
+++ b/servers/roo-state-manager/src/types/index.ts
@@ -46,3 +46,6 @@ export * from './tool-definitions.js';
 
 // Types MachineConfig unifiés (#603 B3)
 export * from './machine-config.js';
+
+// Types UnifiedTask (#1391 — schéma unifié Roo + Claude)
+export * from './unified-task.js';

--- a/servers/roo-state-manager/src/types/unified-task.ts
+++ b/servers/roo-state-manager/src/types/unified-task.ts
@@ -1,0 +1,178 @@
+/**
+ * UnifiedTask — Schema unifié pour les tâches Roo et Claude Code
+ *
+ * @module types/unified-task
+ * @issue #1391 (#1360-1)
+ * @version 1.0.0
+ *
+ * Représente une tâche (conversation/session) de N'IMPORTE QUELLE source
+ * (Roo Code ou Claude Code) dans un format commun, permettant la recherche
+ * cross-source, le reporting unifié et le stockage partagé.
+ */
+
+import { z } from 'zod';
+
+// ─── Enums ────────────────────────────────────────────────────────────────────
+
+export const TaskSource = z.enum(['roo', 'claude-code']);
+export type TaskSource = z.infer<typeof TaskSource>;
+
+export const TaskStatus = z.enum(['active', 'completed', 'abandoned', 'stuck', 'unknown']);
+export type TaskStatus = z.infer<typeof TaskStatus>;
+
+export const TaskOutcome = z.enum(['success', 'failure', 'partial', 'cancelled']);
+export type TaskOutcome = z.infer<typeof TaskOutcome>;
+
+export const StorageTier = z.enum(['hot', 'warm', 'cold']);
+export type StorageTier = z.infer<typeof StorageTier>;
+
+// ─── Core Schema (Zod) ────────────────────────────────────────────────────────
+
+export const UnifiedTaskSchema = z.object({
+  id: z.string().describe('Unique task identifier (taskId from source system)'),
+
+  source: TaskSource.describe('Origin system: Roo Code or Claude Code'),
+
+  parentId: z.string().optional().describe('Parent task ID for sub-task relationships'),
+
+  rootId: z.string().optional().describe('Root task ID in the task hierarchy'),
+
+  // Identity
+  title: z.string().optional().describe('Human-readable task title'),
+  instruction: z.string().optional().describe('Original task prompt/instruction'),
+
+  // Temporal
+  createdAt: z.string().datetime({ offset: true }).describe('ISO 8601 creation timestamp'),
+  lastActivity: z.string().datetime({ offset: true }).describe('ISO 8601 last activity timestamp'),
+  completedAt: z.string().datetime({ offset: true }).optional().describe('ISO 8601 completion timestamp'),
+
+  // Metrics
+  messageCount: z.number().int().min(0).describe('Total message count'),
+  actionCount: z.number().int().min(0).describe('Total tool/action count'),
+  totalSizeBytes: z.number().int().min(0).describe('Total conversation size in bytes'),
+
+  // Context
+  workspace: z.string().optional().describe('Workspace path or identifier'),
+  machineId: z.string().optional().describe('Machine where the task ran'),
+  mode: z.string().optional().describe('Roo mode or Claude agent type used'),
+  model: z.string().optional().describe('LLM model identifier'),
+
+  // Status
+  status: TaskStatus.describe('Current task lifecycle status'),
+  outcome: TaskOutcome.optional().describe('Task outcome (set when status=completed|abandoned)'),
+
+  // Storage (#1393 hot/warm/cold)
+  storageTier: StorageTier.optional().describe('Storage tier for retention policy'),
+
+  // Indexing
+  indexedAt: z.string().datetime({ offset: true }).optional().describe('Last Qdrant indexing timestamp'),
+
+  // Source-specific fields that don't map to unified schema
+  sourceMetadata: z.record(z.unknown()).optional().describe('Opaque source-specific metadata'),
+});
+
+export type UnifiedTask = z.infer<typeof UnifiedTaskSchema>;
+
+// ─── Conversion helpers ───────────────────────────────────────────────────────
+
+/**
+ * Common fields shared by SkeletonHeader and ConversationSummary.
+ * Used as input for conversion functions.
+ */
+interface SourceTaskLike {
+  taskId: string;
+  parentTaskId?: string;
+  metadata: {
+    title?: string;
+    lastActivity: string;
+    createdAt: string;
+    mode?: string;
+    messageCount: number;
+    actionCount?: number;
+    totalSize?: number;
+    workspace?: string;
+    machineId?: string;
+    qdrantIndexedAt?: string;
+    source?: 'roo' | 'claude-code';
+    parentTaskId?: string;
+  };
+  truncatedInstruction?: string;
+  isCompleted?: boolean;
+}
+
+/**
+ * Convert a SkeletonHeader/ConversationSummary to UnifiedTask.
+ */
+export function toUnifiedTask(input: SourceTaskLike): UnifiedTask {
+  const source: TaskSource = input.metadata.source ?? 'roo';
+  const instruction = input.truncatedInstruction;
+
+  let status: TaskStatus = 'unknown';
+  let outcome: TaskOutcome | undefined;
+  let completedAt: string | undefined;
+
+  if (input.isCompleted === true) {
+    status = 'completed';
+    outcome = 'success'; // Default assumption; can be overridden
+    completedAt = input.metadata.lastActivity;
+  } else {
+    const lastActivity = new Date(input.metadata.lastActivity);
+    const staleThreshold = 7 * 24 * 60 * 60 * 1000; // 7 days
+    if (Date.now() - lastActivity.getTime() > staleThreshold) {
+      status = 'stuck';
+    } else {
+      status = 'active';
+    }
+  }
+
+  return {
+    id: input.taskId,
+    source,
+    parentId: input.parentTaskId ?? input.metadata.parentTaskId,
+    rootId: undefined, // Not available in skeleton; populated later via hierarchy
+    title: input.metadata.title,
+    instruction: instruction ? (instruction.length > 500 ? instruction.slice(0, 500) + '...' : instruction) : undefined,
+    createdAt: input.metadata.createdAt,
+    lastActivity: input.metadata.lastActivity,
+    completedAt,
+    messageCount: input.metadata.messageCount,
+    actionCount: input.metadata.actionCount ?? 0,
+    totalSizeBytes: input.metadata.totalSize ?? 0,
+    workspace: input.metadata.workspace,
+    machineId: input.metadata.machineId,
+    mode: input.metadata.mode,
+    status,
+    outcome,
+    indexedAt: input.metadata.qdrantIndexedAt,
+  };
+}
+
+/**
+ * Determine storage tier based on age and activity.
+ */
+export function computeStorageTier(task: UnifiedTask): StorageTier {
+  const age = Date.now() - new Date(task.lastActivity).getTime();
+  const days = age / (24 * 60 * 60 * 1000);
+
+  if (days <= 7) return 'hot';
+  if (days <= 90) return 'warm';
+  return 'cold';
+}
+
+/**
+ * Validate and parse a UnifiedTask from unknown input.
+ */
+export function parseUnifiedTask(data: unknown): UnifiedTask {
+  return UnifiedTaskSchema.parse(data);
+}
+
+/**
+ * Safe parse that returns a result object instead of throwing.
+ */
+export function safeParseUnifiedTask(data: unknown): { success: true; data: UnifiedTask } | { success: false; errors: z.ZodError } {
+  const result = UnifiedTaskSchema.safeParse(data);
+  if (result.success) {
+    return { success: true, data: result.data };
+  }
+  return { success: false, errors: result.error };
+}


### PR DESCRIPTION
## Summary
- Adds `UnifiedTask` type with Zod schema for cross-source task representation
- Supports both Roo Code and Claude Code tasks in a unified format
- Includes conversion helpers (`toUnifiedTask`, `computeStorageTier`, `safeParseUnifiedTask`)
- 28 unit tests covering schema validation, conversion, storage tier logic, and edge cases

## Scope
- `src/types/unified-task.ts` — Core schema, enums, conversion helpers
- `src/types/index.ts` — Barrel export
- `src/__tests__/types/unified-task.test.ts` — Full test coverage

## Test plan
- [x] 28/28 tests pass (`npx vitest run src/__tests__/types/unified-task.test.ts`)
- [x] Build clean (`npm run build`)
- [ ] JSON schema extraction (follow-up #1392)

🤖 Generated with [Claude Code](https://claude.com/claude-code)