### PR TITLE
feat(#1496): fallback observability metadata for semantic search

### DIFF
--- a/servers/roo-state-manager/src/tools/search/__tests__/search-semantic.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-semantic.tool.test.ts
@@ -1420,6 +1420,88 @@ describe('helper functions (indirect via handler)', () => {
 
 			consoleSpy.mockRestore();
 		});
+
+		describe('#1496: Fallback observability metadata', () => {
+			test('circuit breaker fallback includes fallback_used + fallback_reason', async () => {
+				vi.useRealTimers();
+				vi.resetModules();
+
+				const { searchTasksByContentTool, _resetEmbeddingCircuitBreaker } = await import('../search-semantic.tool.js');
+
+				// Trigger circuit breaker with 503
+				const mockError = Object.assign(new Error('Service Unavailable'), {
+					response: { status: 503, statusText: 'Service Unavailable', data: {} }
+				});
+				mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
+				mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
+
+				// First call: triggers circuit breaker -> fallback with embedding_api_error
+				const result = await searchTasksByContentTool.handler({
+					search_query: 'trigger breaker for metadata',
+					workspace: 'd:	est',
+				}, makeCache(), mockEnsureCache, defaultFallback);
+
+				const parsed = JSON.parse(getTextContent(result));
+				expect(parsed.fallback_used).toBe(true);
+				expect(parsed.fallback_reason).toBe('embedding_api_error');
+				expect(parsed.original_search_mode).toBe('semantic');
+				expect(parsed.actual_search_mode).toBe('text');
+
+				// Second call: circuit breaker active -> embedding_circuit_breaker_active
+				const result2 = await searchTasksByContentTool.handler({
+					search_query: 'breaker active fallback',
+					workspace: 'd:	est',
+				}, makeCache(), mockEnsureCache, defaultFallback);
+
+				const parsed2 = JSON.parse(getTextContent(result2));
+				expect(parsed2.fallback_used).toBe(true);
+				expect(parsed2.fallback_reason).toBe('embedding_circuit_breaker_active');
+				expect(parsed2.original_search_mode).toBe('semantic');
+				expect(parsed2.actual_search_mode).toBe('text');
+			});
+
+			test('timeout error sets fallback_reason to embedding_timeout', async () => {
+				vi.useRealTimers();
+				vi.resetModules();
+
+				const { searchTasksByContentTool } = await import('../search-semantic.tool.js');
+
+				const timeoutError = Object.assign(new Error('This operation was aborted'), {
+					code: 'UND_ERR_CONNECT_TIMEOUT'
+				});
+				mockOpenAIClient.embeddings.create.mockRejectedValueOnce(timeoutError);
+				mockOpenAIClient.embeddings.create.mockRejectedValueOnce(timeoutError);
+
+				const result = await searchTasksByContentTool.handler({
+					search_query: 'timeout test',
+					workspace: 'd:	est',
+				}, makeCache(), mockEnsureCache, defaultFallback);
+
+				const parsed = JSON.parse(getTextContent(result));
+				expect(parsed.fallback_used).toBe(true);
+				expect(parsed.fallback_reason).toBe('embedding_timeout');
+				expect(parsed.actual_search_mode).toBe('text');
+			});
+
+			test('successful semantic search has fallback_used=false', async () => {
+				mockOpenAIClient.embeddings.create.mockResolvedValueOnce({
+					data: [{ embedding: new Array(1536).fill(0.1) }]
+				});
+				mockQdrantClient.search.mockResolvedValueOnce([]);
+
+				const result = await searchTasksByContentTool.handler({
+					search_query: 'semantic success test',
+					workspace: 'd:	est',
+				}, makeCache(), mockEnsureCache, defaultFallback);
+
+				expect(result.isError).toBe(false);
+				const parsed = JSON.parse(getTextContent(result));
+				expect(parsed.fallback_used).toBe(false);
+				expect(parsed.original_search_mode).toBe('semantic');
+				expect(parsed.actual_search_mode).toBe('semantic');
+				expect(parsed).not.toHaveProperty('fallback_reason');
+			});
+		});
 	});
 });
 });

--- a/servers/roo-state-manager/src/tools/search/roosync-search.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/roosync-search.tool.ts
@@ -232,11 +232,16 @@ export async function handleRooSyncSearch(
             };
             const textResult = await handleSearchTasksSemanticFallback(fallbackArgs, conversationCache);
 
