### PR TITLE
perf(#2121): reduce MAX_BACKUPS 3→1 to cut GDrive sync ops

### DIFF
--- a/servers/roo-state-manager/src/services/roosync/FileLockManager.simple.ts
+++ b/servers/roo-state-manager/src/services/roosync/FileLockManager.simple.ts
@@ -12,8 +12,8 @@ import { promises as fs } from 'fs';
 import { join } from 'path';
 import { StateManagerError } from '../../types/errors.js';
 
-/** Maximum number of backup files to keep (.bak-1, .bak-2, .bak-3) */
-const MAX_BACKUPS = 3;
+/** Maximum number of backup files to keep (.bak-1) */
+const MAX_BACKUPS = 1;
 
 /**
  * Options de verrouillage
@@ -253,7 +253,7 @@ export class FileLockManager {
   }
 
   /**
-   * Rotate backup files before a write (.bak-3 <- .bak-2 <- .bak-1 <- current)
+   * Rotate backup files before a write (.bak-1 <- current)
    *
    * @param filePath - Chemin du fichier original
    */
@@ -268,7 +268,7 @@ export class FileLockManager {
       }
     }
 
-    // Shift backups: .bak-(N-1) -> .bak-N, ..., .bak-1 -> .bak-2
+    // Shift backups: only when MAX_BACKUPS > 1
     for (let i = MAX_BACKUPS - 1; i >= 1; i--) {
       const src = `${filePath}.bak-${i}`;
       const dest = `${filePath}.bak-${i + 1}`;
@@ -310,7 +310,7 @@ export class FileLockManager {
       console.warn(`[FileLockManager] Corrupt JSON in ${filePath}: ${error.message}, trying backups`);
     }
 
-    // Try backups in order: .bak-1, .bak-2, .bak-3
+    // Try backups in order: .bak-1
     for (let i = 1; i <= MAX_BACKUPS; i++) {
       const backupPath = `${filePath}.bak-${i}`;
       try {

--- a/servers/roo-state-manager/src/services/roosync/__tests__/FileLockManager.simple.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/FileLockManager.simple.test.ts
@@ -356,7 +356,7 @@ describe('FileLockManager', () => {
 			expect(mockCopyFile).toHaveBeenCalledWith('/test/f.json', '/test/f.json.bak-1');
 		});
 
-		test('rotates .bak-1 -> .bak-2 on second write', async () => {
+		test('replaces .bak-1 on subsequent write', async () => {
 			mockWriteFile.mockResolvedValue(undefined);
 			mockUnlink.mockResolvedValue(undefined);
 			mockCopyFile.mockResolvedValue(undefined);
@@ -366,22 +366,12 @@ describe('FileLockManager', () => {
 			const manager = FileLockManager.getInstance();
 			await manager.updateJsonWithLock('/test/f.json', (d) => ({ v: (d?.v ?? 0) + 1 }));
 
-			expect(mockRename).toHaveBeenCalledWith('/test/f.json.bak-1', '/test/f.json.bak-2');
+			// With MAX_BACKUPS=1, old .bak-1 is deleted then recreated
+			expect(mockUnlink).toHaveBeenCalledWith('/test/f.json.bak-1');
+			expect(mockCopyFile).toHaveBeenCalledWith('/test/f.json', '/test/f.json.bak-1');
 		});
 
-		test('deletes oldest .bak-3 when max backups reached', async () => {
-			mockWriteFile.mockResolvedValue(undefined);
-			mockUnlink.mockResolvedValue(undefined);
-			mockCopyFile.mockResolvedValue(undefined);
-			mockRename.mockResolvedValue(undefined);
-			mockReadFile.mockResolvedValue(JSON.stringify({ v: 3 }));
-
-			const manager = FileLockManager.getInstance();
-			await manager.updateJsonWithLock('/test/f.json', (d) => ({ v: (d?.v ?? 0) + 1 }));
-
-			expect(mockUnlink).toHaveBeenCalledWith('/test/f.json.bak-3');
-			expect(mockRename).toHaveBeenCalledWith('/test/f.json.bak-2', '/test/f.json.bak-3');
-		});
+		
 
 		test('falls back to .bak-1 when main file is corrupt', async () => {
 			mockWriteFile.mockResolvedValue(undefined);
@@ -402,15 +392,13 @@ describe('FileLockManager', () => {
 			expect(result.data).toEqual({ recovered: true });
 		});
 
-		test('cascades fallback through .bak-1 -> .bak-2 -> .bak-3', async () => {
+		test('falls back to .bak-1 when main file is corrupt', async () => {
 			mockWriteFile.mockResolvedValue(undefined);
 			mockUnlink.mockResolvedValue(undefined);
 			mockCopyFile.mockResolvedValue(undefined);
 			mockRename.mockResolvedValue(undefined);
 			mockReadFile
 				.mockResolvedValueOnce('bad')
-				.mockResolvedValueOnce('also-bad')
-				.mockResolvedValueOnce('still-bad')
 				.mockResolvedValueOnce(JSON.stringify({ last: true }));
 
 			const manager = FileLockManager.getInstance();


### PR DESCRIPTION
## Summary
- Reduce `MAX_BACKUPS` from 3 to 1 in `FileLockManager.simple.ts`
- Each dashboard write previously triggered delete/rename/copy of `.bak-1/2/3` files (5 GDrive sync ops per write)
- With `MAX_BACKUPS=1`, only `.bak-1` is managed — 2 fewer file ops per write (~40% reduction)
- Updated comments and adapted unit tests (removed cascade .bak-2/.bak-3 tests)

## Test plan
- [x] Build passes (`npm run build`)
- [x] CI tests pass: 9549 passed, 0 failed (`vitest.config.ci.ts`)
- [ ] Verify no regression in dashboard write reliability on one machine before fleet deploy

Refs: jsboige/roo-extensions#2121

🤖 Generated with [Claude Code](https://claude.com/claude-code)