### PR TITLE
fix(#1411): add container-awareness to roosync_diagnose env

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/diagnose.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/diagnose.test.ts
@@ -79,6 +79,9 @@ describe('roosync_diagnose', () => {
       expect(result.data).toBeDefined();
       expect(result.data.system).toBeDefined();
       expect(result.data.system.platform).toBeDefined();
+      expect(result.data.container).toBeDefined();
+      expect(result.data.container).toHaveProperty('dockerHost');
+      expect(result.data.container).toHaveProperty('isWSL');
       expect(result.data.directories).toBeDefined();
       expect(result.data.status).toBe('OK');
     });

--- a/servers/roo-state-manager/src/tools/roosync/diagnose.ts
+++ b/servers/roo-state-manager/src/tools/roosync/diagnose.ts
@@ -158,6 +158,12 @@ async function handleEnvAction(
       totalMemory: os.totalmem(),
       freeMemory: os.freemem()
     },
+    container: {
+      dockerHost: process.env.DOCKER_HOST || null,
+      isWSL: !!process.env.WSL_DISTRO_NAME,
+      isCI: !!(process.env.CI || process.env.GITHUB_ACTIONS),
+      containerEnv: process.env.container || null
+    },
     directories: {},
     envVars: {
       hasPath: !!process.env.PATH,


### PR DESCRIPTION
## Summary
- Add `container` section to `roosync_diagnose` env action output
- Detects Docker (`DOCKER_HOST`), WSL (`WSL_DISTRO_NAME`), CI (`CI`/`GITHUB_ACTIONS`), and container runtime (`container` env var)
- Adds test assertions for new container field

## Context
Issue #1411 (MCP design debt) — last remaining open item of 6. The other 5 were already resolved by prior consolidation work (#1841, #1935, #1609).

## Test plan
- [x] `npx vitest run --config vitest.config.ci.ts src/tools/roosync/__tests__/diagnose.test.ts` — 21/21 pass
- [x] `npm run build` — clean tsc

🤖 Generated with [Claude Code](https://claude.com/claude-code)