### PR TITLE
fix(dashboard): raise roosync_dashboard MCP timeout 600s -> 1800s

### DIFF
--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -60,14 +60,20 @@ const TOOL_TIMEOUTS: Record<string, number> = {
     roosync_search: 180_000,        // 3 min
     conversation_browser: 180_000,  // 3 min (can scan large dirs)
     export_data: 180_000,           // 3 min (large exports)
-    // roosync_dashboard append/write/condense runs the condensation LLM
-    // (qwen3.6-35b reasoning) synchronously over the full dashboard payload.
-    // Observed wall-time up to ~454s on a large workspace dashboard. The prior
-    // 60s cap (#453) cancelled condensation on every append once the dashboard
-    // grew past the 92% threshold, write-blocking the fleet's main coord channel
-    // (regression — dashboards worked before #453). 10 min covers the worst
-    // observed run with margin while still bounding any genuine hang.
-    roosync_dashboard: 600_000,     // 10 min (synchronous LLM condensation)
+    // roosync_dashboard append/write/condense runs condensation: TWO LLM calls
+    // in parallel (qwen3.6-35b reasoning) — generateLLMSummary over the archived
+    // messages (~2KB out) AND generateStatusUpdate, which re-ingests the previous
+    // status (the project's long-term memory, ~18KB) + ALL messages and evolves
+    // it (~18KB out). The status call is the bottleneck: wall-time of 712s has
+    // been observed (490s for the status leg alone). The prior 60s cap (#453),
+    // then 600s, both cancelled legitimate condensations, write-blocking the
+    // fleet's main coord channel (regression — dashboards worked before #453).
+    // Each LLM call has its own 1800s internal timeout (see dashboard.ts), so we
+    // align the MCP wrapper to 1800s: the wrapper must never be tighter than the
+    // operation's own timeout + circuit-breaker (#1792), which are the real
+    // hang-protection. The status section size is bounded separately by its own
+    // targeted condensation (condenseTextIfTooLarge).
+    roosync_dashboard: 1_800_000,   // 30 min (parallel LLM condensation; matches internal per-call timeout)
     roosync_compare_config: 60_000, // 1 min
     roosync_inventory: 60_000,      // 1 min
 };


### PR DESCRIPTION
## Summary
- Raises the per-tool MCP timeout for `roosync_dashboard` from **600s → 1800s** in `registry.ts`.
- Follow-up to #472 (which set 600s). 600s turned out to be **marginal**.

## Why
Dashboard condensation runs **two LLM calls in parallel** ([`dashboard.ts` `condenseIntercom`](servers/roo-state-manager/src/tools/roosync/dashboard.ts)):
- `generateLLMSummary` — condenses the archived messages (~2KB out).
- `generateStatusUpdate` — re-ingests the **~18KB long-term status** + all messages and evolves it via qwen3.6-35b reasoning (~18KB out). **This is the bottleneck.**

Observed wall-time: **712s** total (490s for the status leg alone, intercom log 2026-05-20T21:19). At 600s the MCP wrapper still cancels legitimate condensations once the dashboard crosses the 92% threshold, re-introducing the fleet-wide write-block regression.

Each LLM call already has its own **1800s internal timeout** ([`generateLLMSummary`](servers/roo-state-manager/src/tools/roosync/dashboard.ts#L754) / [`generateStatusUpdate`](servers/roo-state-manager/src/tools/roosync/dashboard.ts#L894)) plus a circuit breaker (#1792). The MCP wrapper should never be tighter than the operation's own timeout, so we align it to 1800s. The status section size remains bounded by its own targeted condensation (`condenseTextIfTooLarge`) — per user decision, we keep that mechanism and only raise the timeout.

## Test plan
- [x] `npm run build` (tsc clean)
- [x] `npx vitest run --config vitest.config.ci.ts` — 470 files / 9570 tests pass, 0 fail
- [ ] Tier reviewer approve (CODEOWNERS: roo-state-manager)
- [ ] Merge + parent pointer-bump on roo-extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)