### PR TITLE
fix(dashboard): anti-collision smart-merge for condensation (#2328)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard-collision.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard-collision.test.ts
@@ -1,0 +1,181 @@
+/**
+ * #2328: Tests for dashboard anti-collision smart-merge.
+ *
+ * Verifies that `applyCondensedWithMerge` preserves concurrent appends
+ * and guards against stale double-condensation overwrites.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm, readFile, writeFile } from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { roosyncDashboard } from '../dashboard.js';
+
+const testTmpBase = path.join(os.tmpdir(), 'dashboard-collision-test-');
+
+describe('dashboard collision #2328', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(testTmpBase);
+    process.env.ROOSYNC_SHARED_PATH = tmpDir;
+    process.env.ROOSYNC_MACHINE_ID = 'test-machine';
+    process.env.ROOSYNC_WORKSPACE_ID = 'test-workspace';
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_BASE_URL;
+    delete process.env.OPENAI_CHAT_MODEL_ID;
+    delete process.env.EMBEDDING_API_KEY;
+    delete process.env.EMBEDDING_API_BASE_URL;
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+    delete process.env.ROOSYNC_SHARED_PATH;
+    delete process.env.ROOSYNC_MACHINE_ID;
+    delete process.env.ROOSYNC_WORKSPACE_ID;
+  });
+
+  /** Helper: read dashboard file and return parsed intercom message ids */
+  async function readMessageIds(key: string): Promise<string[]> {
+    const dashboardsDir = path.join(tmpDir, 'dashboards');
+    const filePath = path.join(dashboardsDir, `${key}.md`);
+    const content = await readFile(filePath, 'utf8');
+    const ids: string[] = [];
+    const regex = /\[msg: ([^\]]+)\]/g;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(content)) !== null) {
+      ids.push(match[1]);
+    }
+    return ids;
+  }
+
+  /** Helper: get dashboard file path */
+  function getDashboardFilePath(key: string): string {
+    return path.join(tmpDir, 'dashboards', `${key}.md`);
+  }
+
+  /** Helper: inject an extra message directly into the file on disk (simulates concurrent append) */
+  async function injectConcurrentMessage(key: string, msgId: string, msgContent: string): Promise<void> {
+    const filePath = getDashboardFilePath(key);
+    let fileContent = await readFile(filePath, 'utf8');
+
+    // Append a new message block
+    const ts = new Date().toISOString();
+    const messageBlock = `\n\n---\n\n### [${ts}] other-machine|other-workspace\n[msg: ${msgId}]\n\n${msgContent}`;
+    fileContent = fileContent.replace(/\*Aucun message\.\*/, '');
+    fileContent += messageBlock;
+
+    // Update totalMessages in frontmatter
+    fileContent = fileContent.replace(
+      /totalMessages: (\d+)/,
+      (_, n) => `totalMessages: ${parseInt(n) + 1}`
+    );
+    // Update message count in section header
+    fileContent = fileContent.replace(
+      /## Intercom \((\d+) messages\)/,
+      (_, n) => `## Intercom (${parseInt(n) + 1} messages)`
+    );
+
+    await writeFile(filePath, fileContent, 'utf8');
+  }
+
+  /** Helper: populate dashboard with N messages */
+  async function populateDashboard(n: number): Promise<string> {
+    const writeResult = await roosyncDashboard({
+      action: 'write',
+      type: 'workspace',
+      content: 'test status',
+      createIfNotExists: true,
+    });
+    const key = writeResult.key;
+
+    for (let i = 0; i < n; i++) {
+      await roosyncDashboard({
+        action: 'append',
+        type: 'workspace',
+        content: `Message ${i}: ${'x'.repeat(500)}`,
+        tags: ['INFO'],
+      });
+    }
+    return key;
+  }
+
+  it('preserves concurrent append after condensation', async () => {
+    const key = await populateDashboard(20);
+    const idsBefore = await readMessageIds(key);
+    expect(idsBefore.length).toBe(20);
+
+    // Inject a concurrent message directly on disk (simulates another machine)
+    const concurrentMsgId = 'concurrent-msg-999';
+    await injectConcurrentMessage(key, concurrentMsgId, 'Concurrent message from another machine');
+
+    const idsAfterInject = await readMessageIds(key);
+    expect(idsAfterInject).toContain(concurrentMsgId);
+
+    // Trigger condensation via append — the in-memory snapshot does NOT contain concurrentMsgId.
+    // applyCondensedWithMerge should re-read disk and stitch the delta back in.
+    const result = await roosyncDashboard({
+      action: 'append',
+      type: 'workspace',
+      content: `Final message: ${'y'.repeat(500)}`,
+      tags: ['INFO'],
+    });
+
+    expect(result.success).toBe(true);
+
+    // The concurrent message must survive condensation
+    const idsAfterCondense = await readMessageIds(key);
+    expect(idsAfterCondense).toContain(concurrentMsgId);
+  });
+
+  it('skips overwrite when another condensation already won', async () => {
+    const key = await populateDashboard(20);
+
+    // Simulate that another machine already condensed: set lastCondensedAt to future
+    const filePath = getDashboardFilePath(key);
+    let fileContent = await readFile(filePath, 'utf8');
+    const futureDate = new Date(Date.now() + 60000).toISOString();
+    if (fileContent.includes('lastCondensedAt:')) {
+      fileContent = fileContent.replace(/lastCondensedAt: .+/, `lastCondensedAt: ${futureDate}`);
+    } else {
+      fileContent = fileContent.replace(/^---\n/, `---\nlastCondensedAt: ${futureDate}\n`);
+    }
+    await writeFile(filePath, fileContent, 'utf8');
+
+    // Append (may trigger condensation). The smart-merge guard should detect
+    // the newer lastCondensedAt and skip the stale overwrite.
+    const result = await roosyncDashboard({
+      action: 'append',
+      type: 'workspace',
+      content: 'New message after concurrent condense',
+      tags: ['INFO'],
+    });
+
+    expect(result.success).toBe(true);
+
+    // Messages should still be present (not lost to stale overwrite)
+    const idsAfter = await readMessageIds(key);
+    expect(idsAfter.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('works correctly when no concurrent append (common case)', async () => {
+    const key = await populateDashboard(20);
+
+    const idsBefore = await readMessageIds(key);
+    expect(idsBefore.length).toBe(20);
+
+    // Trigger condensation via append
+    const result = await roosyncDashboard({
+      action: 'append',
+      type: 'workspace',
+      content: `Final: ${'y'.repeat(500)}`,
+      tags: ['INFO'],
+    });
+
+    expect(result.success).toBe(true);
+
+    // Dashboard should still have messages (condensed or not)
+    const idsAfter = await readMessageIds(key);
+    expect(idsAfter.length).toBeGreaterThan(0);
+  });
+});

--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -502,6 +502,63 @@ ${intercomSection}
 }
 
 /**
+ * #2328: Apply condensed dashboard with smart-merge to avoid overwriting
+ * concurrent appends from other machines during the LLM condensation window (~9 min).
+ *
+ * Before overwriting, re-reads the file from disk and stitches any messages
+ * appended by other machines (identified by msg.id) into the condensed result.
+ * Also guards against double-condensation (skips if another condensation won).
+ */
+async function applyCondensedWithMerge(
+  key: string,
+  snapshotBefore: Dashboard,
+  condensedDashboard: Dashboard
+): Promise<void> {
+  const current = await readDashboardFile(key);
+  if (!current) {
+    await writeDashboardFile(key, condensedDashboard);
+    return;
+  }
+
+  // Guard: if another condensation completed while our LLM was running,
+  // don't overwrite with our stale result.
+  if (
+    current.intercom.lastCondensedAt &&
+    current.intercom.lastCondensedAt > (snapshotBefore.intercom.lastCondensedAt ?? '')
+  ) {
+    logger.warn('[COLLISION] concurrent condensation won — skipping stale overwrite', { key });
+    return;
+  }
+
+  // Delta = messages on disk that weren't in our pre-condensation snapshot.
+  // append-only => these are concurrent appends => always a suffix.
+  const seen = new Set(snapshotBefore.intercom.messages.map(m => m.id));
+  const delta = current.intercom.messages.filter(m => !seen.has(m.id));
+
+  if (delta.length === 0) {
+    await writeDashboardFile(key, condensedDashboard);
+    return;
+  }
+
+  logger.warn('[COLLISION] stitching concurrent appends into condensed result', {
+    key, deltaCount: delta.length, deltaIds: delta.map(m => m.id)
+  });
+
+  const merged: Dashboard = {
+    ...condensedDashboard,
+    lastModified: current.lastModified > condensedDashboard.lastModified
+      ? current.lastModified
+      : condensedDashboard.lastModified,
+    intercom: {
+      messages: [...condensedDashboard.intercom.messages, ...delta],
+      totalMessages: condensedDashboard.intercom.totalMessages + delta.length,
+      lastCondensedAt: condensedDashboard.intercom.lastCondensedAt,
+    },
+  };
+  await writeDashboardFile(key, merged);
+}
+
+/**
  * Append messages to the dashboard file without rewriting existing content.
  * Only updates frontmatter (in-place regex) and appends new messages at the end.
  * Used by handleAppend when no condensation occurred (the common case).
@@ -2231,9 +2288,9 @@ async function handleAppend(
       archivedCount = newlyArchived;
       condensed = newlyArchived > 0;
 
-      // If condensation succeeded, overwrite the incremental append with the condensed version
+      // If condensation succeeded, merge-write (re-read disk to avoid overwriting concurrent appends #2328)
       if (condensed) {
-        await writeDashboardFile(key, finalDashboard);
+        await applyCondensedWithMerge(key, updatedDashboard, finalDashboard);
       }
     } catch (condenseErr) {
       // Condensation failed — message is already persisted, log and continue
@@ -2474,11 +2531,11 @@ async function handleCondense(
   const actuallyCondensed = condensedDashboard.intercom.messages.length < beforeCount;
   // Persist whenever the dashboard changed — either condensation succeeded
   // (count decreased) or LLM failed and an ERROR system message was injected
-  // (count increased). writeDashboardFile is atomic (tmp+rename).
+  // (count increased). Use smart-merge to avoid overwriting concurrent appends (#2328).
   const dashboardChanged = condensedDashboard.intercom.messages.length !== beforeCount;
 
   if (dashboardChanged) {
-    await writeDashboardFile(key, condensedDashboard);
+    await applyCondensedWithMerge(key, dashboard, condensedDashboard);
   }
 
   const archivedCount = actuallyCondensed ? beforeCount - condensedDashboard.intercom.messages.length : 0;


### PR DESCRIPTION
## Summary

- Add `applyCondensedWithMerge` helper that re-reads disk before overwriting condensed dashboard
- Prevents message loss when concurrent appends from other machines land during the ~9min LLM condensation window
- Guards against stale double-condensation via `lastCondensedAt` comparison

## Changes

- **`dashboard.ts`**: New `applyCondensedWithMerge()` helper + patches at 2 overwrite sites:
  - `handleAppend` post-condensation overwrite (was line 2236)
  - Manual condense handler overwrite (was line 2481)
- **`dashboard-collision.test.ts`**: 3 tests (concurrent append survives, double-condensation guard, common case)

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 475 passed, 0 failed
- [x] New collision tests: 3/3 passed
- [ ] Merge → pointer-bump parent (anti-#1799)

Closes #2328

🤖 Generated with [Claude Code](https://claude.com/claude-code)