### PR TITLE
fix(dashboard): force type into required array in MCP tool schema

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/dashboard-schemas.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard-schemas.ts
@@ -140,7 +140,7 @@ export const DashboardArgsSchema = z.object({
     .describe('Action to perform'),
 
   type: z.enum(['global', 'machine', 'workspace']).optional()
-    .describe('Dashboard type (required except list/read_overview/refresh/update)'),
+    .describe('REQUIRED for read/write/append/condense/delete/read_archive. Only list/read_overview/refresh/update may omit it.'),
 
   machineId: z.string().optional()
     .describe('Machine ID (default: local)'),
@@ -214,5 +214,15 @@ export type DashboardArgs = z.infer<typeof DashboardArgsSchema> & Record<string,
 export const dashboardToolMetadata = {
   name: 'roosync_dashboard',
   description: 'Shared dashboards (global/machine/workspace). Actions: read, write, append, condense, list, delete, read_archive, read_overview, refresh, update. Team stages supported. For agent-parseable output, use format="json" on read/read_overview actions. Default is human-readable markdown.',
-  inputSchema: zodToJsonSchema(DashboardArgsSchema as any, { target: 'openApi3' })
+  inputSchema: (() => {
+    const schema = zodToJsonSchema(DashboardArgsSchema as any, { target: 'openApi3' }) as any;
+    // Force 'type' into required array so LLMs always pass it (#1862 schema mismatch fix)
+    // Handler gracefully handles omission for list/read_overview/refresh/update
+    if (schema.required && Array.isArray(schema.required) && !schema.required.includes('type')) {
+      schema.required.push('type');
+    } else if (!schema.required) {
+      schema.required = ['action', 'type'];
+    }
+    return schema;
+  })()
 };


### PR DESCRIPTION
## Summary
- Forces `type` parameter into the `required` array of the `roosync_dashboard` MCP tool schema
- Updates description to be explicit about when `type` is REQUIRED vs optional
- Fixes Hermes (and other LLM clients via mcp-remote) skipping `type` because it was `.optional()` in Zod → not in JSON Schema `required` array → LLM omits it → server throws "type est requis pour action=append/read"

## Root cause
The Zod schema had `type: z.enum([...]).optional()` which correctly generates an optional JSON Schema property. The handler requires `type` for most actions (read/write/append/condense/delete/read_archive) but LLMs reading the schema see it as optional and skip it.

## Fix
Post-process the `zodToJsonSchema` output to add `type` to the `required` array. The handler already gracefully handles omission for `list`/`read_overview`/`refresh`/`update` actions.

## Test plan
- [x] `dashboard-schemas.test.ts` — 77/77 tests pass
- [ ] Manual: verify Hermes can call `roosync_dashboard(action: "append", type: "workspace", ...)` without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)