### PR TITLE
fix(search): EMFILE retry + error classification (#2300)

### DIFF
--- a/servers/roo-state-manager/src/tools/search/search-error-classifier.ts
+++ b/servers/roo-state-manager/src/tools/search/search-error-classifier.ts
@@ -13,6 +13,7 @@ export type FailureMode =
 	| 'qdrant_backend_slow'      // POST search 5xx or timeout > configured threshold
 	| 'qdrant_collection_missing'// 404 collection
 	| 'auth_failed'              // 401/403
+	| 'system_emfile'            // #2300: too many open files — transient FD exhaustion
 	| 'unknown';
 
 export interface ClassifiedError {
@@ -176,6 +177,16 @@ export async function classifySearchError(
 				hint: 'Backend overloaded or misconfigured. Check Qdrant logs and optimizer status.',
 			};
 		}
+	}
+
+	// #2300: EMFILE — system file descriptor exhaustion (transient)
+	if (errorCode === 'EMFILE' || errorMsg.includes('EMFILE') || errorMsg.includes('too many open files')) {
+		return {
+			mode: 'system_emfile',
+			originalError: errorMsg,
+			message: `System file descriptor exhaustion during ${operation}`,
+			hint: 'Too many open files in the MCP server process. Will auto-retry with backoff. If persistent, check concurrent sessions or increase ulimit.',
+		};
 	}
 
 	// Fallback

--- a/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
@@ -90,7 +90,7 @@ async function withRetry<T>(fn: () => Promise<T>, retries: number = SEMANTIC_RET
         return await fn();
     } catch (error) {
         if (retries <= 0) throw error;
-        const isRetryable = isHttpServerError(error) || isAbortOrTimeout(error);
+        const isRetryable = isHttpServerError(error) || isAbortOrTimeout(error) || isEmfileError(error);
         if (!isRetryable) throw error;
         console.warn(`[WARN] #249: Retrying after transient error (${retries} left): ${error instanceof Error ? error.message : String(error)}`);
         await new Promise(resolve => setTimeout(resolve, backoffMs));
@@ -118,6 +118,17 @@ function isAbortOrTimeout(error: unknown): boolean {
     const code = (error as any)?.code || '';
     return msg.includes('abort') || msg.includes('timeout') || msg.includes('ETIMEDOUT') ||
         msg.includes('This operation was aborted') || code === 'UND_ERR_CONNECT_TIMEOUT';
+}
+
+/**
+ * #2300: Check if an error is EMFILE (too many open files).
+ * Transient system error — retryable after backoff allows FDs to be released.
+ */
+function isEmfileError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const msg = error.message;
+    const code = (error as any)?.code || '';
+    return code === 'EMFILE' || msg.includes('EMFILE') || msg.includes('too many open files');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add EMFILE ("too many open files") as a retryable error in `withRetry()` with exponential backoff (2s→4s→8s, 3 total attempts)
- Add `system_emfile` FailureMode to `search-error-classifier.ts` for actionable diagnostics
- Fix is minimal: 24 LOC added across 2 files, no API changes

## Problem
During meta-analysis cycles on ai-01 with 3 concurrent MCP calls + heavy Claude sessions, `roosync_search` failed with `EMFILE: too many open files` because Node.js couldn't open the compiled `.js` file. This is a transient condition — retry after backoff allows FDs to be released.

## Test plan
- [x] Build passes (`npm run build`)
- [x] 9570/9570 tests pass (`vitest.config.ci.ts`)
- [ ] Manual: verify EMFILE errors auto-retry on loaded system
- [ ] Monitor ai-01 meta-analysis cycles for EMFILE classification in logs

Closes jsboige/roo-extensions#2300

🤖 Generated with [Claude Code](https://claude.com/claude-code)