### PR TITLE
fix(roosync): workspace-aware markAsRead prevents cross-workspace pollution (#2287)

### DIFF
--- a/servers/roo-state-manager/src/services/MessageManager.ts
+++ b/servers/roo-state-manager/src/services/MessageManager.ts
@@ -12,7 +12,7 @@ import { existsSync, promises as fs, mkdirSync } from 'fs';
 import { join } from 'path';
 import { createLogger } from '../utils/logger.js';
 import { MessageManagerError, MessageManagerErrorCode } from '../types/errors.js';
-import { parseMachineWorkspace, matchesRecipient, getLocalWorkspaceId } from '../utils/message-helpers.js';
+import { parseMachineWorkspace, matchesRecipient, getLocalWorkspaceId, normalizeWorkspaceId } from '../utils/message-helpers.js';
 // #1110 FIX: Dynamic import to break ESM circular dependency.
 // server-helpers → tools/index → roosync/* → MessageManager → server-helpers
 import { GenericError, GenericErrorCode } from '../types/errors.js';
@@ -708,6 +708,18 @@ export class MessageManager {
     try {
       const content = await fs.readFile(filePath, 'utf-8');
       const message: Message = JSON.parse(content);
+
+      // Workspace guard (#2287): reject markAsRead if reader's workspace ≠ message target workspace
+      if (readerId && message.to && message.to !== 'all' && message.to !== 'All') {
+        const readerParsed = parseMachineWorkspace(readerId);
+        const targetParsed = parseMachineWorkspace(message.to);
+        if (targetParsed.workspaceId && readerParsed.workspaceId) {
+          if (normalizeWorkspaceId(readerParsed.workspaceId) !== normalizeWorkspaceId(targetParsed.workspaceId)) {
+            logger.info(`[#2287] Workspace mismatch: reader "${readerParsed.workspaceId}" ≠ target "${targetParsed.workspaceId}", skipping markAsRead`);
+            return false;
+          }
+        }
+      }
 
       // Track per-machine read status (#629)
       if (readerId) {

--- a/servers/roo-state-manager/src/tools/roosync/manage.ts
+++ b/servers/roo-state-manager/src/tools/roosync/manage.ts
@@ -15,6 +15,7 @@ import {
   formatDate,
   formatDateFull,
   getLocalMachineId,
+  getLocalFullId,
   parseMachineWorkspace
 } from '../../utils/message-helpers.js';
 import { getRooSyncService } from '../../services/lazy-roosync.js';
@@ -112,7 +113,7 @@ Le message était déjà marqué comme lu. Aucune modification nécessaire.`;
 
   // Marquer comme lu (avec tracking per-machine #629)
   logger.info('✉️ Marking message as read');
-  await messageManager.markAsRead(args.message_id, localMachine);
+  await messageManager.markAsRead(args.message_id, getLocalFullId());
 
   // Fire-and-forget heartbeat update: marking a message read proves the machine is active
   (await getRooSyncService()).getHeartbeatService()

--- a/servers/roo-state-manager/src/tools/roosync/read.ts
+++ b/servers/roo-state-manager/src/tools/roosync/read.ts
@@ -18,7 +18,8 @@ import {
   getPriorityIcon,
   getStatusIcon,
   getLocalMachineId,
-  getLocalWorkspaceId
+  getLocalWorkspaceId,
+  getLocalFullId
 } from '../../utils/message-helpers.js';
 import { getRooSyncService } from '../../services/lazy-roosync.js';
 import { AttachmentManager } from '../../services/roosync/AttachmentManager.js';
@@ -268,7 +269,7 @@ Le message n'a pas été trouvé dans :
 
   // Marquer comme lu si demandé (avec tracking per-machine #629)
   if (markAsRead && message.status === 'unread') {
-    await messageManager.markAsRead(messageId, getLocalMachineId());
+    await messageManager.markAsRead(messageId, getLocalFullId());
     message.status = 'read';
   }
 

--- a/servers/roo-state-manager/tests/unit/tools/roosync/manage.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/manage.test.ts
@@ -40,6 +40,7 @@ vi.mock('../../../../src/services/MessageManager.js', () => ({
 
 vi.mock('../../../../src/utils/message-helpers.js', () => ({
     getLocalMachineId: mockGetLocalMachineId,
+    getLocalFullId: vi.fn(() => 'myia-po-2025:roo-extensions'),
     parseMachineWorkspace: mockParseMachineWorkspace,
     formatDate: vi.fn((d: string) => d?.substring(0, 10) || ''),
     formatDateFull: vi.fn((d: string) => d || ''),
@@ -100,7 +101,7 @@ describe('roosync_manage', () => {
             });
             const result = await roosyncManage({ action: 'mark_read', message_id: 'msg-1' });
             expect(result.content[0].text).toContain('marqué comme lu');
-            expect(mockMarkAsRead).toHaveBeenCalledWith('msg-1', 'myia-po-2025');
+            expect(mockMarkAsRead).toHaveBeenCalledWith('msg-1', 'myia-po-2025:roo-extensions');
         });
 
         it('returns not found for missing message', async () => {

--- a/servers/roo-state-manager/tests/unit/tools/roosync/read.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/read.test.ts
@@ -58,6 +58,7 @@ vi.mock('../../../../src/services/MessageManager.js', () => ({
 vi.mock('../../../../src/utils/message-helpers.js', () => ({
     getLocalMachineId: mockGetLocalMachineId,
     getLocalWorkspaceId: mockGetLocalWorkspaceId,
+    getLocalFullId: vi.fn(() => 'myia-po-2025:roo-extensions'),
     formatDate: vi.fn((d: string) => d?.substring(0, 10) || ''),
     formatDateFull: vi.fn((d: string) => d || ''),
     getPriorityIcon: vi.fn((p: string) => ''),
@@ -240,7 +241,7 @@ describe('roosync_read', () => {
                 status: 'unread', timestamp: '2026-05-04T00:00:00.000Z', body: 'Content',
             });
             const result = await roosyncRead({ mode: 'message', message_id: 'msg-2', mark_as_read: true });
-            expect(mockMarkAsRead).toHaveBeenCalledWith('msg-2', 'myia-po-2025');
+            expect(mockMarkAsRead).toHaveBeenCalledWith('msg-2', 'myia-po-2025:roo-extensions');
             expect(result.content[0].text).toContain('READ');
         });
 


### PR DESCRIPTION
## Summary

- `MessageManager.markAsRead()`: add workspace guard — if the reader's workspace ≠ the message's target workspace, skip marking as read and return `false` (prevents cross-workspace pollution)
- `read.ts` / `manage.ts`: pass `getLocalFullId()` (machine:workspace) instead of bare `machineId` to `markAsRead()`, enabling the guard
- Test mocks: add `getLocalFullId` to `vi.mock` factories; update assertions from bare machineId to full ID

Fixes #2287 — agents in workspace A (e.g. `claude-interactive`) could mark as read messages targeted to workspace B (`hermes-agent`) on the same machine.

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 468 pass, 0 fail
- [x] Workspace guard is backward-compatible: bare machine IDs (no workspace) skip the guard transparently

🤖 Generated with [Claude Code](https://claude.com/claude-code)