### PR TITLE
fix(#2227): skeleton refresh uses stale skeleton instead of newHeader for indexingState

### DIFF
--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -465,8 +465,10 @@ export function startSkeletonRefreshWorker(state: ServerState): void {
                                     }
                                     state.conversationCache.set(entry.name, newHeader);
                                     // Queue for Qdrant indexation if lastActivity > lastIndexedAt
-                                    const lastIndexed = skeleton.metadata?.indexingState?.lastIndexedAt;
-                                    if (!lastIndexed || new Date(skeleton.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
+                                    // #2227 FIX: Use newHeader (preserves indexingState from existingSkeleton)
+                                    // skeleton from analyzeConversation() does NOT carry indexingState
+                                    const lastIndexed = newHeader.metadata?.indexingState?.lastIndexedAt;
+                                    if (!lastIndexed || new Date(newHeader.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
                                         state.qdrantIndexQueue.add(entry.name);
                                     }
                                     if (existingSkeleton) { updatedCount++; } else { newCount++; }
@@ -520,8 +522,9 @@ export function startSkeletonRefreshWorker(state: ServerState): void {
                                             newHeader.metadata.indexingState = existingSkeleton.metadata.indexingState;
                                         }
                                         state.conversationCache.set(taskId, newHeader);
-                                        const lastIndexed = skeleton.metadata?.indexingState?.lastIndexedAt;
-                                        if (!lastIndexed || new Date(skeleton.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
+                                        // #2227 FIX: Use newHeader (preserves indexingState)
+                                        const lastIndexed = newHeader.metadata?.indexingState?.lastIndexedAt;
+                                        if (!lastIndexed || new Date(newHeader.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
                                             state.qdrantIndexQueue.add(taskId);
                                         }
                                         if (existingSkeleton) { updatedCount++; } else { newCount++; }


### PR DESCRIPTION
## Summary

Fixes infinite re-queuing in the skeleton refresh worker that caused ~100 req/min sustained embedding traffic.

**Root cause:** Lines 468-469 and 523-524 used `skeleton.metadata?.indexingState?.lastIndexedAt` for the queue check, but `skeleton` comes from `analyzeConversation()` which does NOT carry `indexingState`. The preserved state is in `newHeader` (enriched at lines 462-464 and 518-522 from `existingSkeleton`).

**Impact:**
- ~100 req/min sustained embedding traffic that never stops
- GPU at 100% constantly
- 8.6s latency, 2.6% error rate (4,595 5xx errors)

**Fix:** Replace `skeleton.metadata` with `newHeader.metadata` at both locations. The `newHeader` correctly preserves `indexingState` from `existingSkeleton` (lines 462-464), so the TTL check works as intended.

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 467 passed, 0 failed
- [ ] Deploy and monitor embedding traffic (should drop from ~100 req/min to near-zero for already-indexed tasks)

## Related
- Closes #2227
- Related: #2209 (circuit breaker deadlock — fixed), #435 (reset indexingState — fixed)