### PR TITLE
fix(storage): BOM stripping + JSONL error logging (#756)

### DIFF
--- a/servers/roo-state-manager/src/utils/claude-storage-detector.ts
+++ b/servers/roo-state-manager/src/utils/claude-storage-detector.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs/promises';
 import { existsSync } from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { stripBOM } from './encoding-helpers.js';
 import {
     ConversationSkeleton,
     MessageSkeleton,
@@ -251,14 +252,20 @@ export class ClaudeStorageDetector {
                 return entries;
             }
 
-            const content = await fs.readFile(filePath, 'utf-8');
+            const content = stripBOM(await fs.readFile(filePath, 'utf-8'));
             const lines = content.split('\n');
 
+            let skippedEntries = 0;
             for (const line of lines) {
                 const entry = await this.parseJsonlLine(line);
                 if (entry) {
                     entries.push(entry);
+                } else if (line.trim()) {
+                    skippedEntries++;
                 }
+            }
+            if (skippedEntries > 0) {
+                console.warn(`[ClaudeStorageDetector] ⚠️ ${skippedEntries} invalid JSONL lines skipped in ${path.basename(filePath)}`);
             }
         } catch (error) {
             console.error(`[ClaudeStorageDetector] Error parsing JSONL file ${filePath}:`, error);

--- a/servers/roo-state-manager/src/utils/roo-storage-detector.ts
+++ b/servers/roo-state-manager/src/utils/roo-storage-detector.ts
@@ -8,6 +8,7 @@ import { createReadStream, Stats, existsSync } from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as readline from 'readline';
+import { stripBOM } from './encoding-helpers.js';
 import { glob } from 'glob';
 import {
     RooStorageLocation,
@@ -1235,7 +1236,7 @@ export class RooStorageDetector {
       allSkeletonPaths,
       async (skeletonPath) => {
         try {
-          const skeletonContent = await fs.readFile(skeletonPath, 'utf-8');
+          const skeletonContent = stripBOM(await fs.readFile(skeletonPath, 'utf-8'));
           const skeleton: ConversationSkeleton = JSON.parse(skeletonContent);
 
           if (skeleton.childTaskInstructionPrefixes && skeleton.childTaskInstructionPrefixes.length > 0) {
@@ -1423,14 +1424,18 @@ export class RooStorageDetector {
           // Tentative 3: JSONL (une entrée JSON par ligne)
           const lines = processedContent.split('\n');
           const jsonlItems: any[] = [];
+          let skippedJsonl = 0;
           for (const line of lines) {
             const trimmed = line.trim();
             if (!trimmed) continue;
             try {
               jsonlItems.push(JSON.parse(trimmed));
             } catch (_e3) {
-              // ignorer les lignes invalides
+              skippedJsonl++;
             }
+          }
+          if (skippedJsonl > 0) {
+            console.warn(`[extractFromMessageFile] ⚠️ ${skippedJsonl} invalid JSONL lines skipped in ${path.basename(filePath)}`);
           }
           if (jsonlItems.length > 0) {
             messages = jsonlItems;
@@ -1557,7 +1562,7 @@ export class RooStorageDetector {
    */
   private static async extractParentFromApiHistory(apiHistoryPath: string): Promise<string | undefined> {
     try {
-      const content = await fs.readFile(apiHistoryPath, 'utf-8');
+      const content = stripBOM(await fs.readFile(apiHistoryPath, 'utf-8'));
       const data = JSON.parse(content);
       const messages = Array.isArray(data) ? data : (data?.messages || []);
 
@@ -1581,7 +1586,7 @@ export class RooStorageDetector {
    */
   private static async extractParentFromUiMessages(uiMessagesPath: string): Promise<string | undefined> {
     try {
-      const content = await fs.readFile(uiMessagesPath, 'utf-8');
+      const content = stripBOM(await fs.readFile(uiMessagesPath, 'utf-8'));
       const data = JSON.parse(content);
       const messages = Array.isArray(data) ? data : [];
 
@@ -1690,14 +1695,18 @@ export class RooStorageDetector {
             // 3. Fallback final en mode JSONL
             const lines = content.split('\n');
             const items: any[] = [];
+            let skippedLines = 0;
             for (const line of lines) {
                 if (line.trim()) {
                     try {
                         items.push(JSON.parse(line));
                     } catch (lineError) {
-                       // ignorer la ligne
+                       skippedLines++;
                     }
                 }
+            }
+            if (skippedLines > 0) {
+                console.warn(`[readJsonFile] ⚠️ \${skippedLines} invalid JSONL lines skipped in \${path.basename(filePath)}`);
             }
             if(items.length > 0) {
                 console.log(`[readJsonFile] ✅ Parsed ${items.length} items as JSONL from ${path.basename(filePath)}`);

--- a/servers/roo-state-manager/src/utils/roo-storage-detector.ts
+++ b/servers/roo-state-manager/src/utils/roo-storage-detector.ts
@@ -1706,7 +1706,7 @@ export class RooStorageDetector {
                 }
             }
             if (skippedLines > 0) {
-                console.warn(`[readJsonFile] ⚠️ \${skippedLines} invalid JSONL lines skipped in \${path.basename(filePath)}`);
+                console.warn(`[readJsonFile] ⚠️ ${skippedLines} invalid JSONL lines skipped in ${path.basename(filePath)}`);
             }
             if(items.length > 0) {
                 console.log(`[readJsonFile] ✅ Parsed ${items.length} items as JSONL from ${path.basename(filePath)}`);


### PR DESCRIPTION
## Summary
- Add `stripBOM()` from `encoding-helpers.ts` at **4 locations** that were missing BOM handling in `roo-storage-detector.ts` and `claude-storage-detector.ts`
- Add **aggregate warning logging** at 3 sites that silently swallowed JSONL parse errors (zero logging before)
- Uses existing `stripBOM` utility instead of duplicating `charCodeAt(0) === 0xFEFF` pattern

## Changes

### BOM stripping (4 locations)
1. `roo-storage-detector.ts` — `rebuildIndexFromExistingSkeletons` reads `.skeleton` files
2. `roo-storage-detector.ts` — `extractParentFromApiHistory` reads `api_conversation_history.json`
3. `roo-storage-detector.ts` — `extractParentFromUiMessages` reads `ui_messages.json`
4. `claude-storage-detector.ts` — `parseJsonlFile` reads `.jsonl` files

### JSONL error logging (3 locations)
1. `roo-storage-detector.ts` — `readJsonFile` JSONL fallback: counts skipped lines, logs aggregate warning
2. `roo-storage-detector.ts` — `extractFromMessageFile` JSONL fallback: same pattern
3. `claude-storage-detector.ts` — `parseJsonlFile` loop: tracks non-empty lines returning null from `parseJsonlLine`

## Test plan
- [x] Build passes (`npm run build`)
- [x] CI tests pass (475 passed, 0 failed)
- [ ] Manual verification: files with BOM are parsed correctly at all locations

Closes #756 (partial — BOM + JSONL items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)