### PR TITLE
fix(#2227): skeleton refresh re-queues all tasks infinitely

### DIFF
--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -465,8 +465,9 @@ export function startSkeletonRefreshWorker(state: ServerState): void {
                                     }
                                     state.conversationCache.set(entry.name, newHeader);
                                     // Queue for Qdrant indexation if lastActivity > lastIndexedAt
-                                    const lastIndexed = skeleton.metadata?.indexingState?.lastIndexedAt;
-                                    if (!lastIndexed || new Date(skeleton.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
+                                    // #2227: use newHeader (has indexingState from existingSkeleton) not skeleton (from analyzeConversation, no indexingState)
+                                    const lastIndexed = newHeader.metadata?.indexingState?.lastIndexedAt;
+                                    if (!lastIndexed || new Date(newHeader.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
                                         state.qdrantIndexQueue.add(entry.name);
                                     }
                                     if (existingSkeleton) { updatedCount++; } else { newCount++; }
@@ -520,8 +521,9 @@ export function startSkeletonRefreshWorker(state: ServerState): void {
                                             newHeader.metadata.indexingState = existingSkeleton.metadata.indexingState;
                                         }
                                         state.conversationCache.set(taskId, newHeader);
-                                        const lastIndexed = skeleton.metadata?.indexingState?.lastIndexedAt;
-                                        if (!lastIndexed || new Date(skeleton.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
+                                        // #2227: use newHeader (has indexingState preserved) not skeleton (no indexingState)
+                                        const lastIndexed = newHeader.metadata?.indexingState?.lastIndexedAt;
+                                        if (!lastIndexed || new Date(newHeader.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
                                             state.qdrantIndexQueue.add(taskId);
                                         }
                                         if (existingSkeleton) { updatedCount++; } else { newCount++; }


### PR DESCRIPTION
## Summary
- Fix infinite embedding traffic caused by skeleton refresh loop re-queuing all modified tasks every cycle
- Root cause: queue check read `indexingState` from `skeleton` (analyzeConversation output, no indexingState) instead of `newHeader` (which has indexingState preserved from existingSkeleton)
- `!lastIndexed` always evaluated to `true` → every active task re-queued → ~100 req/min sustained traffic

## Fix
- Use `newHeader.metadata?.indexingState?.lastIndexedAt` instead of `skeleton.metadata?.indexingState?.lastIndexedAt` at both queue check locations:
  - Line 468: Roo tasks
  - Line 523: Claude Code sessions
- `newHeader` correctly carries `indexingState` from `existingSkeleton` (preserved at lines 462-464 and 518-520)

## Testing
- `npm run build`: clean
- `npx vitest run --config vitest.config.ci.ts`: 9566 passed, 23 skipped, 0 failures

## Impact
- Eliminates ~100 req/min sustained embedding API traffic that never stops
- GPU usage should drop from 100% constant to on-demand only
- Latency should recover from 8+ seconds to normal

Closes #2227 (parent issue in roo-extensions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)