### PR TITLE
test(coverage): Add tests for encoding-helpers - idle worker coverage improvement

### DIFF
--- a/servers/roo-state-manager/src/utils/__tests__/encoding-helpers.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/encoding-helpers.test.ts
@@ -124,4 +124,87 @@ describe('encoding-helpers', () => {
 			fsSync.unlinkSync(filePath);
 		});
 	});
+
+	describe('readFileWithoutBOM', () => {
+		test('reads file without BOM using async method', async () => {
+			const filePath = './test-file-async.tmp';
+			fsSync.writeFileSync(filePath, testContent);
+
+			const result = await readFileWithoutBOM(filePath);
+			expect(result).toBe(testContent);
+
+			fsSync.unlinkSync(filePath);
+		});
+
+		test('reads file with BOM using async method', async () => {
+			const filePath = './test-file-async-bom.tmp';
+			fsSync.writeFileSync(filePath, testContentWithBOM);
+
+			const result = await readFileWithoutBOM(filePath);
+			expect(result).toBe(testContent);
+
+			fsSync.unlinkSync(filePath);
+		});
+
+		test('throws error for non-existent file (async)', async () => {
+			await expect(readFileWithoutBOM('./non-existent-async.tmp')).rejects.toThrow();
+		});
+
+		test('respects custom encoding parameter (async)', async () => {
+			const filePath = './test-file-encoding.tmp';
+			fsSync.writeFileSync(filePath, testContent);
+
+			const result = await readFileWithoutBOM(filePath, 'utf-8');
+			expect(result).toBe(testContent);
+
+			fsSync.unlinkSync(filePath);
+		});
+	});
+
+	describe('readJSONFileWithoutBOM', () => {
+		test('reads and parses JSON file without BOM (async)', async () => {
+			const filePath = './test-json-async.tmp';
+			fsSync.writeFileSync(filePath, testContent);
+
+			const result = await readJSONFileWithoutBOM(filePath);
+			expect(result).toEqual({ test: 'data', number: 42 });
+
+			fsSync.unlinkSync(filePath);
+		});
+
+		test('reads and parses JSON file with BOM (async)', async () => {
+			const filePath = './test-json-async-bom.tmp';
+			fsSync.writeFileSync(filePath, testContentWithBOM);
+
+			const result = await readJSONFileWithoutBOM(filePath);
+			expect(result).toEqual({ test: 'data', number: 42 });
+
+			fsSync.unlinkSync(filePath);
+		});
+
+		test('throws error for non-existent file (async)', async () => {
+			await expect(readJSONFileWithoutBOM('./non-existent-async.json')).rejects.toThrow();
+		});
+
+		test('throws error for invalid JSON file (async)', async () => {
+			const filePath = './test-json-async-invalid.tmp';
+			fsSync.writeFileSync(filePath, 'invalid json');
+
+			await expect(readJSONFileWithoutBOM(filePath)).rejects.toThrow();
+
+			fsSync.unlinkSync(filePath);
+		});
+
+		test('supports generic type parameter (async)', async () => {
+			const filePath = './test-json-generic.tmp';
+			fsSync.writeFileSync(filePath, testContent);
+
+			type TestData = { test: string; number: number };
+			const result = await readJSONFileWithoutBOM<TestData>(filePath);
+			expect(result.test).toBe('data');
+			expect(result.number).toBe(42);
+
+			fsSync.unlinkSync(filePath);
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- Added 8 new tests for async functions \`readFileWithoutBOM\` and \`readJSONFileWithoutBOM\`
- Previously only sync versions were tested
- All 24 tests passing

## Test plan
- [x] Run \`npx vitest run src/utils/__tests__/encoding-helpers.test.ts\` - 24 tests passing
- [x] No code changes, only test additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)