### PR TITLE
fix(test): eliminate timing-sensitive boundary test in unified-task

### DIFF
--- a/servers/roo-state-manager/src/__tests__/types/unified-task.test.ts
+++ b/servers/roo-state-manager/src/__tests__/types/unified-task.test.ts
@@ -285,14 +285,15 @@ describe('computeStorageTier', () => {
     expect(computeStorageTier(task)).toBe('cold');
   });
 
-  test('boundary: exactly 7 days = hot', () => {
-    const date = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  test('boundary: just under 7 days = hot', () => {
+    // Use -1ms to avoid microsecond drift between Date.now() calls
+    const date = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000 + 1).toISOString();
     const task = { ...validClaudeTask, lastActivity: date };
     expect(computeStorageTier(task)).toBe('hot');
   });
 
-  test('boundary: exactly 90 days = warm', () => {
-    const date = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+  test('boundary: just under 90 days = warm', () => {
+    const date = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000 + 1).toISOString();
     const task = { ...validClaudeTask, lastActivity: date };
     expect(computeStorageTier(task)).toBe('warm');
   });


### PR DESCRIPTION
## Summary
- Fix flaky test `unified-task.test.ts:291` where boundary tests ("exactly 7 days = hot", "exactly 90 days = warm") could fail due to microsecond drift between `Date.now()` calls
- Root cause: test creates date at `Date.now() - N*ms`, but `computeStorageTier` calls `Date.now()` again microseconds later, pushing age slightly over the `<=` boundary
- Fix: use `Date.now() - N*ms + 1` to create dates just under the boundary, ensuring stable results

## Test plan
- [x] 28 tests pass (including the fixed boundary tests)
- [x] Build passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)