### PR TITLE
feat(#603): CONS-8 remove 4 dead tools from tools/list (19→15)

### DIFF
--- a/servers/roo-state-manager/src/tools/__tests__/registry.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/registry.test.ts
@@ -133,7 +133,7 @@ describe('registry.ts - Tool Registration', () => {
         // [REMOVED #291] export_config test removed — tool removed from allToolDefinitions (ListTools)
         // Backward compat redirect preserved in registry.ts for CallTool
 
-        it('should have tools count greater than 15', async () => {
+        it('should have tools count greater than 10', async () => {
             const mockServer = {
                 setRequestHandler: vi.fn()
             } as any;
@@ -142,7 +142,7 @@ describe('registry.ts - Tool Registration', () => {
 
             const handler = mockServer.setRequestHandler.mock.calls[0][1];
             const result = await handler();
-            expect(result.tools.length).toBeGreaterThan(15);
+            expect(result.tools.length).toBeGreaterThan(10);
         });
     });
 

--- a/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
@@ -47,44 +47,28 @@ import {
     roosyncMessagesDefinition
 } from '../tool-definitions.js';
 
-const EXPECTED_TOOL_COUNT = 19; // #1836: 18 → 19 (roosync_claim added)
+const EXPECTED_TOOL_COUNT = 15; // CONS-8 #603: 19 → 15 (removed init, claim, decision, list_diffs)
 
 // Order MUST mirror allToolDefinitions in tool-definitions.ts.
-// #1863: 3 deprecated definitions removed from allToolDefinitions
-// #1935 Cluster D: analyze_roosync_problems removed — fused into roosync_diagnose(action: "analyze")
-// #1935 Cluster E: get_status removed — fused into roosync_inventory(type: "status")
+// CONS-8 #603: 4 dead tools removed from allToolDefinitions (init, claim, decision, list_diffs)
 const allDefinitions = [
     conversationBrowserDefinition,
     roosyncSearchDefinition,
     roosyncIndexingDefinition,
     codebaseSearchDefinition,
     readVscodeLogsDefinition,
-    // [REMOVED #291] getMcpBestPracticesDefinition — removed from allToolDefinitions
     exportDataDefinition,
-    // [REMOVED #291] exportConfigDefinition — removed from allToolDefinitions
-    // [REMOVED #291] viewTaskDetailsDefinition — removed from allToolDefinitions
-    // [REMOVED #291] getRawConversationDefinition — removed from allToolDefinitions
-    // [REMOVED #1935 Cluster D] analyzeRooSyncProblemsDefinition — fused into roosync_diagnose
-    roosyncInitDefinition,
-    // [REMOVED #1935 Cluster E] roosyncGetStatusDefinition — fused into roosync_inventory(type: "status")
+    // [REMOVED CONS-8 #603] roosyncInitDefinition — dead code
     roosyncCompareConfigDefinition,
-    roosyncListDiffsDefinition,
-    roosyncDecisionDefinition,
+    // [REMOVED CONS-8 #603] roosyncListDiffsDefinition — thin wrapper
+    // [REMOVED CONS-8 #603] roosyncDecisionDefinition — pipeline mort
     roosyncBaselineDefinition,
     roosyncConfigDefinition,
     roosyncInventoryDefinition,
-    // #1609: roosyncHeartbeatDefinition removed — auto-heartbeat on any tool call
     roosyncMcpManagementDefinition,
     roosyncStorageManagementDefinition,
     roosyncDiagnoseDefinition,
-    // #1836: roosync_claim added — pre-claim enforcement tool
-    roosyncClaimDefinition,
-    // [REMOVED #291] roosyncRefreshDashboardDefinition — removed from allToolDefinitions
-    // [REMOVED #291] roosyncUpdateDashboardDefinition — removed from allToolDefinitions
-    // [REMOVED #1841 Cluster G] roosyncSendDefinition — fused into roosync_messages
-    // [REMOVED #1841 Cluster G] roosyncReadDefinition — fused into roosync_messages
-    // [REMOVED #1841 Cluster G] roosyncManageDefinition — fused into roosync_messages
-    // [REMOVED #1841 Cluster G] roosyncAttachmentsDefinition — fused into roosync_messages
+    // [REMOVED CONS-8 #603] roosyncClaimDefinition — never adopted
     roosyncMessagesDefinition,
     roosyncDashboardDefinition
 ];
@@ -317,10 +301,7 @@ describe('tool-definitions.ts — Schema Validation', () => {
             expect(actions).toContain('export');
         });
 
-        it('roosync_decision should require action and decisionId', () => {
-            expect(roosyncDecisionDefinition.inputSchema.required).toContain('action');
-            expect(roosyncDecisionDefinition.inputSchema.required).toContain('decisionId');
-        });
+        // [REMOVED CONS-8 #603] roosync_decision schema test — dead tool removed from tools/list
 
         it('roosync_attachments should require action', () => {
             expect(roosyncAttachmentsDefinition.inputSchema.required).toContain('action');
@@ -334,14 +315,7 @@ describe('tool-definitions.ts — Schema Validation', () => {
             expect(exportConfigDefinition.inputSchema.required).toContain('action');
         });
 
-
-        it('roosync_list_diffs should have filterType enum', () => {
-            const filterTypes = (roosyncListDiffsDefinition.inputSchema.properties.filterType as Record<string, unknown>).enum as string[];
-            expect(filterTypes).toContain('all');
-            expect(filterTypes).toContain('config');
-            expect(filterTypes).toContain('files');
-            expect(filterTypes).toContain('settings');
-        });
+        // [REMOVED CONS-8 #603] roosync_list_diffs schema test — dead tool removed from tools/list
 
         // #1935 Cluster B: roosync_update_dashboard definition removed — merged into roosync_dashboard
         it('roosync_dashboard should support refresh and update actions', () => {
@@ -367,10 +341,11 @@ describe('tool-definitions.ts — Schema Validation', () => {
 
     describe('additionalProperties: false where declared', () => {
         const strictTools = [
-            roosyncInitDefinition,
+            // [REMOVED CONS-8 #603] roosyncInitDefinition — dead tool
             // [REMOVED #1935 Cluster E] roosyncGetStatusDefinition — fused into roosync_inventory
             roosyncCompareConfigDefinition,
-            roosyncListDiffsDefinition, roosyncBaselineDefinition, roosyncConfigDefinition,
+            // [REMOVED CONS-8 #603] roosyncListDiffsDefinition — dead tool
+            roosyncBaselineDefinition, roosyncConfigDefinition,
             roosyncInventoryDefinition,
             // #1609: roosyncHeartbeatDefinition removed
             // #1863: roosyncMachinesDefinition removed

--- a/servers/roo-state-manager/src/tools/__tests__/tool-discoverability.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-discoverability.test.ts
@@ -283,10 +283,7 @@ describe('Category 3: Consolidated Tool Action Completeness', () => {
             actions: ['task', 'conversation', 'project'],
         },
         // [REMOVED #291] export_config removed from allToolDefinitions — backward compat via registry.ts redirect
-        'roosync_decision': {
-            field: 'action',
-            actions: ['approve', 'reject', 'apply', 'rollback', 'info'],
-        },
+        // [REMOVED CONS-8 #603] roosync_decision — dead tool, no longer exposed
         'roosync_baseline': {
             field: 'action',
             actions: ['update', 'version', 'restore', 'export'],
@@ -475,7 +472,7 @@ describe('Category 5: Description Discoverability', () => {
         // #1609: roosync_heartbeat removed — auto-heartbeat on any tool call
         'roosync_diagnose': ['diagnos'],                 // "diagnostic et debug"
         'roosync_mcp_management': ['MCP'],               // "Gestion complète des serveurs MCP"
-        'roosync_decision': ['décision'],                // "workflow de décision RooSync"
+        // [REMOVED CONS-8 #603] roosync_decision — dead tool, no longer exposed
         'roosync_baseline': ['baseline'],                // "baselines RooSync"
         'roosync_indexing': ['index'],                   // "index sémantique"
         'export_data': ['export'],                       // "exporter des données"

--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -67,9 +67,7 @@ export const TOOL_CAPABILITIES: Record<string, Capability[]> = {
 	roosync_inventory: ['sharedPath'],
 	roosync_config: ['sharedPath'],
 	roosync_compare_config: ['sharedPath'],
-	roosync_list_diffs: ['sharedPath'],
-	roosync_decision: ['sharedPath'],
-	roosync_init: ['sharedPath'],
+	// [REMOVED CONS-8 #603] roosync_list_diffs, roosync_decision, roosync_init — dead tools
 	roosync_diagnose: ['sharedPath'],
 	roosync_baseline: ['sharedPath'],
 	roosync_indexing: ['sharedPath'],
@@ -478,24 +476,28 @@ export function registerCallToolHandler(
               }
               break;
           }
+          // [REMOVED CONS-8 #603] roosync_list_diffs — thin wrapper, use compare_config
           case 'roosync_list_diffs': {
-              try {
-                  const m = await import('./roosync/list-diffs.js');
-                  const roosyncResult = await m.roosyncListDiffs(args as any);
-                  result = { content: [{ type: 'text', text: JSON.stringify(roosyncResult, null, 2) }] };
-              } catch (error) {
-                  result = { content: [{ type: 'text', text: `Error: ${(error as Error).message}` }], isError: true };
-              }
+              result = {
+                  content: [{ type: 'text', text: JSON.stringify({
+                      status: 'deprecated',
+                      message: 'roosync_list_diffs removed (CONS-8 #603). Thin wrapper with no unique logic.',
+                      alternative: 'Use roosync_compare_config to compare configs between machines.'
+                  }) }],
+                  isError: false
+              };
               break;
           }
+          // [REMOVED CONS-8 #603] roosync_init — dead code (all machines initialized)
           case 'roosync_init': {
-              try {
-                  const m = await import('./roosync/roosync_init.js');
-                  const roosyncResult = await m.roosyncInit(args as any);
-                  result = { content: [{ type: 'text', text: JSON.stringify(roosyncResult, null, 2) }] };
-              } catch (error) {
-                  result = { content: [{ type: 'text', text: `Error: ${(error as Error).message}` }], isError: true };
-              }
+              result = {
+                  content: [{ type: 'text', text: JSON.stringify({
+                      status: 'deprecated',
+                      message: 'roosync_init removed (CONS-8 #603). All machines already initialized. No action needed.',
+                      alternative: 'Use roosync_diagnose(action: "env") for environment checks.'
+                  }) }],
+                  isError: false
+              };
               break;
           }
           case 'roosync_diagnose': {
@@ -508,15 +510,16 @@ export function registerCallToolHandler(
               }
               break;
           }
-          // CONS-5: Consolidated decision tools (5→2)
+          // [REMOVED CONS-8 #603] roosync_decision — pipeline mort, never operationalized in prod
           case 'roosync_decision': {
-              try {
-                  const m = await import('./roosync/decision.js');
-                  const roosyncResult = await m.roosyncDecision(args as any);
-                  result = { content: [{ type: 'text', text: JSON.stringify(roosyncResult, null, 2) }] };
-              } catch (error) {
-                  result = { content: [{ type: 'text', text: `Error: ${(error as Error).message}` }], isError: true };
-              }
+              result = {
+                  content: [{ type: 'text', text: JSON.stringify({
+                      status: 'deprecated',
+                      message: 'roosync_decision removed (CONS-8 #603). Decision pipeline never operationalized in production.',
+                      alternative: 'Use roosync_dashboard for coordination. For config arbitration, use roosync_compare_config + dashboard discussion.'
+                  }) }],
+                  isError: false
+              };
               break;
           }
           // #1863 FUSION A1: roosync_decision_info removed — redirects to roosync_decision(action: "info")
@@ -688,14 +691,16 @@ export function registerCallToolHandler(
                }
                break;
            }
-          // #1836: Pre-claim enforcement — prevents concurrent agent collisions
+          // [REMOVED CONS-8 #603] roosync_claim — never adopted (#1836), no harness integration
           case 'roosync_claim': {
-              try {
-                  const m = await import('./claims/claim.tool.js');
-                  result = await m.handleClaimTool(args as any);
-              } catch (error) {
-                  result = { content: [{ type: 'text', text: `Error: ${(error as Error).message}` }], isError: true };
-              }
+              result = {
+                  content: [{ type: 'text', text: JSON.stringify({
+                      status: 'deprecated',
+                      message: 'roosync_claim removed (CONS-8 #603). Pre-claim enforcement was never adopted by the harness.',
+                      alternative: 'Use dashboard [CLAIMED] tags for manual coordination (per .claude/rules/agent-claim-discipline.md).'
+                  }) }],
+                  isError: false
+              };
               break;
           }
            default:

--- a/servers/roo-state-manager/src/tools/roosync/index.ts
+++ b/servers/roo-state-manager/src/tools/roosync/index.ts
@@ -288,21 +288,20 @@ export type {
 
 /**
  * Liste de tous les outils RooSync pour enregistrement MCP
- * Version 3.18 : 19 outils (#1863: 3 deprecated definitions removed from tools/list — decision_info, machines, cleanup_messages)
- * Version 3.17 : 22 outils (CONS-7: 3 outils attachments → 1 roosync_attachments)
+ * Version 3.19 : 15 outils (CONS-8 #603: 4 dead tools removed — init, claim, decision, list_diffs)
+ * Version 3.18 : 19 outils (#1863: 3 deprecated definitions removed from tools/list)
  *
- * - Configuration: init, compare-config, roosync_config (CONS-3), baseline (CONS-4)
- * - Services: inventory (CONS-6), machines (CONS-6)
- * - Presentation: get-status, list-diffs, refresh-dashboard
- * - Decision (CONS-5): roosync_decision, roosync_decision_info
- * - Heartbeat: ADR 008 passive model (heartbeat.ts/heartbeat-service.ts/heartbeat-status.ts removed Phase 2)
- * - [DEPRECATED] Synchronisation automatique (CONS-#443 Groupe 2): roosync_sync_event retiré (#533)
- * - Messagerie (CONS-1): roosync_send, roosync_read, roosync_manage, roosync_cleanup_messages
- * - Attachments (CONS-7): roosync_attachments (remplace roosync_list/get/delete_attachment)
+ * - Configuration: compare-config, roosync_config (CONS-3), baseline (CONS-4)
+ * - Services: inventory (CONS-6)
+ * - Decision: REMOVED CONS-8 (pipeline mort)
+ * - Init: REMOVED CONS-8 (dead code)
+ * - Claim: REMOVED CONS-8 (never adopted)
+ * - List-diffs: REMOVED CONS-8 (thin wrapper, use compare_config)
+ * - Messagerie (CONS-8): roosync_messages (fused send+read+manage+attachments)
  * - Gestion MCP (CONS-#443 Groupe 3): roosync_mcp_management
  * - Gestion stockage (CONS-#443 Groupe 4): roosync_storage_management
  * - Diagnostic (CONS-#443 Groupe 5): roosync_diagnose
- * - Dashboards: roosync_refresh_dashboard, roosync_update_dashboard (#546), roosync_dashboard (#675)
+ * - Dashboards: roosync_dashboard (#675)
  */
 
 // #1470: roosyncTools array removed — orphan, never consumed by registry.ts

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -664,12 +664,11 @@ export const allToolDefinitions = [
     // [REMOVED #1841] getRawConversationDefinition — export_data(format: "json", target: "task") provides equivalent, redirect in registry.ts
     // WP4: Diagnostic
     // [REMOVED #1935 Cluster D] analyzeRooSyncProblemsDefinition — fused into roosync_diagnose(action: "analyze")
-    // RooSync tools (23) — same order as roosyncTools array in roosync/index.ts
-    roosyncInitDefinition,
+    // [REMOVED CONS-8 #603] roosyncInitDefinition — dead code (all machines initialized), redirect in registry.ts
     // [REMOVED #1935 Cluster E] roosyncGetStatusDefinition — fused into roosync_inventory(type: "status")
     roosyncCompareConfigDefinition,
-    roosyncListDiffsDefinition,
-    roosyncDecisionDefinition,
+    // [REMOVED CONS-8 #603] roosyncListDiffsDefinition — thin wrapper, use roosync_compare_config instead, redirect in registry.ts
+    // [REMOVED CONS-8 #603] roosyncDecisionDefinition — pipeline mort (never operationalized), redirect in registry.ts
     roosyncBaselineDefinition,
     roosyncConfigDefinition,
     roosyncInventoryDefinition,
@@ -677,8 +676,7 @@ export const allToolDefinitions = [
     roosyncMcpManagementDefinition,
     roosyncStorageManagementDefinition,
     roosyncDiagnoseDefinition,
-    // #1836: Pre-claim enforcement
-    roosyncClaimDefinition,
+    // [REMOVED CONS-8 #603] roosyncClaimDefinition — never adopted (#1836), redirect in registry.ts
     // [REMOVED #1935 Cluster B] roosyncRefreshDashboardDefinition — fused into roosync_dashboard(action: "refresh"), redirect in registry.ts
     // [REMOVED #1935 Cluster B] roosyncUpdateDashboardDefinition — fused into roosync_dashboard(action: "update"), redirect in registry.ts
     // [REMOVED #1841 Cluster G] roosyncSendDefinition — fused into roosync_messages(action: "send"/"reply"/"amend"), redirect in registry.ts

--- a/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
@@ -299,7 +299,7 @@ describe('#1935 Fusion E: get_status → inventory(type: "status")', () => {
 // Cross-cutting: Definition count and deprecation removal verification
 // ============================================================
 describe('#1863 Cross-cutting: tool count and deprecation markers', () => {
-  it('allToolDefinitions should contain 19 tools (18 + #1836 roosync_claim)', () => {
+  it('allToolDefinitions should contain 15 tools (CONS-8 removed init, claim, decision, list_diffs)', () => {
     // Before: 32 tools → #1922 Pass 4 removed 3 deprecated → 29
     // #1841 removed 6 low-usage → 23. allToolDefinitions baseline = 24.
     // Cluster D (#1935) fused analyze_roosync_problems → roosync_diagnose: 24 → 23
@@ -307,8 +307,9 @@ describe('#1863 Cross-cutting: tool count and deprecation markers', () => {
     // Cluster G (#1841) fused send+read+manage+attachments → roosync_messages: 22 → 19
     // Cluster H (#1841) fused task_export → export_data: 19 → 18
     // #1836 added roosync_claim: 18 → 19
+    // CONS-8 #603 removed 4 dead tools (init, claim, decision, list_diffs): 19 → 15
     // Backward compat redirect handlers in registry.ts are preserved
-    expect(allToolDefinitions.length).toBe(19);
+    expect(allToolDefinitions.length).toBe(15);
   });
 
   it('deprecated tools should NOT be in allToolDefinitions', () => {
@@ -316,10 +317,14 @@ describe('#1863 Cross-cutting: tool count and deprecation markers', () => {
     expect(names).not.toContain('roosync_decision_info');
     expect(names).not.toContain('roosync_machines');
     expect(names).not.toContain('roosync_cleanup_messages');
+    // CONS-8 #603: additionally removed dead tools
+    expect(names).not.toContain('roosync_init');
+    expect(names).not.toContain('roosync_claim');
+    expect(names).not.toContain('roosync_decision');
+    expect(names).not.toContain('roosync_list_diffs');
   });
 
   it('canonical tools should not be deprecated', () => {
-    expect(roosyncDecisionDefinition.description).not.toContain('DEPRECATED');
     expect(roosyncInventoryDefinition.description).not.toContain('DEPRECATED');
   });
 


### PR DESCRIPTION
## Summary

Remove 4 unused/dead tools from MCP `tools/list` exposure (19→15), while preserving backward-compat redirect handlers in `registry.ts`.

**Removed from `allToolDefinitions`:**

| Tool | Reason | Lines Removed |
|------|--------|---------------|
| `roosync_init` | Dead code — all machines already initialized | 401 |
| `roosync_claim` | Never adopted — #1836, no harness integration | 378 |
| `roosync_decision` | Pipeline mort — never operationalized in production | ~600 |
| `roosync_list_diffs` | Thin wrapper — no unique logic over compare_config | 117 |

**Total recoverable: ~1,496 LOC** (source files retained for backward compat)

## Changes

- `tool-definitions.ts`: Remove 4 entries from `allToolDefinitions` array
- `registry.ts`: Add deprecation redirect handlers (return structured JSON with alternatives)
- `registry.ts`: Remove dead tools from `serviceDependencies` map
- `roosync/index.ts`: Update version comment (3.18→3.19, 19→15 tools)
- Test files: Update expected tool counts and remove dead tool schema tests

## Backward Compatibility

All 4 removed tools still have `case` handlers in `registry.ts` that return:
```json
{ "status": "deprecated", "message": "...", "alternative": "..." }
```

Source files are retained (no breaking imports for internal consumers).

## Test plan

- [x] `npx vitest run --config vitest.config.ci.ts` — 9585 passed, 0 failed
- [x] `npm run build` — clean
- [x] Tool discoverability test: 15 tools listed, all ≥10 chars descriptions
- [x] Backward compat: deprecated tools return structured response

## Issue

Part of #603 Phase 2 — RooSync Config Management consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)