### PR TITLE
feat(#1442): scheduler execution metrics in HeartbeatService + get-status

### DIFF
--- a/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
+++ b/servers/roo-state-manager/src/services/roosync/HeartbeatService.ts
@@ -26,6 +26,16 @@ export interface HeartbeatConfig {
   // Interface kept empty for forward compat with callers that pass config objects.
 }
 
+export interface SchedulerMetrics {
+  totalRuns: number;
+  successCount: number;
+  failureCount: number;
+  lastRunAt?: string;
+  lastRunDurationMs?: number;
+  lastRunStatus?: 'success' | 'failure';
+  lastError?: string;
+}
+
 export interface HeartbeatData {
   machineId: string;
   lastHeartbeat: string;
@@ -33,6 +43,7 @@ export interface HeartbeatData {
   metadata: {
     firstSeen: string;
     lastUpdated: string;
+    scheduler?: SchedulerMetrics;
   };
 }
 
@@ -179,6 +190,75 @@ export class HeartbeatService {
 
     this.updateMachineStatus();
     this.state.statistics.lastHeartbeatCheck = new Date().toISOString();
+    return result;
+  }
+
+  /**
+   * Record a scheduler run outcome for a machine (#1442)
+   *
+   * In-memory only. Called by tools that observe scheduler activity
+   * (e.g. dashboard intercom parsing, inventory collection).
+   */
+  public recordSchedulerRun(
+    machineId: string,
+    outcome: { success: boolean; durationMs?: number; error?: string }
+  ): void {
+    machineId = machineId.toLowerCase();
+    const now = new Date().toISOString();
+
+    let data = this.state.heartbeats.get(machineId);
+    if (!data) {
+      // Auto-register machine if not yet known
+      data = {
+        machineId,
+        lastHeartbeat: now,
+        status: 'online',
+        metadata: { firstSeen: now, lastUpdated: now }
+      };
+      this.state.heartbeats.set(machineId, data);
+      this.updateMachineStatus();
+    }
+
+    const sched: SchedulerMetrics = data.metadata.scheduler ?? {
+      totalRuns: 0,
+      successCount: 0,
+      failureCount: 0
+    };
+
+    sched.totalRuns++;
+    if (outcome.success) {
+      sched.successCount++;
+    } else {
+      sched.failureCount++;
+    }
+    sched.lastRunAt = now;
+    sched.lastRunDurationMs = outcome.durationMs;
+    sched.lastRunStatus = outcome.success ? 'success' : 'failure';
+    sched.lastError = outcome.success ? undefined : outcome.error;
+
+    data.metadata.scheduler = sched;
+    data.metadata.lastUpdated = now;
+    logger.debug(`Scheduler run recorded: ${machineId} → ${outcome.success ? 'ok' : 'fail'}`);
+  }
+
+  /**
+   * Get scheduler metrics for a specific machine (#1442)
+   */
+  public getSchedulerMetrics(machineId: string): SchedulerMetrics | undefined {
+    const data = this.state.heartbeats.get(machineId.toLowerCase());
+    return data?.metadata.scheduler;
+  }
+
+  /**
+   * Get scheduler metrics for all machines (#1442)
+   */
+  public getAllSchedulerMetrics(): Map<string, SchedulerMetrics> {
+    const result = new Map<string, SchedulerMetrics>();
+    for (const [machineId, data] of this.state.heartbeats.entries()) {
+      if (data.metadata.scheduler) {
+        result.set(machineId, data.metadata.scheduler);
+      }
+    }
     return result;
   }
 

--- a/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/HeartbeatService.test.ts
@@ -520,4 +520,106 @@ describe('HeartbeatService', () => {
       expect(offlineCb).toHaveBeenCalledWith('remote-machine');
     });
   });
