### PR TITLE
fix(roosync): baseline list_versions cwd + config 0-file usability

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/config.integration.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/config.integration.test.ts
@@ -422,9 +422,9 @@ describe('roosyncConfig (integration)', () => {
         targets: ['modes']
       });
 
-      // Should return a result even if no files collected
+      // Should return warning when no files collected
       expect(result).toBeDefined();
-      expect(result.status).toBe('success');
+      expect(result.status).toBe('warning');
     });
   });
 

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/config.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/config.test.ts
@@ -196,7 +196,7 @@ describe('roosyncConfig', () => {
 
       const result = await roosyncConfig(args);
 
-      expect(result.status).toBe('success');
+      expect(result.status).toBe('warning');
       expect(mockCollectConfig).toHaveBeenCalledWith({
         targets: ['modes', 'mcp'],
         dryRun: true

--- a/servers/roo-state-manager/src/tools/roosync/baseline.ts
+++ b/servers/roo-state-manager/src/tools/roosync/baseline.ts
@@ -763,9 +763,6 @@ async function handleRestoreAction(args: BaselineArgs, timestamp: string): Promi
  * Découvre les versions de baseline disponibles (tags Git baseline-v*)
  */
 async function handleListVersionsAction(args: BaselineArgs, timestamp: string): Promise<BaselineResult> {
-  const sharedStatePath = getSharedStatePath();
-  const configDir = join(sharedStatePath, 'configs');
-
   interface VersionInfo {
     tag: string;
     date: string;
@@ -775,8 +772,7 @@ async function handleListVersionsAction(args: BaselineArgs, timestamp: string): 
   try {
     const allTags = execSync('git tag -l "baseline-v*"', {
       encoding: 'utf8',
-      timeout: GIT_QUICK_TIMEOUT_MS,
-      cwd: configDir
+      timeout: GIT_QUICK_TIMEOUT_MS
     });
 
     const tags = allTags.split('\n').filter(t => t.trim());
@@ -803,15 +799,13 @@ async function handleListVersionsAction(args: BaselineArgs, timestamp: string): 
       try {
         date = execSync(`git log -1 --format=%ai ${tag}`, {
           encoding: 'utf8',
-          timeout: GIT_QUICK_TIMEOUT_MS,
-          cwd: configDir
+          timeout: GIT_QUICK_TIMEOUT_MS
         }).trim();
       } catch { /* skip */ }
       try {
         message = execSync(`git log -1 --format=%s ${tag}`, {
           encoding: 'utf8',
-          timeout: GIT_QUICK_TIMEOUT_MS,
-          cwd: configDir
+          timeout: GIT_QUICK_TIMEOUT_MS
         }).trim();
       } catch { /* skip */ }
       versions.push({ tag, date, message });

--- a/servers/roo-state-manager/src/tools/roosync/config.ts
+++ b/servers/roo-state-manager/src/tools/roosync/config.ts
@@ -141,6 +141,16 @@ export async function roosyncConfig(args: ConfigArgs) {
           scope // Issue #601 - Pass scope to collect
         });
 
+        if (result.filesCount === 0) {
+          return {
+            status: 'warning',
+            message: `Aucun fichier collecté pour les targets: ${targets.join(', ')}. Vérifiez que les répertoires sources existent.`,
+            packagePath: result.packagePath,
+            totalSize: result.totalSize,
+            manifest: result.manifest
+          };
+        }
+
         return {
           status: 'success',
           message: `Configuration collectée avec succès (${result.filesCount} fichiers)`,

--- a/servers/roo-state-manager/tests/unit/tools/roosync/config-execution.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/config-execution.test.ts
@@ -100,7 +100,7 @@ describe('roosync_config - Execution - Action Collect', () => {
       dryRun: true
     });
 
-    expect(result.status).toBe('success');
+    expect(result.status).toBe('warning');
     expect(mockCollectConfig).toHaveBeenCalledWith({
       targets: ['modes', 'mcp'],
       dryRun: true


### PR DESCRIPTION
## Summary
- Fix `roosync_baseline list_versions` failing with `fatal: not a git repository` by removing `cwd: configDir` from git commands. The GDrive configs path is not a git repo — `version` and `restore` handlers already use process CWD (the repo).
- Return `status: 'warning'` instead of `success` when `roosync_config collect` returns 0 files, with actionable message listing requested targets.

## Test plan
- [x] `npm run build` passes
- [x] `npx vitest run --config vitest.config.ci.ts` passes (474/474, 9609 tests)
- [x] Updated 3 test files to expect `warning` on 0-file collect

🤖 Generated with [Claude Code](https://claude.com/claude-code)