### PR TITLE
fix(tools): embed known gotchas in MCP tool descriptions (#2307 Phase 4)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/dashboard-schemas.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard-schemas.ts
@@ -213,7 +213,7 @@ export type DashboardArgs = z.infer<typeof DashboardArgsSchema> & Record<string,
 
 export const dashboardToolMetadata = {
   name: 'roosync_dashboard',
-  description: 'Shared dashboards (global/machine/workspace). Actions: read, write, append, list, delete, read_archive, read_overview, refresh, update. Team stages supported. For agent-parseable output, use format="json" on read/read_overview actions. Default is human-readable markdown. Auto-condensation at 92% threshold — no manual condense needed.',
+  description: 'Shared dashboards (global/machine/workspace). Actions: read, write, append, list, delete, read_archive, read_overview, refresh, update. Team stages supported. For agent-parseable output, use format="json" on read/read_overview actions. Default is human-readable markdown. Gotchas: (1) Only 3 types exist: global, machine, workspace. (2) If response contains "written to file:", use Read tool on that file path. (3) Auto-condensation at 92% — no manual condense needed.',
   inputSchema: (() => {
     const schema = zodToJsonSchema(DashboardArgsSchema as any, { target: 'openApi3' }) as any;
     // Force 'type' into required array so LLMs always pass it (#1862 schema mismatch fix)

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -18,7 +18,7 @@ import { dashboardToolMetadata } from './roosync/dashboard-schemas.js';
 // ============================================================
 export const conversationBrowserDefinition = {
     name: 'conversation_browser',
-    description: 'Navigate, visualize and summarize conversations. Actions: list, tree, current, view, summarize (trace/cluster), rebuild. Note: synthesis is disabled (#788).',
+    description: 'Navigate, visualize and summarize conversations. Actions: list, tree, current, view, summarize (trace/cluster), rebuild. Gotchas: (1) ALWAYS start with "list" to discover IDs — other actions need task_id. (2) synthesis is disabled (#788), use trace or cluster. (3) For view, use smart_truncation:true for conversations >10K chars.',
     inputSchema: {
         type: 'object',
         properties: {
@@ -117,7 +117,7 @@ export const taskExportDefinition = {
 // ============================================================
 export const roosyncSearchDefinition = {
     name: 'roosync_search',
-    description: "Recherche unifiée dans les tâches Roo (semantic, text, index diagnostics)",
+    description: "Recherche unifiée dans les tâches Roo (semantic, text, index diagnostics). Gotcha: workspace defaults to MCP server workspace — pass '*' or 'all' for cross-workspace search.",
     inputSchema: {
         type: 'object',
         properties: {
@@ -125,7 +125,7 @@ export const roosyncSearchDefinition = {
             search_query: { type: 'string', description: 'Required for semantic/text' },
             conversation_id: { type: 'string' },
             max_results: { type: 'number' },
-            workspace: { type: 'string', description: 'Workspace name or "*" for cross-workspace. Auto-defaults to MCP workspace.' },
+            workspace: { type: 'string', description: 'Workspace name. Defaults to MCP server workspace — use "*" or "all" for cross-workspace search.' },
             source: { type: 'string', enum: ['roo', 'claude-code'] },
             chunk_type: { type: 'string', enum: ['message_exchange', 'tool_interaction'] },
             role: { type: 'string', enum: ['user', 'assistant'] },
@@ -169,12 +169,12 @@ export const roosyncIndexingDefinition = {
 // ============================================================
 export const codebaseSearchDefinition = {
     name: 'codebase_search',
-    description: 'Recherche sémantique dans le code par concept. Auto-detects workspace if omitted.',
+    description: 'Recherche sémantique dans le code par concept. ALWAYS pass workspace explicitly — auto-detection hard-fails if MCP roots/WORKSPACE_PATH unavailable (#1861). Use English keywords matching code vocabulary, not natural language.',
     inputSchema: {
         type: 'object',
         properties: {
-            query: { type: 'string', description: 'Semantic query. Ex: "rate limiting for embeddings"' },
-            workspace: { type: 'string', description: 'Absolute workspace path. Auto-detected via MCP roots or WORKSPACE_PATH if omitted.' },
+            query: { type: 'string', description: 'Semantic query in English (concept, not exact text). Ex: "rate limiting for embeddings", "authentication middleware"' },
+            workspace: { type: 'string', description: 'REQUIRED: Absolute workspace path. Auto-detection may fail — always pass explicitly. Ex: "C:/dev/roo-extensions".' },
             directory_prefix: { type: 'string', description: 'Directory filter. Ex: "src/services"' },
             limit: { type: 'number', description: 'Max results (default: 15, max: 50)' },
             min_score: { type: 'number', description: 'Min similarity 0-1 (default: 0.5)' }


### PR DESCRIPTION
## Summary

Moves per-tool gotchas from CLAUDE.md into MCP tool descriptions (#2307 Phase 4 structural item).

Agents without project-level CLAUDE.md context (new agents, different workspaces) can now see critical usage hints directly in the tool descriptions returned by `ListTools`.

### Changes (4 tools, 2 files)

| Tool | Gotcha Added |
|------|-------------|
| `codebase_search` | Workspace auto-detection hard-fails if MCP roots/WORKSPACE_PATH unavailable (#1861) — always pass explicitly |
| `roosync_search` | `workspace` defaults to MCP server workspace — use `"*"` for cross-workspace search |
| `roosync_dashboard` | Only 3 types (global/machine/workspace), file redirect gotcha (#984), auto-condensation at 92% |
| `conversation_browser` | Always start with `list` to discover IDs, synthesis disabled (#788), use `smart_truncation:true` |

### Files

- `src/tools/tool-definitions.ts` — 3 tool descriptions updated
- `src/tools/roosync/dashboard-schemas.ts` — dashboard description updated

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 9617/9617 pass (0 fail)
- [ ] Verify descriptions appear correctly in MCP `ListTools` response after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)