### PR TITLE
fix(#1409): filter isKnownMachine on registry machine IDs

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -348,7 +348,8 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
     }
 
     // #1409: Use machine registry as authoritative source for total count
-    const registryMachineIds = service.getKnownMachineIds();
+    // Filter out orphan test entries (test-machine, ci-test-machine, etc.)
+    const registryMachineIds = service.getKnownMachineIds().filter(isKnownMachine);
     const heartbeatTotal = filteredOnlineMachines.length + filteredUnknownMachines.length;
     const totalMachines = Math.max(
       registryMachineIds.length,


### PR DESCRIPTION
## Summary
- Apply `isKnownMachine` filter to `getKnownMachineIds()` result in `get-status.ts:351`
- Fixes inflated machine count (8→6) caused by orphan test entries in `.machine-registry.json` (`test-machine`, `ci-test-machine`)

## Test plan
- [x] `npm run build` passes
- [x] 22/22 `get-status.test.ts` CI tests pass
- [ ] Verify `roosync_inventory(type: "status")` returns `total: 6` (not 8) after merge
- [ ] GDrive cleanup: remove 2 orphan test entries from `.machine-registry.json` (separate manual action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)