### PR TITLE
fix(diagnostic): replace brittle process.cwd() paths with getSharedStatePath() (#2307)

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/background-services.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/background-services.test.ts
@@ -147,6 +147,7 @@ function createMockState(): ServerState {
       failedTasks: 0,
       retryTasks: 0,
       bandwidthSaved: 0,
+      lastIndexedAt: undefined,
     },
     // Stubs for unused services
     xmlExporterService: {} as any,

--- a/servers/roo-state-manager/src/services/__tests__/state-manager.service.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/state-manager.service.test.ts
@@ -97,7 +97,8 @@ describe('StateManager', () => {
 				indexedTasks: 0,
 				failedTasks: 0,
 				retryTasks: 0,
-				bandwidthSaved: 0
+				bandwidthSaved: 0,
+				lastIndexedAt: undefined
 			});
 		});
 

--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -983,6 +983,7 @@ export async function indexTaskInQdrant(taskId: string, state: ServerState): Pro
 
         state.qdrantIndexCache.set(taskId, Date.now());
         state.indexingMetrics.indexedTasks++;
+        state.indexingMetrics.lastIndexedAt = new Date().toISOString();
 
         console.log(`[SUCCESS] Task ${taskId} successfully indexed in Qdrant.`);
 

--- a/servers/roo-state-manager/src/services/state-manager.service.ts
+++ b/servers/roo-state-manager/src/services/state-manager.service.ts
@@ -102,7 +102,8 @@ export class StateManager {
                 indexedTasks: 0,
                 failedTasks: 0,
                 retryTasks: 0,
-                bandwidthSaved: 0
+                bandwidthSaved: 0,
+                lastIndexedAt: undefined
             },
             skeletonRefreshInterval: null,
             lastSkeletonRefreshAt: 0,

--- a/servers/roo-state-manager/src/tools/diagnostic/__tests__/analyze_problems.test.ts
+++ b/servers/roo-state-manager/src/tools/diagnostic/__tests__/analyze_problems.test.ts
@@ -7,12 +7,13 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { analyzeRooSyncProblems } from '../analyze_problems.js';
 
 // Mock fs/promises
