### PR TITLE
feat(#2195): emit [EMB-METRICS] periodic log at every indexing cycle

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/background-services.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/background-services.test.ts
@@ -692,6 +692,39 @@ describe('background-services', () => {
       // Queue should be empty
       expect(state.qdrantIndexQueue.size).toBe(0);
     });
+
+    // #2195: Acceptance criterion #2 — per-cycle [EMB-METRICS] log emission
+    it('should log [EMB-METRICS] snapshot at every interval (including empty/disabled cycles)', async () => {
+      const state = createMockState();
+      // Disabled + empty queue: log must STILL fire (observability stays live when nothing happens)
+      state.isQdrantIndexingEnabled = false;
+
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      startQdrantIndexingBackgroundProcess(state);
+
+      // Advance one cycle
+      vi.advanceTimersByTime(ANTI_LEAK_CONFIG.MAX_BACKGROUND_INTERVAL);
+      await vi.runOnlyPendingTimersAsync();
+
+      const metricsLogs = logSpy.mock.calls
+        .map(call => String(call[0] ?? ''))
+        .filter(s => s.startsWith('[EMB-METRICS]'));
+
+      expect(metricsLogs.length).toBeGreaterThanOrEqual(1);
+
+      // Format spec from issue #2195: called=N cached=N preflight_skipped=N post_skipped=N
+      // breaker_blocked=N preflight_fail=N
+      const line = metricsLogs[0];
+      expect(line).toMatch(/called=\d+/);
+      expect(line).toMatch(/cached=\d+/);
+      expect(line).toMatch(/preflight_skipped=\d+/);
+      expect(line).toMatch(/post_skipped=\d+/);
+      expect(line).toMatch(/breaker_blocked=\d+/);
+      expect(line).toMatch(/preflight_fail=\d+/);
+
+      logSpy.mockRestore();
+    });
   });
 
   describe('indexTaskInQdrant', () => {

--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -13,7 +13,7 @@ import { RooStorageDetector } from '../utils/roo-storage-detector.js';
 import { ServerState } from './state-manager.service.js';
 import { ANTI_LEAK_CONFIG } from '../config/server-config.js';
 import { TaskIndexer, getHostIdentifier } from './task-indexer.js';
-import { getCircuitBreakerState, isCircuitBreakerBlocking } from './task-indexer/VectorIndexer.js';
+import { getCircuitBreakerState, isCircuitBreakerBlocking, getEmbeddingMetrics } from './task-indexer/VectorIndexer.js';
 import { SkeletonCacheService } from './skeleton-cache.service.js';
 // REMOVED: import * as toolExports — was unused, added 6s to startup by importing ALL tools
 import { RooStorageDetectorError, RooStorageDetectorErrorCode, GenericErrorCode } from '../types/errors.js';
@@ -871,6 +871,19 @@ export function startQdrantIndexingBackgroundProcess(state: ServerState): void {
     }
 
     state.qdrantIndexInterval = setInterval(async () => {
+        // #2195: Emit per-cycle embedding metrics snapshot at every interval (including
+        // empty/blocked cycles) so observability stays live even when no indexing happens.
+        // Counts are cumulative since MCP boot; rates are derived by subtracting two snapshots.
+        const m = getEmbeddingMetrics();
+        console.log(
+            `[EMB-METRICS] called=${m.embeddings_called_total} ` +
+            `cached=${m.embeddings_cached_hit_total} ` +
+            `preflight_skipped=${m.embeddings_preflight_skipped_total} ` +
+            `post_skipped=${m.embeddings_post_dedup_skipped_total} ` +
+            `breaker_blocked=${m.embeddings_circuit_breaker_blocked_total} ` +
+            `preflight_fail=${m.preflight_batches_qdrant_unreachable_total}`
+        );
+
         if (!state.isQdrantIndexingEnabled || state.qdrantIndexQueue.size === 0) {
             return;
         }


### PR DESCRIPTION
## Context

Follow-up to PR #428 (merged 2026-05-15T12:08:14Z), which landed the `EmbeddingMetrics` instrumentation infrastructure for issue [#2195](https://github.com/jsboige/roo-extensions/issues/2195) (per-cycle embedding metrics observability).

**PR #428 delivered:**
- `EmbeddingMetrics` interface (11 counters) in `VectorIndexer.ts`
- `getEmbeddingMetrics()` getter + `resetEmbeddingMetricsForTest()`
- Counter increments wired into all 6 anti-hammering barriers (10 increment sites)
- `roosync_diagnose` extension exposing metrics snapshot
- 5 unit tests in `embedding-metrics.test.ts`

**What was missing:** Acceptance criterion #2 from issue #2195 — *"À chaque cycle d'indexation Qdrant en arrière-plan, émettre une ligne de log compacte"*. No `[EMB-METRICS]` string existed anywhere in `src/` (verified via grep).

## Change

Surgical addition (+47 / -1, 2 files) — emit `[EMB-METRICS]` snapshot at the top of every interval callback in `startQdrantIndexingBackgroundProcess`, **including empty and disabled cycles**, so observability stays live even when no indexing happens.

```
[EMB-METRICS] called=N cached=N preflight_skipped=N post_skipped=N breaker_blocked=N preflight_fail=N
```

Counts are cumulative since MCP boot; rates are derived by subtracting two snapshots. Format matches the spec in issue #2195 body.

## Files

- `servers/roo-state-manager/src/services/background-services.ts` (+15 / -1)
  - Extended import on line 16 to include `getEmbeddingMetrics`
  - Inserted log emission at top of `setInterval` callback (before the disabled/empty early return)
- `servers/roo-state-manager/src/services/__tests__/background-services.test.ts` (+33 / -0)
  - New test: *"should log [EMB-METRICS] snapshot at every interval (including empty/disabled cycles)"*
  - Exercises disabled + empty queue scenario to prove log fires even when nothing else happens
  - Asserts all 6 expected fields are present via regex

## Validation

```
npm run build                                                                          # tsc silent OK
npx vitest run src/services/__tests__/background-services.test.ts --config vitest.config.ci.ts  # 43/43 PASS (was 42 before)
npx vitest run src/services/task-indexer/__tests__/embedding-metrics.test.ts --config vitest.config.ci.ts  # 5/5 PASS (no regression)
```

## Surgical scope (#1936 compliance)

- No changes to existing counter increment paths (PR #428 wiring untouched)
- No changes to `roosync_diagnose` extension
- No changes to anti-hammering barrier logic
- Only: missing log emission + 1 test

## Issue #2195 acceptance criteria status after this PR

- [x] **Criterion #1** — metrics counters wired into all anti-hammering barriers (PR #428)
- [x] **Criterion #2** — periodic `[EMB-METRICS]` log emitted at every cycle (this PR)
- [x] **Criterion #3** — `roosync_diagnose` exposes metrics snapshot (PR #428)
- [ ] **Criterion #4** — 7-day post-merge dashboard check that rates are non-zero in production (remains by design, requires real fleet traffic)

## Risk

Minimal. Single `console.log` per 5-min interval (`MAX_BACKGROUND_INTERVAL`). Counters are getters — no allocation, no I/O. Disabled cycle path now emits +1 log line every 5 min, which is intentional (observability requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
