### PR TITLE
fix(conversation-browser): prevent OOM on oversized conversation files

### DIFF
--- a/servers/roo-state-manager/src/types/conversation.ts
+++ b/servers/roo-state-manager/src/types/conversation.ts
@@ -45,6 +45,7 @@ export interface SkeletonMetadata {
     messageCount: number;
     actionCount: number;
     totalSize: number;
+    oversizedFiles?: string[];
     workspace?: string;
     machineId?: string;
     qdrantIndexedAt?: string; // DEPRECATED - utiliser indexingState.lastIndexedAt

--- a/servers/roo-state-manager/src/utils/claude-storage-detector.ts
+++ b/servers/roo-state-manager/src/utils/claude-storage-detector.ts
@@ -26,6 +26,7 @@ import {
  * Détecteur pour les conversations Claude Code
  */
 export class ClaudeStorageDetector {
+    private static readonly MAX_CONVERSATION_FILE_SIZE = 10 * 1024 * 1024; // 10MB — prevents OOM on traces >40MB
     // Nom du répertoire de stockage Claude Code
     private static readonly CLAUDE_PROJECTS_DIR = 'projects';
     private static readonly CLAUDE_CONFIG_DIR = '.claude';
@@ -188,11 +189,18 @@ export class ClaudeStorageDetector {
             // Parser tous les fichiers JSONL
             const allEntries: ClaudeJsonlEntry[] = [];
             let totalSize = 0;
+            const oversizedFiles: string[] = [];
 
             for (const file of jsonlFiles) {
                 const filePath = path.join(projectPath, file);
                 const fileStats = await fs.stat(filePath);
                 totalSize += fileStats.size;
+
+                if (fileStats.size > this.MAX_CONVERSATION_FILE_SIZE) {
+                    console.warn(`⚠️ [ClaudeStorageDetector] File too large, skipping: ${file} (${(fileStats.size / 1024 / 1024).toFixed(1)}MB)`);
+                    oversizedFiles.push(`${file} (${(fileStats.size / 1024 / 1024).toFixed(1)}MB)`);
+                    continue;
+                }
 
                 const entries = await this.parseJsonlFile(filePath);
                 allEntries.push(...entries);
@@ -221,6 +229,7 @@ export class ClaudeStorageDetector {
                     ...metadata,
                     workspace,
                     machineId: os.hostname(), // Ajouter l'identifiant de la machine
+                    ...(oversizedFiles.length > 0 ? { oversizedFiles } : {}),
                 },
             };
         } catch (error) {
@@ -236,6 +245,12 @@ export class ClaudeStorageDetector {
         const entries: ClaudeJsonlEntry[] = [];
 
         try {
+            const fileStats = await fs.stat(filePath);
+            if (fileStats.size > this.MAX_CONVERSATION_FILE_SIZE) {
+                console.warn(`⚠️ [ClaudeStorageDetector] parseJsonlFile: File too large, skipping: ${filePath} (${(fileStats.size / 1024 / 1024).toFixed(1)}MB)`);
+                return entries;
+            }
+
             const content = await fs.readFile(filePath, 'utf-8');
             const lines = content.split('\n');
 

--- a/servers/roo-state-manager/src/utils/roo-storage-detector.ts
+++ b/servers/roo-state-manager/src/utils/roo-storage-detector.ts
@@ -31,6 +31,7 @@ import { getParsingConfig, isComparisonMode, shouldUseNewParsing } from './parsi
 import { WorkspaceDetector } from './workspace-detector.js';
 
 export class RooStorageDetector {
+  private static readonly MAX_CONVERSATION_FILE_SIZE = 10 * 1024 * 1024; // 10MB — prevents OOM on traces >40MB
   private static readonly COMMON_ROO_PATHS = [
     // Chemins VSCode typiques
     path.join(os.homedir(), '.vscode', 'extensions'),
@@ -513,19 +514,30 @@ export class RooStorageDetector {
         // Previously ui_messages.json was read 3 times and api_conversation_history.json 2 times per task
         let preloadedUiContent: string | undefined = undefined;
         let preloadedApiContent: string | undefined = undefined;
+        const oversizedFiles: string[] = [];
         if (uiMessagesStats) {
-            try {
-                let raw = await fs.readFile(uiMessagesPath, 'utf-8');
-                if (raw.charCodeAt(0) === 0xFEFF) raw = raw.slice(1);
-                preloadedUiContent = raw;
-            } catch { /* will be handled by individual callers */ }
+            if (uiMessagesStats.size > this.MAX_CONVERSATION_FILE_SIZE) {
+                console.warn(`⚠️ [analyzeConversation] ${taskId}: ui_messages.json too large (${(uiMessagesStats.size / 1024 / 1024).toFixed(1)}MB > 10MB), skipping to prevent OOM`);
+                oversizedFiles.push(`ui_messages.json (${(uiMessagesStats.size / 1024 / 1024).toFixed(1)}MB)`);
+            } else {
+                try {
+                    let raw = await fs.readFile(uiMessagesPath, 'utf-8');
+                    if (raw.charCodeAt(0) === 0xFEFF) raw = raw.slice(1);
+                    preloadedUiContent = raw;
+                } catch { /* will be handled by individual callers */ }
+            }
         }
         if (apiHistoryStats) {
-            try {
-                let raw = await fs.readFile(apiHistoryPath, 'utf-8');
-                if (raw.charCodeAt(0) === 0xFEFF) raw = raw.slice(1);
-                preloadedApiContent = raw;
-            } catch { /* will be handled by individual callers */ }
+            if (apiHistoryStats.size > this.MAX_CONVERSATION_FILE_SIZE) {
+                console.warn(`⚠️ [analyzeConversation] ${taskId}: api_conversation_history.json too large (${(apiHistoryStats.size / 1024 / 1024).toFixed(1)}MB > 10MB), skipping to prevent OOM`);
+                oversizedFiles.push(`api_conversation_history.json (${(apiHistoryStats.size / 1024 / 1024).toFixed(1)}MB)`);
+            } else {
+                try {
+                    let raw = await fs.readFile(apiHistoryPath, 'utf-8');
+                    if (raw.charCodeAt(0) === 0xFEFF) raw = raw.slice(1);
+                    preloadedApiContent = raw;
+                } catch { /* will be handled by individual callers */ }
+            }
         }
 
         // 🚀 PRODUCTION : Logique de reconstruction hiérarchique en deux passes
@@ -668,6 +680,7 @@ export class RooStorageDetector {
                 totalSize,
                 workspace: extractedWorkspace || rawMetadata.workspace,
                 dataSource: taskPath, // ✅ CRITIQUE: Chemin pour que HierarchyEngine trouve ui_messages.json
+                ...(oversizedFiles.length > 0 ? { oversizedFiles } : {}),
             },
             childTaskInstructionPrefixes: childTaskInstructionPrefixes.length > 0 ? childTaskInstructionPrefixes : undefined,
             // 🚀 NOUVEAUX CHAMPS : Ajout des fonctionnalités demandées


### PR DESCRIPTION
## Summary
- Add 10MB file size guard before reading conversation history files in both `RooStorageDetector` and `ClaudeStorageDetector`
- Files exceeding the limit are skipped with a warning, preventing OOM on traces >40MB
- New `oversizedFiles` field in `SkeletonMetadata` tracks which files were skipped

## Problem
`smart_truncation` bounds output to ≤150K chars but provides zero protection during the INPUT phase. `fs.readFile` + `JSON.parse` on a 40MB file can transiently need several hundred MB, causing OOM/context explosion.

## Test plan
- [x] Build: `tsc` clean
- [x] CI tests: 9622 passed / 0 failed / 23 skipped (474 files)
- [ ] Verify `conversation_browser(action: "view")` returns minimal skeleton with `oversizedFiles` for large traces

Refs jsboige/roo-extensions#2307

🤖 Generated with [Claude Code](https://claude.com/claude-code)