### PR TITLE
fix(#1314): remove as any cast in detectSynthesis

### DIFF
--- a/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
+++ b/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
@@ -387,32 +387,31 @@ interface SynthesisInfo {
  */
 async function detectSynthesis(skeleton: ConversationSkeleton): Promise<SynthesisInfo> {
     try {
-        // Check if skeleton has synthesis metadata
-        const synthesisMetadata = (skeleton as any).synthesisMetadata;
-        if (!synthesisMetadata) {
+        const synthesis = skeleton.metadata?.synthesis;
+        if (!synthesis || synthesis.status !== 'completed') {
             return { available: false };
         }
 
         // Priority 1: Condensed batch (higher priority)
-        if (synthesisMetadata.condensedBatchPath) {
-            const summary = await readSynthesisFile(synthesisMetadata.condensedBatchPath);
+        if (synthesis.condensedBatchPath) {
+            const summary = await readSynthesisFile(synthesis.condensedBatchPath);
             if (summary) {
                 return {
                     available: true,
                     summary: truncateSummary(summary, 200),
-                    generatedAt: synthesisMetadata.lastUpdated
+                    generatedAt: synthesis.lastUpdated
                 };
             }
         }
 
         // Priority 2: Atomic synthesis
-        if (synthesisMetadata.analysisFilePath) {
-            const summary = await readSynthesisFile(synthesisMetadata.analysisFilePath);
+        if (synthesis.analysisFilePath) {
+            const summary = await readSynthesisFile(synthesis.analysisFilePath);
             if (summary) {
                 return {
                     available: true,
                     summary: truncateSummary(summary, 200),
-                    generatedAt: synthesisMetadata.lastUpdated
+                    generatedAt: synthesis.lastUpdated
                 };
             }
         }


### PR DESCRIPTION
## Summary
- Replace `(skeleton as any).synthesisMetadata` with properly typed `skeleton.metadata?.synthesis`
- Add `status === 'completed'` guard consistent with NarrativeContextBuilderService
- Build passes clean

## Context
Part of #1296 (stubs decision: IMPLEMENT). The `detectSynthesis()` function in `list-conversations.tool.ts` used an untyped `as any` cast to access synthesis metadata, while `getSummaryForTask()` in NarrativeContextBuilderService was already fixed to use the typed path. This aligns both code paths.

## Test plan
- [x] `npm run build` passes
- [ ] CI green (vitest)
- [ ] No remaining `as any` for synthesisMetadata in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)