### PR TITLE
feat(#2241): shorthand resolution for bot addresses in roosync_messages send

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/messages.ts
+++ b/servers/roo-state-manager/src/tools/roosync/messages.ts
@@ -18,6 +18,28 @@ import { roosyncSend } from './send.js';
 import { roosyncRead } from './read.js';
 import { roosyncManage } from './manage.js';
 import { roosyncAttachments } from './roosync-attachments.tool.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('RooSyncMessagesTool');
+
+// ====================================================================
+// SHORTHAND RESOLUTION (#2241)
+// ====================================================================
+
+const SHORTHAND_MAP: Record<string, string> = {
+  hermes: 'myia-po-2026:hermes-agent',
+  nanoclaw: 'myia-ai-01:nanoclaw',
+};
+
+function resolveAddressShorthand(to: string | undefined): string | undefined {
+  if (!to) return to;
+  const resolved = SHORTHAND_MAP[to.toLowerCase()];
+  if (resolved) {
+    logger.info(`[#2241] Shorthand resolved: "${to}" → "${resolved}"`);
+    return resolved;
+  }
+  return to;
+}
 
 // ====================================================================
 // SCHEMA
@@ -91,7 +113,7 @@ export async function roosyncMessages(args: MessagesArgs) {
     case 'send':
       return roosyncSend({
         action: 'send',
-        to: args.to,
+        to: resolveAddressShorthand(args.to),
         subject: args.subject,
         body: args.body,
         priority: args.priority,


### PR DESCRIPTION
## Summary

Implements address shorthand resolution in `roosync_messages` (action: send) for ergonomic bot addressing — closes scope 2 of #2241 (parent: jsboige/roo-extensions#2241).

- `hermes` → `myia-po-2026:hermes-agent`
- `nanoclaw` → `myia-ai-01:nanoclaw`

Resolution happens at the consolidated tool level (`messages.ts`, case `'send'`) before dispatch to `roosyncSend`. Logs canonical resolution via `createLogger` for traceability.

## Changed file

`servers/roo-state-manager/src/tools/roosync/messages.ts`
- Add `SHORTHAND_MAP` constant
- Add `resolveAddressShorthand(to)` function
- Apply in `case 'send':` before passing `to` to `roosyncSend`

## Test plan

- [x] Build OK (`npm run build`)
- [x] CI tests: 9541/9572 pass (8 failures = pre-existing untracked `validate-full-reconstruction.test.ts`, unrelated to this change)
- [ ] E2E validation: send `to: "hermes"` → verify inbox on `myia-po-2026:hermes-agent` (requires po-2026/ai-01)

## Non-goals

- Shorthand for `reply_to` (separate scope)
- Doc tool description update (tracked in parent #2241)
- E2E validation (requires live bots on po-2026/ai-01)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — myia-po-2025 interactive session R66