### PR TITLE
fix(#2108): lightweight notebook parsing for read_cells list mode

### DIFF
--- a/servers/jupyter-papermill-mcp-server/papermill_mcp/services/notebook_crud_service.py
+++ b/servers/jupyter-papermill-mcp-server/papermill_mcp/services/notebook_crud_service.py
@@ -457,8 +457,11 @@ class NotebookCRUDService:
                 if start_index is None:
                     raise ValueError("mode='range' requires 'start_index' parameter")
 
-            # Read notebook
-            notebook = FileUtils.read_notebook(resolved_path)
+            # Read notebook — use lightweight parse for list mode (#2108)
+            if mode == "list":
+                notebook = FileUtils.read_notebook_light(resolved_path)
+            else:
+                notebook = FileUtils.read_notebook(resolved_path)
             total_cells = len(notebook.cells)
 
             # Mode SINGLE: Retourner une seule cellule

--- a/servers/jupyter-papermill-mcp-server/papermill_mcp/utils/file_utils.py
+++ b/servers/jupyter-papermill-mcp-server/papermill_mcp/utils/file_utils.py
@@ -58,6 +58,22 @@ class FileUtils:
             raise ValueError(f"Invalid notebook format in {path}: {e}")
 
     @staticmethod
+    def read_notebook_light(path: Union[str, Path]) -> NotebookNode:
+        """Read a notebook with outputs stripped from code cells."""
+        path = Path(path)
+        if not path.exists():
+            raise FileNotFoundError(f"Notebook file not found: {path}")
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                raw = json.load(f)
+            for cell in raw.get("cells", []):
+                if cell.get("cell_type") == "code":
+                    cell["outputs"] = []
+            return nbformat.reads(json.dumps(raw), as_version=4)
+        except (json.JSONDecodeError, nbformat.ValidationError) as e:
+            raise ValueError(f"Invalid notebook format in {path}: {e}")
+
+    @staticmethod
     def write_notebook(notebook: NotebookNode, path: Union[str, Path]) -> Path:
         """
         Write a Jupyter notebook to file.


### PR DESCRIPTION
## Summary
- Add `FileUtils.read_notebook_light()` that strips code cell outputs before `nbformat` validation
- Use lightweight parse in `notebook_crud_service.read_cells()` for `mode="list"` only
- `mode="single"`, `mode="range"`, `mode="all"` continue using full `nbformat.read()` (outputs needed)

## Root Cause
`read_cells(mode="list")` called `nbformat.read()` which parses all cell outputs including large base64/HTML payloads. The list mode only needs `cell_type`, `source` preview, and `metadata` — never outputs. On notebooks with image-heavy outputs, this caused the tool to hang.

## Test Plan
- [x] Python compilation passes (`py_compile`)
- [ ] Manual test with large notebook containing base64 images
- [ ] Verify `mode="single"`, `mode="range"`, `mode="all"` still return outputs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)