### PR TITLE
feat(sk-agent): get_file_history for PR review tier 2 (#1587)

### DIFF
--- a/servers/sk-agent/github_plugin.py
+++ b/servers/sk-agent/github_plugin.py
@@ -228,6 +228,46 @@ class GitHubPlugin:
             return json.dumps({"error": f"Failed to decode file: {e}"})
 
     @kernel_function(
+        description="Get recent commit history for a file. Returns last N commits with SHA, author, date, message.",
+        name="get_file_history",
+    )
+    def get_file_history(
+        self,
+        path: str,
+        repo: str = "",
+        limit: int = 10,
+        branch: str = "main",
+    ) -> str:
+        """Get commit history for a file in a repository.
+
+        Args:
+            path: File path in the repository
+            repo: Repository in owner/repo format
+            limit: Number of recent commits to return (max 20). Default: 10
+            branch: Branch to check. Default: main
+        """
+        repo = repo or self._default_repo
+        if not repo:
+            return json.dumps({"error": "repo is required"})
+        limit = max(1, min(20, limit))
+        args = [
+            "api", f"repos/{repo}/commits",
+            "--jq", f".[:{limit}] | .[] | {{sha: .sha[:12], author: .commit.author.name, date: .commit.author.date[:10], message: .commit.message[:120]}}",
+            "-f", f"path={path}",
+            "-f", f"sha={branch}",
+        ]
+        output = self._run_gh(args, timeout=20)
+        if output.startswith('{"error"'):
+            return output
+        try:
+            # The --jq output is one JSON object per line, wrap in array
+            lines = [l.strip() for l in output.strip().split("\n") if l.strip()]
+            commits = [json.loads(l) for l in lines]
+            return json.dumps(commits, indent=2, ensure_ascii=False)
+        except (json.JSONDecodeError, ValueError):
+            return output
+
+    @kernel_function(
         description="Search code in a repository using grep pattern. Returns matching file paths and line numbers.",
         name="grep_code",
     )

--- a/servers/sk-agent/test_github_plugin.py
+++ b/servers/sk-agent/test_github_plugin.py
@@ -205,6 +205,69 @@ class TestReadFile:
         assert "repos/owner/repo/contents/src/file.ts?ref=abc123" in args
 
 
+class TestGetFileHistory:
+    @patch("github_plugin.subprocess.run")
+    def test_returns_commits(self, mock_run, plugin):
+        jq_output = (
+            '{"sha":"abc123456789","author":"dev","date":"2026-05-20","message":"fix bug"}\n'
+            '{"sha":"def456789abc","author":"dev2","date":"2026-05-19","message":"add feature"}\n'
+        )
+        mock_run.return_value = MagicMock(returncode=0, stdout=jq_output)
+        result = plugin.get_file_history("src/main.ts", repo="owner/repo")
+        commits = json.loads(result)
+        assert len(commits) == 2
+        assert commits[0]["sha"] == "abc123456789"
+        assert commits[1]["author"] == "dev2"
+
+    @patch("github_plugin.subprocess.run")
+    def test_uses_default_repo(self, mock_run, plugin):
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        plugin.get_file_history("src/file.ts")
+        args = mock_run.call_args[0][0]
+        assert any("test-owner/test-repo" in a for a in args)
+
+    def test_requires_repo(self):
+        p = GitHubPlugin()
+        result = p.get_file_history("file.txt")
+        data = json.loads(result)
+        assert "error" in data
+
+    @patch("github_plugin.subprocess.run")
+    def test_handles_error(self, mock_run, plugin):
+        mock_run.return_value = MagicMock(returncode=1, stderr="path not found")
+        result = plugin.get_file_history("missing.ts", repo="owner/repo")
+        data = json.loads(result)
+        assert "error" in data
+
+    @patch("github_plugin.subprocess.run")
+    def test_limit_clamped_to_20(self, mock_run, plugin):
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        plugin.get_file_history("f.ts", repo="o/r", limit=100)
+        args = mock_run.call_args[0][0]
+        assert "[:20]" in " ".join(args)
+
+    @patch("github_plugin.subprocess.run")
+    def test_limit_minimum_1(self, mock_run, plugin):
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        plugin.get_file_history("f.ts", repo="o/r", limit=-5)
+        args = mock_run.call_args[0][0]
+        assert "[:1]" in " ".join(args)
+
+    @patch("github_plugin.subprocess.run")
+    def test_branch_param_passed(self, mock_run, plugin):
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        plugin.get_file_history("f.ts", repo="o/r", branch="develop")
+        args = mock_run.call_args[0][0]
+        assert any("develop" in a for a in args)
+
+    @patch("github_plugin.subprocess.run")
+    def test_empty_history(self, mock_run, plugin):
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        result = plugin.get_file_history("new.ts", repo="owner/repo")
+        commits = json.loads(result)
+        assert commits == []
+
+
 class TestGrepCode:
     @patch("github_plugin.subprocess.run")
     def test_returns_matches(self, mock_run, plugin):


### PR DESCRIPTION
## Summary
- Add `get_file_history` kernel function to `GitHubPlugin` for context exploration during tier 2 PR reviews
- Returns recent commit history (SHA, author, date, message) for a given file path via `gh api`
- 8 new tests for `get_file_history` (commits, repo fallback, errors, limit clamping, branch param, empty history)

## Context
Issue #1587 multi-tier PR reviews. Phase 1 scope (tier 2) is now **complete**:
- `review_pr` MCP tool: already in place
- GitHub plugin wiring: already in place  
- Agents (`fast-reviewer`, `integration-reviewer`, `context-explorer`): already in config
- Conversations (`pr-review-tier1`, `pr-review-tier2`): already in config
- **This PR adds the missing piece**: `get_file_history` for context exploration

## Test plan
- [x] `pytest test_github_plugin.py` — 32/32 passed (24 existing + 8 new)
- [x] `pytest test_review_pr.py` — 30/30 passed
- [ ] Manual test: `mcp__sk-agent__review_pr(repo: "jsboige/roo-extensions", pr_number: N, tier: 2)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)