### PR TITLE
fix(#1411): update stale tool name in MCP best practices guide

### DIFF
--- a/servers/roo-state-manager/src/tools/get_mcp_best_practices.ts
+++ b/servers/roo-state-manager/src/tools/get_mcp_best_practices.ts
@@ -197,7 +197,7 @@ export const getMcpBestPractices = {
             combinedContent += `## 🚨 CHECKLIST DE DÉBOGAGE URGENT\n\n`;
             combinedContent += `**Quand un MCP ne répond plus:**\n\n`;
             combinedContent += `- [ ] **Force reload:** \`roosync_mcp_management touch\`\n`;
-            combinedContent += `- [ ] **Test connectivité:** outil simple (system_info)\n`;
+            combinedContent += `- [ ] **Test connectivité:** \`roosync_diagnose action=env\` ou \`roosync_inventory type=status\`\n`;
             combinedContent += `- [ ] **Logs diagnostic:** \`read_vscode_logs\`\n`;
             combinedContent += `- [ ] **Progressive isolation** si timeout persiste\n\n`;
             


### PR DESCRIPTION
## Summary
- Replace `system_info` reference (non-existent tool) with `roosync_diagnose action=env` and `roosync_inventory type=status` in the urgent debugging checklist
- Addresses item 6 of #1411 (MCP design debt — 6 minor items)

## Items verified
| Item | Status |
|------|--------|
| 1. Add summary mode to inventory | Already implemented (`summary` param exists) |
| 4. Surface pagination in roosync_read | Already implemented (`page`/`per_page` params) |
| **6. Update tool names in best practices guide** | **Fixed by this PR** |
| 2,3,5 | Not in scope (require deeper changes) |

## Test plan
- [x] Build passes (`npm run build`)
- [ ] Verify guide output renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)