### PR TITLE
fix(search): EMFILE retry + error classification (#2300)

### DIFF
--- a/servers/roo-state-manager/src/tools/search/search-error-classifier.ts
+++ b/servers/roo-state-manager/src/tools/search/search-error-classifier.ts
@@ -13,6 +13,7 @@ export type FailureMode =
 	| 'qdrant_backend_slow'      // POST search 5xx or timeout > configured threshold
 	| 'qdrant_collection_missing'// 404 collection
 	| 'auth_failed'              // 401/403
+	| 'resource_exhausted'       // EMFILE, ENOMEM, etc. — too many open files / out of memory
 	| 'unknown';
 
 export interface ClassifiedError {
@@ -27,6 +28,16 @@ const NETWORK_ERROR_PATTERNS = [
 	'ECONNREFUSED', 'ENOTFOUND', 'ECONNRESET', 'ETIMEDOUT',
 	'CERT_HAS_EXPIRED', 'EPIPE', 'EAI_AGAIN',
 ];
+
+/** Resource exhaustion error codes (EMFILE, ENOMEM, etc.) */
+const RESOURCE_EXHAUSTED_PATTERNS = [
+	'EMFILE', 'ENOMEM', 'ENOSPC', 'ENOBUFS',
+	'too many open files', 'out of memory', 'no space left on device',
+];
+
+function isResourceExhausted(errorCode: string, errorMsg: string): boolean {
+	return RESOURCE_EXHAUSTED_PATTERNS.some(p => errorCode === p || errorMsg.toLowerCase().includes(p.toLowerCase()));
+}
 
 function isNetworkError(errorCode: string, errorMsg: string): boolean {
 	return NETWORK_ERROR_PATTERNS.some(p => errorCode === p || errorMsg.includes(p));
@@ -176,6 +187,16 @@ export async function classifySearchError(
 				hint: 'Backend overloaded or misconfigured. Check Qdrant logs and optimizer status.',
 			};
 		}
+	}
+
+	// Resource exhaustion (EMFILE, ENOMEM, etc.) — applies to all operations
+	if (isResourceExhausted(errorCode, errorMsg)) {
+		return {
+			mode: 'resource_exhausted',
+			originalError: errorMsg,
+			message: `Resource exhausted during ${operation}`,
+			hint: 'Too many file handles or memory. Close unused processes, increase ulimit, or restart the MCP server to release file descriptors.',
+		};
 	}
 
 	// Fallback

--- a/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
@@ -83,19 +83,31 @@ function setCachedQueryEmbedding(query: string, embedding: number[]): void {
 
 /**
  * #249/#2167: Retry wrapper with exponential backoff for transient network/timeout errors.
- * Retries on 5xx, abort, timeout. Does NOT retry on 4xx or validation errors.
+ * Retries on 5xx, abort, timeout, and resource exhaustion (EMFILE).
+ * Does NOT retry on 4xx or validation errors.
  */
 async function withRetry<T>(fn: () => Promise<T>, retries: number = SEMANTIC_RETRY_COUNT, backoffMs: number = SEMANTIC_RETRY_BACKOFF_MS): Promise<T> {
     try {
         return await fn();
     } catch (error) {
         if (retries <= 0) throw error;
-        const isRetryable = isHttpServerError(error) || isAbortOrTimeout(error);
+        const isRetryable = isHttpServerError(error) || isAbortOrTimeout(error) || isResourceExhausted(error);
         if (!isRetryable) throw error;
-        console.warn(`[WARN] #249: Retrying after transient error (${retries} left): ${error instanceof Error ? error.message : String(error)}`);
+        console.warn(`[WARN] #249/#2300: Retrying after transient error (${retries} left): ${error instanceof Error ? error.message : String(error)}`);
         await new Promise(resolve => setTimeout(resolve, backoffMs));
         return withRetry(fn, retries - 1, backoffMs * 2);
     }
+}
+
+/**
+ * #2300: Check if an error is resource exhaustion (EMFILE, ENOMEM, etc.) — eligible for retry.
+ */
+function isResourceExhausted(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const msg = error.message.toLowerCase();
+    const code = ((error as any)?.code || '').toUpperCase();
+    return code === 'EMFILE' || code === 'ENOMEM' || code === 'ENOSPC' ||
+        msg.includes('too many open files') || msg.includes('emfile');
 }
 
 /**


### PR DESCRIPTION
## Summary

Fix for #2300: EMFILE \	oo many open files\ error on roosync_search causes semantic search to fail without retry.

## Changes

### search-error-classifier.ts
- Add \esource_exhausted\ FailureMode for EMFILE/ENOMEM/ENOSPC errors
- Add \RESOURCE_EXHAUSTED_PATTERNS\ array and \isResourceExhausted()\ helper
- Classify EMFILE errors with directional remediation hint

### search-semantic.tool.ts
- Add \isResourceExhausted()\ helper function
- Extend \withRetry()\ to retry on EMFILE with exponential backoff (same as HTTP 5xx/timeout)
- Retry count: 2 retries (3 total attempts), 2s initial backoff, exponential

## Testing
- Build: \
pm run build\ passes
- Tests: 220/220 tests pass in search test suite
- No breaking changes to existing behavior

## Impact
- EMFILE errors now retry 3 times with exponential backoff before failing
- Error classification provides actionable hint: \Close unused processes, increase ulimit, or restart the MCP server to release file descriptors\
- No changes to existing retry behavior for HTTP 5xx/timeout errors