### PR TITLE
feat(#1392): extraction layer for cross-format task extraction

### DIFF
--- a/servers/roo-state-manager/src/services/extraction/__tests__/claude-task-extractor.test.ts
+++ b/servers/roo-state-manager/src/services/extraction/__tests__/claude-task-extractor.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for ClaudeTaskExtractor — #1392
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../utils/claude-storage-detector.js', () => ({
+  ClaudeStorageDetector: {
+    detectStorageLocations: vi.fn(),
+    listProjects: vi.fn(),
+    analyzeConversation: vi.fn(),
+    findConversationById: vi.fn(),
+  },
+}));
+
+vi.mock('../../../types/unified-task.js', async () => {
+  const actual = await vi.importActual('../../../types/unified-task.js');
+  return {
+    ...actual,
+    computeStorageTier: vi.fn().mockReturnValue('warm'),
+  };
+});
+
+import { ClaudeTaskExtractor } from '../claude-task-extractor.js';
+import { ClaudeStorageDetector } from '../../../utils/claude-storage-detector.js';
+
+const mockClaude = vi.mocked(ClaudeStorageDetector);
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ClaudeTaskExtractor', () => {
+  let extractor: ClaudeTaskExtractor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    extractor = new ClaudeTaskExtractor();
+  });
+
+  test('has sourceName "claude-code"', () => {
+    expect(extractor.sourceName).toBe('claude-code');
+  });
+
+  describe('isAvailable', () => {
+    test('returns true when locations exist', async () => {
+      mockClaude.detectStorageLocations.mockResolvedValue([{ path: '~/.claude' }]);
+      await expect(extractor.isAvailable()).resolves.toBe(true);
+    });
+
+    test('returns false when no locations', async () => {
+      mockClaude.detectStorageLocations.mockResolvedValue([]);
+      await expect(extractor.isAvailable()).resolves.toBe(false);
+    });
+
+    test('returns false on error', async () => {
+      mockClaude.detectStorageLocations.mockRejectedValue(new Error('fail'));
+      await expect(extractor.isAvailable()).resolves.toBe(false);
+    });
+  });
+
+  describe('extractAll', () => {
+    test('extracts tasks from projects', async () => {
+      mockClaude.detectStorageLocations.mockResolvedValue([
+        { path: '~/.claude', projectPath: '~/.claude/projects/proj1' },
+      ]);
+      mockClaude.listProjects.mockResolvedValue(['proj1', 'proj2']);
+      mockClaude.analyzeConversation.mockResolvedValue({
+        taskId: 'claude-proj1',
+        metadata: {
+          title: 'Claude session',
+          lastActivity: '2026-05-10T14:00:00Z',
+          createdAt: '2026-05-10T13:00:00Z',
+          messageCount: 20,
+          actionCount: 5,
+          totalSize: 8192,
+          workspace: '/dev/test',
+        },
+      });
+
+      const result = await extractor.extractAll();
+      expect(result.source).toBe('claude-code');
+      expect(result.tasks).toHaveLength(2); // 2 projects
+      expect(result.errors).toHaveLength(0);
+    });
+
+    test('handles per-project errors gracefully', async () => {
+      mockClaude.detectStorageLocations.mockResolvedValue([
+        { path: '~/.claude', projectPath: '~/.claude/projects/proj1' },
+      ]);
+      mockClaude.listProjects.mockResolvedValue(['proj1']);
+      mockClaude.analyzeConversation.mockRejectedValue(new Error('corrupt'));
+
+      const result = await extractor.extractAll();
+      expect(result.tasks).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].taskId).toBe('claude-proj1');
+    });
+
+    test('handles top-level failure', async () => {
+      mockClaude.detectStorageLocations.mockRejectedValue(new Error('no disk'));
+
+      const result = await extractor.extractAll();
+      expect(result.tasks).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('Claude extraction failed');
+    });
+
+    test('skips null skeletons', async () => {
+      mockClaude.detectStorageLocations.mockResolvedValue([
+        { path: '~/.claude', projectPath: '~/.claude/projects/p1' },
+      ]);
+      mockClaude.listProjects.mockResolvedValue(['p1']);
+      mockClaude.analyzeConversation.mockResolvedValue(null);
+
+      const result = await extractor.extractAll();
+      expect(result.tasks).toHaveLength(0);
+    });
+
+    test('applies machineId option', async () => {
+      mockClaude.detectStorageLocations.mockResolvedValue([
+        { path: '~/.claude', projectPath: '~/.claude/projects/p1' },
+      ]);
+      mockClaude.listProjects.mockResolvedValue(['p1']);
+      mockClaude.analyzeConversation.mockResolvedValue({
+        taskId: 'claude-p1',
+        metadata: {
+          lastActivity: '2026-05-10T14:00:00Z',
+          messageCount: 5,
+        },
+      });
+
+      const result = await extractor.extractAll({ machineId: 'test-box' });
+      expect(result.tasks[0].machineId).toBe('test-box');
+    });
+  });
+
+  describe('extractById', () => {
+    test('returns task when found', async () => {
+      mockClaude.findConversationById.mockResolvedValue({
+        taskId: 'claude-proj1',
+        metadata: {
+          title: 'Found session',
+          lastActivity: '2026-05-10T14:00:00Z',
+          messageCount: 10,
+        },
+      });
+
+      const task = await extractor.extractById('claude-proj1');
+      expect(task).not.toBeNull();
+      expect(task!.id).toBe('claude-proj1');
+    });
+
+    test('returns null when not found', async () => {
+      mockClaude.findConversationById.mockResolvedValue(null);
+      const task = await extractor.extractById('claude-nope');
+      expect(task).toBeNull();
+    });
+
+    test('returns null on error', async () => {
+      mockClaude.findConversationById.mockRejectedValue(new Error('boom'));
+      const task = await extractor.extractById('claude-x');
+      expect(task).toBeNull();
+    });
+  });
+});