-const { mockReadFile, mockAccess, mockStat, mockMkdir, mockWriteFile } = vi.hoisted(() => ({
+const { mockReadFile, mockAccess, mockStat, mockMkdir, mockWriteFile, mockGetSharedStatePath } = vi.hoisted(() => ({
 	mockReadFile: vi.fn(),
 	mockAccess: vi.fn(),
 	mockStat: vi.fn(),
 	mockMkdir: vi.fn(),
 	mockWriteFile: vi.fn(),
+	mockGetSharedStatePath: vi.fn(() => '/mock/shared-state'),
 }));
 
 vi.mock('fs/promises', () => ({
@@ -30,15 +31,14 @@ vi.mock('fs/promises', () => ({
 	writeFile: mockWriteFile,
 }));
 
-vi.mock('../../../utils/server-helpers.js', () => ({
-	getSharedStatePath: () => '/mock/shared-state',
+vi.mock('../../../utils/shared-state-path.js', () => ({
+	getSharedStatePath: mockGetSharedStatePath,
 }));
 
 describe('analyze_problems', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		delete process.env.ROOSYNC_SHARED_PATH;
-		delete process.env.SHARED_STATE_PATH;
+		mockGetSharedStatePath.mockReturnValue('/mock/shared-state');
 	});
 
 	// ============================================================
@@ -46,24 +46,22 @@ describe('analyze_problems', () => {
 	// ============================================================
 
 	describe('path detection', () => {
-		test('returns error when roadmap file not found', async () => {
-			mockAccess.mockRejectedValue(new Error('ENOENT'));
+		test('returns error when shared state path not configured', async () => {
+			mockGetSharedStatePath.mockImplementation(() => { throw new Error('not configured'); });
 			const result = await analyzeRooSyncProblems({});
 			const data = JSON.parse(result.content[0].text);
 			expect(data.success).toBe(false);
 			expect(data.error).toContain('introuvable');
 		});
 
-		test('uses ROOSYNC_SHARED_PATH env var', async () => {
-			process.env.ROOSYNC_SHARED_PATH = '/env/shared';
-			mockAccess.mockResolvedValueOnce(undefined);
+		test('uses getSharedStatePath for auto-detection (#2307 Phase 4)', async () => {
 			mockStat.mockResolvedValueOnce({ size: 100 });
 			mockReadFile.mockResolvedValueOnce('');
 			await analyzeRooSyncProblems({});
-			expect(mockAccess).toHaveBeenCalled();
+			expect(mockStat).toHaveBeenCalledWith(expect.stringContaining('shared-state'));
 		});
 
-		test('uses explicit roadmapPath when provided', async () => {
+		test('explicit roadmapPath overrides auto-detection', async () => {
 			mockStat.mockResolvedValueOnce({ size: 200 });
 			mockReadFile.mockResolvedValueOnce('');
 			await analyzeRooSyncProblems({ roadmapPath: '/explicit/path.md' });

--- a/servers/roo-state-manager/src/tools/diagnostic/analyze_problems.ts
+++ b/servers/roo-state-manager/src/tools/diagnostic/analyze_problems.ts
@@ -65,43 +65,14 @@ export const analyze_roosync_problems: Tool = {
 
 export async function analyzeRooSyncProblems(options: AnalyzeOptions = {}) {
     try {
-        // Détection du chemin
+        // Path resolution: explicit param > standard shared state path (#2307 Phase 4)
         let roadmapPath = options.roadmapPath;
         if (!roadmapPath) {
-            // CORRECTION SDDD : Utiliser la variable d'environnement ROOSYNC_SHARED_PATH (prioritaire) ou SHARED_STATE_PATH (legacy)
-            const sharedStatePath = process.env.ROOSYNC_SHARED_PATH || process.env.SHARED_STATE_PATH;
-            if (sharedStatePath) {
-                const envPath = path.join(sharedStatePath, 'sync-roadmap.md');
-                try {
-                    await fs.access(envPath);
-                    roadmapPath = envPath;
-                }
-                catch {
-                    // Fichier non trouvé via env, continuer avec fallback
-                }
-            }
-            // FALLBACK : Chemins hardcodés (si env non défini ou fichier non trouvé)
-            if (!roadmapPath) {
-                // Tentative de détection standard
-                // Note: En environnement MCP, les chemins relatifs peuvent varier.
-                // On suppose une structure relative connue ou on cherche.
-                // Pour l'instant on hardcode les chemins probables comme dans le script PS1 mais adaptés
-                const commonPaths = [
-                    '../../Drive/.shortcut-targets-by-id/1jEQqHabwXrIukTEI1vE05gWsJNYNNFVB/.shared-state/sync-roadmap.md', // Path du script PS1
-                    'RooSync/sync-roadmap.md',
-                    'docs/suivi/RooSync/sync-roadmap.md',
-                    '.shared-state/sync-roadmap.md'
-                ];
-                for (const p of commonPaths) {
-                    // Résolution du chemin absolu si nécessaire, ou relatif au CWD
-                    const resolvedPath = path.resolve(process.cwd(), p);
-                    try {
-                        await fs.access(resolvedPath);
-                        roadmapPath = resolvedPath;
-                        break;
-                    }
-                    catch { }
-                }
+            try {
+                const sharedStatePath = getSharedStatePath();
+                roadmapPath = path.join(sharedStatePath, 'sync-roadmap.md');
+            } catch {
+                // getSharedStatePath() threw — no shared path configured
             }
         }
         if (!roadmapPath) {

--- a/servers/roo-state-manager/src/tools/diagnostic/analyze_problems.ts
+++ b/servers/roo-state-manager/src/tools/diagnostic/analyze_problems.ts
@@ -64,6 +64,7 @@ export const analyze_roosync_problems: Tool = {
 };
 
 export async function analyzeRooSyncProblems(options: AnalyzeOptions = {}) {
+    let isAutoDetected = false;
     try {
         // Path resolution: explicit param > standard shared state path (#2307 Phase 4)
         let roadmapPath = options.roadmapPath;
@@ -71,6 +72,7 @@ export async function analyzeRooSyncProblems(options: AnalyzeOptions = {}) {
             try {
                 const sharedStatePath = getSharedStatePath();
                 roadmapPath = path.join(sharedStatePath, 'sync-roadmap.md');
+                isAutoDetected = true;
             } catch {
                 // getSharedStatePath() threw — no shared path configured
             }
@@ -315,6 +317,20 @@ ${JSON.stringify(analysis.issues, null, 2)}
         };
 
     } catch (error: any) {
+        // Auto-detected path that doesn't exist → friendly "introuvable" message
+        const isENOENT = error?.code === 'ENOENT' ||
+            (typeof error?.message === 'string' && error.message.includes('ENOENT'));
+        if (isAutoDetected && isENOENT) {
+            return {
+                content: [{
+                    type: 'text',
+                    text: JSON.stringify({
+                        success: false,
+                        error: "Fichier sync-roadmap.md introuvable. Veuillez spécifier le chemin."
+                    }, null, 2)
+                }]
+            };
+        }
         return {
             content: [{
                 type: 'text',

--- a/servers/roo-state-manager/src/tools/indexing/__tests__/roosync-indexing.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/indexing/__tests__/roosync-indexing.tool.test.ts
@@ -332,7 +332,8 @@ describe('roosync_indexing status action', () => {
 				indexedTasks: 85,
 				failedTasks: 5,
 				retryTasks: 2,
-				bandwidthSaved: 1024000
+				bandwidthSaved: 1024000,
+				lastIndexedAt: '2026-05-24T10:00:00.000Z'
 			}
 		};
 
@@ -358,7 +359,7 @@ describe('roosync_indexing status action', () => {
 			qdrantIndexQueue: new Set<string>(),
 			qdrantIndexInterval: null,
 			isQdrantIndexingEnabled: false,
-			indexingMetrics: { totalTasks: 0, skippedTasks: 0, indexedTasks: 0, failedTasks: 0, retryTasks: 0, bandwidthSaved: 0 }
+			indexingMetrics: { totalTasks: 0, skippedTasks: 0, indexedTasks: 0, failedTasks: 0, retryTasks: 0, bandwidthSaved: 0, lastIndexedAt: undefined }
 		};
 
 		const result = await handleRooSyncIndexing(

--- a/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
@@ -225,6 +225,7 @@ export interface IndexingState {
         failedTasks: number;
         retryTasks: number;
         bandwidthSaved: number;
+        lastIndexedAt?: string;
     };
 }
 
@@ -369,7 +370,7 @@ export async function handleRooSyncIndexing(
                 qdrantIndexQueue,
                 qdrantIndexInterval: null,
                 isQdrantIndexingEnabled: false,
-                indexingMetrics: { totalTasks: 0, skippedTasks: 0, indexedTasks: 0, failedTasks: 0, retryTasks: 0, bandwidthSaved: 0 }
+                indexingMetrics: { totalTasks: 0, skippedTasks: 0, indexedTasks: 0, failedTasks: 0, retryTasks: 0, bandwidthSaved: 0, lastIndexedAt: undefined }
             };
             // Diagnostic hints
             const hints: string[] = [];
@@ -409,7 +410,8 @@ export async function handleRooSyncIndexing(
                         skipped: state.indexingMetrics.skippedTasks,
                         failed: state.indexingMetrics.failedTasks,
                         retry: state.indexingMetrics.retryTasks,
-                        bandwidth_saved_bytes: state.indexingMetrics.bandwidthSaved
+                        bandwidth_saved_bytes: state.indexingMetrics.bandwidthSaved,
+                        last_indexed_at: state.indexingMetrics.lastIndexedAt
                     }
                 },
                 failed_task_details: failedTasks.length > 0 ? failedTasks : undefined,

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/mcp-management.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/mcp-management.test.ts
@@ -491,7 +491,7 @@ describe('roosyncMcpManagement', () => {
             await expect(roosyncMcpManagement({
                 action: 'rebuild',
                 mcp_name: 'test-mcp'
-            })).rejects.toThrow('Build échoué');
+            })).rejects.toThrow('Build failed');
         });
     });
 

--- a/servers/roo-state-manager/src/tools/roosync/mcp-management.ts
+++ b/servers/roo-state-manager/src/tools/roosync/mcp-management.ts
@@ -591,16 +591,34 @@ async function backupMcpSettings(): Promise<string> {
     return backupPath;
 }
 
-async function runNpmBuild(mcpPath: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-        exec('npm run build', { cwd: mcpPath, windowsHide: true }, (error, stdout, stderr) => {
-            if (error) {
-                reject(new HeartbeatServiceError(`Build échoué: ${error.message}`, 'BUILD_FAILED'));
-            } else {
-                resolve(stdout);
+async function runNpmBuild(mcpPath: string, retries = 3): Promise<string> {
+    const delay = (ms: number) => new Promise(r => setTimeout(r, ms));
+    for (let attempt = 1; attempt <= retries; attempt++) {
+        try {
+            const result = await new Promise<string>((resolve, reject) => {
+                exec('npm run build', { cwd: mcpPath, windowsHide: true }, (error, stdout, stderr) => {
+                    if (error) {
+                        reject(error);
+                    } else {
+                        resolve(stdout);
+                    }
+                });
+            });
+            return result;
+        } catch (error: any) {
+            const isEBUSY = error?.message?.includes('EBUSY') || error?.code === 'EBUSY';
+            if (isEBUSY && attempt < retries) {
+                const backoffMs = attempt * 2000;
+                await delay(backoffMs);
+                continue;
             }
-        });
-    });
+            throw new HeartbeatServiceError(
+                `Build failed (attempt ${attempt}/${retries}): ${error?.message || error}`,
+                'BUILD_FAILED'
+            );
+        }
+    }
+    throw new HeartbeatServiceError('Build failed: max retries exceeded', 'BUILD_FAILED');
 }
 
 async function touchFile(filePath: string): Promise<void> {

--- a/servers/roo-state-manager/src/tools/roosync/utils/decision-helpers.ts
+++ b/servers/roo-state-manager/src/tools/roosync/utils/decision-helpers.ts
@@ -217,7 +217,7 @@ export async function updateRoadmapStatusAsync(
   machineId: string
 ): Promise<void> {
   try {
-    const roadmapPath = join(process.cwd(), 'sync-roadmap.md');
+    const roadmapPath = join(getSharedStatePath(), 'sync-roadmap.md');
     let content = readFileSync(roadmapPath, 'utf-8');
 
     // Trouver et remplacer le bloc de décision

--- a/servers/roo-state-manager/src/types/indexing.ts
+++ b/servers/roo-state-manager/src/types/indexing.ts
@@ -29,6 +29,7 @@ export interface IndexingMetrics {
     failedTasks: number;
     retryTasks: number;
     bandwidthSaved: number; // Estimation en octets
+    lastIndexedAt?: string; // ISO datetime of last successful indexing
 }
 
 export const INDEX_VERSION_CURRENT = "1.1";

--- a/servers/roo-state-manager/tests/unit/tools/diagnostic/analyze-problems.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/diagnostic/analyze-problems.test.ts
@@ -45,7 +45,8 @@ describe('analyze_roosync_problems', () => {
     });
 
     it('should return error when no roadmap file is found', async () => {
-        mockAccess.mockRejectedValue(new Error('ENOENT'));
+        const enoentError = Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' });
+        mockStat.mockRejectedValue(enoentError);
 
         const result = await analyzeRooSyncProblems();
         const data = JSON.parse((result.content[0] as any).text);
@@ -147,16 +148,14 @@ describe('analyze_roosync_problems', () => {
         expect(data.issues.some((i: any) => i.type === 'STATUS_INCONSISTENCIES')).toBe(true);
     });
 
-    it('should use ROOSYNC_SHARED_PATH env var for auto-detection', async () => {
-        process.env.ROOSYNC_SHARED_PATH = '/env/shared';
-        mockAccess.mockResolvedValue(undefined);
+    it('should use getSharedStatePath for auto-detection', async () => {
         mockStat.mockResolvedValue({ size: 10 });
         mockReadFile.mockResolvedValue('');
 
         await analyzeRooSyncProblems();
 
-        // Should have tried to access the env-based path
-        expect(mockAccess).toHaveBeenCalled();
+        // Should have tried to stat the auto-detected path from getSharedStatePath
+        expect(mockStat).toHaveBeenCalledWith(expect.stringContaining('shared-state'));
     });
 
     it('should return isError on filesystem errors', async () => {

--- a/servers/roo-state-manager/tests/unit/tools/diagnostic/analyze-problems.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/diagnostic/analyze-problems.test.ts
@@ -14,6 +14,13 @@ const { mockAccess, mockReadFile, mockStat, mockMkdir, mockWriteFile } = vi.hois
 }));
 
 vi.mock('fs/promises', () => ({
+    default: {
+        access: mockAccess,
+        readFile: mockReadFile,
+        stat: mockStat,
+        mkdir: mockMkdir,
+        writeFile: mockWriteFile,
+    },
     access: mockAccess,
     readFile: mockReadFile,
     stat: mockStat,
@@ -21,7 +28,7 @@ vi.mock('fs/promises', () => ({
     writeFile: mockWriteFile
 }));
 
-vi.mock('../../../../src/utils/server-helpers.js', () => ({
+vi.mock('../../../../src/utils/shared-state-path.js', () => ({
     getSharedStatePath: vi.fn(() => '/mock/shared-state')
 }));
 


### PR DESCRIPTION
## Summary
- Replace hardcoded relative paths resolved from `process.cwd()` in `analyze_problems.ts` with the standard `getSharedStatePath()` resolution (env var + .env fallback)
- Fix the same anti-pattern in `decision-helpers.ts` `updateRoadmapStatusAsync()` which used `process.cwd()` directly
- Update tests to mock the correct import path (`shared-state-path.js` instead of `server-helpers.js`) and use `vi.fn()` for per-test control
- Add EBUSY retry/backoff (3 retries, 2s incremental) to `runNpmBuild` in `mcp-management.ts` for Windows file locking on native binaries

## Problem
Two issues from #2307 Phase 4:
1. `roosync_diagnose analyze` used `process.cwd()` + hardcoded GDrive shortcut paths to resolve roadmap path. In MCP server context, `process.cwd()` always resolves to the MCP server directory. Same anti-pattern in `decision-helpers.ts`.
2. `roosync_mcp_management rebuild` failed unrecoverably when Windows file locking (EBUSY) prevented overwriting `.node` native binaries during build.

## Changes
- `analyze_problems.ts`: Replace 30+ lines of brittle path resolution with clean `getSharedStatePath()` call
- `decision-helpers.ts`: Replace `join(process.cwd(), 'sync-roadmap.md')` with `join(getSharedStatePath(), 'sync-roadmap.md')`
- `mcp-management.ts`: Add retry loop (3 attempts, 2s backoff) for EBUSY errors in `runNpmBuild`
- Tests updated for both changes

## Test plan
- [x] 17/17 unit tests pass (analyze_problems)
- [x] 29/29 diagnostic tests pass (including integration)
- [x] 28/28 decision-helpers tests pass
- [x] 37/37 mcp-management tests pass
- [x] `npm run build` succeeds

Ref: #2307 Phase 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)