### PR TITLE
fix(tools): schema drift fixes from #2307 infrastructure audit

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/diagnose.ts
+++ b/servers/roo-state-manager/src/tools/roosync/diagnose.ts
@@ -114,7 +114,7 @@ export async function roosyncDiagnose(args: DiagnoseArgs): Promise<DiagnoseResul
         const m = await import('../diagnostic/analyze_problems.js');
         const analyzeResult = await m.analyzeRooSyncProblems(args as any) as any;
         return {
-          success: true,
+          success: analyzeResult?.success !== false,
           action: 'analyze',
           timestamp,
           data: analyzeResult
@@ -124,9 +124,9 @@ export async function roosyncDiagnose(args: DiagnoseArgs): Promise<DiagnoseResul
       // #1935 Cluster D: fused from get_mcp_best_practices
       case 'best-practices': {
         const m = await import('../get_mcp_best_practices.js');
-        const result = await m.getMcpBestPractices.handler({ mcp_name: args.mcp_name });
+        const result = await m.getMcpBestPractices.handler({ mcp_name: args.mcp_name }) as any;
         return {
-          success: true,
+          success: !result?.isError,
           action: 'best-practices',
           timestamp,
           data: result

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -130,11 +130,11 @@ export const roosyncSearchDefinition = {
 // ============================================================
 export const roosyncIndexingDefinition = {
     name: 'roosync_indexing',
-    description: "Manage semantic index, cache, and archiving (index, reset, rebuild, diagnose, archive, status, repair_gaps)",
+    description: "Manage semantic index, cache, and archiving (index, reset, rebuild, diagnose, archive, status, repair_gaps, cleanup, garbage_scan, cleanup_orphans)",
     inputSchema: {
         type: 'object',
         properties: {
-            action: { type: 'string', enum: ['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'repair_gaps'], description: 'index=Qdrant, reset=clear collection, rebuild=SQLite, diagnose=health, archive=GDrive, status=metrics, repair_gaps=fix missing' },
+            action: { type: 'string', enum: ['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'repair_gaps', 'cleanup', 'garbage_scan', 'cleanup_orphans'], description: 'index=Qdrant, reset=clear, rebuild=SQLite, diagnose=health, archive=GDrive, status=metrics, repair_gaps=fix, cleanup=orphan tasks, garbage_scan=detect, cleanup_orphans=purge' },
             task_id: { type: 'string', description: 'Required for action=index' },
             confirm: { type: 'boolean', description: 'Required for action=reset', default: false },
             workspace_filter: { type: 'string' },
@@ -459,11 +459,11 @@ export const roosyncStorageManagementDefinition = {
 
 export const roosyncDiagnoseDefinition = {
     name: 'roosync_diagnose',
-    description: 'RooSync diagnostics and debug. Actions: env, debug, reset, test, analyze (roadmap), best-practices (MCP guide).',
+    description: 'RooSync diagnostics and debug. Actions: env, debug, reset, test, health (skeleton cache), analyze (roadmap), best-practices (MCP guide).',
     inputSchema: {
         type: 'object',
         properties: {
-            action: { type: 'string', enum: ['env', 'debug', 'reset', 'test', 'analyze', 'best-practices'] },
+            action: { type: 'string', enum: ['env', 'debug', 'reset', 'test', 'health', 'analyze', 'best-practices'] },
             checkDiskSpace: { type: 'boolean' },
             verbose: { type: 'boolean' },
             clearCache: { type: 'boolean' },


### PR DESCRIPTION
## Summary
- Add `health` action to `roosyncDiagnoseDefinition` enum + description (BUG-1: was implemented but undiscoverable via `ListTools`)
- Add `cleanup`, `garbage_scan`, `cleanup_orphans` to `roosyncIndexingDefinition` (BUG-3: 7→10 actions, handler already supports all 10)
- Fix `analyze`/`best-practices` hardcoded `success: true` → propagate actual result from delegated tools (BUG-2)
- Update descriptions to reflect full action sets

## Context
Issue #2307 Phase 1 — Infrastructure tools audit (po-2026). Three bugs found where actions were fully implemented in handlers but invisible in the advertised MCP schema, or reporting false success.

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 476/476 files, 9626/9626 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)