### PR TITLE
feat(#1313): implement getConversationAnalysis() read-through cache

### DIFF
--- a/servers/roo-state-manager/src/services/synthesis/NarrativeContextBuilderService.ts
+++ b/servers/roo-state-manager/src/services/synthesis/NarrativeContextBuilderService.ts
@@ -1005,8 +1005,62 @@ export class NarrativeContextBuilderService {
             return this.analysisCache.get(taskId)!;
         }
 
-        // TODO Phase 2: Charger depuis le fichier de synthèse et mettre en cache
-        return null; // Placeholder Phase 1
+        // Récupérer le squelette depuis le cache global
+        const skeleton = this.conversationCache.get(taskId);
+        if (!skeleton) {
+            return null;
+        }
+
+        // Essayer de charger depuis le fichier de synthèse sur disque
+        let analysis: ConversationAnalysis | null = null;
+        try {
+            const path = await import('path');
+            const fs = await import('fs/promises');
+            const analysisPath = path.join(this.options.synthesisBaseDir, `${taskId}.json`);
+            const content = await fs.readFile(analysisPath, 'utf-8');
+            analysis = JSON.parse(content) as ConversationAnalysis;
+        } catch {
+            // Pas de fichier disque — générer une analyse basique depuis le squelette
+            analysis = this.buildAnalysisFromSkeleton(skeleton);
+        }
+
+        if (analysis) {
+            this.analysisCache.set(taskId, analysis);
+        }
+        return analysis;
+    }
+
+    /**
+     * Construit une ConversationAnalysis basique à partir des métadonnées du squelette.
+     * Utilisé quand aucune synthèse LLM n'existe sur disque.
+     */
+    private buildAnalysisFromSkeleton(skeleton: ConversationSkeleton): ConversationAnalysis {
+        return {
+            taskId: skeleton.taskId,
+            analysisEngineVersion: '1.0.0-skeleton-derived',
+            analysisTimestamp: new Date().toISOString(),
+            llmModelId: 'none',
+            contextTrace: {
+                rootTaskId: skeleton.taskId,
+                parentTaskId: skeleton.parentTaskId,
+                previousSiblingTaskIds: [],
+                parentContexts: [],
+                synthesisType: 'generated_on_demand',
+            },
+            objectives: {},
+            strategy: {},
+            quality: {},
+            metrics: {
+                messageCount: skeleton.metadata.messageCount,
+                actionCount: skeleton.metadata.actionCount,
+            },
+            synthesis: {
+                initialContextSummary: '',
+                finalTaskSummary: `[Auto-derived] ${skeleton.metadata.messageCount} messages, ${skeleton.metadata.actionCount} actions` +
+                    (skeleton.metadata.mode ? `, mode ${skeleton.metadata.mode}` : '') +
+                    (skeleton.metadata.workspace ? `, ${skeleton.metadata.workspace}` : ''),
+            },
+        };
     }
 
     // =========================================================================

--- a/servers/roo-state-manager/src/services/synthesis/__tests__/NarrativeContextBuilderService.test.ts
+++ b/servers/roo-state-manager/src/services/synthesis/__tests__/NarrativeContextBuilderService.test.ts
@@ -296,14 +296,16 @@ describe('NarrativeContextBuilderService', () => {
 			expect(children).toEqual([]);
 		});
 
-		test('returns empty when children have no analyses', async () => {
+		test('returns skeleton-derived analyses for children without disk files', async () => {
 			cache.set('parent', createSkeleton('parent'));
 			cache.set('child-1', createSkeleton('child-1', { parentTaskId: 'parent' }));
 			const service = new NarrativeContextBuilderService(defaultOptions, cache);
 
-			// No analysis files exist, so returns empty
+			// Phase 2: getConversationAnalysis generates from skeleton when no disk file
 			const children = await service.collectChildrenSyntheses('parent');
-			expect(children).toEqual([]);
+			expect(children).toHaveLength(1);
+			expect(children[0].taskId).toBe('child-1');
+			expect(children[0].synthesis.finalTaskSummary).toContain('10 messages');
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Implement Phase 2 of `getConversationAnalysis()` with read-through cache pattern
- Check analysis cache → load from disk (`synthesisBaseDir`) → generate from skeleton metadata as fallback
- New private helper `buildAnalysisFromSkeleton()` creates full `ConversationAnalysis` from skeleton data
- 3 existing callers (lines 823, 899, `collectChildrenSyntheses`) now receive real data instead of null
- Updated test expectations for Phase 2 behavior (skeleton-derived analyses)

## Test plan
- [x] Build passes (`npm run build`)
- [x] 34/34 synthesis tests pass
- [x] 9273/9290 CI tests pass (1 known non-blocking circuit breaker failure)
- [x] `collectChildrenSyntheses` returns skeleton-derived analyses for children without disk files

Closes #1313

🤖 Generated with [Claude Code](https://claude.com/claude-code)