### PR TITLE
fix(mcp): per-call timeout guard prevents indefinite hangs (#2267)

### DIFF
--- a/servers/roo-state-manager/src/index.ts
+++ b/servers/roo-state-manager/src/index.ts
@@ -107,6 +107,18 @@ import { createMcpServer, SERVER_CONFIG } from './config/server-config.js';
 import { createLogger } from './utils/logger.js';
 import { recordToolCall } from './utils/tool-call-metrics.js';
 
+// #2267: Per-MCP-call global timeout — prevents tool calls from hanging indefinitely.
+// Observed incident: roosync_dashboard hung 22h (TBXark session death + GDrive I/O stall).
+// Default: 5 min. Override via MCP_TOOL_TIMEOUT_MS env var.
+const MCP_TOOL_TIMEOUT_MS = parseInt(process.env.MCP_TOOL_TIMEOUT_MS || '300000', 10);
+// Legitimately-slow tools get a higher cap (10 min).
+const MCP_TOOL_TIMEOUT_OVERRIDES: Readonly<Record<string, number>> = {
+    export_data: 600000,
+    roosync_baseline: 600000,
+    roosync_indexing: 600000,
+    roosync_storage_management: 600000,
+};
+
 const logger = createLogger('RooStateManagerServer');
 const require = createRequire(import.meta.url);
 const packageJson = require('../package.json');
@@ -390,19 +402,40 @@ class RooStateManagerServer {
 
                 let result;
                 let hadError = false;
+                // #2267: Per-call timeout guard. Race the actual tool against a timer;
+                // on timeout return a structured error instead of hanging forever.
+                let timeoutHandle: NodeJS.Timeout | undefined;
                 try {
-                    if (this.toolInterceptor) {
-                        result = await this.toolInterceptor.interceptToolCall(
+                    const timeoutMs = MCP_TOOL_TIMEOUT_OVERRIDES[toolName ?? ''] ?? MCP_TOOL_TIMEOUT_MS;
+                    const timeoutPromise = new Promise<never>((_, reject) => {
+                        timeoutHandle = setTimeout(() => {
+                            reject(new Error(
+                                `[#2267] Tool "${toolName}" timed out after ${timeoutMs}ms. ` +
+                                `Likely cause: GDrive I/O stall or dead TBXark proxy session. ` +
+                                `Override timeout via MCP_TOOL_TIMEOUT_MS env var.`
+                            ));
+                        }, timeoutMs);
+                        if (typeof timeoutHandle?.unref === 'function') timeoutHandle.unref();
+                    });
+                    const toolCallPromise = this.toolInterceptor
+                        ? this.toolInterceptor.interceptToolCall(
                             request.params.name,
                             request.params.arguments,
                             async () => await originalCallTool(request)
-                        );
-                    } else {
-                        result = await originalCallTool(request);
-                    }
+                          )
+                        : originalCallTool(request);
+                    result = await Promise.race([toolCallPromise, timeoutPromise]);
                 } catch (toolError) {
                     hadError = true;
-                    throw toolError;
+                    const msg = toolError instanceof Error ? toolError.message : String(toolError);
+                    if (msg.includes('[#2267]')) {
+                        // Timeout: surface as structured error result, not an unhandled throw
+                        result = { content: [{ type: 'text', text: msg }], isError: true };
+                    } else {
+                        throw toolError;
+                    }
+                } finally {
+                    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
                 }
 
                 const durationMs = Date.now() - startMs;


### PR DESCRIPTION
## Summary

- Add `Promise.race([handler, timeout])` at the MCP server dispatch layer (`registerHandlers` in `src/index.ts`) — every tool call now has an upper bound on execution time
- Default 5 minutes (`MCP_TOOL_TIMEOUT_MS` env override); legitimately-slow tools (`export_data`, `roosync_baseline`, `roosync_indexing`, `roosync_storage_management`) get 10 minutes
- On timeout: return `{ content: [...], isError: true }` structured result — client receives a clear error immediately rather than hanging
- Timer is `unref()`'d — never blocks Node.js process exit
- Timer cleared on success — no leak

Addresses action #2 from issue jsboige/roo-extensions#2267 (22h hang on `roosync_dashboard`). The existing `conversation_browser` tool already uses this exact pattern (#1262); this extends it fleet-wide at the server level.

## Test plan
- [x] `npm run build` — clean TypeScript compilation
- [x] `npx vitest run --config vitest.config.ci.ts` — 468/468 pass, 0 fail
- [x] No existing tests affected (pure addition to the wrapper, not a behavior change for normal calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)