### PR TITLE
refactor(#2121): PresenceManager + IdentityManager dashboard-derived

### DIFF
--- a/servers/roo-state-manager/src/services/RooSyncService.ts
+++ b/servers/roo-state-manager/src/services/RooSyncService.ts
@@ -168,10 +168,12 @@ export class RooSyncService {
       this.syncDecisionManager = new SyncDecisionManager(this.config, this.powershellExecutor);
       this.configComparator = new ConfigComparator(this.config, this.baselineService);
       this.baselineManager = new BaselineManager(this.config, this.baselineService, this.configComparator);
-      this.presenceManager = new PresenceManager(this.config);
-      this.identityManager = new IdentityManager(this.config, this.presenceManager);
-      this.nonNominativeBaselineService = new NonNominativeBaselineService(this.config.sharedPath);
+      // #2121 Phase 2.1: HeartbeatService created BEFORE PresenceManager/IdentityManager
+      // (they now depend on it for in-memory state instead of GDrive writes)
       this.heartbeatService = new HeartbeatService(this.config.sharedPath);
+      this.presenceManager = new PresenceManager(this.config, this.heartbeatService);
+      this.identityManager = new IdentityManager(this.config, this.presenceManager, this.heartbeatService);
+      this.nonNominativeBaselineService = new NonNominativeBaselineService(this.config.sharedPath);
 
     } catch (error) {
       debugLog('ERREUR dans constructeur RooSyncService', {
@@ -226,24 +228,15 @@ export class RooSyncService {
         }
       }
       
-      // Validation supplémentaire des fichiers de présence avec PresenceManager
-      await this.validatePresenceFiles();
-      
-      // Mettre à jour la présence de la machine courante
-      const presenceUpdate = await this.presenceManager.updateCurrentPresence('online', 'code');
-      if (!presenceUpdate.success) {
-        console.warn(`[RooSyncService] Échec mise à jour présence: ${presenceUpdate.warningMessage}`);
-        if (presenceUpdate.conflictDetected) {
-          console.error(`[RooSyncService] Conflit de présence détecté: ${presenceUpdate.warningMessage}`);
-        }
-      }
+      // #2121 Phase 2.1: Presence now uses HeartbeatService (in-memory, no GDrive writes)
+      // Register heartbeat for this machine on startup
+      await this.presenceManager.updateCurrentPresence('online', 'code');
 
-      // Synchroniser le registre d'identité central
-      try {
-        await this.identityManager.syncIdentityRegistry();
-      } catch (error) {
-        console.warn('[RooSyncService] Erreur synchronisation registre d\'identité (non bloquant):', error);
-      }
+      // #2121 Phase 2.1: syncIdentityRegistry is now a no-op (dashboard-derived)
+      await this.identityManager.syncIdentityRegistry();
+
+      // Lightweight identity conflict check (HeartbeatService-based, no disk I/O)
+      await this.identityManager.checkIdentityConflict();
       
     } catch (error) {
       console.error('[RooSyncService] Erreur lors validation démarrage:', error);
@@ -252,41 +245,9 @@ export class RooSyncService {
   }
 
   /**
-   * Validation des fichiers de présence pour détecter les conflits avec PresenceManager
+   * Validation des fichiers de présence — removed (#2121 Phase 2.1)
+   * PresenceManager now uses HeartbeatService (in-memory). No disk scans needed.
    */
-  private async validatePresenceFiles(): Promise<void> {
-    try {
-      console.log(`[RooSyncService] Validation des fichiers de présence avec PresenceManager`);
-      
-      // Valider l'unicité des fichiers de présence
-      const uniquenessValidation = await this.presenceManager.validatePresenceUniqueness();
-      
-      if (!uniquenessValidation.isValid) {
-        console.error(`[RooSyncService] ⚠️ CONFLITS DE PRÉSENCE DÉTECTÉS:`);
-        for (const conflict of uniquenessValidation.conflicts) {
-          console.error(`[RooSyncService] ${conflict.warningMessage}`);
-        }
-        console.warn(`[RooSyncService] Des conflits de présence ont été détectés. Veuillez résoudre ces conflits manuellement.`);
-      } else {
-        console.log(`[RooSyncService] ✅ Aucun conflit de présence détecté`);
-      }
-      
-      // Vérifier le fichier de présence de la machine courante
-      const currentPresence = await this.presenceManager.readPresence(this.config.machineId);
-      if (currentPresence) {
-        if (currentPresence.id !== this.config.machineId) {
-          console.warn(`[RooSyncService] ⚠️ INCOHÉRENCE DÉTECTÉE: Le fichier de présence contient l'ID ${currentPresence.id} mais le service utilise ${this.config.machineId}`);
-        } else {
-          console.log(`[RooSyncService] ✅ Fichier de présence cohérent pour ${this.config.machineId}`);
-        }
-      } else {
-        console.log(`[RooSyncService] Aucun fichier de présence trouvé pour ${this.config.machineId}, création prévue`);
-      }
-      
-    } catch (error) {
-      console.warn('[RooSyncService] Erreur validation fichiers de présence:', error);
-    }
-  }
 
   /**
    * Obtenir le gestionnaire de présence

--- a/servers/roo-state-manager/src/services/roosync/IdentityManager.ts
+++ b/servers/roo-state-manager/src/services/roosync/IdentityManager.ts
@@ -1,21 +1,24 @@
 /**
- * Gestionnaire central d'identité pour RooSync
+ * Gestionnaire central d'identité pour RooSync — #2121 Phase 2.1
  *
- * Responsable d'unifier toutes les sources d'identité en une seule
- * source de vérité et de prévenir les conflits d'écrasement.
+ * Dashboard-derived identity model. No disk I/O — derives machine identities
+ * from HeartbeatService in-memory state. GDrive writes to .identity-registry.json
+ * eliminated.
  *
  * @module IdentityManager
- * @version 1.0.0
+ * @version 2.0.0 (#2121 Phase 2.1: dashboard-derived identity)
  */
 
-import { promises as fs, existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { createLogger } from '../../utils/logger.js';
 import { RooSyncConfig } from '../../config/roosync-config.js';
 import { PresenceManager } from './PresenceManager.js';
+import { HeartbeatService } from './HeartbeatService.js';
 import {
   IdentityManagerError,
   IdentityManagerErrorCode
 } from '../../types/errors.js';
+
+const logger = createLogger('IdentityManager');
 
 /**
  * Sources d'identité possibles
@@ -55,305 +58,79 @@ export interface IdentityValidationResult {
 }
 
 /**
-/**
- * Gestionnaire central d'identité
+ * Gestionnaire central d'identité — dashboard-derived, no disk I/O
  */
 export class IdentityManager {
   constructor(
     private config: RooSyncConfig,
-    private presenceManager: PresenceManager
+    private presenceManager: PresenceManager,
+    private heartbeatService: HeartbeatService
   ) {}
 
   /**
-   * Obtenir le chemin du registre d'identité
-   */
-  private getIdentityRegistryPath(): string {
-    return join(this.config.sharedPath, '.identity-registry.json');
-  }
-
-  /**
-   * Charger le registre d'identité depuis le disque
-   * @throws {IdentityManagerError} Si le chargement échoue
-   */
-  private async loadIdentityRegistry(): Promise<Map<string, IdentityInfo>> {
-    const registryPath = this.getIdentityRegistryPath();
-
-    try {
-      if (existsSync(registryPath)) {
-        const content = await fs.readFile(registryPath, 'utf-8');
-        const data = JSON.parse(content);
-
-        const registry = new Map<string, IdentityInfo>();
-        for (const [machineId, info] of Object.entries(data.identities || {})) {
-          registry.set(machineId.toLowerCase(), info as IdentityInfo);
-        }
-
-        console.log(`[IdentityManager] Registre d'identité chargé: ${registry.size} identités`);
-        return registry;
-      }
-    } catch (error) {
-      console.warn('[IdentityManager] Erreur chargement registre d\'identité:', error);
-
-      if (error instanceof SyntaxError) {
-        throw new IdentityManagerError(
-          `Erreur de parsing JSON dans le registre d'identité: ${error.message}`,
-          IdentityManagerErrorCode.REGISTRY_LOAD_FAILED,
-          { registryPath },
-          error
-        );
-      }
-
-      throw new IdentityManagerError(
-        `Erreur lors du chargement du registre d'identité: ${error instanceof Error ? error.message : String(error)}`,
-        IdentityManagerErrorCode.REGISTRY_LOAD_FAILED,
-        { registryPath },
-        error instanceof Error ? error : undefined
-      );
-    }
-
-    return new Map<string, IdentityInfo>();
-  }
-
-  /**
-   * Sauvegarder le registre d'identité sur le disque
-   * @throws {IdentityManagerError} Si la sauvegarde échoue
-   */
-  private async saveIdentityRegistry(registry: Map<string, IdentityInfo>): Promise<void> {
-    const registryPath = this.getIdentityRegistryPath();
-
-    try {
-      const data = {
-        identities: Object.fromEntries(registry),
-        lastUpdated: new Date().toISOString(),
-        version: '1.0.0'
-      };
-
-      await fs.writeFile(
-        registryPath,
-        JSON.stringify(data, null, 2),
-        'utf-8'
-      );
-
-      console.log(`[IdentityManager] Registre d'identité sauvegardé: ${registry.size} identités`);
-    } catch (error) {
-      console.error('[IdentityManager] Erreur sauvegarde registre d\'identité:', error);
-
-      throw new IdentityManagerError(
-        `Impossible de sauvegarder le registre d'identité: ${error instanceof Error ? error.message : String(error)}`,
-        IdentityManagerErrorCode.REGISTRY_SAVE_FAILED,
-        { registryPath, registrySize: registry.size },
-        error instanceof Error ? error : undefined
-      );
-    }
-  }
-
-  /**
-   * Collecter les identités depuis toutes les sources
+   * Collecter les identités depuis HeartbeatService + config
    */
   public async collectAllIdentities(): Promise<Map<string, IdentityInfo>> {
     const identities = new Map<string, IdentityInfo>();
     const now = new Date().toISOString();
 
-    try {
-      // 1. Identité depuis la configuration
-      const configIdentity: IdentityInfo = {
-        machineId: this.config.machineId,
-        source: 'config',
-        firstSeen: now,
-        lastSeen: now,
-        status: 'valid',
-        metadata: {
-          configPath: process.env.ROOSYNC_CONFIG_PATH || 'environment'
-        }
-      };
-      identities.set(this.config.machineId, configIdentity);
+    // 1. Config identity (this machine)
+    identities.set(this.config.machineId, {
+      machineId: this.config.machineId,
+      source: 'config',
+      firstSeen: now,
+      lastSeen: now,
+      status: 'valid',
+      metadata: { configPath: process.env.ROOSYNC_CONFIG_PATH || 'environment' }
+    });
 
-      // 2. Identités depuis les fichiers de présence
-      const allPresence = await this.presenceManager.listAllPresence();
-      for (const presence of allPresence) {
-        const presenceIdentity: IdentityInfo = {
-          machineId: presence.id,
-          source: 'presence',
-          firstSeen: presence.firstSeen || presence.lastSeen,
-          lastSeen: presence.lastSeen,
-          status: 'valid',
-          metadata: {
-            presencePath: join(this.config.sharedPath, 'presence', `${presence.id}.json`)
-          }
-        };
-
-        // Fusionner avec l'identité existante si déjà présente
-        const existing = identities.get(presence.id);
-        if (existing) {
-          // Conserver la première date d'apparition
-          presenceIdentity.firstSeen = existing.firstSeen;
-          presenceIdentity.status = 'conflict'; // Marquer comme conflit
-        }
-
-        identities.set(presence.id, presenceIdentity);
-      }
-
-      // 3. Identité depuis la baseline
-      const baselinePath = join(this.config.sharedPath, 'sync-config.ref.json');
-      if (existsSync(baselinePath)) {
-        try {
-          const baselineContent = readFileSync(baselinePath, 'utf-8');
-          const baselineData = JSON.parse(baselineContent);
-
-          if (baselineData.machineId) {
-            const baselineIdentity: IdentityInfo = {
-              machineId: baselineData.machineId,
-              source: 'baseline',
-              firstSeen: baselineData.timestamp || now,
-              lastSeen: now,
-              status: 'valid',
-              metadata: {
-                baselinePath
-              }
-            };
-
-            // Fusionner avec l'identité existante si déjà présente
-            const existing = identities.get(baselineData.machineId);
-            if (existing) {
-              baselineIdentity.firstSeen = existing.firstSeen;
-              baselineIdentity.status = 'conflict'; // Marquer comme conflit
-            }
-
-            identities.set(baselineData.machineId, baselineIdentity);
-          }
-        } catch (error) {
-          console.warn('[IdentityManager] Erreur lecture baseline:', error);
-          // On ne propage pas l'erreur ici car la baseline est optionnelle
-        }
-      }
-
-      // 4. Identité depuis le dashboard
-      const dashboardPath = join(this.config.sharedPath, 'sync-dashboard.json');
-      if (existsSync(dashboardPath)) {
-        try {
-          const dashboardContent = readFileSync(dashboardPath, 'utf-8');
-          const dashboardData = JSON.parse(dashboardContent);
-
-          if (dashboardData.machines) {
-            for (const [machineId, machineInfo] of Object.entries(dashboardData.machines)) {
-              const dashboardIdentity: IdentityInfo = {
-                machineId,
-                source: 'dashboard',
-                firstSeen: now,
-                lastSeen: now,
-                status: 'valid',
-                metadata: {
-                  dashboardPath
-                }
-              };
-
-              // Fusionner avec l'identité existante si déjà présente
-              const existing = identities.get(machineId);
-              if (existing) {
-                dashboardIdentity.firstSeen = existing.firstSeen;
-                dashboardIdentity.status = 'conflict'; // Marquer comme conflit
-              }
-
-              identities.set(machineId, dashboardIdentity);
-            }
-          }
-        } catch (error) {
-          console.warn('[IdentityManager] Erreur lecture dashboard:', error);
-          // On ne propage pas l'erreur ici car le dashboard est optionnel
-        }
-      }
-
-      console.log(`[IdentityManager] Collecte terminée: ${identities.size} identités trouvées`);
-      return identities;
-
-    } catch (error) {
-      console.error('[IdentityManager] Erreur collecte identités:', error);
-
-      throw new IdentityManagerError(
-        `Erreur lors de la collecte des identités: ${error instanceof Error ? error.message : String(error)}`,
-        IdentityManagerErrorCode.COLLECTION_FAILED,
-        { machineId: this.config.machineId },
-        error instanceof Error ? error : undefined
-      );
+    // 2. HeartbeatService state (all known machines)
+    const state = this.heartbeatService.getState();
+    for (const [machineId, data] of state.heartbeats.entries()) {
+      if (identities.has(machineId)) continue; // config identity takes priority
+      identities.set(machineId, {
+        machineId,
+        source: 'heartbeat' as IdentitySource,
+        firstSeen: data.metadata.firstSeen,
+        lastSeen: data.lastHeartbeat,
+        status: 'valid'
+      });
     }
+
+    // 3. PresenceManager (backward compat — reads from HeartbeatService)
+    const allPresence = await this.presenceManager.listAllPresence();
+    for (const presence of allPresence) {
+      if (identities.has(presence.id)) continue;
+      identities.set(presence.id, {
+        machineId: presence.id,
+        source: 'presence',
+        firstSeen: presence.firstSeen || presence.lastSeen,
+        lastSeen: presence.lastSeen,
+        status: 'valid',
+        metadata: { presencePath: 'heartbeat-derived' }
+      });
+    }
+
+    logger.info(`Collected ${identities.size} identities from HeartbeatService`);
+    return identities;
   }
 
   /**
-   * Valider toutes les identités et détecter les conflits
+   * Valider toutes les identités — in-memory, always valid
    */
   public async validateIdentities(): Promise<IdentityValidationResult> {
-    try {
-      const identities = await this.collectAllIdentities();
-      const conflicts: Array<{
-        machineId: string;
-        sources: IdentitySource[];
-        warningMessage: string;
-      }> = [];
+    const identities = await this.collectAllIdentities();
+    const conflicts: IdentityValidationResult['conflicts'] = [];
+    const orphaned: IdentityInfo[] = [];
 
-      const machineIdMap = new Map<string, IdentitySource[]>();
-
-      // Grouper les identités par machineId
-      for (const identity of identities.values()) {
-        const sources = machineIdMap.get(identity.machineId) || [];
-        sources.push(identity.source);
-        machineIdMap.set(identity.machineId, sources);
-      }
-
-      // Détecter les conflits
-      for (const [machineId, sources] of machineIdMap) {
-        if (sources.length > 1) {
-          const warningMessage = `⚠️ CONFLIT D'IDENTITÉ: MachineId "${machineId}" trouvé dans ${sources.length} sources: ${sources.join(', ')}`;
-          console.error(`[IdentityManager] ${warningMessage}`);
-
-          conflicts.push({
-            machineId,
-            sources,
-            warningMessage
-          });
-        }
-      }
-
-      // Identifier les identités orphelines
-      const orphaned: IdentityInfo[] = [];
-      for (const identity of identities.values()) {
-        if (identity.status === 'orphaned') {
-          orphaned.push(identity);
-        }
-      }
-
-      // Générer des recommandations
-      const recommendations: string[] = [];
-      if (conflicts.length > 0) {
-        recommendations.push(`Résoudre les ${conflicts.length} conflits d'identité détectés`);
-        recommendations.push('Utiliser des machineId uniques pour chaque machine');
-        recommendations.push('Nettoyer les fichiers de présence obsolètes');
-      }
-
-      if (orphaned.length > 0) {
-        recommendations.push(`Nettoyer les ${orphaned.length} identités orphelines`);
-      }
-
-      if (recommendations.length === 0) {
-        recommendations.push('✅ Aucun problème d\'identité détecté');
-      }
-
-      return {
-        isValid: conflicts.length === 0 && orphaned.length === 0,
-        conflicts,
-        orphaned,
-        recommendations
-      };
-
-    } catch (error) {
-      console.error('[IdentityManager] Erreur validation identités:', error);
-
-      throw new IdentityManagerError(
-        `Erreur lors de la validation des identités: ${error instanceof Error ? error.message : String(error)}`,
-        IdentityManagerErrorCode.VALIDATION_FAILED,
-        { machineId: this.config.machineId },
-        error instanceof Error ? error : undefined
-      );
-    }
+    return {
+      isValid: conflicts.length === 0 && orphaned.length === 0,
+      conflicts,
+      orphaned,
+      recommendations: conflicts.length === 0 && orphaned.length === 0
+        ? ['No identity issues detected']
+        : []
+    };
   }
 
   /**
@@ -373,188 +150,44 @@ export class IdentityManager {
   }
 
   /**
-   * Synchroniser le registre d'identité avec l'état actuel
+   * Synchroniser le registre d'identité — deprecated no-op (#2121 Phase 2.1)
    */
   public async syncIdentityRegistry(): Promise<void> {
-    try {
-      console.log('[IdentityManager] Synchronisation du registre d\'identité');
-
-      const currentIdentities = await this.collectAllIdentities();
-      await this.saveIdentityRegistry(currentIdentities);
-
-      // Valider après synchronisation
-      const validation = await this.validateIdentities();
-
-      if (!validation.isValid) {
-        console.warn('[IdentityManager] ⚠️ Problèmes d\'identité détectés après synchronisation:');
-        for (const conflict of validation.conflicts) {
-          console.warn(`[IdentityManager] ${conflict.warningMessage}`);
-        }
-        for (const recommendation of validation.recommendations) {
-          console.info(`[IdentityManager] 💡 ${recommendation}`);
-        }
-      } else {
-        console.log('[IdentityManager] ✅ Registre d\'identité synchronisé sans conflits');
-      }
-
-    } catch (error) {
-      console.error('[IdentityManager] Erreur synchronisation registre:', error);
-
-      if (error instanceof IdentityManagerError) {
-        throw error;
-      }
-
-      throw new IdentityManagerError(
-        `Erreur lors de la synchronisation du registre d'identité: ${error instanceof Error ? error.message : String(error)}`,
-        IdentityManagerErrorCode.REGISTRY_SAVE_FAILED,
-        { machineId: this.config.machineId },
-        error instanceof Error ? error : undefined
-      );
-    }
+    logger.info('syncIdentityRegistry() — deprecated no-op (dashboard-derived identity)');
   }
 
   /**
-   * Nettoyer les identités orphelines ou en conflit
+   * Nettoyer les identités orphelines — deprecated no-op (#2121 Phase 2.1)
    */
-  public async cleanupIdentities(options: {
+  public async cleanupIdentities(_options?: {
     removeOrphaned?: boolean;
     resolveConflicts?: boolean;
     dryRun?: boolean;
-  } = {}): Promise<{
-    removed: string[];
-    resolved: string[];
-    errors: string[];
-  }> {
-    const { removeOrphaned = false, resolveConflicts = false, dryRun = false } = options;
-
-    const result = {
-      removed: [] as string[],
-      resolved: [] as string[],
-      errors: [] as string[]
-    };
-
-    try {
-      const validation = await this.validateIdentities();
-
-      // Nettoyer les identités orphelines
-      if (removeOrphaned) {
-        for (const orphan of validation.orphaned) {
-          try {
-            if (!dryRun) {
-              if (orphan.source === 'presence') {
-                await this.presenceManager.removePresence(orphan.machineId);
-              } else if (orphan.source === 'registry') {
-                // Remove from local identity registry
-                const registry = await this.loadIdentityRegistry();
-                registry.delete(orphan.machineId);
-                await this.saveIdentityRegistry(registry);
-              }
-              // 'baseline' and 'dashboard' are on GDrive — log only, don't modify
-            }
-            result.removed.push(orphan.machineId);
-            console.log(`[IdentityManager] ${dryRun ? '[DRY RUN] ' : ''}Identité orpheline supprimée: ${orphan.machineId} (${orphan.source})`);
-          } catch (error) {
-            result.errors.push(`Erreur suppression ${orphan.machineId}: ${error}`);
-          }
-        }
-      }
-
-      // Résoudre les conflits
-      if (resolveConflicts) {
-        for (const conflict of validation.conflicts) {
-          try {
-            // Stratégie: conserver l'identité de la configuration courante
-            if (conflict.machineId === this.config.machineId) {
-              if (!dryRun) {
-                // Re-sync registry: config identity is authoritative
-                // Remove stale entries from non-config sources, keep config as primary
-                for (const source of conflict.sources) {
-                  if (source === 'presence') {
-                    // Re-register in presence to ensure it's current
-                    await this.presenceManager.updatePresence(conflict.machineId, { status: 'online' });
-                  }
-                }
-                // Update the registry to reflect resolved state
-                await this.syncIdentityRegistry();
-              }
-              result.resolved.push(conflict.machineId);
-              console.log(`[IdentityManager] ${dryRun ? '[DRY RUN] ' : ''}Conflit résolu pour: ${conflict.machineId} (identité principale conservée)`);
-            }
-          } catch (error) {
-            result.errors.push(`Erreur résolution ${conflict.machineId}: ${error}`);
-          }
-        }
-      }
-
-      return result;
-
-    } catch (error) {
-      console.error('[IdentityManager] Erreur nettoyage identités:', error);
-
-      throw new IdentityManagerError(
-        `Erreur lors du nettoyage des identités: ${error instanceof Error ? error.message : String(error)}`,
-        IdentityManagerErrorCode.CLEANUP_FAILED,
-        { options },
-        error instanceof Error ? error : undefined
-      );
-    }
+  }): Promise<{ removed: string[]; resolved: string[]; errors: string[] }> {
+    return { removed: [], resolved: [], errors: [] };
   }
+
   /**
    * Vérifier s'il y a un conflit d'identité au démarrage
    *
-   * Cette méthode détecte si une autre instance avec le même ROOSYNC_MACHINE_ID
-   * est déjà active. Si c'est le cas, elle lève une erreur pour bloquer le démarrage.
-   *
-   * @throws {IdentityManagerError} Si un conflit d'identité est détecté
+   * With auto-heartbeat (ADR 008), concurrent identity is normal — multiple
+   * MCP instances for the same machineId register heartbeats independently.
+   * Only warn if a heartbeat is very recent AND from a different process.
    */
   public async checkIdentityConflict(): Promise<void> {
-    try {
-      console.log(`[IdentityManager] Vérification des conflits d'identité pour machineId: ${this.config.machineId}`);
+    const data = this.heartbeatService.getHeartbeatData(this.config.machineId);
+    if (!data) {
+      logger.info(`No existing heartbeat for ${this.config.machineId} — first registration`);
+      return;
+    }
 
-      // Lire les données de présence pour le machineId courant
-      const presence = await this.presenceManager.readPresence(this.config.machineId);
+    const elapsed = Date.now() - new Date(data.lastHeartbeat).getTime();
+    const ACTIVE_THRESHOLD_MS = 5 * 60 * 1000; // 5 min
 
-      if (!presence) {
-        // Aucune présence existante, pas de conflit
-        console.log(`[IdentityManager] ✅ Aucune présence existante pour ${this.config.machineId}`);
-        return;
-      }
-
-      // Vérifier si l'instance est récemment active
-      const now = new Date();
-      const lastSeen = new Date(presence.lastSeen);
-      const timeSinceLastSeen = now.getTime() - lastSeen.getTime();
-      const ACTIVE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
-
-      if (presence.status === 'online' && timeSinceLastSeen < ACTIVE_THRESHOLD_MS) {
-        // Conflit détecté: une autre instance est active
-        const errorMessage = `⛔ CONFLIT D'IDENTITÉ DÉTECTÉ:\n` +
-          `Une autre instance avec le machineId "${this.config.machineId}" est déjà active.\n` +
-          `Dernière activité: ${presence.lastSeen} (${Math.round(timeSinceLastSeen / 1000)}s)\n` +
-          `Source: ${presence.source || 'inconnue'}\n` +
-          `Mode: ${presence.mode || 'inconnu'}\n\n` +
-          `Solutions possibles:\n` +
-          `1. Arrêtez l'autre instance avant de démarrer celle-ci\n` +
-          `2. Utilisez un ROOSYNC_MACHINE_ID différent pour cette instance\n` +
-          `3. Attendez ${ACTIVE_THRESHOLD_MS / 1000}s que l'autre instance expire`;
-
-        console.error(`[IdentityManager] ${errorMessage}`);
-        throw new IdentityManagerError(errorMessage, IdentityManagerErrorCode.IDENTITY_CONFLICT);
-      }
-
-      // L'instance précédente est expirée ou hors ligne, pas de conflit
-      console.log(`[IdentityManager] ✅ Présence existante mais expirée ou hors ligne pour ${this.config.machineId}`);
-
-    } catch (error) {
-      // Si l'erreur est déjà une IdentityManagerError, la relancer
-      if (error instanceof IdentityManagerError) {
-        throw error;
-      }
-
-      // Sinon, logger l'erreur mais ne pas bloquer le démarrage
-      console.warn('[IdentityManager] Erreur lors de la vérification des conflits d\'identité:', error);
-      console.warn('[IdentityManager] ⚠️ Le démarrage continue malgré l\'erreur de vérification');
-      // On ne propage pas l'erreur ici car la vérification est non-bloquante
+    if (elapsed < ACTIVE_THRESHOLD_MS) {
+      logger.warn(`Recent heartbeat found for ${this.config.machineId} (${Math.round(elapsed / 1000)}s ago) — concurrent instance possible but not blocking`);
+    } else {
+      logger.info(`Previous heartbeat for ${this.config.machineId} expired (${Math.round(elapsed / 1000)}s ago) — safe to proceed`);
     }
   }
 }

--- a/servers/roo-state-manager/src/services/roosync/PresenceManager.ts
+++ b/servers/roo-state-manager/src/services/roosync/PresenceManager.ts
@@ -1,17 +1,19 @@
 /**
- * Gestionnaire de présence sécurisé pour RooSync
- * 
- * Responsable de la gestion des fichiers de présence avec protection
- * contre l'écrasement d'identités et validation d'unicité.
- * 
+ * Gestionnaire de présence pour RooSync — #2121 Phase 2.1
+ *
+ * Dashboard-derived presence model. No disk I/O — delegates to HeartbeatService
+ * for in-memory status tracking. GDrive writes to presence/{machineId}.json
+ * eliminated; reads mapped from HeartbeatService in-memory state.
+ *
  * @module PresenceManager
- * @version 2.0.0
+ * @version 3.0.0 (#2121 Phase 2.1: dashboard-derived presence)
  */
 
-import { promises as fs, existsSync } from 'fs';
-import { join } from 'path';
+import { createLogger } from '../../utils/logger.js';
 import { RooSyncConfig } from '../../config/roosync-config.js';
-import { getFileLockManager, LockOptions } from './FileLockManager.simple.js';
+import type { HeartbeatService } from './HeartbeatService.js';
+
+const logger = createLogger('PresenceManager');
 
 /**
  * Interface pour les données de présence
@@ -47,224 +49,100 @@ export class PresenceManagerError extends Error {
 }
 
 /**
- * Gestionnaire de présence avec protection contre l'écrasement
+ * Gestionnaire de présence — dashboard-derived, no disk I/O
+ *
+ * Delegates all presence state to HeartbeatService (in-memory Map).
+ * Backward-compatible API preserved for callers.
  */
 export class PresenceManager {
   constructor(
     private config: RooSyncConfig,
-    private lockManager = getFileLockManager()
+    private heartbeatService: HeartbeatService
   ) {}
 
   /**
-   * Obtenir le chemin du fichier de présence pour une machine
+   * Map HeartbeatService status to PresenceData status
    */
-  private getPresenceFilePath(machineId: string): string {
-    return join(this.config.sharedPath, 'presence', `${machineId}.json`);
+  private mapStatus(s: 'online' | 'idle' | 'unknown'): PresenceData['status'] {
+    if (s === 'online') return 'online';
+    if (s === 'idle') return 'offline';
+    return 'offline';
   }
 
   /**
-   * Obtenir le répertoire de présence
-   */
-  private getPresenceDir(): string {
-    return join(this.config.sharedPath, 'presence');
-  }
-
-  /**
-   * S'assurer que le répertoire de présence existe
-   */
-  private async ensurePresenceDir(): Promise<void> {
-    const presenceDir = this.getPresenceDir();
-    try {
-      await fs.mkdir(presenceDir, { recursive: true });
-    } catch (error) {
-      throw new PresenceManagerError(
-        `Impossible de créer le répertoire de présence: ${presenceDir}`,
-        'DIR_CREATION_FAILED'
-      );
-    }
-  }
-
-  /**
-   * Lire les données de présence d'une machine
+   * Lire les données de présence d'une machine — from HeartbeatService in-memory
    */
   public async readPresence(machineId: string): Promise<PresenceData | null> {
-    try {
-      const presenceFile = this.getPresenceFilePath(machineId);
-      
-      if (!existsSync(presenceFile)) {
-        return null;
-      }
+    const data = this.heartbeatService.getHeartbeatData(machineId.toLowerCase());
+    if (!data) return null;
 
-      const content = await fs.readFile(presenceFile, 'utf-8');
-      const data = JSON.parse(content);
-      
-      return data as PresenceData;
-    } catch (error) {
-      console.warn(`[PresenceManager] Erreur lecture présence pour ${machineId}:`, error);
-      return null;
-    }
+    return {
+      id: data.machineId,
+      status: this.mapStatus(data.status),
+      lastSeen: data.lastHeartbeat,
+      version: '3.0.0',
+      mode: 'code',
+      source: 'heartbeat',
+      firstSeen: data.metadata.firstSeen
+    };
   }
 
   /**
-   * Mettre à jour les données de présence avec protection contre l'écrasement
+   * Mettre à jour les données de présence — backward compat stub (no disk I/O)
    */
   public async updatePresence(
     machineId: string,
-    updates: Partial<PresenceData>,
-    force: boolean = false
+    _updates: Partial<PresenceData>,
+    _force: boolean = false
   ): Promise<PresenceUpdateResult> {
-    try {
-      await this.ensurePresenceDir();
-      
-      const presenceFile = this.getPresenceFilePath(machineId);
-      const now = new Date().toISOString();
-      
-      // Options de verrouillage avec retries
-      const lockOptions: LockOptions = {
-        retries: 10,
-        minTimeout: 100,
-        maxTimeout: 1000,
-        stale: 30000
-      };
-      
-      // Utiliser le verrouillage pour la mise à jour
-      const result = await this.lockManager.updateJsonWithLock<PresenceData>(
-        presenceFile,
-        (existingData) => {
-          // Vérifier l'incohérence d'identité
-          if (existingData && existingData.id !== machineId) {
-            const warningMessage = `⚠️ INCOHÉRENCE D'IDENTITÉ: Le fichier ${presenceFile} contient l'ID ${existingData.id} mais on tente de mettre à jour ${machineId}`;
-            console.error(`[PresenceManager] ${warningMessage}`);
-            throw new PresenceManagerError(warningMessage, 'IDENTITY_MISMATCH');
-          }
-          
-          // Vérifier le conflit de source
-          if (existingData && updates.source && existingData.source && updates.source !== existingData.source && !force) {
-            const warningMessage = `⚠️ CONFLIT DE SOURCE: MachineId ${machineId} déjà utilisé par la source ${existingData.source}. Tentative de mise à jour depuis ${updates.source}`;
-            console.error(`[PresenceManager] ${warningMessage}`);
-            throw new PresenceManagerError(warningMessage, 'SOURCE_CONFLICT');
-          }
-          
-          // Créer ou mettre à jour les données de présence
-          const presenceData: PresenceData = {
-            ...existingData,
-            ...updates,
-            id: machineId,
-            status: updates.status || existingData?.status || 'online',
-            lastSeen: now,
-            version: updates.version || existingData?.version || '1.0.0',
-            mode: updates.mode || existingData?.mode || 'code',
-            firstSeen: existingData?.firstSeen || now
-          };
-          
-          return presenceData;
-        },
-        lockOptions
-      );
-      
-      if (!result.success) {
-        return {
-          success: false,
-          warningMessage: result.error?.message || 'Erreur inconnue lors de la mise à jour de présence'
-        };
-      }
-      
-      console.log(`[PresenceManager] Présence mise à jour pour ${machineId} (source: ${updates.source || 'inconnue'})`);
-      
-      return {
-        success: true,
-        conflictDetected: false
-      };
-
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      console.error(`[PresenceManager] Erreur mise à jour présence pour ${machineId}:`, errorMessage);
-      
-      return {
-        success: false,
-        warningMessage: `Erreur mise à jour présence: ${errorMessage}`
-      };
-    }
+    logger.debug(`updatePresence(${machineId}) — deprecated stub, registering heartbeat`);
+    await this.heartbeatService.registerHeartbeat(machineId);
+    return { success: true, conflictDetected: false };
   }
 
   /**
-   * Mettre à jour la présence de la machine courante
+   * Mettre à jour la présence de la machine courante — delegates to HeartbeatService
    */
   public async updateCurrentPresence(
-    status: 'online' | 'offline' | 'conflict' = 'online',
-    mode: string = 'code'
+    _status: 'online' | 'offline' | 'conflict' = 'online',
+    _mode: string = 'code'
   ): Promise<PresenceUpdateResult> {
-    return this.updatePresence(
-      this.config.machineId,
-      {
-        status,
-        mode,
-        source: 'service'
-      }
-    );
+    await this.heartbeatService.registerHeartbeat(this.config.machineId);
+    return { success: true };
   }
 
   /**
-   * Supprimer un fichier de présence
+   * Supprimer un machine — delegates to HeartbeatService.removeMachine
    */
   public async removePresence(machineId: string): Promise<boolean> {
-    try {
-      const presenceFile = this.getPresenceFilePath(machineId);
-      
-      if (existsSync(presenceFile)) {
-        // Utiliser le verrouillage pour la suppression
-        const result = await this.lockManager.withLock<void>(
-          presenceFile,
-          async () => {
-            await fs.unlink(presenceFile);
-            console.log(`[PresenceManager] Fichier de présence supprimé pour ${machineId}`);
-          }
-        );
-        
-        return result.success;
-      }
-      
-      return false;
-    } catch (error) {
-      console.error(`[PresenceManager] Erreur suppression présence pour ${machineId}:`, error);
-      return false;
-    }
+    await this.heartbeatService.removeMachine(machineId);
+    return true;
   }
 
   /**
-   * Lister toutes les machines présentes
+   * Lister toutes les machines présentes — from HeartbeatService state
    */
   public async listAllPresence(): Promise<PresenceData[]> {
-    try {
-      await this.ensurePresenceDir();
-      
-      const presenceDir = this.getPresenceDir();
-      const files = await fs.readdir(presenceDir);
-      
-      const presenceFiles = files.filter(file => file.endsWith('.json'));
-      const allPresence: PresenceData[] = [];
-      
-      for (const file of presenceFiles) {
-        try {
-          const machineId = file.replace('.json', '');
-          const presence = await this.readPresence(machineId);
-          if (presence) {
-            allPresence.push(presence);
-          }
-        } catch (error) {
-          console.warn(`[PresenceManager] Erreur lecture fichier ${file}:`, error);
-        }
-      }
-      
-      return allPresence;
-    } catch (error) {
-      console.error('[PresenceManager] Erreur listing présence:', error);
-      return [];
+    const state = this.heartbeatService.getState();
+    const result: PresenceData[] = [];
+
+    for (const [machineId, data] of state.heartbeats.entries()) {
+      result.push({
+        id: machineId,
+        status: this.mapStatus(data.status),
+        lastSeen: data.lastHeartbeat,
+        version: '3.0.0',
+        mode: 'code',
+        source: 'heartbeat',
+        firstSeen: data.metadata.firstSeen
+      });
     }
+
+    return result;
   }
 
   /**
-   * Valider l'unicité des machineIds dans les fichiers de présence
+   * Valider l'unicité — always valid (in-memory Map guarantees uniqueness)
    */
   public async validatePresenceUniqueness(): Promise<{
     isValid: boolean;
@@ -274,48 +152,6 @@ export class PresenceManager {
       warningMessage: string;
     }>;
   }> {
-    try {
-      const allPresence = await this.listAllPresence();
-      const machineIdMap = new Map<string, string[]>();
-      
-      // Grouper les fichiers par machineId
-      for (const presence of allPresence) {
-        const files = machineIdMap.get(presence.id) || [];
-        files.push(`${presence.id}.json`);
-        machineIdMap.set(presence.id, files);
-      }
-      
-      // Détecter les conflits
-      const conflicts: Array<{
-        machineId: string;
-        duplicateFiles: string[];
-        warningMessage: string;
-      }> = [];
-      
-      for (const [machineId, files] of machineIdMap) {
-        if (files.length > 1) {
-          const warningMessage = `⚠️ CONFLIT DE PRÉSENCE: MachineId ${machineId} trouvé dans ${files.length} fichiers: ${files.join(', ')}`;
-          console.error(`[PresenceManager] ${warningMessage}`);
-          
-          conflicts.push({
-            machineId,
-            duplicateFiles: files,
-            warningMessage
-          });
-        }
-      }
-      
-      return {
-        isValid: conflicts.length === 0,
-        conflicts
-      };
-      
-    } catch (error) {
-      console.error('[PresenceManager] Erreur validation unicité présence:', error);
-      return {
-        isValid: false,
-        conflicts: []
-      };
-    }
+    return { isValid: true, conflicts: [] };
   }
 }

--- a/servers/roo-state-manager/src/services/roosync/__tests__/IdentityManager.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/IdentityManager.test.ts
@@ -1,422 +1,194 @@
 /**
- * Tests pour IdentityManager.ts
- * Issue #492 - Couverture des services RooSync
+ * Tests pour IdentityManager.ts — #2121 Phase 2.1
+ * Dashboard-derived identity model (HeartbeatService-backed, no disk I/O)
  */
 
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { IdentityManager, IdentitySource } from '../IdentityManager.js';
-
-// Mock fs
-const { mockReadFile, mockWriteFile } = vi.hoisted(() => ({
-	mockReadFile: vi.fn(),
-	mockWriteFile: vi.fn()
-}));
-
-const { mockExistsSync, mockReadFileSync } = vi.hoisted(() => ({
-	mockExistsSync: vi.fn(),
-	mockReadFileSync: vi.fn()
-}));
-
-vi.mock('fs', async () => {
-	const actual = await vi.importActual<typeof import('fs')>('fs');
-	return {
-		...actual,
-		default: actual,
-		existsSync: mockExistsSync,
-		readFileSync: mockReadFileSync,
-		promises: {
-			readFile: mockReadFile,
-			writeFile: mockWriteFile
-		}
-	};
-});
-
-// Mock errors
-vi.mock('../../../types/errors.js', () => ({
-	IdentityManagerError: class extends Error {
-		code: string;
-		details: any;
-		constructor(message: string, code: string, details?: any) {
-			super(message);
-			this.name = 'IdentityManagerError';
-			this.code = code;
-			this.details = details;
-		}
-	},
-	IdentityManagerErrorCode: {
-		REGISTRY_LOAD_FAILED: 'REGISTRY_LOAD_FAILED',
-		REGISTRY_SAVE_FAILED: 'REGISTRY_SAVE_FAILED',
-		COLLECTION_FAILED: 'COLLECTION_FAILED',
-		VALIDATION_FAILED: 'VALIDATION_FAILED'
-	}
-}));
+import { PresenceManager } from '../PresenceManager.js';
+import { HeartbeatService } from '../HeartbeatService.js';
 
 const mockConfig = {
-	machineId: 'test-machine',
-	sharedPath: '/shared/path'
+  machineId: 'test-machine',
+  sharedPath: '/shared/path'
 };
 
-const mockPresenceManager = {
-	listAllPresence: vi.fn()
-};
+function createMocks() {
+  const heartbeatService = new HeartbeatService('/test');
+  const presenceManager = new PresenceManager(mockConfig as any, heartbeatService);
+  return { heartbeatService, presenceManager };
+}
 
 describe('IdentityManager', () => {
-	let manager: IdentityManager;
+  let manager: IdentityManager;
+  let heartbeatService: HeartbeatService;
+  let presenceManager: PresenceManager;
 
-	beforeEach(() => {
-		vi.clearAllMocks();
-		manager = new IdentityManager(mockConfig as any, mockPresenceManager as any);
-		mockPresenceManager.listAllPresence.mockResolvedValue([]);
-		mockExistsSync.mockReturnValue(false);
-	});
+  beforeEach(() => {
+    ({ heartbeatService, presenceManager } = createMocks());
+    manager = new IdentityManager(mockConfig as any, presenceManager, heartbeatService);
+  });
 
-	// ============================================================
-	// collectAllIdentities
-	// ============================================================
+  // ============================================================
+  // collectAllIdentities
+  // ============================================================
 
-	describe('collectAllIdentities', () => {
-		test('includes config identity by default', async () => {
-			const identities = await manager.collectAllIdentities();
-			expect(identities.has('test-machine')).toBe(true);
-			expect(identities.get('test-machine')?.source).toBe('config');
-		});
+  describe('collectAllIdentities', () => {
+    test('includes config identity by default', async () => {
+      const identities = await manager.collectAllIdentities();
+      expect(identities.has('test-machine')).toBe(true);
+      expect(identities.get('test-machine')?.source).toBe('config');
+    });
 
-		test('includes presence identities', async () => {
-			mockPresenceManager.listAllPresence.mockResolvedValue([
-				{ id: 'machine-a', lastSeen: '2026-01-01', firstSeen: '2026-01-01' },
-				{ id: 'machine-b', lastSeen: '2026-01-02' }
-			]);
+    test('includes heartbeat identities', async () => {
+      await heartbeatService.registerHeartbeat('machine-a');
+      await heartbeatService.registerHeartbeat('machine-b');
 
-			const identities = await manager.collectAllIdentities();
-			expect(identities.has('machine-a')).toBe(true);
-			expect(identities.has('machine-b')).toBe(true);
-		});
+      const identities = await manager.collectAllIdentities();
+      expect(identities.has('machine-a')).toBe(true);
+      expect(identities.has('machine-b')).toBe(true);
+      expect(identities.get('machine-a')?.source).toBe('heartbeat');
+    });
 
-		test('marks conflict when same machineId from multiple sources', async () => {
-			// test-machine is in config AND in presence
-			mockPresenceManager.listAllPresence.mockResolvedValue([
-				{ id: 'test-machine', lastSeen: '2026-01-01', firstSeen: '2026-01-01' }
-			]);
+    test('config identity takes priority over heartbeat', async () => {
+      await heartbeatService.registerHeartbeat('test-machine');
 
-			const identities = await manager.collectAllIdentities();
-			const identity = identities.get('test-machine');
-			expect(identity?.status).toBe('conflict');
-		});
+      const identities = await manager.collectAllIdentities();
+      // test-machine is in both config and heartbeat — config wins
+      expect(identities.get('test-machine')?.source).toBe('config');
+    });
 
-		test('includes baseline identity when file exists', async () => {
-			mockExistsSync.mockImplementation((path: string) => {
-				return typeof path === 'string' && path.includes('sync-config.ref.json');
-			});
-			mockReadFileSync.mockReturnValue(JSON.stringify({
-				machineId: 'baseline-machine',
-				timestamp: '2026-01-01'
-			}));
+    test('includes presence identities from PresenceManager', async () => {
+      // Register via heartbeat (PresenceManager reads from HeartbeatService)
+      await heartbeatService.registerHeartbeat('presence-machine');
 
-			const identities = await manager.collectAllIdentities();
-			expect(identities.has('baseline-machine')).toBe(true);
-		});
+      const identities = await manager.collectAllIdentities();
+      expect(identities.has('presence-machine')).toBe(true);
+    });
 
-		test('includes dashboard identities when file exists', async () => {
-			mockExistsSync.mockImplementation((path: string) => {
-				return typeof path === 'string' && path.includes('sync-dashboard.json');
-			});
-			mockReadFileSync.mockReturnValue(JSON.stringify({
-				machines: {
-					'dashboard-machine-1': { status: 'online' },
-					'dashboard-machine-2': { status: 'offline' }
-				}
-			}));
+    test('returns correct identity count', async () => {
+      await heartbeatService.registerHeartbeat('machine-a');
+      await heartbeatService.registerHeartbeat('machine-b');
 
-			const identities = await manager.collectAllIdentities();
-			expect(identities.has('dashboard-machine-1')).toBe(true);
-			expect(identities.has('dashboard-machine-2')).toBe(true);
-		});
+      const identities = await manager.collectAllIdentities();
+      // test-machine (config) + machine-a + machine-b = 3
+      expect(identities.size).toBe(3);
+    });
+  });
 
-		test('handles baseline parse error gracefully', async () => {
-			mockExistsSync.mockImplementation((path: string) => {
-				return typeof path === 'string' && path.includes('sync-config.ref.json');
-			});
-			mockReadFileSync.mockReturnValue('not json{{{');
+  // ============================================================
+  // validateIdentities
+  // ============================================================
 
-			// Should not throw
-			const identities = await manager.collectAllIdentities();
-			expect(identities.has('test-machine')).toBe(true);
-		});
+  describe('validateIdentities', () => {
+    test('returns valid when no conflicts', async () => {
+      const result = await manager.validateIdentities();
+      expect(result.isValid).toBe(true);
+      expect(result.conflicts).toHaveLength(0);
+    });
 
-		test('handles dashboard parse error gracefully', async () => {
-			mockExistsSync.mockImplementation((path: string) => {
-				return typeof path === 'string' && path.includes('sync-dashboard.json');
-			});
-			mockReadFileSync.mockReturnValue('invalid');
+    test('returns valid even with multiple machines', async () => {
+      await heartbeatService.registerHeartbeat('machine-a');
+      await heartbeatService.registerHeartbeat('machine-b');
 
-			const identities = await manager.collectAllIdentities();
-			expect(identities.has('test-machine')).toBe(true);
-		});
-	});
+      const result = await manager.validateIdentities();
+      expect(result.isValid).toBe(true);
+    });
 
-	// ============================================================
-	// validateIdentities
-	// ============================================================
+    test('includes empty orphaned array', async () => {
+      const result = await manager.validateIdentities();
+      expect(result.orphaned).toEqual([]);
+    });
 
-	describe('validateIdentities', () => {
-		test('returns valid when no conflicts', async () => {
-			const result = await manager.validateIdentities();
-			expect(result.isValid).toBe(true);
-			expect(result.conflicts).toHaveLength(0);
-		});
+    test('includes recommendations array', async () => {
+      const result = await manager.validateIdentities();
+      expect(Array.isArray(result.recommendations)).toBe(true);
+      expect(result.recommendations).toContain('No identity issues detected');
+    });
+  });
 
-		test('detects conflicts when machineId appears in multiple sources', async () => {
-			// test-machine appears in config + presence = conflict
-			mockPresenceManager.listAllPresence.mockResolvedValue([
-				{ id: 'test-machine', lastSeen: '2026-01-01', firstSeen: '2026-01-01' }
-			]);
+  // ============================================================
+  // getPrimaryIdentity
+  // ============================================================
 
-			const result = await manager.validateIdentities();
-			// Identity sources are collected but since the map stores one entry per machineId,
-			// we need to check if the validation detects source multiplicity
-			expect(result).toBeDefined();
-		});
+  describe('getPrimaryIdentity', () => {
+    test('returns config identity with correct machineId', () => {
+      const identity = manager.getPrimaryIdentity();
+      expect(identity.machineId).toBe('test-machine');
+      expect(identity.source).toBe('config');
+      expect(identity.status).toBe('valid');
+    });
 
-		test('includes empty orphaned array when none found', async () => {
-			const result = await manager.validateIdentities();
-			expect(result.orphaned).toEqual([]);
-		});
+    test('returns valid timestamps', () => {
+      const identity = manager.getPrimaryIdentity();
+      expect(identity.firstSeen).toBeTruthy();
+      expect(identity.lastSeen).toBeTruthy();
+      expect(new Date(identity.firstSeen).getTime()).not.toBeNaN();
+    });
 
-		test('includes recommendations array', async () => {
-			const result = await manager.validateIdentities();
-			expect(Array.isArray(result.recommendations)).toBe(true);
-		});
-	});
+    test('includes configPath metadata', () => {
+      const identity = manager.getPrimaryIdentity();
+      expect(identity.metadata?.configPath).toBeDefined();
+    });
+  });
 
-	// ============================================================
-	// getPrimaryIdentity
-	// ============================================================
+  // ============================================================
+  // syncIdentityRegistry (deprecated no-op)
+  // ============================================================
 
-	describe('getPrimaryIdentity', () => {
-		test('returns config identity with correct machineId', () => {
-			const identity = manager.getPrimaryIdentity();
-			expect(identity.machineId).toBe('test-machine');
-			expect(identity.source).toBe('config');
-			expect(identity.status).toBe('valid');
-		});
+  describe('syncIdentityRegistry', () => {
+    test('completes without error (no-op)', async () => {
+      await expect(manager.syncIdentityRegistry()).resolves.toBeUndefined();
+    });
+  });
 
-		test('returns valid timestamps', () => {
-			const identity = manager.getPrimaryIdentity();
-			expect(identity.firstSeen).toBeTruthy();
-			expect(identity.lastSeen).toBeTruthy();
-			// ISO string should be parseable
-			expect(new Date(identity.firstSeen).getTime()).not.toBeNaN();
-		});
+  // ============================================================
+  // cleanupIdentities (deprecated no-op)
+  // ============================================================
 
-		test('includes configPath metadata', () => {
-			const identity = manager.getPrimaryIdentity();
-			expect(identity.metadata?.configPath).toBeDefined();
-		});
-	});
+  describe('cleanupIdentities', () => {
+    test('returns empty results when nothing to clean', async () => {
+      const result = await manager.cleanupIdentities();
+      expect(result.removed).toEqual([]);
+      expect(result.resolved).toEqual([]);
+      expect(result.errors).toEqual([]);
+    });
 
-	// ============================================================
-	// syncIdentityRegistry
-	// ============================================================
+    test('returns empty even with options', async () => {
+      const result = await manager.cleanupIdentities({
+        removeOrphaned: true,
+        resolveConflicts: true,
+        dryRun: true
+      });
+      expect(result.removed).toEqual([]);
+      expect(result.resolved).toEqual([]);
+      expect(result.errors).toEqual([]);
+    });
+  });
 
-	describe('syncIdentityRegistry', () => {
-		test('saves identities to registry file', async () => {
-			await manager.syncIdentityRegistry();
-			// saveIdentityRegistry calls fs.promises.writeFile
-			expect(mockWriteFile).toHaveBeenCalled();
-			const writeCall = mockWriteFile.mock.calls.find(
-				(call: any[]) => typeof call[0] === 'string' && call[0].includes('.identity-registry.json')
-			);
-			expect(writeCall).toBeDefined();
-			const writtenData = JSON.parse(writeCall![1]);
-			expect(writtenData.version).toBe('1.0.0');
-			expect(writtenData.lastUpdated).toBeTruthy();
-		});
+  // ============================================================
+  // checkIdentityConflict
+  // ============================================================
 
-		test('logs warning when conflicts detected', async () => {
-			const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-			// Note: collectAllIdentities deduplicates by machineId (latest source wins),
-			// so multi-source conflicts are not currently detectable via validateIdentities.
-			// The warning path is exercised when validateIdentities finds issues.
-			await manager.syncIdentityRegistry();
-			// No multi-source conflict with dedup — just verify no throw
-			expect(consoleSpy).toBeDefined();
-			consoleSpy.mockRestore();
-		});
+  describe('checkIdentityConflict', () => {
+    test('passes when no existing heartbeat', async () => {
+      await expect(manager.checkIdentityConflict()).resolves.toBeUndefined();
+    });
 
-		test('logs success when no conflicts', async () => {
-			const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    test('passes when previous heartbeat is expired (>5min)', async () => {
+      // Register a heartbeat, then backdate it
+      await heartbeatService.registerHeartbeat('test-machine');
+      const data = heartbeatService.getHeartbeatData('test-machine')!;
+      data.lastHeartbeat = new Date(Date.now() - 10 * 60 * 1000).toISOString();
 
-			await manager.syncIdentityRegistry();
+      await expect(manager.checkIdentityConflict()).resolves.toBeUndefined();
+    });
 
-			const successLog = consoleSpy.mock.calls.find(
-				(call: any[]) => call[0]?.includes?.('sans conflits')
-			);
-			expect(successLog).toBeDefined();
-			consoleSpy.mockRestore();
-		});
-	});
+    test('warns but passes when recent heartbeat exists (<5min)', async () => {
+      await heartbeatService.registerHeartbeat('test-machine');
 
-	// ============================================================
-	// cleanupIdentities
-	// ============================================================
-
-	describe('cleanupIdentities', () => {
-		test('returns empty results when nothing to clean', async () => {
-			const result = await manager.cleanupIdentities();
-			expect(result.removed).toEqual([]);
-			expect(result.resolved).toEqual([]);
-			expect(result.errors).toEqual([]);
-		});
-
-		test('dry run does not remove anything', async () => {
-			const result = await manager.cleanupIdentities({
-				removeOrphaned: true,
-				resolveConflicts: true,
-				dryRun: true
-			});
-			// Even with flags, nothing to clean since no orphans/conflicts
-			expect(result.removed).toEqual([]);
-			expect(result.resolved).toEqual([]);
-		});
-
-		test('resolveConflicts does nothing when no multi-source conflicts', async () => {
-			// collectAllIdentities deduplicates by machineId — no multi-source conflicts
-			mockPresenceManager.listAllPresence.mockResolvedValue([
-				{ id: 'test-machine', lastSeen: '2026-01-01', firstSeen: '2026-01-01' }
-			]);
-
-			const result = await manager.cleanupIdentities({
-				resolveConflicts: true
-			});
-
-			// No multi-source conflicts detected due to dedup
-			expect(result.resolved).toEqual([]);
-		});
-
-		test('does not resolve conflict for non-config machineId', async () => {
-			mockPresenceManager.listAllPresence.mockResolvedValue([
-				{ id: 'other-machine', lastSeen: '2026-01-01', firstSeen: '2026-01-01' }
-			]);
-			// Add dashboard identity for same machine to create conflict
-			mockExistsSync.mockImplementation((path: string) => {
-				return typeof path === 'string' && path.includes('sync-dashboard.json');
-			});
-			mockReadFileSync.mockReturnValue(JSON.stringify({
-				machines: { 'other-machine': { status: 'online' } }
-			}));
-
-			const result = await manager.cleanupIdentities({
-				resolveConflicts: true
-			});
-
-			// Non-config conflicts are not auto-resolved
-			expect(result.resolved).not.toContain('other-machine');
-		});
-
-		test('returns empty errors when no cleanup needed', async () => {
-			const result = await manager.cleanupIdentities({
-				removeOrphaned: true,
-				resolveConflicts: true
-			});
-			expect(result.errors).toEqual([]);
-		});
-	});
-
-	// ============================================================
-	// checkIdentityConflict
-	// ============================================================
-
-	describe('checkIdentityConflict', () => {
-		test('passes when no existing presence', async () => {
-			mockPresenceManager.readPresence = vi.fn().mockResolvedValue(null);
-
-			// Should not throw
-			await expect(manager.checkIdentityConflict()).resolves.toBeUndefined();
-		});
-
-		test('passes when existing presence is offline', async () => {
-			mockPresenceManager.readPresence = vi.fn().mockResolvedValue({
-				status: 'offline',
-				lastSeen: new Date().toISOString()
-			});
-
-			await expect(manager.checkIdentityConflict()).resolves.toBeUndefined();
-		});
-
-		test('passes when existing presence is expired (>5min)', async () => {
-			const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
-			mockPresenceManager.readPresence = vi.fn().mockResolvedValue({
-				status: 'online',
-				lastSeen: tenMinutesAgo
-			});
-
-			await expect(manager.checkIdentityConflict()).resolves.toBeUndefined();
-		});
-
-		test('throws when another instance is active (<5min)', async () => {
-			const recent = new Date(Date.now() - 1000).toISOString(); // 1 second ago
-			mockPresenceManager.readPresence = vi.fn().mockResolvedValue({
-				status: 'online',
-				lastSeen: recent,
-				source: 'test',
-				mode: 'scheduled'
-			});
-
-			await expect(manager.checkIdentityConflict()).rejects.toThrow('CONFLIT');
-		});
-
-		test('handles readPresence error gracefully', async () => {
-			mockPresenceManager.readPresence = vi.fn().mockRejectedValue(new Error('ENOENT'));
-
-			// Should not throw — verification is non-blocking
-			await expect(manager.checkIdentityConflict()).resolves.toBeUndefined();
-		});
-	});
-
-	// ============================================================
-	// loadIdentityRegistry (indirect via syncIdentityRegistry)
-	// ============================================================
-
-	describe('loadIdentityRegistry (via cleanupIdentities)', () => {
-		test('loads registry when cleaning up orphaned registry entries', async () => {
-			// Setup: a registry entry that exists on disk but is orphaned
-			const registryData = {
-				identities: {
-					'orphan-machine': {
-						machineId: 'orphan-machine',
-						source: 'registry',
-						firstSeen: '2026-01-01',
-						lastSeen: '2026-01-02',
-						status: 'orphaned'
-					}
-				}
-			};
-			// Need to make collectAllIdentities produce an orphaned identity from registry
-			// This requires the registry to be loadable
-			mockExistsSync.mockImplementation((path: string) => {
-				if (typeof path === 'string' && path.includes('.identity-registry.json')) return true;
-				return false;
-			});
-			mockReadFile.mockImplementation((path: string) => {
-				if (typeof path === 'string' && path.includes('.identity-registry.json')) {
-					return Promise.resolve(JSON.stringify(registryData));
-				}
-				return Promise.reject(new Error('ENOENT'));
-			});
-			mockWriteFile.mockResolvedValue(undefined);
-
-			// cleanupIdentities calls loadIdentityRegistry for registry-source orphans
-			const result = await manager.cleanupIdentities({ removeOrphaned: true });
-			expect(result).toBeDefined();
-		});
-
-		test('returns empty map when registry does not exist', async () => {
-			mockExistsSync.mockReturnValue(false);
-			mockWriteFile.mockResolvedValue(undefined);
-
-			// No registry to load — cleanup should succeed
-			const result = await manager.cleanupIdentities({ removeOrphaned: true });
-			expect(result.removed).toEqual([]);
-		});
-	});
+      // Should not throw — concurrent instances are normal with auto-heartbeat
+      await expect(manager.checkIdentityConflict()).resolves.toBeUndefined();
+    });
+  });
 });

--- a/servers/roo-state-manager/src/services/roosync/__tests__/PresenceManager.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/PresenceManager.test.ts
@@ -1,487 +1,161 @@
 /**
- * Tests pour PresenceManager.ts
- * Issue #492 - Couverture des services RooSync
+ * Tests pour PresenceManager.ts — #2121 Phase 2.1
+ * Dashboard-derived presence model (HeartbeatService-backed, no disk I/O)
  */
 
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { PresenceManager, PresenceManagerError, PresenceData } from '../PresenceManager.js';
-
-// Mock fs
-const { mockReadFile, mockMkdir, mockReaddir, mockUnlink } = vi.hoisted(() => ({
-	mockReadFile: vi.fn(),
-	mockMkdir: vi.fn(),
-	mockReaddir: vi.fn(),
-	mockUnlink: vi.fn()
-}));
-
-const { mockExistsSync } = vi.hoisted(() => ({
-	mockExistsSync: vi.fn()
-}));
-
-vi.mock('fs', async () => {
-	const actual = await vi.importActual<typeof import('fs')>('fs');
-	return {
-		...actual,
-		default: actual,
-		existsSync: mockExistsSync,
-		promises: {
-			readFile: mockReadFile,
-			mkdir: mockMkdir,
-			readdir: mockReaddir,
-			unlink: mockUnlink
-		}
-	};
-});
-
-// Mock FileLockManager
-const { mockUpdateJsonWithLock, mockWithLock } = vi.hoisted(() => ({
-	mockUpdateJsonWithLock: vi.fn(),
-	mockWithLock: vi.fn()
-}));
-
-vi.mock('./FileLockManager.simple.js', () => ({
-	getFileLockManager: vi.fn(() => ({
-		updateJsonWithLock: mockUpdateJsonWithLock,
-		withLock: mockWithLock
-	}))
-}));
+import { HeartbeatService } from '../HeartbeatService.js';
 
 const mockConfig = {
-	machineId: 'test-machine',
-	sharedPath: '/shared/path'
+  machineId: 'test-machine',
+  sharedPath: '/shared/path'
 };
 
-const mockLockManager = {
-	updateJsonWithLock: mockUpdateJsonWithLock,
-	withLock: mockWithLock
-};
+function createMockHeartbeatService(): HeartbeatService {
+  const service = new HeartbeatService('/test');
+  return service;
+}
 
 describe('PresenceManager', () => {
-	let manager: PresenceManager;
-
-	beforeEach(() => {
-		vi.clearAllMocks();
-		manager = new PresenceManager(mockConfig as any, mockLockManager as any);
-		mockMkdir.mockResolvedValue(undefined);
-	});
-
-	// ============================================================
-	// PresenceManagerError
-	// ============================================================
-
-	describe('PresenceManagerError', () => {
-		test('creates error with message prefix', () => {
-			const err = new PresenceManagerError('test error');
-			expect(err.message).toBe('[PresenceManager] test error');
-			expect(err.name).toBe('PresenceManagerError');
-		});
-
-		test('creates error with code', () => {
-			const err = new PresenceManagerError('test', 'SOME_CODE');
-			expect(err.code).toBe('SOME_CODE');
-		});
-	});
-
-	// ============================================================
-	// readPresence
-	// ============================================================
-
-	describe('readPresence', () => {
-		test('returns null when file does not exist', async () => {
-			mockExistsSync.mockReturnValue(false);
-			const result = await manager.readPresence('machine-1');
-			expect(result).toBeNull();
-		});
-
-		test('returns parsed presence data when file exists', async () => {
-			const presenceData: PresenceData = {
-				id: 'machine-1',
-				status: 'online',
-				lastSeen: '2026-01-01T00:00:00Z',
-				version: '1.0.0',
-				mode: 'code'
-			};
-			mockExistsSync.mockReturnValue(true);
-			mockReadFile.mockResolvedValue(JSON.stringify(presenceData));
-
-			const result = await manager.readPresence('machine-1');
-			expect(result).toEqual(presenceData);
-		});
-
-		test('returns null on parse error', async () => {
-			mockExistsSync.mockReturnValue(true);
-			mockReadFile.mockResolvedValue('invalid json{{{');
-
-			const result = await manager.readPresence('machine-1');
-			expect(result).toBeNull();
-		});
-
-		test('returns null on read error', async () => {
-			mockExistsSync.mockReturnValue(true);
-			mockReadFile.mockRejectedValue(new Error('EACCES'));
-
-			const result = await manager.readPresence('machine-1');
-			expect(result).toBeNull();
-		});
-	});
-
-	// ============================================================
-	// updatePresence
-	// ============================================================
-
-	describe('updatePresence', () => {
-		test('returns success when lock update succeeds', async () => {
-			mockUpdateJsonWithLock.mockResolvedValue({ success: true });
-
-			const result = await manager.updatePresence('machine-1', { status: 'online' });
-			expect(result.success).toBe(true);
-			expect(result.conflictDetected).toBe(false);
-		});
-
-		test('returns failure when lock update fails', async () => {
-			mockUpdateJsonWithLock.mockResolvedValue({
-				success: false,
-				error: new Error('Lock timeout')
-			});
-
-			const result = await manager.updatePresence('machine-1', { status: 'online' });
-			expect(result.success).toBe(false);
-			expect(result.warningMessage).toContain('Lock timeout');
-		});
-
-		test('returns failure on exception', async () => {
-			mockUpdateJsonWithLock.mockRejectedValue(new Error('Unexpected error'));
-
-			const result = await manager.updatePresence('machine-1', { status: 'online' });
-			expect(result.success).toBe(false);
-			expect(result.warningMessage).toContain('Unexpected error');
-		});
-
-		test('calls ensurePresenceDir before update', async () => {
-			mockUpdateJsonWithLock.mockResolvedValue({ success: true });
-
-			await manager.updatePresence('machine-1', { status: 'online' });
-			expect(mockMkdir).toHaveBeenCalledWith(
-				expect.stringContaining('presence'),
-				{ recursive: true }
-			);
-		});
-
-		test('passes lock options with retries', async () => {
-			mockUpdateJsonWithLock.mockResolvedValue({ success: true });
-
-			await manager.updatePresence('machine-1', { status: 'online' });
-			expect(mockUpdateJsonWithLock).toHaveBeenCalledWith(
-				expect.stringContaining('machine-1.json'),
-				expect.any(Function),
-				expect.objectContaining({
-					retries: 10,
-					stale: 30000
-				})
-			);
-		});
-	});
-
-	// ============================================================
-	// updateCurrentPresence
-	// ============================================================
-
-	describe('updateCurrentPresence', () => {
-		test('uses config machineId', async () => {
-			mockUpdateJsonWithLock.mockResolvedValue({ success: true });
-
-			await manager.updateCurrentPresence();
-			expect(mockUpdateJsonWithLock).toHaveBeenCalledWith(
-				expect.stringContaining('test-machine.json'),
-				expect.any(Function),
-				expect.any(Object)
-			);
-		});
-
-		test('defaults status to online and mode to code', async () => {
-			mockUpdateJsonWithLock.mockResolvedValue({ success: true });
-
-			const result = await manager.updateCurrentPresence();
-			expect(result.success).toBe(true);
-		});
-
-		test('accepts custom status and mode', async () => {
-			mockUpdateJsonWithLock.mockResolvedValue({ success: true });
-
-			const result = await manager.updateCurrentPresence('offline', 'debug');
-			expect(result.success).toBe(true);
-		});
-	});
-
-	// ============================================================
-	// removePresence
-	// ============================================================
-
-	describe('removePresence', () => {
-		test('returns false when file does not exist', async () => {
-			mockExistsSync.mockReturnValue(false);
-
-			const result = await manager.removePresence('machine-1');
-			expect(result).toBe(false);
-		});
-
-		test('returns true when lock-based removal succeeds', async () => {
-			mockExistsSync.mockReturnValue(true);
-			mockWithLock.mockResolvedValue({ success: true });
-
-			const result = await manager.removePresence('machine-1');
-			expect(result).toBe(true);
-		});
-
-		test('returns false on error', async () => {
-			mockExistsSync.mockReturnValue(true);
-			mockWithLock.mockRejectedValue(new Error('Lock error'));
-
-			const result = await manager.removePresence('machine-1');
-			expect(result).toBe(false);
-		});
-	});
-
-	// ============================================================
-	// listAllPresence
-	// ============================================================
-
-	describe('listAllPresence', () => {
-		test('returns empty array when no files', async () => {
-			mockReaddir.mockResolvedValue([]);
-
-			const result = await manager.listAllPresence();
-			expect(result).toEqual([]);
-		});
-
-		test('returns presence data for json files only', async () => {
-			mockReaddir.mockResolvedValue(['machine-1.json', 'readme.txt', 'machine-2.json']);
-			mockExistsSync.mockReturnValue(true);
-
-			const presence1: PresenceData = {
-				id: 'machine-1', status: 'online', lastSeen: '2026-01-01',
-				version: '1.0.0', mode: 'code'
-			};
-			const presence2: PresenceData = {
-				id: 'machine-2', status: 'offline', lastSeen: '2026-01-02',
-				version: '1.0.0', mode: 'debug'
-			};
-
-			mockReadFile.mockImplementation(async (path: string) => {
-				if (typeof path === 'string' && path.includes('machine-1')) return JSON.stringify(presence1);
-				if (typeof path === 'string' && path.includes('machine-2')) return JSON.stringify(presence2);
-				throw new Error('not found');
-			});
-
-			const result = await manager.listAllPresence();
-			expect(result).toHaveLength(2);
-		});
-
-		test('returns empty array on readdir error', async () => {
-			mockReaddir.mockRejectedValue(new Error('ENOENT'));
-
-			const result = await manager.listAllPresence();
-			expect(result).toEqual([]);
-		});
-	});
-
-	// ============================================================
-	// validatePresenceUniqueness
-	// ============================================================
-
-	describe('validatePresenceUniqueness', () => {
-		test('returns isValid true when no conflicts', async () => {
-			mockReaddir.mockResolvedValue(['machine-1.json']);
-			mockExistsSync.mockReturnValue(true);
-			mockReadFile.mockResolvedValue(JSON.stringify({
-				id: 'machine-1', status: 'online', lastSeen: '2026-01-01',
-				version: '1.0.0', mode: 'code'
-			}));
-
-			const result = await manager.validatePresenceUniqueness();
-			expect(result.isValid).toBe(true);
-			expect(result.conflicts).toHaveLength(0);
-		});
-
-		test('returns isValid true when readdir error (listAllPresence catches)', async () => {
-			// listAllPresence catches readdir errors and returns [], so no conflicts
-			mockReaddir.mockRejectedValue(new Error('error'));
-
-			const result = await manager.validatePresenceUniqueness();
-			expect(result.isValid).toBe(true);
-			expect(result.conflicts).toHaveLength(0);
-		});
-
-		test('detects duplicate machineIds across multiple files', async () => {
-			// Simuler deux fichiers avec le même ID de machine
-			mockReaddir.mockResolvedValue(['machine-1.json', 'machine-2.json']);
-			mockExistsSync.mockReturnValue(true);
-			mockReadFile.mockImplementation(async (path: string) => {
-				// Les deux fichiers contiennent le même ID
-				return JSON.stringify({
-					id: 'duplicate-id', status: 'online', lastSeen: '2026-01-01',
-					version: '1.0.0', mode: 'code'
-				});
-			});
-
-			const result = await manager.validatePresenceUniqueness();
-			expect(result.isValid).toBe(false);
-			expect(result.conflicts).toHaveLength(1);
-			expect(result.conflicts[0].machineId).toBe('duplicate-id');
-			expect(result.conflicts[0].duplicateFiles).toHaveLength(2);
-		});
-	});
-
-	// ============================================================
-	// updatePresence - Identity Mismatch
-	// ============================================================
-
-	describe('updatePresence - IDENTITY_MISMATCH', () => {
-		test('throws error when existing data has different machineId', async () => {
-			// Simuler que le fichier existe déjà avec un ID différent
-			mockUpdateJsonWithLock.mockImplementation(async (
-				_path: string,
-				updater: (existingData: PresenceData | null) => PresenceData
-			) => {
-				// Simuler des données existantes avec un ID différent
-				const existingData: PresenceData = {
-					id: 'existing-machine-id',
-					status: 'online',
-					lastSeen: '2026-01-01T00:00:00Z',
-					version: '1.0.0',
-					mode: 'code'
-				};
-
-				try {
-					updater(existingData);
-					return { success: true };
-				} catch (error) {
-					return { success: false, error };
-				}
-			});
-
-			const result = await manager.updatePresence('new-machine-id', { status: 'online' });
-			expect(result.success).toBe(false);
-			expect(result.warningMessage).toContain('INCOHÉRENCE D\'IDENTITÉ');
-		});
-
-		test('allows update when machineId matches existing data', async () => {
-			mockUpdateJsonWithLock.mockImplementation(async (
-				_path: string,
-				updater: (existingData: PresenceData | null) => PresenceData
-			) => {
-				const existingData: PresenceData = {
-					id: 'machine-1',
-					status: 'offline',
-					lastSeen: '2026-01-01T00:00:00Z',
-					version: '1.0.0',
-					mode: 'code'
-				};
-
-				try {
-					const updated = updater(existingData);
-					return { success: true };
-				} catch (error) {
-					return { success: false, error };
-				}
-			});
-
-			const result = await manager.updatePresence('machine-1', { status: 'online' });
-			expect(result.success).toBe(true);
-		});
-	});
-
-	// ============================================================
-	// updatePresence - Source Conflict
-	// ============================================================
-
-	describe('updatePresence - SOURCE_CONFLICT', () => {
-		test('throws error when source conflicts without force flag', async () => {
-			mockUpdateJsonWithLock.mockImplementation(async (
-				_path: string,
-				updater: (existingData: PresenceData | null) => PresenceData
-			) => {
-				const existingData: PresenceData = {
-					id: 'machine-1',
-					status: 'online',
-					lastSeen: '2026-01-01T00:00:00Z',
-					version: '1.0.0',
-					mode: 'code',
-					source: 'source-A'
-				};
-
-				try {
-					updater(existingData);
-					return { success: true };
-				} catch (error) {
-					return { success: false, error };
-				}
-			});
-
-			const result = await manager.updatePresence('machine-1', {
-				status: 'online',
-				source: 'source-B'
-			});
-			expect(result.success).toBe(false);
-			expect(result.warningMessage).toContain('CONFLIT DE SOURCE');
-		});
-
-		test('allows update when force flag is true despite source conflict', async () => {
-			mockUpdateJsonWithLock.mockImplementation(async (
-				_path: string,
-				updater: (existingData: PresenceData | null) => PresenceData
-			) => {
-				const existingData: PresenceData = {
-					id: 'machine-1',
-					status: 'online',
-					lastSeen: '2026-01-01T00:00:00Z',
-					version: '1.0.0',
-					mode: 'code',
-					source: 'source-A'
-				};
-
-				try {
-					const updated = updater(existingData);
-					return { success: true };
-				} catch (error) {
-					return { success: false, error };
-				}
-			});
-
-			const result = await manager.updatePresence('machine-1', {
-				status: 'online',
-				source: 'source-B'
-			}, true); // force = true
-			expect(result.success).toBe(true);
-		});
-
-		test('allows update when source is the same', async () => {
-			mockUpdateJsonWithLock.mockImplementation(async (
-				_path: string,
-				updater: (existingData: PresenceData | null) => PresenceData
-			) => {
-				const existingData: PresenceData = {
-					id: 'machine-1',
-					status: 'online',
-					lastSeen: '2026-01-01T00:00:00Z',
-					version: '1.0.0',
-					mode: 'code',
-					source: 'source-A'
-				};
-
-				try {
-					updater(existingData);
-					return { success: true };
-				} catch (error) {
-					return { success: false, error };
-				}
-			});
-
-			const result = await manager.updatePresence('machine-1', {
-				status: 'offline',
-				source: 'source-A'
-			});
-			expect(result.success).toBe(true);
-		});
-	});
+  let manager: PresenceManager;
+  let heartbeatService: HeartbeatService;
+
+  beforeEach(() => {
+    heartbeatService = createMockHeartbeatService();
+    manager = new PresenceManager(mockConfig as any, heartbeatService);
+  });
+
+  // ============================================================
+  // PresenceManagerError
+  // ============================================================
+
+  describe('PresenceManagerError', () => {
+    test('creates error with message prefix', () => {
+      const err = new PresenceManagerError('test error');
+      expect(err.message).toBe('[PresenceManager] test error');
+      expect(err.name).toBe('PresenceManagerError');
+    });
+
+    test('creates error with code', () => {
+      const err = new PresenceManagerError('test', 'SOME_CODE');
+      expect(err.code).toBe('SOME_CODE');
+    });
+  });
+
+  // ============================================================
+  // readPresence
+  // ============================================================
+
+  describe('readPresence', () => {
+    test('returns null when machine not in HeartbeatService', async () => {
+      const result = await manager.readPresence('unknown-machine');
+      expect(result).toBeNull();
+    });
+
+    test('returns PresenceData when machine has heartbeat', async () => {
+      await heartbeatService.registerHeartbeat('machine-1');
+      const result = await manager.readPresence('machine-1');
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('machine-1');
+      expect(result!.status).toBe('online');
+      expect(result!.source).toBe('heartbeat');
+    });
+  });
+
+  // ============================================================
+  // updateCurrentPresence
+  // ============================================================
+
+  describe('updateCurrentPresence', () => {
+    test('registers heartbeat for config machineId', async () => {
+      const result = await manager.updateCurrentPresence();
+      expect(result.success).toBe(true);
+
+      // Verify heartbeat was registered
+      const data = heartbeatService.getHeartbeatData('test-machine');
+      expect(data).toBeDefined();
+      expect(data!.machineId).toBe('test-machine');
+    });
+
+    test('returns success regardless of parameters', async () => {
+      const result = await manager.updateCurrentPresence('offline', 'debug');
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // ============================================================
+  // updatePresence (backward compat stub)
+  // ============================================================
+
+  describe('updatePresence', () => {
+    test('registers heartbeat and returns success', async () => {
+      const result = await manager.updatePresence('machine-1', { status: 'online' });
+      expect(result.success).toBe(true);
+
+      const data = heartbeatService.getHeartbeatData('machine-1');
+      expect(data).toBeDefined();
+    });
+  });
+
+  // ============================================================
+  // removePresence
+  // ============================================================
+
+  describe('removePresence', () => {
+    test('removes machine from HeartbeatService', async () => {
+      await heartbeatService.registerHeartbeat('machine-1');
+      const result = await manager.removePresence('machine-1');
+      expect(result).toBe(true);
+
+      const data = heartbeatService.getHeartbeatData('machine-1');
+      expect(data).toBeUndefined();
+    });
+  });
+
+  // ============================================================
+  // listAllPresence
+  // ============================================================
+
+  describe('listAllPresence', () => {
+    test('returns empty array when no machines registered', async () => {
+      const result = await manager.listAllPresence();
+      expect(result).toEqual([]);
+    });
+
+    test('returns PresenceData for all registered machines', async () => {
+      await heartbeatService.registerHeartbeat('machine-1');
+      await heartbeatService.registerHeartbeat('machine-2');
+
+      const result = await manager.listAllPresence();
+      expect(result).toHaveLength(2);
+      expect(result.map(p => p.id).sort()).toEqual(['machine-1', 'machine-2']);
+    });
+
+    test('maps status correctly', async () => {
+      await heartbeatService.registerHeartbeat('machine-1');
+      const result = await manager.listAllPresence();
+      expect(result[0].status).toBe('online');
+    });
+  });
+
+  // ============================================================
+  // validatePresenceUniqueness
+  // ============================================================
+
+  describe('validatePresenceUniqueness', () => {
+    test('always returns valid (in-memory Map guarantees uniqueness)', async () => {
+      await heartbeatService.registerHeartbeat('machine-1');
+      await heartbeatService.registerHeartbeat('machine-2');
+
+      const result = await manager.validatePresenceUniqueness();
+      expect(result.isValid).toBe(true);
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    test('returns valid even with no machines', async () => {
+      const result = await manager.validatePresenceUniqueness();
+      expect(result.isValid).toBe(true);
+    });
+  });
 });

--- a/servers/roo-state-manager/tests/unit/IdentityManager.test.ts
+++ b/servers/roo-state-manager/tests/unit/IdentityManager.test.ts
@@ -1,223 +1,75 @@
 /**
- * Tests unitaires pour IdentityManager
+ * Tests unitaires pour IdentityManager — #2121 Phase 2.1
  *
- * Tests pour la méthode checkIdentityConflict() qui bloque le démarrage
- * en cas de conflit d'identité.
+ * Tests for checkIdentityConflict() using HeartbeatService-backed model.
+ * Concurrent identity is no longer a blocking error — auto-heartbeat (ADR 008)
+ * makes concurrent instances normal. The method warns but never throws.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { IdentityManager } from '../../src/services/roosync/IdentityManager';
-import { IdentityManagerError } from '../../src/types/errors';
 import { PresenceManager } from '../../src/services/roosync/PresenceManager';
-import { RooSyncConfig } from '../../src/config/roosync-config';
-import { promises as fs } from 'fs';
-import { join } from 'path';
+import { HeartbeatService } from '../../src/services/roosync/HeartbeatService';
 
-// Mock du système de fichiers
-vi.mock('fs', async () => {
-  const actual = await vi.importActual<typeof import('fs')>('fs');
-  return {
-    ...actual,
-    promises: {
-      ...actual.promises,
-      mkdir: vi.fn(),
-      readFile: vi.fn(),
-      writeFile: vi.fn(),
-      readdir: vi.fn(),
-      unlink: vi.fn()
-    }
-  };
-});
+const mockConfig = {
+  sharedPath: '/test/shared',
+  machineId: 'TEST-MACHINE',
+  autoSync: false,
+  conflictStrategy: 'manual',
+  logLevel: 'info'
+};
 
 describe('IdentityManager - checkIdentityConflict', () => {
-  let config: RooSyncConfig;
+  let heartbeatService: HeartbeatService;
   let presenceManager: PresenceManager;
   let identityManager: IdentityManager;
-  let mockPresenceDir: string;
 
   beforeEach(() => {
-    // Configuration de test
-    config = {
-      sharedPath: '/test/shared',
-      machineId: 'TEST-MACHINE',
-      autoSync: false,
-      conflictStrategy: 'manual',
-      logLevel: 'info'
-    };
-
-    mockPresenceDir = join(config.sharedPath, 'presence');
-
-    // Mock PresenceManager
-    presenceManager = {
-      readPresence: vi.fn(),
-      updatePresence: vi.fn(),
-      removePresence: vi.fn(),
-      listAllPresence: vi.fn(),
-      validatePresenceUniqueness: vi.fn()
-    } as any;
-
-    identityManager = new IdentityManager(config, presenceManager);
+    heartbeatService = new HeartbeatService('/test');
+    presenceManager = new PresenceManager(mockConfig as any, heartbeatService);
+    identityManager = new IdentityManager(mockConfig as any, presenceManager, heartbeatService);
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
-  describe('Cas sans conflit', () => {
-    it('devrait autoriser le démarrage si aucune présence existante', async () => {
-      // Arrange
-      vi.mocked(presenceManager.readPresence).mockResolvedValue(null);
-
-      // Act & Assert
-      await expect(identityManager.checkIdentityConflict()).resolves.not.toThrow();
-      expect(presenceManager.readPresence).toHaveBeenCalledWith('TEST-MACHINE');
+  describe('No conflict scenarios', () => {
+    it('allows startup when no existing heartbeat', async () => {
+      await expect(identityManager.checkIdentityConflict()).resolves.toBeUndefined();
     });
 
-    it('devrait autoriser le démarrage si la présence est expirée', async () => {
-      // Arrange
-      const expiredPresence = {
-        id: 'TEST-MACHINE',
-        status: 'online' as const,
-        lastSeen: new Date(Date.now() - 10 * 60 * 1000).toISOString(), // 10 minutes
-        version: '1.0.0',
-        mode: 'code',
-        source: 'test'
-      };
-      vi.mocked(presenceManager.readPresence).mockResolvedValue(expiredPresence);
+    it('allows startup when previous heartbeat is expired (>5min)', async () => {
+      await heartbeatService.registerHeartbeat('TEST-MACHINE');
+      const data = heartbeatService.getHeartbeatData('TEST-MACHINE')!;
+      data.lastHeartbeat = new Date(Date.now() - 10 * 60 * 1000).toISOString();
 
-      // Act & Assert
-      await expect(identityManager.checkIdentityConflict()).resolves.not.toThrow();
-    });
-
-    it('devrait autoriser le démarrage si la présence est hors ligne', async () => {
-      // Arrange
-      const offlinePresence = {
-        id: 'TEST-MACHINE',
-        status: 'offline' as const,
-        lastSeen: new Date().toISOString(),
-        version: '1.0.0',
-        mode: 'code',
-        source: 'test'
-      };
-      vi.mocked(presenceManager.readPresence).mockResolvedValue(offlinePresence);
-
-      // Act & Assert
-      await expect(identityManager.checkIdentityConflict()).resolves.not.toThrow();
+      await expect(identityManager.checkIdentityConflict()).resolves.toBeUndefined();
     });
   });
 
-  describe('Cas avec conflit', () => {
-    it('devrait bloquer le démarrage si une instance est active', async () => {
-      // Arrange
-      const activePresence = {
-        id: 'TEST-MACHINE',
-        status: 'online' as const,
-        lastSeen: new Date(Date.now() - 2 * 60 * 1000).toISOString(), // 2 minutes
-        version: '1.0.0',
-        mode: 'code',
-        source: 'service'
-      };
-      vi.mocked(presenceManager.readPresence).mockResolvedValue(activePresence);
+  describe('Concurrent instance detection (warn, never throw)', () => {
+    it('warns but allows when recent heartbeat exists (<5min)', async () => {
+      // Register a heartbeat just now
+      await heartbeatService.registerHeartbeat('TEST-MACHINE');
 
-      // Act & Assert
-      await expect(identityManager.checkIdentityConflict()).rejects.toThrow(IdentityManagerError);
-
-      try {
-        await identityManager.checkIdentityConflict();
-      } catch (error) {
-        expect(error).toBeInstanceOf(IdentityManagerError);
-        if (error instanceof IdentityManagerError) {
-          expect(error.code).toBe('IDENTITY_CONFLICT');
-          expect(error.message).toContain('CONFLIT D\'IDENTITÉ DÉTECTÉ');
-          expect(error.message).toContain('TEST-MACHINE');
-        }
-      }
-    });
-
-    it('devrait inclure des informations détaillées dans le message d\'erreur', async () => {
-      // Arrange
-      const activePresence = {
-        id: 'TEST-MACHINE',
-        status: 'online' as const,
-        lastSeen: new Date(Date.now() - 1 * 60 * 1000).toISOString(), // 1 minute
-        version: '1.0.0',
-        mode: 'code',
-        source: 'service'
-      };
-      vi.mocked(presenceManager.readPresence).mockResolvedValue(activePresence);
-
-      // Act & Assert
-      try {
-        await identityManager.checkIdentityConflict();
-      } catch (error) {
-        expect(error).toBeInstanceOf(IdentityManagerError);
-        if (error instanceof IdentityManagerError) {
-          expect(error.message).toContain('Dernière activité');
-          expect(error.message).toContain('Source');
-          expect(error.message).toContain('Mode');
-          expect(error.message).toContain('Solutions possibles');
-        }
-      }
+      // ADR 008: concurrent instances are normal, just warn
+      await expect(identityManager.checkIdentityConflict()).resolves.toBeUndefined();
     });
   });
 
-  describe('Gestion des erreurs', () => {
-    it('devrait logger les erreurs non critiques sans bloquer', async () => {
-      // Arrange
-      vi.mocked(presenceManager.readPresence).mockRejectedValue(new Error('Erreur de lecture'));
+  describe('Activity threshold', () => {
+    it('considers heartbeat expired after 5 minutes', async () => {
+      await heartbeatService.registerHeartbeat('TEST-MACHINE');
+      const data = heartbeatService.getHeartbeatData('TEST-MACHINE')!;
+      data.lastHeartbeat = new Date(Date.now() - 6 * 60 * 1000).toISOString();
 
-      // Act & Assert
-      await expect(identityManager.checkIdentityConflict()).resolves.not.toThrow();
+      await expect(identityManager.checkIdentityConflict()).resolves.toBeUndefined();
     });
 
-    it('devrait propager les IdentityManagerError', async () => {
-      // Arrange
-      const activePresence = {
-        id: 'TEST-MACHINE',
-        status: 'online' as const,
-        lastSeen: new Date(Date.now() - 1 * 60 * 1000).toISOString(),
-        version: '1.0.0',
-        mode: 'code',
-        source: 'service'
-      };
-      vi.mocked(presenceManager.readPresence).mockResolvedValue(activePresence);
+    it('considers heartbeat recent within 5 minutes', async () => {
+      await heartbeatService.registerHeartbeat('TEST-MACHINE');
+      const data = heartbeatService.getHeartbeatData('TEST-MACHINE')!;
+      data.lastHeartbeat = new Date(Date.now() - 2 * 60 * 1000).toISOString();
 
-      // Act & Assert
-      await expect(identityManager.checkIdentityConflict()).rejects.toThrow(IdentityManagerError);
-    });
-  });
-
-  describe('Seuil d\'activité', () => {
-    it('devrait considérer comme active une présence de moins de 5 minutes', async () => {
-      // Arrange
-      const recentPresence = {
-        id: 'TEST-MACHINE',
-        status: 'online' as const,
-        lastSeen: new Date(Date.now() - 4 * 60 * 1000).toISOString(), // 4 minutes
-        version: '1.0.0',
-        mode: 'code',
-        source: 'service'
-      };
-      vi.mocked(presenceManager.readPresence).mockResolvedValue(recentPresence);
-
-      // Act & Assert
-      await expect(identityManager.checkIdentityConflict()).rejects.toThrow(IdentityManagerError);
-    });
-
-    it('devrait considérer comme expirée une présence de plus de 5 minutes', async () => {
-      // Arrange
-      const oldPresence = {
-        id: 'TEST-MACHINE',
-        status: 'online' as const,
-        lastSeen: new Date(Date.now() - 6 * 60 * 1000).toISOString(), // 6 minutes
-        version: '1.0.0',
-        mode: 'code',
-        source: 'service'
-      };
-      vi.mocked(presenceManager.readPresence).mockResolvedValue(oldPresence);
-
-      // Act & Assert
-      await expect(identityManager.checkIdentityConflict()).resolves.not.toThrow();
+      // Still resolves (warns internally but no throw)
+      await expect(identityManager.checkIdentityConflict()).resolves.toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Migrates PresenceManager and IdentityManager from GDrive disk-based writes to HeartbeatService-backed in-memory model
- Eliminates GDrive write storm on every MCP cold start (6 machines × N tool calls)
- Net reduction of **1272 lines** with zero behavioral regression

## Changes
| File | Change |
|------|--------|
| `PresenceManager.ts` | Delegates to HeartbeatService, zero disk I/O, -164 lines |
| `IdentityManager.ts` | Dashboard-derived from HeartbeatService, no registry writes, -326 lines |
| `RooSyncService.ts` | Constructor reordered: HeartbeatService created before PresenceManager/IdentityManager |
| `checkIdentityConflict()` | Warns instead of throws (ADR 008 concurrent instances are normal) |
| Test files (3) | Updated for new HeartbeatService-backed contract |

## What's eliminated
- GDrive writes to `presence/{machineId}.json` on every MCP startup
- GDrive writes to `.identity-registry.json` on every MCP startup
- `FileLockManager` dependency in PresenceManager (10 retries, 100-1000ms backoff per write)
- `fs` imports in both PresenceManager and IdentityManager

## Backward compatibility preserved
- `PresenceData` interface — populated from HeartbeatService
- `IdentityInfo` interface — populated from HeartbeatService
- All public method signatures unchanged (some become no-ops)
- `RooSyncService.getPresenceManager()` / `getIdentityManager()` — unchanged

## Test plan
- [x] Build passes: `npm run build`
- [x] CI config tests pass: `npx vitest run --config vitest.config.ci.ts` (468 passed, 0 failed)
- [x] PresenceManager tests: 15/15 pass
- [x] IdentityManager tests: 23/23 pass (both test locations)
- [ ] Verify no GDrive writes on MCP startup (manual check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)