### PR TITLE
fix(indexing): restore chunk_type taxonomy (#2247)

### DIFF
--- a/servers/roo-state-manager/src/services/task-indexer/ChunkExtractor.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/ChunkExtractor.ts
@@ -20,12 +20,13 @@ const UUID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
  */
 export function computeChunkId(
     taskId: string,
-    chunkType: string,
+    _chunkType: string,
     sequenceOrder: number,
     content: string
 ): string {
+    // #2247: chunk_type removed from seed — future taxonomy fixes won't break UUIDs
     const contentHash = crypto.createHash('sha256').update(content).digest('hex').slice(0, 16);
-    const seed = `${taskId}|${chunkType}|seq:${sequenceOrder}|${contentHash}`;
+    const seed = `${taskId}|seq:${sequenceOrder}|${contentHash}`;
     return uuidv5(seed, UUID_NAMESPACE);
 }
 
@@ -280,7 +281,7 @@ export async function extractChunksFromTask(taskId: string, taskPath: string): P
                         chunk_type: 'tool_interaction',
                         sequence_order: seq,
                         timestamp: msg.timestamp || new Date().toISOString(),
-                        indexed: false,
+                        indexed: true, // #2247: tool interactions are valuable search targets
                         content: toolContent,
                         tool_details: {
                             tool_name: toolCall.function.name,

--- a/servers/roo-state-manager/src/services/task-indexer/__tests__/ChunkExtractor.test.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/__tests__/ChunkExtractor.test.ts
@@ -274,10 +274,10 @@ describe('ChunkExtractor', () => {
       expect(idA).not.toBe(idB);
     });
 
-    it('different chunk_type produces different UUIDs', () => {
+    it('different chunk_type no longer affects UUIDs (#2247 decoupled)', () => {
       const idMsg = computeChunkId('task-1', 'message_exchange', 0, 'shared');
       const idTool = computeChunkId('task-1', 'tool_interaction', 0, 'shared');
-      expect(idMsg).not.toBe(idTool);
+      expect(idMsg).toBe(idTool); // seed excludes chunk_type since #2247
     });
 
     it('different task_id produces different UUIDs', () => {


### PR DESCRIPTION
## Summary

Fixes #2247 — 100% `message_exchange` collapse in Qdrant caused by `indexed: false` on `tool_interaction` chunks.

**Root cause** (identified by forensic analysis comment on #2247): `ChunkExtractor.ts:283` set `indexed: false` for tool_interaction chunks, causing `VectorIndexer.ts:836` (`if (chunk.indexed)`) to skip them entirely during embedding.

**Option A** — Set `indexed: true` for tool_interaction chunks (1-line fix)

**Option B** — Remove `chunk_type` from UUIDv5 seed in `computeChunkId()`. Prevents future taxonomy changes from breaking chunk IDs. Forward-compatible: new chunks get new IDs, old data unchanged until re-indexed.

## Changes

- `ChunkExtractor.ts:283`: `indexed: false` → `indexed: true`
- `ChunkExtractor.ts:21-30`: seed now `${taskId}|seq:${sequenceOrder}|${contentHash}` (chunk_type removed)
- `ChunkExtractor.test.ts`: Updated test to verify chunk_type no longer affects UUIDs

## Test plan

- [x] 9571 tests pass (0 failures)
- [x] Build passes
- [ ] Post-merge: `roosync_indexing(action: "rebuild")` to re-index all tasks with the fix
- [ ] Verify: `roosync_search(chunk_type: "tool_interaction")` returns results
- [ ] Expected distribution: ~40-60% message_exchange, ~30-50% tool_interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)