### PR TITLE
fix(indexing): repair_gaps exact count — Qdrant approximate count returns spurious values with filters

### DIFF
--- a/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
@@ -596,9 +596,11 @@ export async function handleRooSyncIndexing(
 
                     let pointsCount = 0;
                     try {
+                        // #2246: Use exact:true — approximate count with filters returns
+                        // spurious values (e.g. 161K for a task with 0 points).
                         const countResult = await qdrant.count(collectionName, {
                             filter: { must: [{ key: 'task_id', match: { value: taskId } }] },
-                            exact: false
+                            exact: true
                         });
                         pointsCount = (countResult as any).count ?? 0;
                     } catch {


### PR DESCRIPTION
## Summary
- `repair_gaps` action used `exact: false` for Qdrant count queries with `task_id` filter
- Qdrant approximate count with filters returns wildly inaccurate values (e.g. 161,760 for tasks with 0 actual points)
- Switched to `exact: true` for accurate per-task point counts

## Root Cause
Discovered during #2196 investigation. Qdrant `count(filter=..., exact=false)` returns approximate counts that are unreliable when filters are applied. Every "never_indexed" task was reported as having 161,760 points when they actually had 0.

**Verification:**
```
# exact: false → 161,760 (wrong)
# exact: true  → 0 (correct)
```

## Test Plan
- [x] `npm run build` passes
- [x] `npx vitest run --config vitest.config.ci.ts` — 9,567/9,567 tests pass
- [x] Verified with live Qdrant: `curl ... /points/count {"filter":{"must":[{"key":"task_id","match":{"value":"..."}}]},"exact":true}` returns correct count

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>