### PR TITLE
fix(#2209): reset indexingState on collection reset

### DIFF
--- a/servers/roo-state-manager/src/tools/indexing/__tests__/reset-collection.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/indexing/__tests__/reset-collection.tool.test.ts
@@ -200,4 +200,67 @@ describe('resetQdrantCollectionTool', () => {
 		expect(parsed.message).toContain('Confirmation requise');
 		expect(mockResetCollection).not.toHaveBeenCalled();
 	});
+
+	// #2209: indexingState must also be reset (not just legacy qdrantIndexedAt)
+	test('handler resets modern indexingState (#2209)', async () => {
+		mockResetCollection.mockResolvedValue(undefined);
+
+		const skeleton = {
+			metadata: {
+				indexingState: {
+					indexStatus: 'success',
+					lastIndexedAt: '2026-05-04T17:33:10Z',
+					nextReindexAfter: '2026-05-11T17:33:10Z',
+					indexVersion: '1.0',
+					indexRetryCount: 0,
+				},
+			},
+		};
+		const cache = new Map<string, any>();
+		cache.set('task-modern', skeleton);
+
+		const saveCallback = vi.fn().mockResolvedValue(undefined);
+		const indexQueue = new Set<string>();
+
+		await resetQdrantCollectionTool.handler(
+			{ confirm: true },
+			cache,
+			saveCallback,
+			indexQueue,
+			vi.fn()
+		);
+
+		expect(saveCallback).toHaveBeenCalledWith(skeleton);
+		expect(skeleton.metadata.indexingState).toEqual({ indexVersion: '1.0' });
+		expect(indexQueue.has('task-modern')).toBe(true);
+	});
+
+	test('handler resets both legacy and modern indexing state', async () => {
+		mockResetCollection.mockResolvedValue(undefined);
+
+		const skeleton = {
+			metadata: {
+				qdrantIndexedAt: '2026-05-01T00:00:00Z',
+				indexingState: {
+					indexStatus: 'success',
+					lastIndexedAt: '2026-05-04T17:33:10Z',
+					indexVersion: '1.0',
+				},
+			},
+		};
+		const cache = new Map<string, any>();
+		cache.set('task-both', skeleton);
+
+		const saveCallback = vi.fn().mockResolvedValue(undefined);
+		await resetQdrantCollectionTool.handler(
+			{ confirm: true },
+			cache,
+			saveCallback,
+			new Set(),
+			vi.fn()
+		);
+
+		expect(skeleton.metadata.qdrantIndexedAt).toBeUndefined();
+		expect(skeleton.metadata.indexingState).toEqual({ indexVersion: '1.0' });
+	});
 });

--- a/servers/roo-state-manager/src/tools/indexing/reset-collection.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/reset-collection.tool.ts
@@ -61,10 +61,29 @@ export const resetQdrantCollectionTool = {
             await taskIndexer.resetCollection();
             
             // Marquer tous les squelettes comme non-indexés
+            // Fix #2209: Reset BOTH legacy qdrantIndexedAt AND modern indexingState.
+            // Before this fix, only qdrantIndexedAt was cleared — skeletons with
+            // indexingState.indexStatus='success' and nextReindexAfter in the future
+            // were skipped by shouldIndex(), preventing re-indexation after a reset.
             let skeletonsReset = 0;
             for (const [taskId, skeleton] of conversationCache.entries()) {
+                let modified = false;
+
+                // Reset legacy field
                 if (skeleton.metadata.qdrantIndexedAt) {
                     delete skeleton.metadata.qdrantIndexedAt;
+                    modified = true;
+                }
+
+                // Reset modern indexingState (keeps indexVersion only)
+                if (skeleton.metadata.indexingState) {
+                    skeleton.metadata.indexingState = {
+                        indexVersion: skeleton.metadata.indexingState.indexVersion,
+                    };
+                    modified = true;
+                }
+
+                if (modified) {
                     await saveSkeletonCallback(skeleton);
                     skeletonsReset++;
                 }


### PR DESCRIPTION
## Summary
- `reset_qdrant_collection` now resets BOTH legacy `qdrantIndexedAt` AND modern `indexingState` on all skeletons
- Previously only `qdrantIndexedAt` was cleared — skeletons with `indexingState.indexStatus='success'` and TTL not expired were skipped by `shouldIndex()` after collection reset
- 2 new tests covering the #2209 fix

## Root Cause
Phase 1bis Qdrant migration (May 9-13) recreated the collection via `reset_qdrant_collection`. The tool deleted `qdrantIndexedAt` from skeletons but left `indexingState` intact. Skeletons that had been indexed before the migration kept their `indexStatus: 'success'` with `nextReindexAfter` days/weeks in the future → `shouldIndex()` skipped them → 0 new points indexed.

## Test plan
- [x] Build passes (`npm run build`)
- [x] 13/13 tests pass in `reset-collection.tool.test.ts` (11 existing + 2 new)
- [ ] Manual verification: run `roosync_indexing(action: "reset", confirm: true)` and confirm skeletons are re-indexed
- [ ] Verify new points appear in `roo_tasks_semantic_index` after reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)