### PR TITLE
fix(dashboard): append-first condensation for message persistence guarantee

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
@@ -976,10 +976,11 @@ describe('roosync_dashboard', () => {
 
     it('archivedCount clamped to 0 on failed append (regression: CoursIA -2)', async () => {
       // #1792: Circuit breaker — now uses fallback truncation, archives messages
-      // When an append triggers preemptive+reactive condense that both fail
-      // with LLM null content, the old accounting computed negative archivedCount.
+      // When an append triggers condensation that fails with LLM null content,
+      // the old accounting computed negative archivedCount.
       // With circuit breaker, messages are archived via fallback, so archivedCount > 0.
-      // NOTE: Must use mockImplementation to override the throwing mockImplementation from beforeEach
+      // Append-first: condensation runs AFTER the message is persisted. During fill-up,
+      // one of the intermediate appends will trigger post-append condense with fallback.
       mockGetChatClient.mockImplementation(() => ({
         chat: { completions: { create: mockChatCreate } }
       }));
@@ -987,32 +988,35 @@ describe('roosync_dashboard', () => {
       mockChatCreate.mockRejectedValue(new Error('LLM API unavailable'));
 
       await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
-      // Fill past 92% with enough 3KB messages to trigger preemptive
+      // Fill past 92% with enough 3KB messages
       const filler = 'X'.repeat(3000);
+      let condensedResult: any = null;
       for (let i = 0; i < 16; i++) {
-        await roosyncDashboard({ action: 'append', type: 'global', content: `${filler} m${i}` });
+        const result = await roosyncDashboard({
+          action: 'append',
+          type: 'global',
+          content: `${filler} m${i}`
+        });
+        if (result.condensed && !condensedResult) {
+          condensedResult = result;
+        }
       }
 
-      // Now append something else — triggers preemptive (at >= 92%) + possibly reactive
-      const result = await roosyncDashboard({
-        action: 'append',
-        type: 'global',
-        content: `${filler} trigger`
-      });
-
-      expect(result.success).toBe(true);
+      // At least one intermediate append must have triggered fallback truncation
+      expect(condensedResult).not.toBeNull();
+      expect(condensedResult.success).toBe(true);
       // #1792: With fallback truncation, archivedCount should be > 0
-      expect(result.archivedCount).toBeGreaterThan(0);
-      expect(result.condensed).toBe(true); // Changed: fallback archives messages
+      expect(condensedResult.archivedCount).toBeGreaterThan(0);
+      expect(condensedResult.condensed).toBe(true);
       // Diagnostic must show the failure mode
-      expect(result.condenseDiagnostic).toBeDefined();
-      expect(result.condenseDiagnostic!.length).toBeGreaterThanOrEqual(1);
-      const failedPasses = result.condenseDiagnostic!.filter(d =>
+      expect(condensedResult.condenseDiagnostic).toBeDefined();
+      expect(condensedResult.condenseDiagnostic!.length).toBeGreaterThanOrEqual(1);
+      const failedPasses = condensedResult.condenseDiagnostic!.filter(d =>
         d.outcome === 'fallback-truncated' || d.outcome === 'llm-failed-dedup' || d.outcome === 'llm-failed-injected'
       );
       expect(failedPasses.length).toBeGreaterThanOrEqual(1);
       // #1792: With circuit breaker fallback, message reports success (not LLM failure)
-      expect(result.message).toContain('auto-condensation');
+      expect(condensedResult.message).toContain('auto-condensation');
     });
 
     it('dedup within 20min window does NOT re-inject a second error message', async () => {
@@ -1257,24 +1261,24 @@ describe('roosync_dashboard', () => {
       });
 
       await roosyncDashboard({ action: 'write', type: 'global', content: '# Init' });
-      // Fill past 92% of 50KB with 16 ≥ CONDENSE_KEEP messages of 3KB each.
+      // Fill past 92% of 50KB with ≥ CONDENSE_KEEP messages of 3KB each.
+      // Append-first: condensation fires on one of the intermediate appends.
       const filler = 'A'.repeat(3000);
-      for (let i = 0; i < 16; i++) {
-        await roosyncDashboard({
+      let condensedResult: any = null;
+      for (let i = 0; i < 20; i++) {
+        const result = await roosyncDashboard({
           action: 'append',
           type: 'global',
           content: `${filler} msg${i}`
         });
+        if (result.condensed && !condensedResult) {
+          condensedResult = result;
+        }
       }
 
-      const result = await roosyncDashboard({
-        action: 'append',
-        type: 'global',
-        content: 'trigger preemptive'
-      });
-
-      expect(result.condensed).toBe(true);
-      expect(result.durationBreakdown!.preemptiveCondenseMs).toBeGreaterThanOrEqual(0);
+      expect(condensedResult).not.toBeNull();
+      expect(condensedResult.condensed).toBe(true);
+      expect(condensedResult.durationBreakdown!.preemptiveCondenseMs).toBeGreaterThanOrEqual(0);
     });
 
     it('unblocks a saturated dashboard pattern (3 large + filler)', async () => {

--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -691,7 +691,7 @@ function isMentioned(mentions: ParsedMention[], localMachineId: string, localWor
  *                            truncation without LLM (keep last N, template summary)
  */
 export interface CondenseAttemptInfo {
-  phase: 'preemptive' | 'reactive' | 'manual';
+  phase: 'preemptive' | 'reactive' | 'manual' | 'post-append';
   outcome: 'condensed' | 'no-op' | 'llm-failed-dedup' | 'llm-failed-injected' | 'fallback-truncated';
   elapsedMs: number;
   archivedMessageCount: number;
@@ -2074,40 +2074,11 @@ async function handleAppend(
     dashboard = createEmptyDashboard(args.type!, key, author);
   }
 
-  // #1497: Preemptive condensation at 92% utilization
-  // Runs BEFORE the new message is appended, so condense operates on the existing
-  // messages (current state) rather than waiting for the post-append size check
-  // to fire at 100%. Prevents client-side timeout when dashboard is near-saturation.
-  //
-  // Concurrency contract: this function is NOT serialized per-key. Concurrent
-  // appends to the same dashboard that both cross the 92% threshold will each
-  // enter condenseIntercom, and the writeDashboardFile at the end uses
-  // last-writer-wins semantics (same as the pre-existing reactive path). The
-  // #1497 change does not introduce a new race beyond what already exists in
-  // the reactive condense at 100%. If strict serialization is needed, wrap this
-  // handler in a per-key mutex (see future issue if observed in production).
-  // NOTE: `dashboard` is reassigned below — subsequent code must use the
-  // post-condense binding.
-  let preemptivelyCondensed = false;
-  let preemptivelyArchivedCount = 0;
+  // Append-first architecture: the message is persisted to disk BEFORE any
+  // condensation attempt. Condensation (LLM calls that can take minutes) is
+  // best-effort after the write. This guarantees no message is lost even if
+  // condensation times out or the LLM is unavailable.
   const condenseDiagnostics: CondenseAttemptInfo[] = [];
-  const preAppendSize = estimateDashboardSize(dashboard);
-  if (preAppendSize >= PREEMPTIVE_CONDENSE_THRESHOLD_BYTES && dashboard.intercom.messages.length > CONDENSE_KEEP) {
-    logger.info('Preemptive condensation triggered (#1497)', {
-      key,
-      preAppendSize: `${Math.round(preAppendSize / 1024)}KB`,
-      preemptiveThreshold: `${Math.round(PREEMPTIVE_CONDENSE_THRESHOLD_BYTES / 1024)}KB (92% of ${Math.round(MAX_DASHBOARD_SIZE_BYTES / 1024)}KB)`,
-      messageCount: dashboard.intercom.messages.length
-    });
-    const beforePreemptive = dashboard.intercom.messages.length;
-    const preemptiveDiag = newDiagnostic('preemptive');
-    const tPre = Date.now();
-    dashboard = await condenseIntercom(key, dashboard, CONDENSE_KEEP, preemptiveDiag);
-    preemptiveCondenseMs = Date.now() - tPre;
-    condenseDiagnostics.push(preemptiveDiag);
-    preemptivelyArchivedCount = beforePreemptive - dashboard.intercom.messages.length;
-    preemptivelyCondensed = preemptivelyArchivedCount > 0;
-  }
 
   // Use provided messageId or generate a new one
   // Check in order:
@@ -2186,41 +2157,60 @@ async function handleAppend(
     }
   };
 
-  // Auto-condensation based on file size (50KB threshold)
-  // Estimate the file size by serializing the dashboard content
-  // NOTE (#1497): preemptive condense above should normally keep us below this
-  // threshold. This remains as a safety net for edge cases (very large single
-  // messages, pre-condense skipped because below message count threshold).
-  let condensed = preemptivelyCondensed;
-  let archivedCount = preemptivelyArchivedCount;
+  // === WRITE-FIRST: persist message to disk immediately ===
+  // The message is guaranteed to be on disk before any condensation attempt.
+  // If condensation below fails or times out, the message is NOT lost.
+  let condensed = false;
+  let archivedCount = 0;
   let finalDashboard = updatedDashboard;
-  const estimatedSize = estimateDashboardSize(updatedDashboard);
-  if (estimatedSize > MAX_DASHBOARD_SIZE_BYTES && updatedDashboard.intercom.messages.length > CONDENSE_KEEP) {
-    logger.info('Auto-condensation déclenchée (taille)', {
-      key,
-      estimatedSize: `${Math.round(estimatedSize / 1024)}KB`,
-      threshold: `${Math.round(MAX_DASHBOARD_SIZE_BYTES / 1024)}KB`,
-      messageCount: updatedDashboard.intercom.messages.length
-    });
-    const beforeCount = updatedDashboard.intercom.messages.length;
-    const reactiveDiag = newDiagnostic('reactive');
-    const tReact = Date.now();
-    finalDashboard = await condenseIntercom(key, updatedDashboard, CONDENSE_KEEP, reactiveDiag);
-    reactiveCondenseMs = Date.now() - tReact;
-    condenseDiagnostics.push(reactiveDiag);
-    const newlyArchived = beforeCount - finalDashboard.intercom.messages.length;
-    archivedCount += newlyArchived;
-    condensed = condensed || newlyArchived > 0;
-  }
 
   const tWrite = Date.now();
-  // #2121: Use incremental append when no condensation (avoids re-serializing all messages)
-  if (!condensed && finalDashboard === updatedDashboard) {
-    await appendDashboardIncremental(key, finalDashboard, newMessages.length);
-  } else {
-    await writeDashboardFile(key, finalDashboard);
-  }
+  await appendDashboardIncremental(key, updatedDashboard, newMessages.length);
   writeMs = Date.now() - tWrite;
+
+  // === CONDENSE-AFTER: best-effort condensation ===
+  // Now that the message is safely persisted, attempt condensation if the
+  // dashboard exceeds the threshold. If condensation succeeds, it overwrites
+  // the file with the condensed version. If it fails, the incremental append
+  // above is the authoritative state — no message loss.
+  const estimatedSize = estimateDashboardSize(updatedDashboard);
+  const needsCondense = estimatedSize >= PREEMPTIVE_CONDENSE_THRESHOLD_BYTES
+    && updatedDashboard.intercom.messages.length > CONDENSE_KEEP;
+
+  if (needsCondense) {
+    logger.info('Post-append condensation triggered (append-first)', {
+      key,
+      estimatedSize: `${Math.round(estimatedSize / 1024)}KB`,
+      threshold: `${Math.round(PREEMPTIVE_CONDENSE_THRESHOLD_BYTES / 1024)}KB`,
+      messageCount: updatedDashboard.intercom.messages.length
+    });
+    try {
+      const beforeCount = updatedDashboard.intercom.messages.length;
+      const condenseDiag = newDiagnostic('post-append');
+      const tCondense = Date.now();
+      finalDashboard = await condenseIntercom(key, updatedDashboard, CONDENSE_KEEP, condenseDiag);
+      preemptiveCondenseMs = Date.now() - tCondense;
+      condenseDiagnostics.push(condenseDiag);
+      const newlyArchived = beforeCount - finalDashboard.intercom.messages.length;
+      archivedCount = newlyArchived;
+      condensed = newlyArchived > 0;
+
+      // If condensation succeeded, overwrite the incremental append with the condensed version
+      if (condensed) {
+        await writeDashboardFile(key, finalDashboard);
+      }
+    } catch (condenseErr) {
+      // Condensation failed — message is already persisted, log and continue
+      logger.warn('Post-append condensation failed (message already persisted, no data loss)', {
+        key,
+        error: condenseErr instanceof Error ? condenseErr.message : String(condenseErr)
+      });
+      const failedDiag = newDiagnostic('post-append');
+      failedDiag.outcome = 'llm-failed-injected';
+      failedDiag.elapsedMs = 0;
+      condenseDiagnostics.push(failedDiag);
+    }
+  }
 
   // Fire-and-forget: Send mention notifications if mentions were detected
   if (mentions.length > 0) {


### PR DESCRIPTION
## Summary
- Restructures `handleAppend()` in `dashboard.ts` to guarantee message persistence before any condensation attempt
- Previously, preemptive condensation (LLM calls that can take minutes) ran **before** the message was written to disk — if it timed out, the message was **lost**
- New flow: write message immediately → attempt condensation as best-effort → if condensation fails, message is already persisted

## Changes
- **`dashboard.ts`**: Removed preemptive condensation (pre-append) and reactive condensation (post-append but pre-write). Replaced with a single "write-first, condense-after" architecture using `appendDashboardIncremental()` for immediate persistence
- **`dashboard.test.ts`**: Updated 2 tests that assumed preemptive condensation fires on the "trigger" append. With append-first, condensation fires on intermediate appends during fill-up — tests now check for any intermediate condensed result

## Test plan
- [x] `npm run build` passes
- [x] 101/102 dashboard tests pass (1 pre-existing skip)
- [x] Condensation still triggers when dashboard exceeds 92% threshold
- [x] Fallback truncation still works when LLM fails
- [x] Circuit breaker behavior unchanged
- [x] Cross-post, mentions, and notifications unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)