### PR TITLE
fix(indexing): skeleton refresh re-queue uses newHeader for indexingState (#2227)

### DIFF
--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -465,8 +465,9 @@ export function startSkeletonRefreshWorker(state: ServerState): void {
                                     }
                                     state.conversationCache.set(entry.name, newHeader);
                                     // Queue for Qdrant indexation if lastActivity > lastIndexedAt
-                                    const lastIndexed = skeleton.metadata?.indexingState?.lastIndexedAt;
-                                    if (!lastIndexed || new Date(skeleton.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
+                                    // #2227: Use newHeader (has indexingState preserved from existingSkeleton)
+                                    const lastIndexed = newHeader.metadata?.indexingState?.lastIndexedAt;
+                                    if (!lastIndexed || new Date(newHeader.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
                                         state.qdrantIndexQueue.add(entry.name);
                                     }
                                     if (existingSkeleton) { updatedCount++; } else { newCount++; }
@@ -520,8 +521,9 @@ export function startSkeletonRefreshWorker(state: ServerState): void {
                                             newHeader.metadata.indexingState = existingSkeleton.metadata.indexingState;
                                         }
                                         state.conversationCache.set(taskId, newHeader);
-                                        const lastIndexed = skeleton.metadata?.indexingState?.lastIndexedAt;
-                                        if (!lastIndexed || new Date(skeleton.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
+                                        // #2227: Use newHeader (has indexingState preserved from existingSkeleton)
+                                        const lastIndexed = newHeader.metadata?.indexingState?.lastIndexedAt;
+                                        if (!lastIndexed || new Date(newHeader.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
                                             state.qdrantIndexQueue.add(taskId);
                                         }
                                         if (existingSkeleton) { updatedCount++; } else { newCount++; }


### PR DESCRIPTION
## Summary

Fixes infinite embedding traffic caused by skeleton refresh loop re-queuing ALL tasks every cycle.

## Root Cause

In `background-services.ts`, the skeleton refresh queue check at lines 468 and 523 reads `indexingState` from `skeleton` (output of `analyzeConversation()`) which does NOT carry `indexingState`. The `newHeader` variable (line 464/520) correctly preserves `indexingState` from `existingSkeleton`, but was not used in the queue decision.

## Fix

Replace `skeleton.metadata?.indexingState?.lastIndexedAt` with `newHeader.metadata?.indexingState?.lastIndexedAt` at both sites (Roo tasks line 468, Claude Code sessions line 523). Also use `newHeader.metadata.lastActivity` instead of `skeleton.metadata.lastActivity` for the comparison.

## Impact

- **Before:** ~100 req/min sustained embedding traffic, GPU at 100%, 8+ seconds latency
- **After:** Tasks only re-queued when genuinely needing re-indexing (TTL expired or new activity)

## Test plan
- [x] Build passes (`npm run build`)
- [x] CI tests pass (9565/9565, 467 files)
- [ ] Verify embedding traffic drops to baseline after deploy
- [ ] Confirm existing indexed tasks are NOT re-queued on refresh

## Related
- Parent issue: #2227
- Previous fixes: #435 (indexingState reset), #2209 (circuit breaker), #434 (batching)