--- a/servers/roo-state-manager/src/services/extraction/__tests__/roo-task-extractor.test.ts
+++ b/servers/roo-state-manager/src/services/extraction/__tests__/roo-task-extractor.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for RooTaskExtractor — #1392
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+// Mock RooStorageDetector before importing the extractor
+vi.mock('../../../utils/roo-storage-detector.js', () => ({
+  RooStorageDetector: {
+    detectStorageLocations: vi.fn(),
+    buildHierarchicalSkeletons: vi.fn(),
+    findConversationById: vi.fn(),
+  },
+}));
+
+// Mock computeStorageTier (used internally via toUnifiedTask)
+vi.mock('../../../types/unified-task.js', async () => {
+  const actual = await vi.importActual('../../../types/unified-task.js');
+  return {
+    ...actual,
+    computeStorageTier: vi.fn().mockReturnValue('hot'),
+  };
+});
+
+import { RooTaskExtractor } from '../roo-task-extractor.js';
+import { RooStorageDetector } from '../../../utils/roo-storage-detector.js';
+
+const mockRoo = vi.mocked(RooStorageDetector);
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const makeSkeleton = (overrides: Record<string, any> = {}) => ({
+  taskId: 'abc-123-def',
+  parentTaskId: undefined,
+  metadata: {
+    title: 'Test task',
+    lastActivity: '2026-05-10T12:00:00Z',
+    createdAt: '2026-05-10T10:00:00Z',
+    mode: 'code-simple',
+    messageCount: 10,
+    actionCount: 3,
+    totalSize: 4096,
+    workspace: '/dev/test',
+  },
+  truncatedInstruction: 'do something',
+  isCompleted: false,
+  ...overrides,
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('RooTaskExtractor', () => {
+  let extractor: RooTaskExtractor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    extractor = new RooTaskExtractor();
+  });
+
+  test('has sourceName "roo"', () => {
+    expect(extractor.sourceName).toBe('roo');
+  });
+
+  describe('isAvailable', () => {
+    test('returns true when locations exist', async () => {
+      mockRoo.detectStorageLocations.mockResolvedValue([{ path: '/some/path' }]);
+      await expect(extractor.isAvailable()).resolves.toBe(true);
+    });
+
+    test('returns false when no locations', async () => {
+      mockRoo.detectStorageLocations.mockResolvedValue([]);
+      await expect(extractor.isAvailable()).resolves.toBe(false);
+    });
+
+    test('returns false on error', async () => {
+      mockRoo.detectStorageLocations.mockRejectedValue(new Error('fail'));
+      await expect(extractor.isAvailable()).resolves.toBe(false);
+    });
+  });
+
+  describe('extractAll', () => {
+    test('extracts tasks from skeletons', async () => {
+      mockRoo.buildHierarchicalSkeletons.mockResolvedValue([
+        makeSkeleton(),
+        makeSkeleton({ taskId: 'task-2', metadata: { messageCount: 5 } }),
+      ]);
+
+      const result = await extractor.extractAll();
+      expect(result.source).toBe('roo');
+      expect(result.tasks).toHaveLength(2);
+      expect(result.errors).toHaveLength(0);
+      expect(result.tasks[0].id).toBe('abc-123-def');
+    });
+
+    test('collects errors for bad skeletons', async () => {
+      mockRoo.buildHierarchicalSkeletons.mockResolvedValue([
+        makeSkeleton({ taskId: undefined }), // will cause toUnifiedTask to fail or produce bad result
+      ]);
+
+      const result = await extractor.extractAll();
+      // Even with bad data, toUnifiedTask may still produce a result
+      // The key is no unhandled exceptions
+      expect(result.source).toBe('roo');
+    });
+
+    test('handles top-level failure', async () => {
+      mockRoo.buildHierarchicalSkeletons.mockRejectedValue(new Error('disk error'));
+
+      const result = await extractor.extractAll();
+      expect(result.tasks).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('Roo extraction failed');
+    });
+
+    test('applies machineId option', async () => {
+      mockRoo.buildHierarchicalSkeletons.mockResolvedValue([makeSkeleton()]);
+
+      const result = await extractor.extractAll({ machineId: 'test-machine' });
+      expect(result.tasks[0].machineId).toBe('test-machine');
+    });
+  });
+
+  describe('extractById', () => {
+    test('returns task when found', async () => {
+      mockRoo.findConversationById.mockResolvedValue({
+        taskId: 'abc-123',
+        lastActivity: '2026-05-10T12:00:00Z',
+        messageCount: 10,
+        size: 4096,
+        metadata: { title: 'Found task', workspace: '/dev/test' },
+      });
+
+      const task = await extractor.extractById('abc-123');
+      expect(task).not.toBeNull();
+      expect(task!.id).toBe('abc-123');
+    });
+
+    test('returns null when not found', async () => {
+      mockRoo.findConversationById.mockResolvedValue(null);
+
+      const task = await extractor.extractById('nonexistent');
+      expect(task).toBeNull();
+    });
+
+    test('returns null on error', async () => {
+      mockRoo.findConversationById.mockRejectedValue(new Error('io'));
+
+      const task = await extractor.extractById('abc-123');
+      expect(task).toBeNull();
+    });
+  });
+});

