### PR TITLE
fix(#2165): stop embedding-server hammering — gate indexTask on circuit breaker

### DIFF
--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -13,9 +13,10 @@ import { RooStorageDetector } from '../utils/roo-storage-detector.js';
 import { ServerState } from './state-manager.service.js';
 import { ANTI_LEAK_CONFIG } from '../config/server-config.js';
 import { TaskIndexer, getHostIdentifier } from './task-indexer.js';
+import { getCircuitBreakerState, isCircuitBreakerBlocking } from './task-indexer/VectorIndexer.js';
 import { SkeletonCacheService } from './skeleton-cache.service.js';
 // REMOVED: import * as toolExports — was unused, added 6s to startup by importing ALL tools
-import { RooStorageDetectorError, RooStorageDetectorErrorCode } from '../types/errors.js';
+import { RooStorageDetectorError, RooStorageDetectorErrorCode, GenericErrorCode } from '../types/errors.js';
 // #1140: Lazy import — RooSyncService loads 17 heavy modules (~6s).
 // Only needed when HEARTBEAT_AUTO_START=true (disabled by default).
 // import { RooSyncService } from './RooSyncService.js';
@@ -874,11 +875,34 @@ export function startQdrantIndexingBackgroundProcess(state: ServerState): void {
             return;
         }
 
+        // #2165: Global back-off. If the Qdrant circuit breaker is OPEN, every
+        // indexTask() call would extract chunks and (before this fix) compute
+        // embeddings only to have the upsert rejected — hammering the embedding
+        // server. With the breaker open, skip the ENTIRE cycle: leave the queue
+        // intact so tasks are retried once Qdrant recovers, and burn zero GPU.
+        if (isCircuitBreakerBlocking()) {
+            const snap = getCircuitBreakerState();
+            console.warn(
+                `🚫 [Qdrant-Worker] Circuit breaker OPEN — skipping indexing cycle ` +
+                `(${state.qdrantIndexQueue.size} tasks queued, retry in ~${Math.round(snap.msUntilHalfOpen / 1000)}s). ` +
+                `No embeddings computed this cycle.`
+            );
+            return;
+        }
+
         // Traiter un batch de tâches par intervalle (au lieu d'une seule)
         const taskIds = Array.from(state.qdrantIndexQueue.values()).slice(0, QDRANT_INDEX_BATCH_SIZE);
         for (const taskId of taskIds) {
             state.qdrantIndexQueue.delete(taskId);
             await indexTaskInQdrant(taskId, state);
+
+            // #2165: If a task tripped the breaker, stop the rest of this batch
+            // immediately — the remaining tasks would all hit the open breaker
+            // and (re-)extract chunks for nothing. They stay queued for next cycle.
+            if (isCircuitBreakerBlocking()) {
+                console.warn(`🚫 [Qdrant-Worker] Circuit breaker opened mid-batch — aborting remaining ${taskIds.length - taskIds.indexOf(taskId) - 1} task(s) this cycle.`);
+                break;
+            }
         }
     }, ANTI_LEAK_CONFIG.MAX_BACKGROUND_INTERVAL);
 
