### PR TITLE
fix(inventory): add crossMachineWarning to heartbeat types (#2318)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/inventory.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/inventory.test.ts
@@ -231,6 +231,17 @@ describe('inventoryTool', () => {
       expect(result.data.heartbeatState.statistics.unknownCount).toBe(1);
       expect(result.data.heartbeatState.statistics.idleCount).toBe(1);
     });
+
+    test('should include crossMachineWarning (#2318)', async () => {
+      const result = await inventoryTool.execute(
+        { type: 'heartbeat' },
+        mockExecutionContext
+      );
+
+      expect(result.data.heartbeatState.crossMachineWarning).toBeDefined();
+      expect(result.data.heartbeatState.crossMachineWarning).toContain('LOCAL-SELF only');
+      expect(result.data.heartbeatState.crossMachineWarning).toContain('type="status"');
+    });
   });
 
   // ============================================================
@@ -256,6 +267,16 @@ describe('inventoryTool', () => {
       );
 
       expect(result.data.heartbeatState.heartbeats).toBeDefined();
+    });
+
+    test('should include crossMachineWarning in all mode (#2318)', async () => {
+      const result = await inventoryTool.execute(
+        { type: 'all' },
+        mockExecutionContext
+      );
+
+      expect(result.data.heartbeatState.crossMachineWarning).toBeDefined();
+      expect(result.data.heartbeatState.crossMachineWarning).toContain('LOCAL-SELF only');
     });
 
     test('should exclude heartbeat data in all mode when includeHeartbeats=false', async () => {

--- a/servers/roo-state-manager/src/tools/roosync/inventory.ts
+++ b/servers/roo-state-manager/src/tools/roosync/inventory.ts
@@ -167,7 +167,13 @@ export const inventoryTool: UnifiedToolContract = {
         }
       }
 
-      // Récupérer l'état heartbeat si demandé
+      // #2318: Heartbeat is LOCAL-SELF only (ADR 008 in-memory per-process).
+      // Cross-machine presence is via type="status" (dashboard-derived).
+      // Annotate with crossMachineWarning so agents cannot misinterpret.
+      const CROSS_MACHINE_WARNING = 'Heartbeat data is LOCAL-SELF only (ADR 008). ' +
+        'This machine sees itself as online and all others as unknown. ' +
+        'Use type="status" for reliable cross-machine presence (dashboard-derived).';
+
       if (type === 'heartbeat' || type === 'all') {
         const rooSyncService = await getRooSyncService();
         const heartbeatService = rooSyncService.getHeartbeatService();
@@ -179,6 +185,7 @@ export const inventoryTool: UnifiedToolContract = {
           idleMachines: state.idleMachines,
           statistics: state.statistics,
           heartbeats: includeHeartbeats ? Object.fromEntries(state.heartbeats) : undefined,
+          crossMachineWarning: CROSS_MACHINE_WARNING,
           retrievedAt
         };
         if (!summary) {
@@ -230,6 +237,7 @@ export const inventoryTool: UnifiedToolContract = {
             machinesData.idleCount = idleMachines.length;
           }
         }
+        machinesData.crossMachineWarning = CROSS_MACHINE_WARNING;
         if (!summary) {
           Object.assign(result, machinesData);
         }
@@ -303,7 +311,7 @@ export const inventoryTool: UnifiedToolContract = {
  */
 export const inventoryToolMetadata = {
   name: 'roosync_inventory',
-  description: 'Récupération de l\'inventaire machine, état heartbeat, ou snapshot système. type="status" pour snapshot compact avec flags actionnables (fused from roosync_get_status).',
+  description: 'Récupération de l\'inventaire machine, état heartbeat, ou snapshot système. type="status" pour snapshot compact avec flags actionnables (fused from roosync_get_status). IMPORTANT: type="heartbeat"/"all"/"machines" returns LOCAL-SELF only heartbeat data (ADR 008) — use type="status" for reliable cross-machine presence.',
   inputSchema: {
     type: 'object' as const,
     properties: {


### PR DESCRIPTION
## Summary
- Add `crossMachineWarning` field to `roosync_inventory` responses for `type="heartbeat"`, `"all"`, and `"machines"`
- Heartbeat data is LOCAL-SELF only (ADR 008 in-memory per-process) — agents were misinterpreting it as cross-machine truth
- Update tool description to warn about the limitation and recommend `type="status"` for cross-machine presence

## Test plan
- [x] Build passes (`npm run build`)
- [x] 9638 tests pass (CI config)
- [x] 2 new tests: `crossMachineWarning` present in `type="heartbeat"` and `type="all"` responses
- [x] Warning contains "LOCAL-SELF only" and `type="status"` reference

## References
- Issue: #2318 (criterion 1 — annotate heartbeat types as non-cross-machine)
- Epic: #2121 (presence + config consolidation)
- ADR 008: Heartbeat redesign (in-memory per-process)

🤖 Generated with [Claude Code](https://claude.com/claude-code)