### PR TITLE
fix(#1410): respect limit param when per_page is also set

### DIFF
--- a/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
+++ b/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
@@ -945,7 +945,7 @@ export const listConversationsTool = {
         //   When only `limit` is provided (no `per_page`), it acts as both page size and total cap.
         //   The floor of 10 does NOT apply to `limit` — the caller explicitly asked for fewer.
         const hasExplicitPerPage = args.per_page !== undefined && args.per_page !== null;
-        const hasLimit = !hasExplicitPerPage && args.limit !== undefined && args.limit !== null;
+        const hasLimit = args.limit !== undefined && args.limit !== null;
         const rawPerPage = (hasExplicitPerPage ? args.per_page : (args.limit || 10)) as number;
         const perPage = hasExplicitPerPage
             ? Math.min(Math.max(rawPerPage, 10), 100)


### PR DESCRIPTION
## Summary
- Fix `conversation_browser(list)` ignoring the `limit` parameter when `per_page` is also provided
- Root cause: `hasLimit` was gated behind `!hasExplicitPerPage`, making `limit` a no-op when pagination was used
- One-line fix: removed the `!hasExplicitPerPage &&` condition so `limit` always acts as a hard cap

## Test plan
- [x] Build passes (`npm run build`)
- [x] 460/463 CI tests pass (3 failures = pre-existing untracked test file)
- [ ] Manual: `conversation_browser(list, limit: 3, per_page: 10)` should return max 3 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>