--- a/servers/roo-state-manager/src/services/extraction/__tests__/unified-task-extractor.test.ts
+++ b/servers/roo-state-manager/src/services/extraction/__tests__/unified-task-extractor.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for UnifiedTaskExtractor — #1392
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import type { TaskExtractor, ExtractionResult } from '../task-extractor.js';
+import type { UnifiedTask } from '../../../types/unified-task.js';
+
+// ─── Mock extractors ──────────────────────────────────────────────────────────
+
+function makeMockExtractor(
+  sourceName: 'roo' | 'claude-code',
+  tasks: UnifiedTask[] = [],
+): TaskExtractor {
+  return {
+    sourceName,
+    isAvailable: vi.fn().mockResolvedValue(true),
+    extractAll: vi.fn().mockResolvedValue({
+      tasks,
+      source: sourceName,
+      errors: [],
+    } satisfies ExtractionResult),
+    extractById: vi.fn().mockImplementation(async (id: string) =>
+      tasks.find(t => t.id === id) ?? null,
+    ),
+  };
+}
+
+const sampleRooTask: UnifiedTask = {
+  id: 'roo-001',
+  source: 'roo',
+  title: 'Roo task',
+  createdAt: '2026-05-10T10:00:00Z',
+  lastActivity: '2026-05-10T11:00:00Z',
+  messageCount: 10,
+  actionCount: 3,
+  totalSizeBytes: 4096,
+  status: 'active',
+};
+
+const sampleClaudeTask: UnifiedTask = {
+  id: 'claude-proj1',
+  source: 'claude-code',
+  title: 'Claude session',
+  createdAt: '2026-05-10T12:00:00Z',
+  lastActivity: '2026-05-10T13:00:00Z',
+  messageCount: 5,
+  actionCount: 1,
+  totalSizeBytes: 2048,
+  status: 'active',
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('UnifiedTaskExtractor', () => {
+  let rooExtractor: TaskExtractor;
+  let claudeExtractor: TaskExtractor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rooExtractor = makeMockExtractor('roo', [sampleRooTask]);
+    claudeExtractor = makeMockExtractor('claude-code', [sampleClaudeTask]);
+  });
+
+  test('extractAll merges tasks from all sources', async () => {
+    const unified = new (await import('../unified-task-extractor.js')).UnifiedTaskExtractor(
+      [rooExtractor, claudeExtractor],
+    );
+
+    const result = await unified.extractAll();
+    expect(result.tasks).toHaveLength(2);
+    expect(result.bySource.roo.tasks).toHaveLength(1);
+    expect(result.bySource['claude-code'].tasks).toHaveLength(1);
+    expect(result.totalErrors).toBe(0);
+  });
+
+  test('extractAll aggregates errors', async () => {
+    const errorRoo = makeMockExtractor('roo');
+    (errorRoo.extractAll as ReturnType<typeof vi.fn>).mockResolvedValue({
+      tasks: [],
+      source: 'roo',
+      errors: [{ taskId: 'x', message: 'fail 1' }, { message: 'fail 2' }],
+    });
+    const errorClaude = makeMockExtractor('claude-code');
+    (errorClaude.extractAll as ReturnType<typeof vi.fn>).mockResolvedValue({
+      tasks: [],
+      source: 'claude-code',
+      errors: [{ message: 'fail 3' }],
+    });
+
+    const unified = new (await import('../unified-task-extractor.js')).UnifiedTaskExtractor(
+      [errorRoo, errorClaude],
+    );
+    const result = await unified.extractAll();
+    expect(result.totalErrors).toBe(3);
+  });
+
+  test('extractById routes claude- prefixed IDs to claude extractor', async () => {
+    const unified = new (await import('../unified-task-extractor.js')).UnifiedTaskExtractor(
+      [rooExtractor, claudeExtractor],
+    );
+
+    const task = await unified.extractById('claude-proj1');
+    expect(task).not.toBeNull();
+    expect(task!.id).toBe('claude-proj1');
+    expect(claudeExtractor.extractById).toHaveBeenCalledWith('claude-proj1', undefined);
+    expect(rooExtractor.extractById).not.toHaveBeenCalled();
+  });
+
+  test('extractById routes non-claude IDs to roo extractor', async () => {
+    const unified = new (await import('../unified-task-extractor.js')).UnifiedTaskExtractor(
+      [rooExtractor, claudeExtractor],
+    );
+
+    const task = await unified.extractById('roo-001');
+    expect(task).not.toBeNull();
+    expect(task!.id).toBe('roo-001');
+    expect(rooExtractor.extractById).toHaveBeenCalledWith('roo-001', undefined);
+    expect(claudeExtractor.extractById).not.toHaveBeenCalled();
+  });
+
+  test('getAvailableSources returns only available ones', async () => {
+    (rooExtractor.isAvailable as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    (claudeExtractor.isAvailable as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    const unified = new (await import('../unified-task-extractor.js')).UnifiedTaskExtractor(
+      [rooExtractor, claudeExtractor],
+    );
+
+    const sources = await unified.getAvailableSources();
+    expect(sources).toEqual(['roo']);
+  });
+
+  test('getAvailableSources returns both when both available', async () => {
+    const unified = new (await import('../unified-task-extractor.js')).UnifiedTaskExtractor(
+      [rooExtractor, claudeExtractor],
+    );
+
+    const sources = await unified.getAvailableSources();
+    expect(sources).toEqual(['roo', 'claude-code']);
+  });
+
+  test('passes options through to extractors', async () => {
+    const unified = new (await import('../unified-task-extractor.js')).UnifiedTaskExtractor(
+      [rooExtractor, claudeExtractor],
+    );
+
+    const opts = { machineId: 'test', includeComputedFields: true };
+    await unified.extractAll(opts);
+    expect(rooExtractor.extractAll).toHaveBeenCalledWith(opts);
+    expect(claudeExtractor.extractAll).toHaveBeenCalledWith(opts);
+  });
+});

--- a/servers/roo-state-manager/src/services/extraction/claude-task-extractor.ts
+++ b/servers/roo-state-manager/src/services/extraction/claude-task-extractor.ts
@@ -1,0 +1,128 @@
+/**
+ * ClaudeTaskExtractor — Extracts UnifiedTasks from Claude Code storage
+ *
+ * @module services/extraction/claude-task-extractor
+ * @issue #1392 (#1360-2)
+ *
+ * Wraps ClaudeStorageDetector and converts ConversationSkeleton → UnifiedTask
+ * via the toUnifiedTask() conversion helper from #1391.
+ */
+
+import * as os from 'os';
+import { ClaudeStorageDetector } from '../../utils/claude-storage-detector.js';
+import {
+  toUnifiedTask,
+  computeStorageTier,
+} from '../../types/unified-task.js';
+import type { UnifiedTask } from '../../types/unified-task.js';
+import type {
+  TaskExtractor,
+  ExtractionOptions,
+  ExtractionResult,
+} from './task-extractor.js';
+
+export class ClaudeTaskExtractor implements TaskExtractor {
+  readonly sourceName = 'claude-code' as const;
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      const locations = await ClaudeStorageDetector.detectStorageLocations();
+      return locations.length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  async extractAll(options?: ExtractionOptions): Promise<ExtractionResult> {
+    const errors: Array<{ taskId?: string; message: string }> = [];
+    const tasks: UnifiedTask[] = [];
+
+    try {
+      const locations = await ClaudeStorageDetector.detectStorageLocations();
+
+      for (const location of locations) {
+        const projects = await ClaudeStorageDetector.listProjects(location.path);
+
+        for (const projectName of projects) {
+          const taskId = `claude-${projectName}`;
+          const projectPath = location.projectPath;
+
+          try {
+            const skeleton = await ClaudeStorageDetector.analyzeConversation(
+              taskId,
+              projectPath,
+            );
+
+            if (skeleton) {
+              const task = this.skeletonToTask(skeleton, options);
+              if (task) tasks.push(this.applyOptions(task, options));
+            }
+          } catch (err) {
+            errors.push({
+              taskId,
+              message: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+      }
+    } catch (err) {
+      errors.push({
+        message: `Claude extraction failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+
+    return { tasks, source: 'claude-code', errors };
+  }
+
+  async extractById(
+    taskId: string,
+    options?: ExtractionOptions,
+  ): Promise<UnifiedTask | null> {
+    try {
+      const skeleton = await ClaudeStorageDetector.findConversationById(taskId);
+      if (!skeleton) return null;
+
+      const task = this.skeletonToTask(skeleton, options);
+      if (!task) return null;
+      return this.applyOptions(task, options);
+    } catch {
+      return null;
+    }
+  }
+
+  private skeletonToTask(
+    skeleton: any,
+    options?: ExtractionOptions,
+  ): UnifiedTask | null {
+    const input = {
+      taskId: skeleton.taskId,
+      metadata: {
+        title: skeleton.metadata?.title,
+        lastActivity: skeleton.metadata?.lastActivity || new Date().toISOString(),
+        createdAt: skeleton.metadata?.createdAt || new Date().toISOString(),
+        messageCount: skeleton.metadata?.messageCount || 0,
+        actionCount: skeleton.metadata?.actionCount || 0,
+        totalSize: skeleton.metadata?.totalSize || 0,
+        workspace: skeleton.metadata?.workspace,
+        machineId: skeleton.metadata?.machineId || os.hostname(),
+        source: 'claude-code' as const,
+      },
+      isCompleted: false,
+    };
+
+    return toUnifiedTask(input);
+  }
+
+  private applyOptions(
+    task: UnifiedTask,
+    options?: ExtractionOptions,
+  ): UnifiedTask {
+    if (options?.machineId) {
+      task.machineId = options.machineId;
+    }
+    if (options?.includeComputedFields) {
+      task.storageTier = computeStorageTier(task);
+    }
+    return task;
+  }
+}

--- a/servers/roo-state-manager/src/services/extraction/index.ts
+++ b/servers/roo-state-manager/src/services/extraction/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Extraction module barrel export
+ * @module services/extraction
+ * @issue #1392
+ */
+
+export { RooTaskExtractor } from './roo-task-extractor.js';
+export { ClaudeTaskExtractor } from './claude-task-extractor.js';
+export { UnifiedTaskExtractor } from './unified-task-extractor.js';
+export type {
+  TaskExtractor,
+  ExtractionOptions,
+  ExtractionResult,
+} from './task-extractor.js';
+export type { UnifiedExtractionResult } from './unified-task-extractor.js';

--- a/servers/roo-state-manager/src/services/extraction/roo-task-extractor.ts
+++ b/servers/roo-state-manager/src/services/extraction/roo-task-extractor.ts
@@ -1,0 +1,133 @@
+/**
+ * RooTaskExtractor — Extracts UnifiedTasks from Roo Code storage
+ *
+ * @module services/extraction/roo-task-extractor
+ * @issue #1392 (#1360-2)
+ *
+ * Wraps RooStorageDetector and converts ConversationSkeleton → UnifiedTask
+ * via the toUnifiedTask() conversion helper from #1391.
+ */
+
+import * as path from 'path';
+import { RooStorageDetector } from '../../utils/roo-storage-detector.js';
+import {
+  toUnifiedTask,
+  computeStorageTier,
+} from '../../types/unified-task.js';
+import type { UnifiedTask } from '../../types/unified-task.js';
+import type {
+  TaskExtractor,
+  ExtractionOptions,
+  ExtractionResult,
+} from './task-extractor.js';
+
+export class RooTaskExtractor implements TaskExtractor {
+  readonly sourceName = 'roo' as const;
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      const locations = await RooStorageDetector.detectStorageLocations();
+      return locations.length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  async extractAll(options?: ExtractionOptions): Promise<ExtractionResult> {
+    const errors: Array<{ taskId?: string; message: string }> = [];
+    const tasks: UnifiedTask[] = [];
+
+    try {
+      const skeletons = await RooStorageDetector.buildHierarchicalSkeletons(
+        undefined,
+        true,
+        false,
+      );
+
+      for (const skeleton of skeletons) {
+        try {
+          const task = this.skeletonToTask(skeleton, options);
+          if (task) tasks.push(task);
+        } catch (err) {
+          errors.push({
+            taskId: skeleton.taskId,
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    } catch (err) {
+      errors.push({
+        message: `Roo extraction failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+
+    return { tasks, source: 'roo', errors };
+  }
+
+  async extractById(
+    taskId: string,
+    options?: ExtractionOptions,
+  ): Promise<UnifiedTask | null> {
+    try {
+      const summary = await RooStorageDetector.findConversationById(taskId);
+      if (!summary) return null;
+
+      const input = {
+        taskId: summary.taskId,
+        metadata: {
+          title: summary.metadata?.title,
+          lastActivity: summary.lastActivity || new Date().toISOString(),
+          createdAt: summary.lastActivity || new Date().toISOString(),
+          messageCount: summary.messageCount || 0,
+          actionCount: 0,
+          totalSize: summary.size || 0,
+          workspace: summary.metadata?.workspace,
+          source: 'roo' as const,
+        },
+        isCompleted: false,
+      };
+
+      return this.applyOptions(toUnifiedTask(input), options);
+    } catch {
+      return null;
+    }
+  }
+
+  private skeletonToTask(
+    skeleton: any,
+    options?: ExtractionOptions,
+  ): UnifiedTask | null {
+    const input = {
+      taskId: skeleton.taskId,
+      parentTaskId: skeleton.parentTaskId,
+      metadata: {
+        title: skeleton.metadata?.title,
+        lastActivity: skeleton.metadata?.lastActivity || new Date().toISOString(),
+        createdAt: skeleton.metadata?.createdAt || new Date().toISOString(),
+        mode: skeleton.metadata?.mode,
+        messageCount: skeleton.metadata?.messageCount || 0,
+        actionCount: skeleton.metadata?.actionCount || 0,
+        totalSize: skeleton.metadata?.totalSize || 0,
+        workspace: skeleton.metadata?.workspace,
+        source: 'roo' as const,
+      },
+      truncatedInstruction: skeleton.truncatedInstruction,
+      isCompleted: skeleton.isCompleted ?? false,
+    };
+
+    return this.applyOptions(toUnifiedTask(input), options);
+  }
+
+  private applyOptions(
+    task: UnifiedTask,
+    options?: ExtractionOptions,
+  ): UnifiedTask {
+    if (options?.machineId) {
+      task.machineId = options.machineId;
+    }
+    if (options?.includeComputedFields) {
+      task.storageTier = computeStorageTier(task);
+    }
+    return task;
+  }
+}

--- a/servers/roo-state-manager/src/services/extraction/task-extractor.ts
+++ b/servers/roo-state-manager/src/services/extraction/task-extractor.ts
@@ -1,0 +1,44 @@
+/**
+ * TaskExtractor — Base interface for cross-format task extraction
+ *
+ * @module services/extraction/task-extractor
+ * @issue #1392 (#1360-2)
+ *
+ * Common API that both Roo and Claude extractors implement,
+ * enabling UnifiedTaskExtractor to delegate transparently.
+ */
+
+import type { UnifiedTask } from '../../types/unified-task.js';
+
+/** Options shared by all extractors */
+export interface ExtractionOptions {
+  /** Include computed fields like storageTier */
+  includeComputedFields?: boolean;
+  /** Custom machine ID override */
+  machineId?: string;
+}
+
+/** Result of a single-source extraction */
+export interface ExtractionResult {
+  tasks: UnifiedTask[];
+  source: 'roo' | 'claude-code';
+  errors: Array<{ taskId?: string; message: string }>;
+}
+
+/**
+ * Base interface for task extractors.
+ * Each source (Roo, Claude Code) implements this interface.
+ */
+export interface TaskExtractor {
+  /** Human-readable source name */
+  readonly sourceName: 'roo' | 'claude-code';
+
+  /** Extract all tasks from this source */
+  extractAll(options?: ExtractionOptions): Promise<ExtractionResult>;
+
+  /** Extract a single task by ID */
+  extractById(taskId: string, options?: ExtractionOptions): Promise<UnifiedTask | null>;
+
+  /** Check if this extractor's storage is available */
+  isAvailable(): Promise<boolean>;
+}

--- a/servers/roo-state-manager/src/services/extraction/unified-task-extractor.ts
+++ b/servers/roo-state-manager/src/services/extraction/unified-task-extractor.ts
@@ -1,0 +1,92 @@
+/**
+ * UnifiedTaskExtractor — Orchestrator for cross-format task extraction
+ *
+ * @module services/extraction/unified-task-extractor
+ * @issue #1392 (#1360-2)
+ *
+ * Delegates to RooTaskExtractor and ClaudeTaskExtractor,
+ * merging results into a single unified collection.
+ */
+
+import type { UnifiedTask } from '../../types/unified-task.js';
+import type {
+  TaskExtractor,
+  ExtractionOptions,
+  ExtractionResult,
+} from './task-extractor.js';
+import { RooTaskExtractor } from './roo-task-extractor.js';
+import { ClaudeTaskExtractor } from './claude-task-extractor.js';
+
+/** Combined result from all extractors */
+export interface UnifiedExtractionResult {
+  tasks: UnifiedTask[];
+  bySource: {
+    roo: ExtractionResult;
+    'claude-code': ExtractionResult;
+  };
+  totalErrors: number;
+}
+
+export class UnifiedTaskExtractor {
+  private readonly extractors: TaskExtractor[];
+
+  constructor(extractors?: TaskExtractor[]) {
+    this.extractors = extractors ?? [
+      new RooTaskExtractor(),
+      new ClaudeTaskExtractor(),
+    ];
+  }
+
+  /** Extract tasks from all available sources */
+  async extractAll(options?: ExtractionOptions): Promise<UnifiedExtractionResult> {
+    const rooResult = await this.extractors[0].extractAll(options);
+    const claudeResult = await this.extractors[1].extractAll(options);
+
+    const allTasks = [...rooResult.tasks, ...claudeResult.tasks];
+    const totalErrors = rooResult.errors.length + claudeResult.errors.length;
+
+    return {
+      tasks: allTasks,
+      bySource: {
+        roo: rooResult,
+        'claude-code': claudeResult,
+      },
+      totalErrors,
+    };
+  }
+
+  /** Extract a single task by ID from the appropriate source */
+  async extractById(
+    taskId: string,
+    options?: ExtractionOptions,
+  ): Promise<UnifiedTask | null> {
+    // Determine source from taskId format
+    const extractor = this.getExtractorForTask(taskId);
+    return extractor.extractById(taskId, options);
+  }
+
+  /** Check which sources are available */
+  async getAvailableSources(): Promise<Array<'roo' | 'claude-code'>> {
+    const available: Array<'roo' | 'claude-code'> = [];
+
+    for (const extractor of this.extractors) {
+      if (await extractor.isAvailable()) {
+        available.push(extractor.sourceName);
+      }
+    }
+
+    return available;
+  }
+
+  /** Pick the right extractor based on taskId format */
+  private getExtractorForTask(taskId: string): TaskExtractor {
+    // Claude tasks use "claude-{projectName}" format
+    if (taskId.startsWith('claude-')) {
+      return this.extractors.find(e => e.sourceName === 'claude-code')
+        ?? this.extractors[1];
+    }
+    // Default to Roo (UUID format or other)
+    return this.extractors.find(e => e.sourceName === 'roo')
+      ?? this.extractors[0];
+  }
+}


### PR DESCRIPTION
## Summary
- Thin extraction layer over existing `RooStorageDetector` and `ClaudeStorageDetector` that converts `ConversationSkeleton` → `UnifiedTask` via `toUnifiedTask()` from #394 (#1391)
- `TaskExtractor` interface provides common API: `extractAll()`, `extractById()`, `isAvailable()`
- `UnifiedTaskExtractor` orchestrator delegates to both source extractors and merges results

## Files (8 new, 0 modified)
- `task-extractor.ts` — Interface + types (`ExtractionOptions`, `ExtractionResult`)
- `roo-task-extractor.ts` — Wraps `RooStorageDetector`
- `claude-task-extractor.ts` — Wraps `ClaudeStorageDetector`
- `unified-task-extractor.ts` — Orchestrator
- `index.ts` — Barrel export
- 3 test files — 30 unit tests (all passing)

## Test plan
- [x] `npm run build` passes
- [x] 30/30 vitest tests pass
- [x] No modifications to existing code (pure addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)