### PR TITLE
fix(#2267): raise roosync_dashboard tool timeout 60s->600s (condensation regression)

### DIFF
--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -60,8 +60,14 @@ const TOOL_TIMEOUTS: Record<string, number> = {
     roosync_search: 180_000,        // 3 min
     conversation_browser: 180_000,  // 3 min (can scan large dirs)
     export_data: 180_000,           // 3 min (large exports)
-    // Dashboard operations with GDrive can be slow
-    roosync_dashboard: 60_000,      // 1 min
+    // roosync_dashboard append/write/condense runs the condensation LLM
+    // (qwen3.6-35b reasoning) synchronously over the full dashboard payload.
+    // Observed wall-time up to ~454s on a large workspace dashboard. The prior
+    // 60s cap (#453) cancelled condensation on every append once the dashboard
+    // grew past the 92% threshold, write-blocking the fleet's main coord channel
+    // (regression — dashboards worked before #453). 10 min covers the worst
+    // observed run with margin while still bounding any genuine hang.
+    roosync_dashboard: 600_000,     // 10 min (synchronous LLM condensation)
     roosync_compare_config: 60_000, // 1 min
     roosync_inventory: 60_000,      // 1 min
 };


### PR DESCRIPTION
## Problem (regression from #453)

`#453` (commit `d6e6b269`) added a per-tool timeout map to `registry.ts`. `roosync_dashboard` got the **shortest** cap (60s) — but `append`/`write`/`condense` run the **condensation LLM (qwen3.6-35b reasoning) synchronously** over the full dashboard payload. Observed wall-time **up to ~454s** on a large workspace dashboard (logged 454s; "status + summary parallèle: 228s").

Once the workspace dashboard grew past the 92% condensation threshold (~46 KB), **every** `append` triggered condensation, which the 60s cap cancelled on client disconnect → condensation **never committed** → space **never freed** → next append re-triggered the same doomed condensation. Net effect: the **fleet's main coordination channel was write-blocked**.

Dashboards worked before #453 → this is a regression, not a new failure. (The 22h indefinite hang #2267 was originally about is a *different* path — the NanoClaw container → `mcp-tools.myia.io` proxy chain — not the local stdio condensation.)

## Fix

`roosync_dashboard`: `60_000` → `600_000` (10 min). Covers the worst observed condensation (~454s) with margin, while still bounding any genuine hang far below 22h.

Surgical: `roosync_compare_config` and `roosync_inventory` (also 60s) are **left unchanged** — they don't run condensation and show no evidence of hanging.

## Validation

- `npm run build` — clean (tsc, 0 errors)
- `npx vitest run --config vitest.config.ci.ts` — **470 files / 9570 tests passed**, 2 files / 23 skipped

## Fleet propagation

After merge: each machine `git pull` + `git submodule update` + rebuild roo-state-manager + restart MCP to pick up the new timeout.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>