### PR TITLE
fix(#2165): remove fake success+TTL from legacy indexing migration

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/indexing-decision.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/indexing-decision.test.ts
@@ -373,7 +373,7 @@ describe('IndexingDecisionService', () => {
   // === migrateLegacyIndexingState ===
 
   describe('migrateLegacyIndexingState', () => {
-    it('should migrate from qdrantIndexedAt to new format', () => {
+    it('should migrate from qdrantIndexedAt to new format without fake success (#2165)', () => {
       const legacyDate = '2026-01-15T10:00:00Z';
       const skeleton = createSkeleton({
         metadata: {
@@ -386,8 +386,11 @@ describe('IndexingDecisionService', () => {
 
       expect(migrated).toBe(true);
       expect(skeleton.metadata.indexingState).toBeDefined();
-      expect(skeleton.metadata.indexingState!.lastIndexedAt).toBe(legacyDate);
-      expect(skeleton.metadata.indexingState!.indexStatus).toBe('success');
+      // #2165: migration no longer sets indexStatus or nextReindexAfter
+      expect(skeleton.metadata.indexingState!.indexStatus).toBeUndefined();
+      expect(skeleton.metadata.indexingState!.nextReindexAfter).toBeUndefined();
+      expect(skeleton.metadata.indexingState!.lastIndexedAt).toBeUndefined();
+      expect(skeleton.metadata.indexingState!.indexVersion).toBeDefined();
       expect(skeleton.metadata.qdrantIndexedAt).toBeUndefined();
     });
 

--- a/servers/roo-state-manager/src/services/indexing-decision.ts
+++ b/servers/roo-state-manager/src/services/indexing-decision.ts
@@ -139,20 +139,20 @@ export class IndexingDecisionService {
 
         // SUPPORT RÉTROCOMPATIBILITÉ : Migration depuis qdrantIndexedAt
         if (!indexingState.indexStatus && skeleton.metadata.qdrantIndexedAt) {
-            const legacyIndexed = new Date(skeleton.metadata.qdrantIndexedAt).getTime();
-            
-            // 🆕 FIX CRITIQUE : Toujours migrer AVANT de décider du skip
+            const legacyDate = skeleton.metadata.qdrantIndexedAt;
+            const legacyIndexed = new Date(legacyDate).getTime();
+
             const migrated = this.migrateLegacyIndexingState(skeleton);
             if (migrated) {
-                console.log(`[MIGRATION] Task ${taskId}: Migration legacy effectuée depuis ${skeleton.metadata.qdrantIndexedAt}`);
+                console.log(`[MIGRATION] Task ${taskId}: Migration legacy effectuée depuis ${legacyDate}`);
             }
-            
+
             if (lastActivity <= legacyIndexed) {
                 return {
                     shouldIndex: false,
-                    reason: `Migration legacy : contenu inchangé depuis ${skeleton.metadata.qdrantIndexedAt}`,
+                    reason: `Migration legacy : contenu inchangé depuis ${legacyDate}`,
                     action: 'skip',
-                    requiresSave: migrated // 🆕 Signal pour sauvegarder si migration effectuée
+                    requiresSave: migrated
                 };
             }
         }
@@ -258,26 +258,23 @@ export class IndexingDecisionService {
 
     /**
      * Migre l'ancien format qdrantIndexedAt vers le nouveau format
+     *
+     * #2165: Only sets indexVersion — no fake success status or TTL.
+     * Setting indexStatus='success' + nextReindexAfter (7d TTL) blocked
+     * reindexing after collection resets, causing the index freeze.
      */
     public migrateLegacyIndexingState(skeleton: SkeletonHeader): boolean {
         if (!skeleton.metadata) {
-            return false; // No metadata at all, nothing to migrate
+            return false;
         }
         if (!skeleton.metadata.indexingState && skeleton.metadata.qdrantIndexedAt) {
-            const now = new Date().toISOString();
-            const nextReindex = new Date(Date.now() + (DEFAULT_REINDEX_TTL_HOURS * 60 * 60 * 1000)).toISOString();
-
             skeleton.metadata.indexingState = {
-                lastIndexedAt: skeleton.metadata.qdrantIndexedAt,
-                indexStatus: 'success',
-                indexVersion: this.indexVersion,
-                nextReindexAfter: nextReindex,
-                lastIndexAttempt: skeleton.metadata.qdrantIndexedAt
+                indexVersion: this.indexVersion
             };
 
             delete skeleton.metadata.qdrantIndexedAt;
-            return true; // Migration effectuée
+            return true;
         }
-        return false; // Pas de migration nécessaire
+        return false;
     }
 }

--- a/servers/roo-state-manager/tests/unit/services/indexing-decision.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/indexing-decision.test.ts
@@ -174,7 +174,7 @@ describe('IndexingDecisionService', () => {
             expect(decision.action).toBe('index');
         });
 
-        it('devrait migrer le format legacy qdrantIndexedAt', () => {
+        it('devrait migrer le format legacy qdrantIndexedAt sans faux succès (#2165)', () => {
             const skeleton: ConversationSkeleton = {
                 ...mockSkeleton,
                 metadata: {
@@ -183,12 +183,15 @@ describe('IndexingDecisionService', () => {
                     indexingState: undefined
                 }
             };
-            
+
             const migrated = service.migrateLegacyIndexingState(skeleton);
-            
+
             expect(migrated).toBe(true);
             expect(skeleton.metadata.indexingState).toBeDefined();
-            expect(skeleton.metadata.indexingState!.indexStatus).toBe('success');
+            // #2165: migration no longer sets indexStatus or nextReindexAfter
+            expect(skeleton.metadata.indexingState!.indexStatus).toBeUndefined();
+            expect(skeleton.metadata.indexingState!.nextReindexAfter).toBeUndefined();
+            expect(skeleton.metadata.indexingState!.indexVersion).toBeDefined();
             expect(skeleton.metadata.qdrantIndexedAt).toBeUndefined();
         });
     });


### PR DESCRIPTION
## Summary

`migrateLegacyIndexingState()` was setting `indexStatus='success'` and `nextReindexAfter` (7-day TTL) when migrating from legacy `qdrantIndexedAt` format. This blocked reindexing for 7 days, causing the semantic index freeze after Qdrant collection resets (#2165).

Fix: migration now only sets `indexVersion`, letting `shouldIndex()` decide naturally whether to reindex.

## Changes
- `migrateLegacyIndexingState()`: Only sets `indexVersion`, removes fake success fields
- `shouldIndex()` legacy block: Fix console.log referencing deleted field
- Tests updated in both test files

## Test plan
- [x] Build passes
- [x] 40/40 indexing-decision tests pass
- [x] Full suite: 491 passed, 5 pre-existing failures
- [ ] Post-merge: verify reindexing resumes on fleet

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>