### PR TITLE
fix(#2227): skeleton refresh re-queue loop — use newHeader for indexingState check

### DIFF
--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -465,8 +465,9 @@ export function startSkeletonRefreshWorker(state: ServerState): void {
                                     }
                                     state.conversationCache.set(entry.name, newHeader);
                                     // Queue for Qdrant indexation if lastActivity > lastIndexedAt
-                                    const lastIndexed = skeleton.metadata?.indexingState?.lastIndexedAt;
-                                    if (!lastIndexed || new Date(skeleton.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
+                                    // #2227: Use newHeader (not skeleton) — skeleton doesn't carry indexingState
+                                    const lastIndexed = newHeader.metadata?.indexingState?.lastIndexedAt;
+                                    if (!lastIndexed || new Date(newHeader.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
                                         state.qdrantIndexQueue.add(entry.name);
                                     }
                                     if (existingSkeleton) { updatedCount++; } else { newCount++; }
@@ -520,8 +521,9 @@ export function startSkeletonRefreshWorker(state: ServerState): void {
                                             newHeader.metadata.indexingState = existingSkeleton.metadata.indexingState;
                                         }
                                         state.conversationCache.set(taskId, newHeader);
-                                        const lastIndexed = skeleton.metadata?.indexingState?.lastIndexedAt;
-                                        if (!lastIndexed || new Date(skeleton.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
+                                        // #2227: Use newHeader (not skeleton) — skeleton doesn't carry indexingState
+                                        const lastIndexed = newHeader.metadata?.indexingState?.lastIndexedAt;
+                                        if (!lastIndexed || new Date(newHeader.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
                                             state.qdrantIndexQueue.add(taskId);
                                         }
                                         if (existingSkeleton) { updatedCount++; } else { newCount++; }


### PR DESCRIPTION
## Summary
- Fix infinite embedding traffic (~100 req/min) caused by skeleton refresh worker re-queuing tasks that are already indexed
- Root cause: `skeleton` (from `analyzeConversation()`) doesn't carry `indexingState`, but `newHeader` (with preserved `indexingState` from #1984) does
- Changed 4 references from `skeleton.metadata` to `newHeader.metadata` at L468-470 (Roo tasks) and L523-525 (Claude Code sessions)

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 467 CI test files pass (9566 tests)
- [ ] Deploy to po-2026 and verify embedding traffic drops to normal
- [ ] Verify new tasks still get queued correctly (no under-queue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)