### PR TITLE
fix(dashboard): force type into required array in MCP tool schema (PR #457 squash)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/dashboard-schemas.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard-schemas.ts
@@ -140,7 +140,7 @@ export const DashboardArgsSchema = z.object({
     .describe('Action to perform'),
 
   type: z.enum(['global', 'machine', 'workspace']).optional()
-    .describe('Dashboard type (required except list/read_overview/refresh/update)'),
+    .describe('REQUIRED for read/write/append/condense/delete/read_archive. Only list/read_overview/refresh/update may omit it.'),
 
   machineId: z.string().optional()
     .describe('Machine ID (default: local)'),
@@ -214,5 +214,15 @@ export type DashboardArgs = z.infer<typeof DashboardArgsSchema> & Record<string,
 export const dashboardToolMetadata = {
   name: 'roosync_dashboard',
   description: 'Shared dashboards (global/machine/workspace). Actions: read, write, append, condense, list, delete, read_archive, read_overview, refresh, update. Team stages supported. For agent-parseable output, use format="json" on read/read_overview actions. Default is human-readable markdown.',
-  inputSchema: zodToJsonSchema(DashboardArgsSchema as any, { target: 'openApi3' })
+  inputSchema: (() => {
+    const schema = zodToJsonSchema(DashboardArgsSchema as any, { target: 'openApi3' }) as any;
+    // Force 'type' into required array so LLMs always pass it (#1862 schema mismatch fix)
+    // Handler gracefully handles omission for list/read_overview/refresh/update
+    if (schema.required && Array.isArray(schema.required) && !schema.required.includes('type')) {
+      schema.required.push('type');
+    } else if (!schema.required) {
+      schema.required = ['action', 'type'];
+    }
+    return schema;
+  })()
 };


### PR DESCRIPTION
## Summary
- Squash-merge of PR #457 (`fix/dashboard-schema-type-required`)
- Forces `type` parameter into the `required` array of `roosync_dashboard` tool schema
- Fixes Hermes/NanoClaw dashboard write failures (LLM clients skipping optional param)

## Test plan
- [x] Build passes (`npm run build`)
- [x] CI tests: 9541/9541 passed (vitest.config.ci.ts)
- [x] Review approved by clusterManager-Myia on original PR #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)