+
+  // ============================================================
+  // Scheduler Metrics (#1442)
+  // ============================================================
+
+  describe('scheduler metrics (#1442)', () => {
+    test('recordSchedulerRun: premier run sur machine inconnue → auto-register', () => {
+      const service = new HeartbeatService();
+
+      service.recordSchedulerRun('myia-po-2023', { success: true, durationMs: 5000 });
+
+      const metrics = service.getSchedulerMetrics('myia-po-2023');
+      expect(metrics).toBeDefined();
+      expect(metrics!.totalRuns).toBe(1);
+      expect(metrics!.successCount).toBe(1);
+      expect(metrics!.failureCount).toBe(0);
+      expect(metrics!.lastRunStatus).toBe('success');
+      expect(metrics!.lastRunDurationMs).toBe(5000);
+      expect(metrics!.lastError).toBeUndefined();
+    });
+
+    test('recordSchedulerRun: incrémente compteurs sur runs successifs', () => {
+      const service = new HeartbeatService();
+
+      service.recordSchedulerRun('myia-po-2023', { success: true });
+      service.recordSchedulerRun('myia-po-2023', { success: false, error: 'build failed' });
+      service.recordSchedulerRun('myia-po-2023', { success: true, durationMs: 3000 });
+
+      const metrics = service.getSchedulerMetrics('myia-po-2023')!;
+      expect(metrics.totalRuns).toBe(3);
+      expect(metrics.successCount).toBe(2);
+      expect(metrics.failureCount).toBe(1);
+      expect(metrics.lastRunStatus).toBe('success');
+      expect(metrics.lastRunDurationMs).toBe(3000);
+    });
+
+    test('recordSchedulerRun: enregistre dernière erreur en cas d\'échec', () => {
+      const service = new HeartbeatService();
+
+      service.recordSchedulerRun('myia-po-2023', { success: false, error: 'timeout' });
+
+      const metrics = service.getSchedulerMetrics('myia-po-2023')!;
+      expect(metrics.lastRunStatus).toBe('failure');
+      expect(metrics.lastError).toBe('timeout');
+    });
+
+    test('recordSchedulerRun: efface lastError après succès', () => {
+      const service = new HeartbeatService();
+
+      service.recordSchedulerRun('myia-po-2023', { success: false, error: 'crash' });
+      service.recordSchedulerRun('myia-po-2023', { success: true });
+
+      const metrics = service.getSchedulerMetrics('myia-po-2023')!;
+      expect(metrics.lastError).toBeUndefined();
+    });
+
+    test('getSchedulerMetrics: retourne undefined pour machine sans runs', async () => {
+      const service = new HeartbeatService();
+      await service.registerHeartbeat('myia-po-2023');
+
+      expect(service.getSchedulerMetrics('myia-po-2023')).toBeUndefined();
+    });
+
+    test('getAllSchedulerMetrics: retourne map des machines avec metrics', async () => {
+      const service = new HeartbeatService();
+
+      service.recordSchedulerRun('myia-po-2023', { success: true });
+      service.recordSchedulerRun('myia-po-2024', { success: false, error: 'OOM' });
+      await service.registerHeartbeat('myia-po-2025'); // no scheduler runs
+
+      const allMetrics = service.getAllSchedulerMetrics();
+      expect(allMetrics.size).toBe(2);
+      expect(allMetrics.has('myia-po-2023')).toBe(true);
+      expect(allMetrics.has('myia-po-2024')).toBe(true);
+      expect(allMetrics.has('myia-po-2025')).toBe(false);
+    });
+
+    test('recordSchedulerRun: case insensitive machineId', () => {
+      const service = new HeartbeatService();
+
+      service.recordSchedulerRun('MYIA-PO-2023', { success: true });
+
+      expect(service.getSchedulerMetrics('myia-po-2023')!.totalRuns).toBe(1);
+    });
+
+    test('metrics préservées après checkHeartbeats', async () => {
+      const service = new HeartbeatService();
+
+      service.recordSchedulerRun('myia-po-2023', { success: true, durationMs: 1000 });
+
+      // Make heartbeat stale
+      const data = service.getHeartbeatData('myia-po-2023')!;
+      data.lastHeartbeat = new Date(Date.now() - 150 * 60 * 1000).toISOString();
+
+      await service.checkHeartbeats();
+
+      // Metrics should survive status change
+      const metrics = service.getSchedulerMetrics('myia-po-2023')!;
+      expect(metrics.totalRuns).toBe(1);
+      expect(metrics.lastRunDurationMs).toBe(1000);
+    });
+  });
 });

