### PR TITLE
feat(indexer): bump INDEX_VERSION 1.0->1.1 + rebuild backoff jitter

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/indexing-decision.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/indexing-decision.test.ts
@@ -74,7 +74,7 @@ describe('IndexingDecisionService', () => {
       expect(decision.reason).toContain('FORCE_REINDEX');
     });
 
-    it('should reindex on version migration', () => {
+    it('should reindex on version migration with rebuild action (jittered)', () => {
       const skeleton = createSkeleton({
         metadata: {
           ...createSkeleton().metadata,
@@ -85,6 +85,7 @@ describe('IndexingDecisionService', () => {
       const decision = service.shouldIndex(skeleton);
 
       expect(decision.shouldIndex).toBe(true);
+      expect(decision.action).toBe('rebuild');
       expect(decision.reason).toContain('Migration');
     });
 

--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -14,6 +14,7 @@ import { ServerState } from './state-manager.service.js';
 import { ANTI_LEAK_CONFIG } from '../config/server-config.js';
 import { TaskIndexer, getHostIdentifier } from './task-indexer.js';
 import { getCircuitBreakerState, isCircuitBreakerBlocking, getEmbeddingMetrics } from './task-indexer/VectorIndexer.js';
+import { REBUILD_BACKOFF_MIN_MS_DEFAULT, REBUILD_BACKOFF_MAX_MS_DEFAULT } from '../types/indexing.js';
 import { SkeletonCacheService } from './skeleton-cache.service.js';
 // REMOVED: import * as toolExports — was unused, added 6s to startup by importing ALL tools
 import { RooStorageDetectorError, RooStorageDetectorErrorCode, GenericErrorCode } from '../types/errors.js';
@@ -945,6 +946,19 @@ export async function indexTaskInQdrant(taskId: string, state: ServerState): Pro
         if (!decision.shouldIndex) {
             console.log(`[SKIP] Task ${taskId}: ${decision.reason} - Protection anti-fuite`);
             return;
+        }
+
+        // Rebuild backoff — when a task is reindexed because of an index-version
+        // migration, sleep a random jitter to spread fleet-wide load on the shared
+        // embedding API. Live/new tasks (action='index'|'retry') process immediately.
+        if (decision.action === 'rebuild') {
+            const minMs = Number.parseInt(process.env.ROO_INDEX_REBUILD_BACKOFF_MIN_MS ?? '', 10) || REBUILD_BACKOFF_MIN_MS_DEFAULT;
+            const maxMs = Number.parseInt(process.env.ROO_INDEX_REBUILD_BACKOFF_MAX_MS ?? '', 10) || REBUILD_BACKOFF_MAX_MS_DEFAULT;
+            const lo = Math.min(minMs, maxMs);
+            const hi = Math.max(minMs, maxMs);
+            const jitter = lo + Math.floor(Math.random() * (hi - lo + 1));
+            console.log(`[REBUILD] Task ${taskId}: backoff ${jitter}ms before reindex (${decision.reason})`);
+            await new Promise(resolve => setTimeout(resolve, jitter));
         }
 
         console.log(`[INDEX] Task ${taskId}: ${decision.reason}`);

--- a/servers/roo-state-manager/src/services/indexing-decision.ts
+++ b/servers/roo-state-manager/src/services/indexing-decision.ts
@@ -57,11 +57,14 @@ export class IndexingDecisionService {
         }
 
         // Migration d'index : version différente = réindexation nécessaire
+        // action 'rebuild' (vs 'index') signals to the worker that this task is a
+        // historical reindex and should be jittered with a random backoff to spread
+        // fleet-wide load on the embedding API. See REBUILD_BACKOFF_*_MS_DEFAULT.
         if (indexingState.indexVersion && indexingState.indexVersion !== this.indexVersion) {
             return {
                 shouldIndex: true,
                 reason: `Migration d'index requise (v${indexingState.indexVersion} → v${this.indexVersion})`,
-                action: 'index'
+                action: 'rebuild'
             };
         }
 

--- a/servers/roo-state-manager/src/types/indexing.ts
+++ b/servers/roo-state-manager/src/types/indexing.ts
@@ -17,7 +17,7 @@ export interface IndexingState {
 export interface IndexingDecision {
     shouldIndex: boolean;
     reason: string;
-    action: 'skip' | 'index' | 'retry';
+    action: 'skip' | 'index' | 'retry' | 'rebuild';
     backoffUntil?: string;
     requiresSave?: boolean; // 🆕 Flag pour signaler qu'une sauvegarde est nécessaire (migration legacy)
 }
@@ -31,7 +31,27 @@ export interface IndexingMetrics {
     bandwidthSaved: number; // Estimation en octets
 }
 
-export const INDEX_VERSION_CURRENT = "1.0";
+export const INDEX_VERSION_CURRENT = "1.1";
 export const DEFAULT_REINDEX_TTL_HOURS = 168; // 7 jours
 export const MAX_RETRY_ATTEMPTS = 3;
 export const RETRY_BACKOFF_BASE_MS = 60000; // 1 minute base
+
+/**
+ * Rebuild backoff — applied ONLY when a task is re-indexed because of an
+ * index-version migration (decision.action === 'rebuild'). Uniform random
+ * jitter [MIN, MAX] in milliseconds is awaited BEFORE processing the task.
+ *
+ * Goals:
+ *  - Avoid the thundering-herd pattern across a fleet of MCP instances all
+ *    bumped to the same INDEX_VERSION_CURRENT at the same time (cf. the
+ *    embedding-service hammering incident around 2026-05-09).
+ *  - Cap fleet-wide load on the shared embedding API while still completing
+ *    the rebuild in a few days, not weeks.
+ *
+ * Defaults sized for ~28K tasks/machine, 6-machine fleet, mean 7s/task ⇒
+ * ~2.3 days/machine end-to-end with ~8.6 req/s fleet load on embeddings —
+ * roughly 10× below the observed crisis level. Override via env vars
+ * ROO_INDEX_REBUILD_BACKOFF_MIN_MS / ROO_INDEX_REBUILD_BACKOFF_MAX_MS.
+ */
+export const REBUILD_BACKOFF_MIN_MS_DEFAULT = 2000;
+export const REBUILD_BACKOFF_MAX_MS_DEFAULT = 12000;

--- a/servers/roo-state-manager/tests/unit/services/indexing-decision.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/indexing-decision.test.ts
@@ -171,7 +171,7 @@ describe('IndexingDecisionService', () => {
             
             expect(decision.shouldIndex).toBe(true);
             expect(decision.reason).toContain('Migration d\'index requise');
-            expect(decision.action).toBe('index');
+            expect(decision.action).toBe('rebuild');
         });
 
         it('devrait migrer le format legacy qdrantIndexedAt sans faux succès (#2165)', () => {


### PR DESCRIPTION
## Summary

Trigger a **fleet-wide reindexation** of all tasks with `indexVersion='1.0'` to recover ~1.7M points lost from `roo_tasks_semantic_index` during the 2026-05-16 05:25 UTC VHDX wipe (split-brain recovery 2026-05-17/18). Re-ingestion uses a **random jitter [2s, 12s]** before each historical task to spread fleet-wide load on the shared embedding API.

## Why this approach

The data loss left a state mismatch: skeleton metadata still says `indexStatus='success'` everywhere (tasks were indexed BEFORE the wipe), so the existing `shouldIndex()` decision returns `skip` on all of them. The collection is empty in Qdrant but the indexer thinks everything is fine. Current ingest rate (only new tasks) = ~12K points/day → **~83 days** to recover naively.

Two ways to bypass the gate:
- `ROO_INDEX_FORCE=1` env var per machine — manual, error-prone, requires per-host action
- **Bump `INDEX_VERSION_CURRENT`** — auto-coordinated via git pull + rebuild, single source of truth ✅ (this PR)

The version bump triggers the existing `Migration d'index requise (v1.0 → v1.1)` branch in [`indexing-decision.ts:60-66`](../tree/feat/index-version-bump-1.1-rebuild-backoff/servers/roo-state-manager/src/services/indexing-decision.ts#L60-L66) for every legacy-indexed task on each machine.

## Why the jitter (and these specific numbers)

Reference dangerous event: **2026-05-09 embedding hammering** at ~4950 req/min crashed the shared API. To stay 10× below that ceiling:

| Backoff | Duration | Peak req/s | Risk |
|---|---|---|---|
| 0s (naive force) | ~16h | ~85 | 🔴 reproduces crisis |
| Uniform [0, 3]s | ~10h | ~24 | 🟡 close to limits |
| **Uniform [2, 12]s** | **~2.3 days** | **~8.6** | 🟢 confortable, 10× margin |
| Uniform [5, 30]s | ~5-7 days | ~3.4 | 🟢 over-prudent |

Sizing: ~28K tasks/machine × ~10 chunks × mean 7s/task = ~2.3 days per machine, all running in parallel. Random uniform decorrelates the 6 machines, avoiding the thundering-herd pattern.

## Changes

1. `src/types/indexing.ts` — `INDEX_VERSION_CURRENT: "1.0" → "1.1"`, add `'rebuild'` to `IndexingDecision.action` union, add `REBUILD_BACKOFF_{MIN,MAX}_MS_DEFAULT` constants (2000/12000)
2. `src/services/indexing-decision.ts` — migration branch returns `action: 'rebuild'` instead of `'index'`
3. `src/services/background-services.ts` — in `indexTaskInQdrant`, when `decision.action === 'rebuild'`, `await sleep(uniform(MIN, MAX))` before processing. Env-tunable via `ROO_INDEX_REBUILD_BACKOFF_MIN_MS` / `ROO_INDEX_REBUILD_BACKOFF_MAX_MS`.
4. `src/services/__tests__/indexing-decision.test.ts` — existing migration test now asserts `action: 'rebuild'`.

## Test plan
- [x] `npm run build` — clean (tsc 0 errors)
- [x] `npx vitest run src/services/__tests__/` — **1002 tests pass**, 0 fail, 4 skipped
- [x] Migration test specifically asserts `action: 'rebuild'`
- [ ] Manual fleet rollout: each machine pulls, rebuilds MCP, observes `[REBUILD] Task ... backoff Xms` log lines and queue growth on `roosync_indexing(action: "status")`
- [ ] Monitor embedding API throughput stays <600 req/min sustained across the fleet

## Rollout (coordinated)

1. Merge this PR.
2. Update submodule pointer in `jsboige/roo-extensions` (companion PR).
3. Each of the 6 machines (myia-ai-01, po-2023/2024/2025/2026, web1) runs `git pull` + `npm run build` in the submodule, then restarts the `roo-state-manager` MCP.
4. Monitor via `roosync_indexing(action: "status")` — queue should grow into thousands as the scanner discovers v1.0 skeletons.
5. Watch embedding service for sustained ≤600 req/min target.

## Companion artifacts
- Backup Layer 1 already deployed (#2283/#2284) — daily snapshots prevent recurrence
- Split-brain recovery memory documents the original incident
- This PR is the **active recovery action** for the data loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)