### PR TITLE
fix(#2167): improve semantic search reliability

### DIFF
--- a/servers/roo-state-manager/src/tools/search/__tests__/search-semantic.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-semantic.tool.test.ts
@@ -1226,7 +1226,8 @@ describe('helper functions (indirect via handler)', () => {
 				response: { status: 502, statusText: 'Bad Gateway', data: {} }
 			});
 			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
-			// #249: Mock enough failures to exhaust withRetry (1 initial + 1 retry)
+			// #249/#2167: Mock enough failures to exhaust withRetry (1 initial + 2 retries)
+			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 
 			const result = await searchTasksByContentTool.handler({
@@ -1245,7 +1246,8 @@ describe('helper functions (indirect via handler)', () => {
 				response: { status: 503, statusText: 'Service Unavailable', data: {} }
 			});
 			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
-			// #249: Mock enough failures to exhaust withRetry (1 initial + 1 retry)
+			// #249/#2167: Mock enough failures to exhaust withRetry (1 initial + 2 retries)
+			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 
 			const result = await searchTasksByContentTool.handler({
@@ -1264,7 +1266,8 @@ describe('helper functions (indirect via handler)', () => {
 				response: { status: 504, statusText: 'Gateway Timeout', data: {} }
 			});
 			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
-			// #249: Mock enough failures to exhaust withRetry (1 initial + 1 retry)
+			// #249/#2167: Mock enough failures to exhaust withRetry (1 initial + 2 retries)
+			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 
 			const result = await searchTasksByContentTool.handler({
@@ -1318,7 +1321,8 @@ describe('helper functions (indirect via handler)', () => {
 				response: { status: 503, statusText: 'Service Unavailable', data: {} }
 			});
 			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
-			// #249: Mock enough failures to exhaust withRetry (1 initial + 1 retry)
+			// #249/#2167: Mock enough failures to exhaust withRetry (1 initial + 2 retries)
+			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 
 			// First call - triggers circuit breaker
@@ -1334,7 +1338,7 @@ describe('helper functions (indirect via handler)', () => {
 			}, makeCache(), mockEnsureCache, defaultFallback);
 
 			expect(result.isError).toBe(false);
-			expect(mockOpenAIClient.embeddings.create).toHaveBeenCalledTimes(2);
+			expect(mockOpenAIClient.embeddings.create).toHaveBeenCalledTimes(3);
 		});
 
 		test('resets after TTL expires', async () => {
@@ -1343,7 +1347,8 @@ describe('helper functions (indirect via handler)', () => {
 			const mockError = Object.assign(new Error('Service Unavailable'), {
 				response: { status: 503, statusText: 'Service Unavailable', data: {} }
 			});
-			// #249: Mock enough failures to exhaust withRetry (1 initial + 1 retry)
+			// #249/#2167: Mock enough failures to exhaust withRetry (1 initial + 2 retries)
+			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 
@@ -1371,8 +1376,8 @@ describe('helper functions (indirect via handler)', () => {
 				workspace: 'd:	test'
 			}, makeCache(), mockEnsureCache, defaultFallback);
 
-			// 2 failures (exhausted retry) + 1 success (post-TTL)
-			expect(mockOpenAIClient.embeddings.create).toHaveBeenCalledTimes(3);
+			// 3 failures (exhausted retry) + 1 success (post-TTL)
+			expect(mockOpenAIClient.embeddings.create).toHaveBeenCalledTimes(4);
 		});
 		test('logs warning when circuit breaker active', async () => {
 			vi.useRealTimers();
@@ -1385,7 +1390,8 @@ describe('helper functions (indirect via handler)', () => {
 			});
 			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 
-			// #249: Mock enough failures to exhaust withRetry (1 initial + 1 retry)
+			// #249/#2167: Mock enough failures to exhaust withRetry (1 initial + 2 retries)
+			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 			mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 			// Trigger circuit breaker
 			await searchTasksByContentTool.handler({
@@ -1415,6 +1421,7 @@ describe('helper functions (indirect via handler)', () => {
 				const mockError = Object.assign(new Error('Service Unavailable'), {
 					response: { status: 503, statusText: 'Service Unavailable', data: {} }
 				});
+				mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 				mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 				mockOpenAIClient.embeddings.create.mockRejectedValueOnce(mockError);
 
@@ -1452,6 +1459,7 @@ describe('helper functions (indirect via handler)', () => {
 				const timeoutError = Object.assign(new Error('This operation was aborted'), {
 					code: 'UND_ERR_CONNECT_TIMEOUT'
 				});
+				mockOpenAIClient.embeddings.create.mockRejectedValueOnce(timeoutError);
 				mockOpenAIClient.embeddings.create.mockRejectedValueOnce(timeoutError);
 				mockOpenAIClient.embeddings.create.mockRejectedValueOnce(timeoutError);
 

--- a/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
@@ -51,12 +51,38 @@ function injectFallbackMeta(result: CallToolResult, reason: FallbackReason): Cal
     }
 }
 
-// #249: Retry configuration for transient failures
-const SEMANTIC_RETRY_COUNT = parseInt(process.env.SEMANTIC_RETRY_COUNT || '1');
+// #249/#2167: Retry configuration for transient failures
+// #2167: Bumped default retry count from 1→2 (3 total attempts) for embedding reliability
+const SEMANTIC_RETRY_COUNT = parseInt(process.env.SEMANTIC_RETRY_COUNT || '2');
 const SEMANTIC_RETRY_BACKOFF_MS = parseInt(process.env.SEMANTIC_RETRY_BACKOFF_MS || '2000');
 
 /**
- * #249: Retry wrapper for transient network/timeout errors.
+ * #2167: Query embedding cache — avoids re-embedding identical queries within TTL.
+ * LRU with TTL 1h. Capped at 100 entries to bound memory.
+ */
+const queryEmbeddingCache = new Map<string, { embedding: number[]; expiresAt: number }>();
+const QUERY_EMBEDDING_CACHE_TTL_MS = parseInt(process.env.QUERY_EMBEDDING_CACHE_TTL_MS || '3600000'); // 1h
+const QUERY_EMBEDDING_CACHE_MAX = 100;
+
+function getCachedQueryEmbedding(query: string): number[] | null {
+    const cached = queryEmbeddingCache.get(query);
+    if (cached && Date.now() < cached.expiresAt) {
+        return cached.embedding;
+    }
+    if (cached) queryEmbeddingCache.delete(query);
+    return null;
+}
+
+function setCachedQueryEmbedding(query: string, embedding: number[]): void {
+    if (queryEmbeddingCache.size >= QUERY_EMBEDDING_CACHE_MAX) {
+        const oldest = queryEmbeddingCache.keys().next().value;
+        if (oldest) queryEmbeddingCache.delete(oldest);
+    }
+    queryEmbeddingCache.set(query, { embedding, expiresAt: Date.now() + QUERY_EMBEDDING_CACHE_TTL_MS });
+}
+
+/**
+ * #249/#2167: Retry wrapper with exponential backoff for transient network/timeout errors.
  * Retries on 5xx, abort, timeout. Does NOT retry on 4xx or validation errors.
  */
 async function withRetry<T>(fn: () => Promise<T>, retries: number = SEMANTIC_RETRY_COUNT, backoffMs: number = SEMANTIC_RETRY_BACKOFF_MS): Promise<T> {
@@ -68,7 +94,7 @@ async function withRetry<T>(fn: () => Promise<T>, retries: number = SEMANTIC_RET
         if (!isRetryable) throw error;
         console.warn(`[WARN] #249: Retrying after transient error (${retries} left): ${error instanceof Error ? error.message : String(error)}`);
         await new Promise(resolve => setTimeout(resolve, backoffMs));
-        return withRetry(fn, retries - 1, backoffMs);
+        return withRetry(fn, retries - 1, backoffMs * 2);
     }
 }
 
@@ -95,11 +121,12 @@ function isAbortOrTimeout(error: unknown): boolean {
 }
 
 /**
- * Reset the circuit breaker state (for testing).
+ * Reset the circuit breaker state and query embedding cache (for testing).
  * @internal
  */
 export function _resetEmbeddingCircuitBreaker(): void {
     lastEmbeddingFailureTime = 0;
+    queryEmbeddingCache.clear();
 }
 
 export interface SearchTasksByContentArgs {
@@ -469,13 +496,19 @@ export const searchTasksByContentTool = {
             const qdrant = getQdrantClient();
             const openai = getOpenAIClient();
 
-            // #249: Wrap embedding call with retry for transient failures
-            const embedding = await withRetry(() => openai.embeddings.create({
-                model: getEmbeddingModel(),
-                input: search_query
-            }));
-
-            const queryVector = embedding.data[0].embedding;
+            // #2167: Check query embedding cache before calling the API
+            let queryVector = getCachedQueryEmbedding(search_query);
+            if (!queryVector) {
+                // #249: Wrap embedding call with retry for transient failures
+                const embedding = await withRetry(() => openai.embeddings.create({
+                    model: getEmbeddingModel(),
+                    input: search_query
+                }));
+                queryVector = embedding.data[0].embedding;
+                setCachedQueryEmbedding(search_query, queryVector);
+            } else {
+                console.log(`[INFO] #2167: Query embedding cache hit for "${search_query.substring(0, 50)}..."`);
+            }
             const collectionName = process.env.QDRANT_COLLECTION_NAME || 'roo_tasks_semantic_index';
 
             // Configuration de la recherche selon conversation_id et workspace

--- a/servers/roo-state-manager/tests/unit/tools/search/roosync-search.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/search/roosync-search.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { roosyncSearchTool, handleRooSyncSearch } from '../../../../src/tools/search/roosync-search.tool.js';
+import { _resetEmbeddingCircuitBreaker } from '../../../../src/tools/search/search-semantic.tool.js';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
@@ -57,6 +58,9 @@ describe('roosync_search - CONS-11', () => {
         });
 
         vi.clearAllMocks();
+
+        // #2167: Reset circuit breaker + query embedding cache between tests
+        _resetEmbeddingCircuitBreaker();
 
         mockOpenAIClient.embeddings.create.mockResolvedValue({
             data: [{ embedding: Array(1536).fill(0.1) }]

--- a/servers/roo-state-manager/tests/unit/tools/search/search-by-content.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/search/search-by-content.test.ts
@@ -1,4 +1,4 @@
-import { searchTasksByContentTool } from '../../../../src/tools/search/search-semantic.tool.js';
+import { searchTasksByContentTool, _resetEmbeddingCircuitBreaker } from '../../../../src/tools/search/search-semantic.tool.js';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
@@ -55,6 +55,9 @@ describe('🔍 search_tasks_by_content', () => {
 
     // Reset mocks
     vi.clearAllMocks();
+
+    // #2167: Reset circuit breaker + query embedding cache between tests
+    _resetEmbeddingCircuitBreaker();
     
     // Setup default mock responses
     mockOpenAIClient.embeddings.create.mockResolvedValue({


### PR DESCRIPTION
**[NanoClaw]** APPROVE — Semantic search reliability fix (#2167). Retry logic + query cache for semantic search tool. Addresses 502 errors from vLLM embeddings endpoint.