### PR TITLE
fix(export): generateConversationXml wrong args in export-data (#2307)

### DIFF
--- a/servers/roo-state-manager/src/tools/export/export-data.ts
+++ b/servers/roo-state-manager/src/tools/export/export-data.ts
@@ -394,8 +394,8 @@ async function handleConversationXml(
         return tasks;
     };
 
-    const allTasks = collectTasks(conversationId!);
-    const xmlContent = (xmlExporterService as any).generateConversationXml(allTasks, {
+    const children = collectTasks(conversationId!).slice(1);
+    const xmlContent = xmlExporterService.generateConversationXml(rootSkeleton, children, {
         includeContent,
         prettyPrint
     });


### PR DESCRIPTION
## Summary

Fixes `children.forEach is not a function` when calling `export_data` with `target=conversation` + `format=xml`.

## Root Cause

`export-data.ts` line 398 called:
```typescript
generateConversationXml(allTasks, { includeContent, prettyPrint })
```

But the signature is:
```typescript
generateConversationXml(rootSkeleton: ConversationSkeleton, children: ConversationSkeleton[], options: XmlExportOptions)
```

The options object `{ includeContent, prettyPrint }` was being received as `children`, causing `children.forEach is not a function`.

Note: `export-conversation-xml.ts` (a separate entry point for the same operation) had the correct calling convention. Only this code path in `export-data.ts` was broken.

## Fix

Split the `allTasks` array (which starts with rootSkeleton) into:
- `rootSkeleton` — already fetched earlier in the function
- `children` — all tasks except root (`allTasks.slice(1)`)

Also removes the unnecessary `as any` cast.

## Tests

173 tests passed (12 test files in `src/tools/export/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)