### PR TITLE
feat(#2121): 7-day report cap + config snapshot rotation

### DIFF
--- a/servers/roo-state-manager/src/services/ConfigSharingService.ts
+++ b/servers/roo-state-manager/src/services/ConfigSharingService.ts
@@ -189,6 +189,23 @@ export class ConfigSharingService implements IConfigSharingService {
 
     this.logger.info('Publication terminée', { machineId, version: options.version, path: versionDir });
 
+    // #2121: Cap versioned snapshots to 3 most recent per machine
+    try {
+      const entries = await fs.readdir(machineConfigDir);
+      const versionDirs = entries
+        .filter(e => e.startsWith('v') && !e.includes('.'))
+        .sort()
+        .reverse(); // newest first
+      if (versionDirs.length > 3) {
+        for (const old of versionDirs.slice(3)) {
+          await fs.rm(join(machineConfigDir, old), { recursive: true, force: true });
+        }
+        this.logger.info(`#2121: Pruned ${versionDirs.length - 3} old config snapshots for ${machineId}`);
+      }
+    } catch (err) {
+      this.logger.debug('#2121: Config snapshot cap failed', { error: String(err) });
+    }
+
     return {
       success: true,
       version: options.version,

--- a/servers/roo-state-manager/src/tools/diagnostic/analyze_problems.ts
+++ b/servers/roo-state-manager/src/tools/diagnostic/analyze_problems.ts
@@ -303,6 +303,29 @@ Fichier: ${analysis.filePath}
 ${JSON.stringify(analysis.issues, null, 2)}
 `;
             await fs.writeFile(reportPath, reportContent);
+
+            // #2121: 7-day retention cap — purge old reports after each write
+            const retentionMs = 7 * 24 * 60 * 60 * 1000;
+            const cutoff = Date.now() - retentionMs;
+            try {
+                const existing = await fs.readdir(reportDir);
+                let purged = 0;
+                for (const f of existing) {
+                    if (!f.startsWith('PHASE3A-ANALYSE-') || !f.endsWith('.md')) continue;
+                    const match = f.match(/PHASE3A-ANALYSE-(\d{4})-(\d{2})-(\d{2})T/);
+                    if (!match) continue;
+                    const fileDate = new Date(`${match[1]}-${match[2]}-${match[3]}T00:00:00Z`).getTime();
+                    if (fileDate < cutoff) {
+                        await fs.unlink(path.join(reportDir, f));
+                        purged++;
+                    }
+                }
+                if (purged > 0) {
+                    console.log(`#2121: Purged ${purged} reports older than 7 days`);
+                }
+            } catch (err) {
+                // Non-critical — report cap failure doesn't affect analysis
+            }
         }
 
         return {


### PR DESCRIPTION
## Summary
- Add 7-day retention cap for `PHASE3A-ANALYSE-*.md` reports — auto-purge on each write
- Cap versioned config snapshots to 3 most recent per machine after publish
- Prevents re-accumulation of ~15K files (2.34 MB) in GDrive `.shared-state/`

## Changes
- `analyze_problems.ts`: Purge old reports after writing new one
- `ConfigSharingService.ts`: Prune old snapshots keeping 3 newest

## Related
- One-shot purge script: `scripts/gdrive/purge-shared-state-artifacts.ps1` (parent repo)
- Issue: #2121 Phase 2

## Test plan
- [x] Build passes (`npm run build`)
- [x] CI tests pass (9604 passed, 1 pre-existing flaky)
- [x] Purge script dry-run verified (15,218 files)
- [x] Code cap tested in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)