@@ -947,6 +971,17 @@ export async function indexTaskInQdrant(taskId: string, state: ServerState): Pro
     } catch (error: any) {
         if (error.message && error.message.includes('not found in any storage location')) {
             console.warn(`[WARN] Task ${taskId} is in cache but not on disk. Skipping indexing.`);
+        } else if (error?.code === GenericErrorCode.CIRCUIT_BREAKER_OPEN) {
+            // #2165: The circuit breaker was OPEN (or Qdrant was unreachable during
+            // pre-flight dedup) — indexTask() bailed out BEFORE computing any
+            // embeddings. This is a transient infra condition, NOT a task-level
+            // failure. Do NOT call markIndexingFailure(): that would burn the task's
+            // retry budget and could mark it permanently 'failed' after 3 cycles of
+            // Qdrant being slow, even though the task content is perfectly fine.
+            // Just re-queue it for the next cycle (which itself back-offs while the
+            // breaker is open) — no skeleton write, no retry-counter mutation.
+            state.qdrantIndexQueue.add(taskId);
+            console.warn(`[DEFERRED] Task ${taskId}: ${error.message} — re-queued, retry counter untouched.`);
         } else {
             const skeleton = state.conversationCache.get(taskId);
             if (skeleton) {

--- a/servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts
@@ -20,9 +20,64 @@ const INDEXING_BATCH_SIZE = Math.max(1, parseInt(process.env.INDEXING_BATCH_SIZE
 const MAX_RETRY_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 2000; // 2 seconds
 const CIRCUIT_BREAKER_TIMEOUT_MS = 30000; // 30 seconds
-let circuitBreakerState = 'CLOSED'; // CLOSED | OPEN | HALF_OPEN
+type CircuitBreakerState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
+let circuitBreakerState: CircuitBreakerState = 'CLOSED';
 let failureCount = 0;
 let lastFailureTime = 0;
+
+/**
+ * #2165: Observable circuit-breaker state.
+ *
+ * The Qdrant circuit breaker used to be a silent module-level variable: when it
+ * opened, `safeQdrantUpsert` returned `false` and `indexTask` threw — but nothing
+ * upstream could see *why* writes were failing, nor avoid the expensive embedding
+ * computation that precedes the (doomed) upsert. Under sustained Qdrant latency
+ * this produced the embedding-server hammering described in #2165: chunks were
+ * re-embedded every background cycle even though every upsert was being rejected.
+ *
+ * Exposing the state lets `indexTask` short-circuit BEFORE embedding, and lets
+ * diagnostics surface the breaker instead of guessing.
+ */
+export interface CircuitBreakerSnapshot {
+    state: CircuitBreakerState;
+    failureCount: number;
+    lastFailureTime: number;
+    /** ms remaining before an OPEN breaker is allowed to probe (HALF_OPEN). 0 when not OPEN. */
+    msUntilHalfOpen: number;
+}
+
+export function getCircuitBreakerState(): CircuitBreakerSnapshot {
+    let msUntilHalfOpen = 0;
+    if (circuitBreakerState === 'OPEN') {
+        msUntilHalfOpen = Math.max(0, CIRCUIT_BREAKER_TIMEOUT_MS - (Date.now() - lastFailureTime));
+    }
+    return {
+        state: circuitBreakerState,
+        failureCount,
+        lastFailureTime,
+        msUntilHalfOpen,
+    };
+}
+
+/**
+ * #2165: Returns true when the circuit breaker would reject an upsert right now.
+ * Unlike `canMakeRequest()` (which has the side effect of transitioning OPEN→HALF_OPEN),
+ * this is a pure read used by `indexTask` to decide whether embedding is even worth it.
+ */
+export function isCircuitBreakerBlocking(): boolean {
+    if (circuitBreakerState === 'CLOSED' || circuitBreakerState === 'HALF_OPEN') {
+        return false;
+    }
+    // OPEN — blocking unless the cooldown has elapsed (next call would probe via HALF_OPEN)
+    return (Date.now() - lastFailureTime) <= CIRCUIT_BREAKER_TIMEOUT_MS;
+}
+
+/** #2165: Test-only — reset breaker between unit tests without reimporting the module. */
+export function resetCircuitBreakerForTest(): void {
+    circuitBreakerState = 'CLOSED';
+    failureCount = 0;
+    lastFailureTime = 0;
+}
 
 // 🛡️ CACHE ANTI-FUITE POUR ÉVITER EMBEDDINGS RÉPÉTÉS
 const embeddingCache = new Map<string, { vector: number[], timestamp: number }>();
@@ -454,15 +509,28 @@ async function dedupByContentHash(points: PointStruct[]): Promise<PointStruct[]>
  * concurrent MCPs that write the same chunk_id produce identical points (idempotent upsert).
  * The pre-flight check skips embedding computation entirely for already-indexed chunks.
  */
+interface PreflightDedupResult {
+    /** Sub-chunks that still need embedding + upsert. */
+    subChunks: Array<{ chunk: Chunk; contentHash: string }>;
+    /**
+     * #2165: True only if EVERY batch retrieve succeeded. When false, the dedup
+     * check is unreliable (Qdrant unreachable / slow) and the caller must NOT
+     * blindly embed everything — that is exactly the condition that produced the
+     * embedding-server hammering loop. Callers should back off instead.
+     */
+    qdrantReachable: boolean;
+}
+
 async function preflightDedupByChunkId(
     subChunks: Array<{ chunk: Chunk; contentHash: string }>
-): Promise<Array<{ chunk: Chunk; contentHash: string }>> {
-    if (subChunks.length === 0) return subChunks;
+): Promise<PreflightDedupResult> {
+    if (subChunks.length === 0) return { subChunks, qdrantReachable: true };
 
     try {
         const qdrant = getQdrantClient();
         const chunkIds = subChunks.map(sc => sc.chunk.chunk_id);
         const existingContentHashes = new Map<string, string>(); // chunk_id -> contentHash
+        let allBatchesSucceeded = true;
 
         // Batch retrieve — check which chunk_ids already exist (O(1) per ID)
         const BATCH_SIZE = 100;
@@ -480,16 +548,18 @@ async function preflightDedupByChunkId(
                     if (hash) existingContentHashes.set(point.id as string, hash);
                 }
             } catch (retrieveError: any) {
+                // #2165: A failed retrieve does NOT mean "no existing points" — it means
+                // we don't know. Track it so the caller can back off instead of
+                // re-embedding chunks that are very likely already in Qdrant.
+                allBatchesSucceeded = false;
                 console.warn(`[#2018] Preflight retrieve failed for batch ${i}: ${retrieveError?.message || retrieveError}`);
             }
         }
 
-        if (existingContentHashes.size === 0) return subChunks;
-
         // Filter: skip chunks that exist with same contentHash (unchanged content)
         const newSubChunks = subChunks.filter(sc => {
             const existingHash = existingContentHashes.get(sc.chunk.chunk_id);
-            if (!existingHash) return true; // Doesn't exist — needs indexing
+            if (!existingHash) return true; // Doesn't exist (or unknown) — needs indexing
             return existingHash !== sc.contentHash; // Keep if content changed
         });
 
@@ -498,11 +568,11 @@ async function preflightDedupByChunkId(
             console.log(`[#2018] Preflight dedup: ${skipped}/${subChunks.length} chunks already indexed, computing embeddings for ${newSubChunks.length}`);
         }
 
-        return newSubChunks;
+        return { subChunks: newSubChunks, qdrantReachable: allBatchesSucceeded };
     } catch (error: any) {
-        // Non-fatal: if pre-flight fails, proceed with all chunks (fall through to post-dedup)
-        console.warn(`[#2018] Preflight dedup failed (non-blocking): ${error?.message || error}`);
-        return subChunks;
+        // #2165: Total failure — Qdrant unreachable. Signal it so the caller backs off.
+        console.warn(`[#2018] Preflight dedup failed (Qdrant unreachable): ${error?.message || error}`);
+        return { subChunks, qdrantReachable: false };
     }
 }
 
@@ -516,6 +586,26 @@ export async function indexTask(taskId: string, taskPath: string, source: 'roo' 
     console.log(`Starting granular indexing for task: ${taskId} (source: ${source})`);
 
     try {
+        // #2165: ROOT-CAUSE FIX for embedding-server hammering.
+        // Previously, indexTask() extracted chunks, computed ALL embeddings, THEN
+        // discovered the Qdrant circuit breaker was OPEN and threw. Under sustained
+        // Qdrant latency the breaker stays OPEN, yet every background cycle still
+        // burned GPU embedding chunks whose upsert was guaranteed to be rejected.
+        // Short-circuit here, BEFORE any embedding work, when the breaker is open.
+        if (isCircuitBreakerBlocking()) {
+            const snap = getCircuitBreakerState();
+            console.warn(
+                `🚫 [indexTask] Circuit breaker OPEN — skipping task ${taskId} BEFORE embedding ` +
+                `(failures=${snap.failureCount}, retry in ~${Math.round(snap.msUntilHalfOpen / 1000)}s). ` +
+                `No embeddings computed, no GPU burned.`
+            );
+            throw new GenericError(
+                `Qdrant circuit breaker OPEN — indexing for task ${taskId} deferred (no embeddings computed)`,
+                GenericErrorCode.CIRCUIT_BREAKER_OPEN,
+                { taskId, circuitBreaker: snap, service: 'VectorIndexer.indexTask' }
+            );
+        }
+
         await ensureCollectionExists();
 
         // Dispatch to appropriate chunk extractor based on source
@@ -549,7 +639,28 @@ export async function indexTask(taskId: string, taskPath: string, source: 'roo' 
         }
 
         // Phase B: #2018 Phase 2 — Pre-flight dedup (skip already-indexed chunks BEFORE embeddings)
-        const subChunksToEmbed = await preflightDedupByChunkId(allSubChunks);
+        const preflight = await preflightDedupByChunkId(allSubChunks);
+        const subChunksToEmbed = preflight.subChunks;
+
+        // #2165: If the pre-flight dedup could not reach Qdrant, the "needs embedding"
+        // set is unreliable — it most likely contains chunks already indexed. Embedding
+        // them would (a) hammer the embedding server and (b) fail at upsert anyway since
+        // Qdrant is unreachable. Back off instead. This is the second half of the
+        // root-cause fix: the dedup query failing silently was letting 100% of chunks
+        // through to embedding under exactly the load conditions that caused #2165.
+        if (!preflight.qdrantReachable && subChunksToEmbed.length > 0) {
+            console.warn(
+                `🚫 [indexTask] Pre-flight dedup could not reach Qdrant for task ${taskId} — ` +
+                `deferring ${subChunksToEmbed.length} chunk embeddings to avoid re-embedding ` +
+                `already-indexed content. No GPU burned.`
+            );
+            recordFailure();
+            throw new GenericError(
+                `Qdrant unreachable during pre-flight dedup for task ${taskId} — indexing deferred (no embeddings computed)`,
+                GenericErrorCode.CIRCUIT_BREAKER_OPEN,
+                { taskId, chunksDeferred: subChunksToEmbed.length, service: 'VectorIndexer.indexTask' }
+            );
+        }
 
         // Phase C: Compute embeddings only for new/changed chunks
         let pointsToIndex: PointStruct[] = [];
@@ -595,9 +706,15 @@ export async function indexTask(taskId: string, taskPath: string, source: 'roo' 
                     continue;
                 }
 
+                // #2165: A wrong-dimension vector used to be only warned about, then
+                // pushed into pointsToIndex anyway — where validateVectorGlobal() throws
+                // *inside* safeQdrantUpsert's sanitize map, aborting the whole batch and
+                // tripping recordFailure(). One bad chunk poisoned every other chunk in
+                // the task and helped keep the circuit breaker open. Skip it, and do NOT
+                // cache it (caching a bad vector would make it permanently un-indexable).
                 if (vector.length !== expectedDims) {
-                    console.warn(`⚠️ [indexTask] Dimension inattendue: ${vector.length} (attendu: ${expectedDims}) pour chunk ${subChunk.chunk_id}`);
-                    console.warn(`⚠️ [indexTask] Modèle utilisé: ${embeddingModel}`);
+                    console.warn(`⚠️ [indexTask] Dimension inattendue: ${vector.length} (attendu: ${expectedDims}) pour chunk ${subChunk.chunk_id} — chunk ignoré (modèle: ${embeddingModel})`);
+                    continue;
                 }
 
                 embeddingCache.set(contentHash, { vector, timestamp: now });

--- a/servers/roo-state-manager/src/services/task-indexer/__tests__/VectorIndexer.test.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/__tests__/VectorIndexer.test.ts
@@ -505,13 +505,14 @@ describe('VectorIndexer', () => {
 			expect(mockUpsert).toHaveBeenCalled();
 		});
 
-		test('falls through gracefully on retrieve failure', async () => {
+		test('#2165: backs off WITHOUT embedding when pre-flight dedup cannot reach Qdrant', async () => {
 			vi.useRealTimers();
-			const { indexTask } = await import('../VectorIndexer.js');
+			const { indexTask, resetCircuitBreakerForTest } = await import('../VectorIndexer.js');
 			const { extractChunksFromTask } = await import('../ChunkExtractor.js');
 			const { splitChunk } = await import('../ChunkExtractor.js');
 			const expectedCollection = process.env.QDRANT_COLLECTION_NAME || 'roo_tasks_semantic_index';
 
+			resetCircuitBreakerForTest();
 			setupEmbeddingMock();
 
 			(extractChunksFromTask as any).mockResolvedValue([{
@@ -523,13 +524,105 @@ describe('VectorIndexer', () => {
 
 			mockGetCollections.mockResolvedValue({ collections: [{ name: expectedCollection }] });
 
-			// Qdrant retrieve throws
+			// Qdrant retrieve throws — pre-flight dedup cannot determine what is already indexed.
 			mockRetrieve.mockRejectedValue(new Error('Network timeout'));
 
-			const result = await indexTask('task-fail-1', '/fake/path');
+			// #2165: Previously this fell through and re-embedded everything (the hammering bug).
+			// Now it must throw a CIRCUIT_BREAKER_OPEN error and burn ZERO embeddings.
+			await expect(indexTask('task-fail-1', '/fake/path')).rejects.toMatchObject({
+				code: 'CIRCUIT_BREAKER_OPEN'
+			});
 
-			// Should proceed with embedding + upsert (fallback path)
-			expect(mockUpsert).toHaveBeenCalled();
+			// The whole point of the fix: no embedding API call, no upsert.
+			expect(mockEmbeddingsCreate).not.toHaveBeenCalled();
+			expect(mockUpsert).not.toHaveBeenCalled();
 		});
+	});
+
+	// ============================================================
+	// #2165 — Circuit breaker observability + pre-embedding short-circuit
+	// ============================================================
+
+	describe('#2165: circuit breaker observability', () => {
+		test('getCircuitBreakerState exposes a readable snapshot', async () => {
+			const { getCircuitBreakerState, resetCircuitBreakerForTest } = await import('../VectorIndexer.js');
+			resetCircuitBreakerForTest();
+
+			const snap = getCircuitBreakerState();
+			expect(snap.state).toBe('CLOSED');
+			expect(snap.failureCount).toBe(0);
+			expect(snap.msUntilHalfOpen).toBe(0);
+		});
+
+		test('isCircuitBreakerBlocking is false when CLOSED', async () => {
+			const { isCircuitBreakerBlocking, resetCircuitBreakerForTest } = await import('../VectorIndexer.js');
+			resetCircuitBreakerForTest();
+			expect(isCircuitBreakerBlocking()).toBe(false);
+		});
+
+		test('breaker opens after repeated upsert failures and then blocks', async () => {
+			vi.useRealTimers();
+			vi.resetModules();
+			const { safeQdrantUpsert, isCircuitBreakerBlocking, getCircuitBreakerState, resetCircuitBreakerForTest } =
+				await import('../VectorIndexer.js');
+			resetCircuitBreakerForTest();
+
+			const networkError = Object.assign(new Error('ECONNREFUSED'), {
+				response: { status: 503, statusText: 'Service Unavailable', data: {} }
+			});
+			mockUpsert.mockRejectedValue(networkError);
+
+			const points = [{ id: 'cb-test-1', vector: new Array(1536).fill(0.1), payload: { task_id: 't1' } }];
+
+			// 3 failed attempts trip the breaker (MAX_RETRY_ATTEMPTS)
+			await safeQdrantUpsert(points);
+			await safeQdrantUpsert(points);
+			await safeQdrantUpsert(points);
+
+			const snap = getCircuitBreakerState();
+			expect(snap.state).toBe('OPEN');
+			expect(isCircuitBreakerBlocking()).toBe(true);
+			expect(snap.msUntilHalfOpen).toBeGreaterThan(0);
+		}, 30000);
+
+		test('#2165: indexTask short-circuits BEFORE embedding when breaker is OPEN', async () => {
+			vi.useRealTimers();
+			vi.resetModules();
+			const { indexTask, safeQdrantUpsert, resetCircuitBreakerForTest } = await import('../VectorIndexer.js');
+			const { extractChunksFromTask, splitChunk } = await import('../ChunkExtractor.js');
+			const expectedCollection = process.env.QDRANT_COLLECTION_NAME || 'roo_tasks_semantic_index';
+
+			resetCircuitBreakerForTest();
+			setupEmbeddingMock();
+			mockGetCollections.mockResolvedValue({ collections: [{ name: expectedCollection }] });
+
+			// Trip the breaker via 3 failed upserts.
+			const netErr = Object.assign(new Error('ECONNREFUSED'), {
+				response: { status: 503, statusText: 'Service Unavailable', data: {} }
+			});
+			mockUpsert.mockRejectedValue(netErr);
+			const pts = [{ id: 'cb-x', vector: new Array(1536).fill(0.1), payload: { task_id: 'tx' } }];
+			await safeQdrantUpsert(pts);
+			await safeQdrantUpsert(pts);
+			await safeQdrantUpsert(pts);
+
+			// Now the breaker is OPEN. indexTask must NOT extract/embed anything.
+			mockEmbeddingsCreate.mockClear();
+			(extractChunksFromTask as any).mockResolvedValue([{
+				chunk_id: 'c1', content: 'should never be embedded', indexed: true,
+				sequence_order: 0, chunk_type: 'message_exchange', role: 'user',
+				total_chunks: 1, chunk_index: 0
+			}]);
+			(splitChunk as any).mockImplementation((c: any) => [c]);
+
+			await expect(indexTask('task-breaker-open', '/fake/path')).rejects.toMatchObject({
+				code: 'CIRCUIT_BREAKER_OPEN'
+			});
+
+			// Zero GPU burned — this is the core #2165 fix.
+			expect(mockEmbeddingsCreate).not.toHaveBeenCalled();
+			// And it bailed before even touching the chunk extractor.
+			expect(extractChunksFromTask).not.toHaveBeenCalled();
+		}, 30000);
 	});
 });

--- a/servers/roo-state-manager/src/types/errors.ts
+++ b/servers/roo-state-manager/src/types/errors.ts
@@ -207,7 +207,11 @@ export enum GenericErrorCode {
   NETWORK_ERROR = 'NETWORK_ERROR',
   PERMISSION_DENIED = 'PERMISSION_DENIED',
   TIMEOUT = 'TIMEOUT',
-  INVALID_ARGUMENT = 'INVALID_ARGUMENT'
+  INVALID_ARGUMENT = 'INVALID_ARGUMENT',
+  // #2165: Qdrant circuit breaker is OPEN — indexing was skipped *before* any
+  // embedding was computed. This is a transient back-off signal, NOT a task-level
+  // failure: the caller must retry later with backoff, not mark the task failed.
+  CIRCUIT_BREAKER_OPEN = 'CIRCUIT_BREAKER_OPEN'
 }
 
 /**

--- a/servers/roo-state-manager/tests/unit/services/task-indexer/VectorIndexer.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/task-indexer/VectorIndexer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { indexTask, safeQdrantUpsert, QdrantRateLimiter, qdrantRateLimiter, cleanupOldVectors } from '../../../../src/services/task-indexer/VectorIndexer.js';
+import { indexTask, safeQdrantUpsert, QdrantRateLimiter, qdrantRateLimiter, cleanupOldVectors, resetCircuitBreakerForTest } from '../../../../src/services/task-indexer/VectorIndexer.js';
 import { getQdrantClient } from '../../../../src/services/qdrant.js';
 import getOpenAIClient from '../../../../src/services/openai.js';
 import { extractChunksFromTask, splitChunk } from '../../../../src/services/task-indexer/ChunkExtractor.js';
@@ -33,13 +33,23 @@ describe('VectorIndexer', () => {
   let mockOpenAIClient: any;
 
   beforeEach(() => {
+    // #2165: The circuit breaker is module-level state shared across this file's
+    // tests. `safeQdrantUpsert` failure tests trip it OPEN; without an explicit
+    // reset it leaks into the indexTask tests (which then short-circuit before
+    // doing anything). Reset it before every test.
+    resetCircuitBreakerForTest();
+
     mockQdrantClient = {
       getCollections: vi.fn(),
       createCollection: vi.fn(),
       upsert: vi.fn(),
       count: vi.fn(),
       scroll: vi.fn(),
-      delete: vi.fn()
+      delete: vi.fn(),
+      // #2165: preflightDedupByChunkId() calls qdrant.retrieve(). Without it the
+      // mock throws "retrieve is not a function", which the new code correctly
+      // treats as "Qdrant unreachable" and defers. Default: nothing pre-indexed.
+      retrieve: vi.fn().mockResolvedValue([])
     };
     vi.mocked(getQdrantClient).mockReturnValue(mockQdrantClient);
 
@@ -129,7 +139,10 @@ describe('VectorIndexer', () => {
       vi.mocked(extractChunksFromTask).mockResolvedValue(chunks as any);
       vi.mocked(splitChunk).mockReturnValue(subChunks as any);
       mockQdrantClient.getCollections.mockResolvedValue({ collections: [{ name: 'roo_tasks_semantic_index' }] });
-      mockOpenAIClient.embeddings.create.mockResolvedValue({ data: [{ embedding: [0.1] }] });
+      // #2165: must be a full-dimension (1536) vector — indexTask now skips
+      // wrong-dimension embeddings instead of pushing a poison vector that aborts
+      // the whole batch inside safeQdrantUpsert's validation.
+      mockOpenAIClient.embeddings.create.mockResolvedValue({ data: [{ embedding: new Array(1536).fill(0.1) }] });
       mockQdrantClient.upsert.mockResolvedValue({});
 
       const result = await indexTask(taskId, taskPath);


### PR DESCRIPTION
## Problem (#2165)

The embeddings vLLM server (`embeddings.myia.io`) was pinned at GPU 100%, VRAM 98%, 87°C, 8s latency. A 60s proxy capture by po-2026 found:

- **100% of embedding traffic = VectorIndexer** (`encoding_format=base64`), ~141 emb/s continuous
- **~30% of embeddings are exact duplicates** (same content re-embedded in a loop)
- **0 new points** landing in `roo_tasks_semantic_index` despite the constant traffic

This persisted *despite* #2018's preflight dedup + deterministic chunk_ids. Something was bypassing the dedup and re-running the indexer in a loop.

## Root cause — three compounding bugs

### 1. `indexTask()` embedded everything *before* checking the circuit breaker
`VectorIndexer.ts indexTask()` extracted chunks → computed **all** embeddings → **then** called `safeQdrantUpsert()`, which returns `false` when the circuit breaker is `OPEN`, causing `indexTask` to throw. Under sustained Qdrant latency the breaker stays `OPEN`, so every background cycle burned GPU on embeddings whose upsert was guaranteed to be rejected.

### 2. `preflightDedupByChunkId()` silently became a no-op under load
Added in `4ecf082b` (#2018). It swallowed `qdrant.retrieve()` errors and, when `existingContentHashes.size === 0`, returned all sub-chunks unchanged — **unable to distinguish "nothing indexed yet" from "Qdrant unreachable."** Under the exact 8s-latency conditions that caused #2165, the dedup query failed silently → 100% of chunks fell through to embedding → the 30% duplicates. The dedup that was meant to prevent re-embedding stopped working precisely when it was needed.

### 3. The circuit breaker was invisible
A silent module-level variable. Nothing upstream could observe it or back off — the background worker drained the queue task-by-task, each re-extracting + re-embedding for nothing. **Bonus:** a wrong-dimension embedding was only `console.warn`'d then pushed anyway, where `validateVectorGlobal()` throws inside `safeQdrantUpsert`'s sanitize `.map()`, aborting the whole batch and tripping `recordFailure()` — one bad chunk poisoned the entire task.

**The loop:** Qdrant slow → preflight `retrieve` fails silently → all chunks re-embedded → upsert fails → breaker opens → task marked `retry` → re-queued by the 2-min skeleton worker → repeat, recomputing embeddings every cycle.

## Fix (surgical)

| File | Change |
|------|--------|
| `VectorIndexer.ts` | Export `getCircuitBreakerState()` / `isCircuitBreakerBlocking()` / `resetCircuitBreakerForTest()` — breaker is now **observable**. |
| `VectorIndexer.ts` | `indexTask()` short-circuits at the **top** (before extraction/embedding) when the breaker is OPEN, throwing typed `GenericErrorCode.CIRCUIT_BREAKER_OPEN`. **Zero GPU burned.** |
| `VectorIndexer.ts` | `preflightDedupByChunkId()` now returns `{ subChunks, qdrantReachable }`. When the retrieve query failed, `indexTask()` **defers** instead of embedding everything. |
| `VectorIndexer.ts` | Wrong-dimension embeddings are skipped (`continue`) and **not cached**, instead of poisoning the batch. |
| `background-services.ts` | The Qdrant indexing worker **skips the entire cycle** when the breaker is OPEN (queue left intact), and aborts the rest of a batch if the breaker opens mid-batch. |
| `background-services.ts` | `indexTaskInQdrant()` treats `CIRCUIT_BREAKER_OPEN` as transient infra — **re-queues without `markIndexingFailure()`**, so slow Qdrant no longer burns a task's retry budget or marks healthy tasks permanently `failed`. |
| `errors.ts` | New `GenericErrorCode.CIRCUIT_BREAKER_OPEN`. |

### Before / after

- **Before:** breaker open → embed everything → upsert rejected → re-queue → repeat. Embedder hammered continuously.
- **After:** breaker open → `indexTask` bails before embedding → worker skips cycle → task re-queued untouched → **embedder idle until Qdrant recovers.**

## Tests

- **5 new tests** in `src/services/task-indexer/__tests__/VectorIndexer.test.ts`: breaker observability, the pre-embedding short-circuit, and the no-GPU-burned guarantee when Qdrant is unreachable (asserts `mockEmbeddingsCreate` / `extractChunksFromTask` are **never called**).
- Updated `tests/unit/services/task-indexer/VectorIndexer.test.ts`: reset breaker per-test (shared module state was leaking), add `retrieve()` to the Qdrant mock, use full-dimension embedding vectors.
- **Full CI suite: 9550 passed, 0 failed, 23 skipped.** `npm run build` clean.

Refs #2165, #1987, #2018

🤖 Generated with [Claude Code](https://claude.com/claude-code)
