### PR TITLE
feat(#1391): add JSON Schema for UnifiedTask cross-language validation

### DIFF
--- a/servers/roo-state-manager/package.json
+++ b/servers/roo-state-manager/package.json
@@ -71,6 +71,7 @@
     "@types/ws": "^8.5.13",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
+    "ajv": "^8.20.0",
     "cross-env": "^7.0.3",
     "esbuild": "^0.24.0",
     "eslint": "^8.56.0",

--- a/servers/roo-state-manager/src/schemas/__tests__/unified-task-schema.test.ts
+++ b/servers/roo-state-manager/src/schemas/__tests__/unified-task-schema.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for JSON Schema validation of UnifiedTask — #1391
+ */
+
+import { describe, test, expect } from 'vitest';
+import Ajv from 'ajv';
+import type { ValidateFunction } from 'ajv';
+import schema from '../unified-task.json';
+import type { UnifiedTask } from '../../types/unified-task.js';
+
+const ajv = new Ajv({ strict: false });
+const validate = ajv.compile(schema) as ValidateFunction<UnifiedTask>;
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const validRooTask: UnifiedTask = {
+  id: 'task-001',
+  source: 'roo',
+  parentId: 'parent-001',
+  title: 'Fix authentication bug',
+  instruction: 'Fix the login flow bug in auth.ts',
+  createdAt: '2026-05-10T10:00:00Z',
+  lastActivity: '2026-05-10T11:30:00Z',
+  completedAt: '2026-05-10T11:30:00Z',
+  messageCount: 42,
+  actionCount: 15,
+  totalSizeBytes: 8192,
+  workspace: '/dev/roo-extensions',
+  machineId: 'myia-po-2025',
+  mode: 'code-simple',
+  status: 'completed',
+  outcome: 'success',
+  indexedAt: '2026-05-10T12:00:00Z',
+};
+
+const validClaudeTask: UnifiedTask = {
+  id: 'session-abc123',
+  source: 'claude-code',
+  createdAt: '2026-05-11T08:00:00Z',
+  lastActivity: '2026-05-11T08:05:00Z',
+  messageCount: 10,
+  actionCount: 3,
+  totalSizeBytes: 4096,
+  status: 'active',
+};
+
+// ─── JSON Schema validation ───────────────────────────────────────────────────
+
+describe('UnifiedTask JSON Schema', () => {
+  test('validates a complete Roo task', () => {
+    expect(validate(validRooTask)).toBe(true);
+  });
+
+  test('validates a minimal Claude task', () => {
+    expect(validate(validClaudeTask)).toBe(true);
+  });
+
+  test('validates task with all optional fields', () => {
+    const full: UnifiedTask = {
+      ...validRooTask,
+      rootId: 'root-001',
+      model: 'glm-5',
+      storageTier: 'hot',
+      sourceMetadata: { custom: 'data', count: 42 },
+    };
+    expect(validate(full)).toBe(true);
+  });
+
+  test('rejects missing required id', () => {
+    const { id, ...noId } = validClaudeTask;
+    expect(validate(noId)).toBe(false);
+  });
+
+  test('rejects missing required source', () => {
+    const { source, ...noSource } = validClaudeTask;
+    expect(validate(noSource)).toBe(false);
+  });
+
+  test('rejects missing required status', () => {
+    const { status, ...noStatus } = validClaudeTask;
+    expect(validate(noStatus)).toBe(false);
+  });
+
+  test('rejects invalid source enum', () => {
+    expect(validate({ ...validClaudeTask, source: 'unknown-agent' })).toBe(false);
+  });
+
+  test('rejects invalid status enum', () => {
+    expect(validate({ ...validClaudeTask, status: 'pending' })).toBe(false);
+  });
+
+  test('rejects invalid outcome enum', () => {
+    expect(validate({ ...validRooTask, outcome: 'unknown' })).toBe(false);
+  });
+
+  test('rejects negative messageCount', () => {
+    expect(validate({ ...validClaudeTask, messageCount: -1 })).toBe(false);
+  });
+
+  test('rejects negative actionCount', () => {
+    expect(validate({ ...validClaudeTask, actionCount: -5 })).toBe(false);
+  });
+
+  test('rejects additional properties', () => {
+    expect(validate({ ...validClaudeTask, extraField: 'nope' })).toBe(false);
+  });
+
+  test('accepts all valid storageTier values', () => {
+    for (const tier of ['hot', 'warm', 'cold'] as const) {
+      expect(validate({ ...validClaudeTask, storageTier: tier })).toBe(true);
+    }
+  });
+
+  test('accepts all valid outcome values', () => {
+    for (const outcome of ['success', 'failure', 'partial', 'cancelled'] as const) {
+      expect(validate({ ...validRooTask, outcome })).toBe(true);
+    }
+  });
+
+  test('accepts all valid status values', () => {
+    for (const status of ['active', 'completed', 'abandoned', 'stuck', 'unknown'] as const) {
+      expect(validate({ ...validClaudeTask, status })).toBe(true);
+    }
+  });
+});
+
+// ─── Schema structure ─────────────────────────────────────────────────────────
+
+describe('JSON Schema structure', () => {
+  test('has $schema draft-07', () => {
+    expect(schema.$schema).toBe('http://json-schema.org/draft-07/schema#');
+  });
+
+  test('has $id for identification', () => {
+    expect(schema.$id).toBe('https://roo-extensions.myia.io/schemas/unified-task.json');
+  });
+
+  test('has required fields defined', () => {
+    const def = schema.definitions.UnifiedTask;
+    expect(def.required).toContain('id');
+    expect(def.required).toContain('source');
+    expect(def.required).toContain('createdAt');
+    expect(def.required).toContain('lastActivity');
+    expect(def.required).toContain('messageCount');
+    expect(def.required).toContain('actionCount');
+    expect(def.required).toContain('totalSizeBytes');
+    expect(def.required).toContain('status');
+  });
+
+  test('disallows additional properties', () => {
+    const def = schema.definitions.UnifiedTask;
+    expect(def.additionalProperties).toBe(false);
+  });
+
+  test('has correct source enum', () => {
+    const def = schema.definitions.UnifiedTask;
+    expect(def.properties.source.enum).toEqual(['roo', 'claude-code']);
+  });
+
+  test('has correct status enum', () => {
+    const def = schema.definitions.UnifiedTask;
+    expect(def.properties.status.enum).toEqual(['active', 'completed', 'abandoned', 'stuck', 'unknown']);
+  });
+
+  test('has minimum 0 on integer fields', () => {
+    const def = schema.definitions.UnifiedTask;
+    expect(def.properties.messageCount.minimum).toBe(0);
+    expect(def.properties.actionCount.minimum).toBe(0);
+    expect(def.properties.totalSizeBytes.minimum).toBe(0);
+  });
+});

--- a/servers/roo-state-manager/src/schemas/generate-unified-task-schema.ts
+++ b/servers/roo-state-manager/src/schemas/generate-unified-task-schema.ts
@@ -1,0 +1,34 @@
+/**
+ * Generate JSON Schema from Zod UnifiedTaskSchema — #1391
+ *
+ * Run: npx tsx src/schemas/generate-unified-task-schema.ts
+ * Outputs: src/schemas/unified-task.json
+ */
+
+import { writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { UnifiedTaskSchema } from '../types/unified-task.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- zod-to-json-schema deep type instantiation
+const jsonSchema = zodToJsonSchema(UnifiedTaskSchema as any, {
+  name: 'UnifiedTask',
+  $refStrategy: 'root',
+} as any);
+
+// Enrich with metadata
+const enriched = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://roo-extensions.myia.io/schemas/unified-task.json',
+  title: 'UnifiedTask',
+  description:
+    'Unified schema for Roo Code and Claude Code tasks — #1391',
+  ...jsonSchema,
+};
+
+const outPath = join(__dirname, 'unified-task.json');
+writeFileSync(outPath, JSON.stringify(enriched, null, 2) + '\n', 'utf-8');
+console.log(`Written: ${outPath}`);

--- a/servers/roo-state-manager/src/schemas/unified-task.json
+++ b/servers/roo-state-manager/src/schemas/unified-task.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://roo-extensions.myia.io/schemas/unified-task.json",
+  "title": "UnifiedTask",
+  "description": "Unified schema for Roo Code and Claude Code tasks — #1391",
+  "$ref": "#/definitions/UnifiedTask",
+  "definitions": {
+    "UnifiedTask": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique task identifier (taskId from source system)"
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "roo",
+            "claude-code"
+          ],
+          "description": "Origin system: Roo Code or Claude Code"
+        },
+        "parentId": {
+          "type": "string",
+          "description": "Parent task ID for sub-task relationships"
+        },
+        "rootId": {
+          "type": "string",
+          "description": "Root task ID in the task hierarchy"
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable task title"
+        },
+        "instruction": {
+          "type": "string",
+          "description": "Original task prompt/instruction"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 creation timestamp"
+        },
+        "lastActivity": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 last activity timestamp"
+        },
+        "completedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 completion timestamp"
+        },
+        "messageCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total message count"
+        },
+        "actionCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total tool/action count"
+        },
+        "totalSizeBytes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total conversation size in bytes"
+        },
+        "workspace": {
+          "type": "string",
+          "description": "Workspace path or identifier"
+        },
+        "machineId": {
+          "type": "string",
+          "description": "Machine where the task ran"
+        },
+        "mode": {
+          "type": "string",
+          "description": "Roo mode or Claude agent type used"
+        },
+        "model": {
+          "type": "string",
+          "description": "LLM model identifier"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "completed",
+            "abandoned",
+            "stuck",
+            "unknown"
+          ],
+          "description": "Current task lifecycle status"
+        },
+        "outcome": {
+          "type": "string",
+          "enum": [
+            "success",
+            "failure",
+            "partial",
+            "cancelled"
+          ],
+          "description": "Task outcome (set when status=completed|abandoned)"
+        },
+        "storageTier": {
+          "type": "string",
+          "enum": [
+            "hot",
+            "warm",
+            "cold"
+          ],
+          "description": "Storage tier for retention policy"
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last Qdrant indexing timestamp"
+        },
+        "sourceMetadata": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Opaque source-specific metadata"
+        }
+      },
+      "required": [
+        "id",
+        "source",
+        "createdAt",
+        "lastActivity",
+        "messageCount",
+        "actionCount",
+        "totalSizeBytes",
+        "status"
+      ],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Generate Draft-07 JSON Schema from Zod UnifiedTaskSchema using `zod-to-json-schema`
- Add ajv-based test suite (22 tests) covering validation parity between Zod and JSON Schema
- Add `generate-unified-task-schema.ts` script for regenerating the schema when Zod types change

## Deliverables for #1391
- [x] `src/types/unified-task.ts` — Types TypeScript complets (already existed, 178 lines)
- [x] `schemas/unified-task.json` — JSON schema with validation (**NEW**)
- [x] Tests unitaires (50 total: 28 Zod + 22 JSON Schema)
- [x] Documentation JSDoc (already in unified-task.ts)

## Test plan
- [x] `npm run build` passes
- [x] 50/50 tests pass (28 Zod schema + 22 JSON Schema validation)
- [x] Schema validates against Draft-07 specification
- [x] All enum values, required fields, and constraints match Zod schema

## Files changed
- `src/schemas/unified-task.json` — Auto-generated JSON Schema (139 lines)
- `src/schemas/generate-unified-task-schema.ts` — Generator script
- `src/schemas/__tests__/unified-task-schema.test.ts` — 22 ajv validation tests
- `package.json` — Added `ajv` dev dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)