### PR TITLE
feat(#1442): wire scheduler metrics into dashboard append

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -2237,6 +2237,25 @@ async function handleAppend(
     });
   }
 
+  // #1442: Record scheduler cycle outcome when a worker posts [DONE]/[IDLE]/[BLOCKED]
+  if (args.tags && args.tags.length > 0) {
+    const tagStr = args.tags.join(' ').toUpperCase();
+    const isSchedulerCycle = tagStr.includes('DONE') || tagStr.includes('IDLE') || tagStr.includes('BLOCKED');
+    if (isSchedulerCycle) {
+      const success = tagStr.includes('DONE');
+      const idle = tagStr.includes('IDLE');
+      import('./heartbeat-activity.js').then(({ recordSchedulerRunAsync }) => {
+        recordSchedulerRunAsync(
+          author.machineId,
+          success,
+          {
+            error: idle ? 'idle-cycle' : undefined,
+          }
+        );
+      }).catch(() => { /* non-critical */ });
+    }
+  }
+
   // v3 (#1363) — Structured mentions: resolve each to UserId and notify via RooSync.
   // Fire-and-forget, same robustness pattern as v1.
   const crossPostResults: Array<{ key: string; ok: boolean; error?: string }> = [];

--- a/servers/roo-state-manager/src/tools/roosync/heartbeat-activity.ts
+++ b/servers/roo-state-manager/src/tools/roosync/heartbeat-activity.ts
@@ -73,3 +73,33 @@ export function recordRooSyncActivityAsync(
 		logger.debug(`Activité heartbeat en arrière-plan échouée: ${err.message}`);
 	});
 }
+
+/**
+ * Enregistre le résultat d'une exécution scheduler dans les metrics HeartbeatService (#1442)
+ *
+ * Fire-and-forget. Appelé par les outils qui observent l'activité scheduler
+ * (dashboard parsing, inventory collection, etc.).
+ *
+ * @param machineId Machine qui a exécuté le scheduler
+ * @param success Succès ou échec du run
+ * @param options Options: durationMs, error message
+ */
+export function recordSchedulerRunAsync(
+	machineId: string,
+	success: boolean,
+	options?: { durationMs?: number; error?: string }
+): void {
+	(async () => {
+		try {
+			const service = await getRooSyncService();
+			const heartbeatService = service.getHeartbeatService();
+			heartbeatService.recordSchedulerRun(machineId, {
+				success,
+				durationMs: options?.durationMs,
+				error: options?.error
+			});
+		} catch (err) {
+			logger.debug(`Échec enregistrement scheduler run: ${(err as Error).message}`);
+		}
+	})();
+}


### PR DESCRIPTION
## Summary

Connects the scheduler metrics tracking (from PR #442) to actual data sources:

1. **`heartbeat-activity.ts`**: New `recordSchedulerRunAsync(machineId, success, options?)` — fire-and-forget wrapper around `HeartbeatService.recordSchedulerRun()`. Available for any tool that observes scheduler activity.

2. **`dashboard.ts`**: In `handleAppend`, when a worker posts `[DONE]`, `[IDLE]`, or `[BLOCKED]` tagged messages, automatically records a scheduler run outcome for that machine. This gives `roosync_inventory(type="status")` real scheduler activity data visible across the fleet.

## How it works

Every time an agent posts to the dashboard with tags containing `DONE`/`IDLE`/`BLOCKED`:
- `DONE` → recorded as successful scheduler run
- `IDLE` → recorded as failed run with `error: 'idle-cycle'`
- `BLOCKED` → recorded as failed run

The metrics accumulate in-memory on whichever MCP server instance processes the dashboard append (typically ai-01). All machines calling `roosync_inventory(type="status")` will see the aggregated `schedulerMetrics` field.

## Test plan

- [x] Build: `npm run build` — tsc clean
- [x] CI: 468 suites, 9591 passed, 0 failures
- [ ] Manual: Post a `[DONE]` tagged dashboard message, then check `roosync_inventory(type="status")` for `schedulerMetrics` field

Closes #1442

🤖 Generated with [Claude Code](https://claude.com/claude-code)