-            // Inject semantic degraded warning into text results
+            // Inject semantic degraded warning + #1496 fallback metadata into text results
             try {
                 const parsed = JSON.parse((textResult.content?.[0] as any)?.text || '{}');
                 parsed.semantic_degraded = true;
                 parsed.semantic_error = 'Semantic search failed after retry — results are from text search only. Run roosync_search(action: "diagnose") to check backend state.';
+                // #1496: Structured fallback metadata for programmatic consumers
+                parsed.fallback_used = true;
+                parsed.fallback_reason = 'embedding_api_error';
+                parsed.original_search_mode = 'semantic';
+                parsed.actual_search_mode = 'text';
                 return {
                     content: [{ type: 'text', text: JSON.stringify(parsed, null, 2) }]
                 };

--- a/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
@@ -18,6 +18,39 @@ import { classifySearchError, formatClassifiedError } from './search-error-class
 let lastEmbeddingFailureTime = 0;
 const EMBEDDING_CIRCUIT_BREAKER_TTL_MS = parseInt(process.env.EMBEDDING_CIRCUIT_BREAKER_TTL_MS || '300000');
 
+// #1496: Fallback observability — reason codes when semantic degrades to text
+type FallbackReason =
+    | 'embedding_circuit_breaker_active'
+    | 'embedding_api_error'
+    | 'embedding_timeout';
+
+/**
+ * #1496: Inject fallback metadata into a CallToolResult's JSON payload.
+ * When semantic search falls back to text, agents need to know so they don't
+ * treat text results as semantic (cf #1407, #1451 — regressions masked for days).
+ */
+function injectFallbackMeta(result: CallToolResult, reason: FallbackReason): CallToolResult {
+    try {
+        const text = result.content?.[0] && 'text' in result.content[0]
+            ? (result.content[0] as { text: string }).text
+            : '';
+        const parsed = JSON.parse(text);
+        const enriched = {
+            ...parsed,
+            fallback_used: true,
+            fallback_reason: reason,
+            original_search_mode: 'semantic',
+            actual_search_mode: 'text',
+        };
+        return {
+            ...result,
+            content: [{ type: 'text' as const, text: JSON.stringify(enriched, null, 2) }]
+        };
+    } catch {
+        return result;
+    }
+}
+
 // #249: Retry configuration for transient failures
 const SEMANTIC_RETRY_COUNT = parseInt(process.env.SEMANTIC_RETRY_COUNT || '1');
 const SEMANTIC_RETRY_BACKOFF_MS = parseInt(process.env.SEMANTIC_RETRY_BACKOFF_MS || '2000');
@@ -418,7 +451,8 @@ export const searchTasksByContentTool = {
                     { query: args.search_query, workspace: args.workspace },
                     conversationCache
                 );
-                return fallbackResult;
+                // #1496: Tag fallback results so callers know semantic was skipped
+                return injectFallbackMeta(fallbackResult, 'embedding_circuit_breaker_active');
             } catch (fallbackError) {
                 return {
                     isError: false,
@@ -653,6 +687,10 @@ export const searchTasksByContentTool = {
 
             // Build enriched report
             const searchReport = {
+                // #1496: Observability — semantic succeeded, no fallback
+                fallback_used: false,
+                original_search_mode: 'semantic',
+                actual_search_mode: 'semantic',
                 current_machine: {
                     host_id: currentHostId,
                     search_timestamp: new Date().toISOString(),
@@ -717,6 +755,11 @@ export const searchTasksByContentTool = {
 
             console.warn(`[WARN] Semantic search failed (${classified.mode}), falling back to text: ${semanticErrorMsg}`);
 
+            // #1496: Determine fallback reason from classified error
+            const fallbackReason: FallbackReason = isAbortOrTimeout(semanticError)
+                ? 'embedding_timeout'
+                : 'embedding_api_error';
+
             // Fallback vers la recherche textuelle simple (legacy — default path)
             try {
                 const fallbackResult = await fallbackHandler(
@@ -724,7 +767,8 @@ export const searchTasksByContentTool = {
                     conversationCache
                 );
 
-                return fallbackResult;
+                // #1496: Tag fallback results so callers know semantic failed
+                return injectFallbackMeta(fallbackResult, fallbackReason);
             } catch (fallbackError) {
                 console.log(`[ERROR] Fallback handler a échoué: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`);
                 return {


### PR DESCRIPTION
## Summary

- Add structured `fallback_used`, `fallback_reason`, `original_search_mode`, `actual_search_mode` metadata when semantic search degrades to text fallback
- Three fallback reasons: `embedding_circuit_breaker_active`, `embedding_api_error`, `embedding_timeout`
- Successful semantic results include `fallback_used: false` for positive signal
- Mirror metadata in `roosync-search.tool.ts` auto-fallback path
- 3 new tests covering all paths

## Motivation

Agents treating text search results as semantic results caused masked regressions (#1407, #1451). Structured metadata lets callers distinguish degraded mode from healthy operation.

## Test plan

- [x] Build passes (`npm run build`)
- [x] 9276 tests pass (1 pre-existing fake timer failure unrelated)
- [x] 3 new tests for #1496 all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)