### PR TITLE
fix(#2126): exclude _archives/ from dev vitest config

### DIFF
--- a/servers/roo-state-manager/vitest.config.ts
+++ b/servers/roo-state-manager/vitest.config.ts
@@ -32,6 +32,8 @@ export default defineConfig({
       '**/node_modules/**',
       '**/build/**',
       '**/dist/**',
+      // Archived code — tests reference removed/renamed services
+      '**/_archives/**',
       // Backups vitest-migration - anciennes sauvegardes à ne pas exécuter
       // Chemin: vitest-migration/backups/tests-DATE/heures/tests/
       // IMPORTANT: Exclure avant que include ne les matche


### PR DESCRIPTION
## Summary
- Align `vitest.config.ts` (dev) with `vitest.config.unit.ts` which already excludes `**/_archives/**`
- These 7 test files reference archived/removed services and fail with import errors — not a real regression

## Test Results
- **Dev config**: 10→3 failing files (7 `_archives/` tests eliminated)
- **CI config**: 0 failures (unchanged, already excluded)
- All 3 remaining dev failures are known infrastructure tests (Qdrant live + HeartbeatService integration), already excluded from CI

## Evidence
```
Before fix (dev config):  Test Files  10 failed | 496 passed
After fix (dev config):   Test Files  3 failed  | 496 passed
CI config (unchanged):    Test Files  0 failed  | 459 passed
```

Fixes #2126

🤖 Generated with [Claude Code](https://claude.com/claude-code)