--- a/servers/roo-state-manager/src/tools/roosync/get-status.ts
+++ b/servers/roo-state-manager/src/tools/roosync/get-status.ts
@@ -95,6 +95,17 @@ export const GetStatusResultSchema = z.object({
     }))
   }).describe('Per-tool usage stats for current session').optional(),
 
+  // #1442: Scheduler execution metrics per machine
+  schedulerMetrics: z.record(z.object({
+    totalRuns: z.number(),
+    successCount: z.number(),
+    failureCount: z.number(),
+    lastRunAt: z.string().optional(),
+    lastRunDurationMs: z.number().optional(),
+    lastRunStatus: z.enum(['success', 'failure']).optional(),
+    lastError: z.string().optional()
+  })).describe('Per-machine scheduler execution metrics (#1442)').optional(),
+
   flags: z.array(z.string())
     .describe('Flags actionnables (ex: HEARTBEAT_STALE:myia-po-2025)'),
 
@@ -392,6 +403,20 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
       }
     }
 
+    // #1442: Collect scheduler metrics from heartbeat service
+    const schedulerMetrics: Record<string, any> = {};
+    try {
+      const heartbeatService = service.getHeartbeatService();
+      const allMetrics = heartbeatService.getAllSchedulerMetrics();
+      for (const [mid, metrics] of allMetrics.entries()) {
+        if (isKnownMachine(mid)) {
+          schedulerMetrics[mid] = metrics;
+        }
+      }
+    } catch (err) {
+      logger.debug('Scheduler metrics collection skipped', { error: String(err) });
+    }
+
     const result: any = {
       status,
       machines: {
@@ -403,6 +428,7 @@ export async function roosyncGetStatus(args: GetStatusArgs): Promise<GetStatusRe
       inbox: inboxStats,
       decisions: { pending: pendingDecisions },
       dashboards: { active: activeDashboards },
+      ...(Object.keys(schedulerMetrics).length > 0 ? { schedulerMetrics } : {}),
       flags,
       lastUpdated: now,
       // #1855 HUD: extended data when detail="full"


### PR DESCRIPTION
## Summary

- Extend `HeartbeatService` with per-machine scheduler run tracking (in-memory, ADR 008 compliant)
- New `SchedulerMetrics` interface: `totalRuns`, `successCount`, `failureCount`, `lastRunAt`, `lastRunDurationMs`, `lastRunStatus`, `lastError`
- `recordSchedulerRun(machineId, { success, durationMs?, error? })` — auto-registers unknown machines
- `getSchedulerMetrics(machineId)` / `getAllSchedulerMetrics()` query methods
- Exposed in `roosync_inventory(type="status")` response via `schedulerMetrics` field (only when data exists)
- 8 new unit tests in `HeartbeatService.test.ts`

## Files Changed

| File | Change |
|------|--------|
| `HeartbeatService.ts` | +80 lines: `SchedulerMetrics` type, `recordSchedulerRun()`, `getSchedulerMetrics()`, `getAllSchedulerMetrics()` |
| `HeartbeatService.test.ts` | +102 lines: 8 tests (auto-register, counter accumulation, error tracking, case-insensitive, metrics persistence) |
| `get-status.ts` | +26 lines: Zod schema extension + collection from HeartbeatService |

## Test plan

- [x] Build: `npm run build` — tsc clean, 0 errors
- [x] CI suite: `npx vitest run --config vitest.config.ci.ts` — 468 suites, 9591 passed, 0 failures
- [x] New tests: 8/8 passed (auto-register, counters, error tracking, case-insensitive, persistence after status change)

Closes #1442 (partial — tracking infrastructure; caller integration in subsequent PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)