### PR TITLE
fix(messages): eliminate phantom-message race condition (#2307 Phase 4)

### DIFF
--- a/servers/roo-state-manager/src/services/MessageManager.ts
+++ b/servers/roo-state-manager/src/services/MessageManager.ts
@@ -698,13 +698,20 @@ export class MessageManager {
 
     logger.warn(`Message not found: ${messageId}`);
 
-    // #2307 Phase 4: If message was in cache but not on disk, force cache rebuild
+    // #2307 Phase 4: If message was in cache but not on disk, it was likely
+    // auto-archived between cache build and this call. Return the cached copy
+    // (marked as archived) so callers can handle it as "already processed"
+    // instead of returning "Message introuvable" to the agent.
     if (this.inboxFullCache.has(messageId)) {
-      logger.info(`Stale cache entry detected for ${messageId}, forcing rebuild`);
+      logger.info(`Stale cache entry for ${messageId} — returning cached copy as archived`);
+      const cached = this.inboxFullCache.get(messageId)!;
+      // Force cache rebuild so next call is fresh
       this.inboxCache = null;
       this.inboxFullCache = new Map();
       this.cacheBuiltAt = 0;
       this.lastInboxFileCount = -1;
+      // Return cached message with archived status so callers treat it as processed
+      return { ...cached, status: 'archived' as const };
     }
 
     return null;

--- a/servers/roo-state-manager/src/services/__tests__/MessageManager.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/MessageManager.test.ts
@@ -1273,7 +1273,7 @@ describe('MessageManager', () => {
       expect(result).toBe(false);
     });
 
-    test('getMessage invalidates cache when stale entry detected', async () => {
+    test('getMessage returns cached copy as archived when stale entry detected (#2307 Phase 4)', async () => {
       const msg = await messageManager.sendMessage(
         'sender', 'machine-a', 'Cache Invalidation', 'Body', 'MEDIUM'
       );
@@ -1281,17 +1281,19 @@ describe('MessageManager', () => {
       // Force cache build by reading inbox
       await messageManager.readInbox('machine-a');
 
-      // Manually delete BOTH inbox and sent files (simulating external deletion)
+      // Manually delete BOTH inbox and sent files (simulating auto-archive race)
       const inboxFile = join(testSharedStatePath, 'messages/inbox', `${msg.id}.json`);
       const sentFile = join(testSharedStatePath, 'messages/sent', `${msg.id}.json`);
       await fs.unlink(inboxFile);
       if (existsSync(sentFile)) await fs.unlink(sentFile);
 
-      // getMessage should return null and invalidate cache
+      // getMessage should return cached copy with archived status (not null)
+      // so callers can handle it as "already processed" instead of "introuvable"
       const result = await messageManager.getMessage(msg.id, 'machine-a');
-      expect(result).toBeNull();
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe('archived');
 
-      // Subsequent inbox read should not list the deleted message
+      // Subsequent inbox read should not list the deleted message (cache was invalidated)
       const inbox = await messageManager.readInbox('machine-a');
       expect(inbox.find(m => m.id === msg.id)).toBeUndefined();
     });

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/messages.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/messages.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for roosync_messages dispatcher (#2307 Phase 5).
+ *
+ * Covers:
+ * - Schema validation (14 actions, all params)
+ * - Shorthand resolution (hermes, nanoclaw)
+ * - Routing: action → correct sub-tool call
+ * - Exhaustive switch (never guard)
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { MessagesArgsSchema, roosyncMessages } from '../messages.js';
+
+// Mock sub-tools to verify routing without side effects
+vi.mock('../send.js', () => ({
+  roosyncSend: vi.fn().mockResolvedValue('SEND_RESULT'),
+}));
+vi.mock('../read.js', () => ({
+  roosyncRead: vi.fn().mockResolvedValue('READ_RESULT'),
+}));
+vi.mock('../manage.js', () => ({
+  roosyncManage: vi.fn().mockResolvedValue('MANAGE_RESULT'),
+}));
+vi.mock('../roosync-attachments.tool.js', () => ({
+  roosyncAttachments: vi.fn().mockResolvedValue('ATTACHMENTS_RESULT'),
+}));
+
+import { roosyncSend } from '../send.js';
+import { roosyncRead } from '../read.js';
+import { roosyncManage } from '../manage.js';
+import { roosyncAttachments } from '../roosync-attachments.tool.js';
+
+const mockSend = vi.mocked(roosyncSend);
+const mockRead = vi.mocked(roosyncRead);
+const mockManage = vi.mocked(roosyncManage);
+const mockAttachments = vi.mocked(roosyncAttachments);
+
+describe('roosync_messages dispatcher', () => {
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ============================================================
+  // Schema validation
+  // ============================================================
+
+  describe('MessagesArgsSchema', () => {
+    test('should accept all 14 actions', () => {
+      const actions = [
+        'send', 'reply', 'amend',
+        'inbox', 'message',
+        'mark_read', 'archive', 'bulk_mark_read', 'bulk_archive', 'cleanup', 'stats',
+        'attachments_list', 'attachments_get', 'attachments_delete'
+      ];
+      for (const action of actions) {
+        const result = MessagesArgsSchema.safeParse({ action });
+        expect(result.success, `action "${action}" should be valid`).toBe(true);
+      }
+    });
+
+    test('should reject unknown action', () => {
+      const result = MessagesArgsSchema.safeParse({ action: 'unknown_action' });
+      expect(result.success).toBe(false);
+    });
+
+    test('should require action field', () => {
+      const result = MessagesArgsSchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+
+    test('should validate send params', () => {
+      const result = MessagesArgsSchema.safeParse({
+        action: 'send',
+        to: 'myia-po-2023',
+        subject: 'Test',
+        body: 'Hello',
+        priority: 'HIGH',
+        tags: ['test'],
+        auto_destruct: true,
+        destruct_after: '2h'
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test('should validate inbox params', () => {
+      const result = MessagesArgsSchema.safeParse({
+        action: 'inbox',
+        status: 'unread',
+        limit: 10,
+        page: 1,
+        per_page: 5,
+        format: 'json'
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test('should validate bulk params', () => {
+      const result = MessagesArgsSchema.safeParse({
+        action: 'bulk_mark_read',
+        from: 'myia-ai-01',
+        tag: 'INFO'
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test('should strip unknown params', () => {
+      const result = MessagesArgsSchema.safeParse({
+        action: 'inbox',
+        unknownParam: 'value'
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).not.toHaveProperty('unknownParam');
+      }
+    });
+  });
+
+  // ============================================================
+  // Routing: action → correct sub-tool
+  // ============================================================
+
+  describe('routing', () => {
+    test('send routes to roosyncSend', async () => {
+      await roosyncMessages({ action: 'send', to: 'm1', subject: 'S', body: 'B' });
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'send', to: 'm1', subject: 'S', body: 'B' })
+      );
+    });
+
+    test('reply routes to roosyncSend with action=reply', async () => {
+      await roosyncMessages({ action: 'reply', message_id: 'msg-1', body: 'Reply body' });
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'reply', message_id: 'msg-1', body: 'Reply body' })
+      );
+    });
+
+    test('amend routes to roosyncSend with action=amend', async () => {
+      await roosyncMessages({ action: 'amend', message_id: 'msg-1', new_content: 'Updated' });
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'amend', message_id: 'msg-1', new_content: 'Updated' })
+      );
+    });
+
+    test('inbox routes to roosyncRead with mode=inbox', async () => {
+      await roosyncMessages({ action: 'inbox' });
+      expect(mockRead).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: 'inbox' })
+      );
+    });
+
+    test('inbox passes pagination params', async () => {
+      await roosyncMessages({ action: 'inbox', page: 2, per_page: 10 });
+      expect(mockRead).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: 'inbox', page: 2, per_page: 10 })
+      );
+    });
+
+    test('message routes to roosyncRead with mode=message', async () => {
+      await roosyncMessages({ action: 'message', message_id: 'msg-1' });
+      expect(mockRead).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: 'message', message_id: 'msg-1' })
+      );
+    });
+
+    test('mark_read routes to roosyncManage', async () => {
+      await roosyncMessages({ action: 'mark_read', message_id: 'msg-1' });
+      expect(mockManage).toHaveBeenCalledWith({ action: 'mark_read', message_id: 'msg-1' });
+    });
+
+    test('archive routes to roosyncManage', async () => {
+      await roosyncMessages({ action: 'archive', message_id: 'msg-1' });
+      expect(mockManage).toHaveBeenCalledWith({ action: 'archive', message_id: 'msg-1' });
+    });
+
+    test('bulk_mark_read routes to roosyncManage with filters', async () => {
+      await roosyncMessages({ action: 'bulk_mark_read', from: 'ai-01', tag: 'URGENT' });
+      expect(mockManage).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'bulk_mark_read', from: 'ai-01', tag: 'URGENT' })
+      );
+    });
+
+    test('bulk_archive routes to roosyncManage', async () => {
+      await roosyncMessages({ action: 'bulk_archive', before_date: '2026-01-01' });
+      expect(mockManage).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'bulk_archive', before_date: '2026-01-01' })
+      );
+    });
+
+    test('cleanup routes to roosyncManage', async () => {
+      await roosyncMessages({ action: 'cleanup' });
+      expect(mockManage).toHaveBeenCalledWith({ action: 'cleanup' });
+    });
+
+    test('stats routes to roosyncManage', async () => {
+      await roosyncMessages({ action: 'stats', format: 'json' });
+      expect(mockManage).toHaveBeenCalledWith({ action: 'stats', format: 'json' });
+    });
+
+    test('attachments_list routes to roosyncAttachments', async () => {
+      await roosyncMessages({ action: 'attachments_list', message_id: 'msg-1' });
+      expect(mockAttachments).toHaveBeenCalledWith({ action: 'list', message_id: 'msg-1' });
+    });
+
+    test('attachments_get routes to roosyncAttachments', async () => {
+      await roosyncMessages({ action: 'attachments_get', uuid: 'abc-123', targetPath: '/tmp/f' });
+      expect(mockAttachments).toHaveBeenCalledWith({ action: 'get', uuid: 'abc-123', targetPath: '/tmp/f' });
+    });
+
+    test('attachments_delete routes to roosyncAttachments', async () => {
+      await roosyncMessages({ action: 'attachments_delete', uuid: 'abc-123' });
+      expect(mockAttachments).toHaveBeenCalledWith({ action: 'delete', uuid: 'abc-123' });
+    });
+  });
+
+  // ============================================================
+  // Shorthand resolution (#2241)
+  // ============================================================
+
+  describe('shorthand resolution', () => {
+    test('"hermes" resolves to myia-po-2026:hermes-agent', async () => {
+      await roosyncMessages({ action: 'send', to: 'hermes', subject: 'S', body: 'B' });
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'myia-po-2026:hermes-agent' })
+      );
+    });
+
+    test('"HERMES" (uppercase) resolves correctly', async () => {
+      await roosyncMessages({ action: 'send', to: 'HERMES', subject: 'S', body: 'B' });
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'myia-po-2026:hermes-agent' })
+      );
+    });
+
+    test('"nanoclaw" resolves to myia-ai-01:nanoclaw', async () => {
+      await roosyncMessages({ action: 'send', to: 'nanoclaw', subject: 'S', body: 'B' });
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'myia-ai-01:nanoclaw' })
+      );
+    });
+
+    test('full machine ID passes through unchanged', async () => {
+      await roosyncMessages({ action: 'send', to: 'myia-po-2025', subject: 'S', body: 'B' });
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'myia-po-2025' })
+      );
+    });
+
+    test('machine:workspace passes through unchanged', async () => {
+      await roosyncMessages({ action: 'send', to: 'myia-po-2025:Embeddings', subject: 'S', body: 'B' });
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'myia-po-2025:Embeddings' })
+      );
+    });
+  });
+
+  // ============================================================
+  // Return value forwarding
+  // ============================================================
+
+  describe('return values', () => {
+    test('forwards sub-tool return value unchanged', async () => {
+      mockSend.mockResolvedValueOnce('CUSTOM_SEND_RESULT');
+      const result = await roosyncMessages({ action: 'send', to: 'm1', subject: 'S', body: 'B' });
+      expect(result).toBe('CUSTOM_SEND_RESULT');
+    });
+
+    test('forwards read result unchanged', async () => {
+      mockRead.mockResolvedValueOnce('CUSTOM_READ_RESULT');
+      const result = await roosyncMessages({ action: 'inbox' });
+      expect(result).toBe('CUSTOM_READ_RESULT');
+    });
+
+    test('forwards manage result unchanged', async () => {
+      mockManage.mockResolvedValueOnce('CUSTOM_MANAGE_RESULT');
+      const result = await roosyncMessages({ action: 'mark_read', message_id: 'msg-1' });
+      expect(result).toBe('CUSTOM_MANAGE_RESULT');
+    });
+  });
+});

--- a/servers/roo-state-manager/src/tools/roosync/manage.ts
+++ b/servers/roo-state-manager/src/tools/roosync/manage.ts
@@ -91,6 +91,19 @@ Le message n'a pas été trouvé dans :
 - Utilisez \`roosync_read\` avec \`action: inbox\` pour lister les messages disponibles`;
   }
 
+  // #2307 Phase 4: Message was auto-archived between listing and this call
+  if (message.status === 'archived') {
+    return `ℹ️ **Message déjà archivé**
+
+**ID :** \`${args.message_id}\`
+**Sujet :** ${message.subject}
+**De :** ${message.from}
+**À :** ${message.to}
+**Date :** ${formatDateFull(message.timestamp)}
+
+Ce message a été automatiquement archivé entre le moment où il a été listé et maintenant. Aucune action nécessaire.`;
+  }
+
   // Vérifier si déjà lu (per-machine for broadcasts #629)
   const localMachine = getLocalMachineId();
   const isBroadcast = message.to === 'all' || message.to === 'All';

--- a/servers/roo-state-manager/src/tools/roosync/read.ts
+++ b/servers/roo-state-manager/src/tools/roosync/read.ts
@@ -94,6 +94,33 @@ async function readInboxMode(
 
   logger.info('📬 Reading inbox', { machineId: effectiveMachineId, workspaceId: effectiveWorkspaceId, status, limit, page, perPage });
 
+  // #2307 Phase 4: Run cleanup BEFORE listing to prevent phantom-message race.
+  // Previously fire-and-forget AFTER listing — autoArchiveOld could move files
+  // between cache build and a subsequent mark_read/archive call, causing
+  // "Message introuvable" on messages that were just listed.
+  const now = Date.now();
+  if (now - lastCleanupRunAt > CLEANUP_THROTTLE_MS) {
+    lastCleanupRunAt = now;
+    try {
+      const archived = await messageManager.autoArchiveOld(7, true);
+      if (archived > 0) logger.info(`Auto-archived ${archived} old messages (pre-listing)`);
+    } catch (err) {
+      logger.debug('Auto-archive skipped (non-critical)', { error: String(err) });
+    }
+    try {
+      const destroyed = await messageManager.cleanupExpiredMessages();
+      if (destroyed > 0) logger.info(`Destroyed ${destroyed} expired auto-destruct messages`);
+    } catch (err) {
+      logger.debug('Auto-destruct cleanup skipped (non-critical)', { error: String(err) });
+    }
+    try {
+      const reminders = await messageManager.sendExpiryReminders();
+      if (reminders > 0) logger.info(`Sent ${reminders} expiry reminders`);
+    } catch (err) {
+      logger.debug('Expiry reminders skipped (non-critical)', { error: String(err) });
+    }
+  }
+
   // Get counts from cache (single scan, no double-read — #638 perf fix)
   const counts = await messageManager.getFilteredCount(effectiveMachineId, 'all', effectiveWorkspaceId);
 
@@ -108,27 +135,6 @@ async function readInboxMode(
     .then(svc => svc.getHeartbeatService()
       .registerHeartbeat(getLocalMachineId(), { lastActivity: 'roosync_read_inbox', messageCount: messages.length }))
     .catch(err => logger.debug('Heartbeat update skipped (non-critical)', { error: String(err) }));
-
-  // Throttled fire-and-forget cleanup tasks (run at most once every 5 min)
-  const now = Date.now();
-  if (now - lastCleanupRunAt > CLEANUP_THROTTLE_MS) {
-    lastCleanupRunAt = now;
-
-    // Auto-archive old read messages (#638 Phase 3, #809 reduced from 30d to 7d)
-    messageManager.autoArchiveOld(7, true)
-      .then(n => { if (n > 0) logger.info(`Auto-archived ${n} old messages`); })
-      .catch(err => logger.debug('Auto-archive skipped (non-critical)', { error: String(err) }));
-
-    // Cleanup expired auto-destruct messages (#629)
-    messageManager.cleanupExpiredMessages()
-      .then(n => { if (n > 0) logger.info(`Destroyed ${n} expired auto-destruct messages`); })
-      .catch(err => logger.debug('Auto-destruct cleanup skipped (non-critical)', { error: String(err) }));
-
-    // Expiry reminders for approaching TTL (#629)
-    messageManager.sendExpiryReminders()
-      .then(n => { if (n > 0) logger.info(`Sent ${n} expiry reminders`); })
-      .catch(err => logger.debug('Expiry reminders skipped (non-critical)', { error: String(err) }));
-  }
 
   // Cas : aucun message
   if (messages.length === 0 && counts.total === 0) {


### PR DESCRIPTION
## Summary
- Fix phantom-message bug where `inbox` lists a message but `mark_read`/`archive` returns "Message introuvable"
- **Root cause**: `autoArchiveOld()` ran as fire-and-forget AFTER inbox listing, moving files between cache build and mutation call
- **Fix Part 1**: Run cleanup BEFORE listing (synchronous await) instead of fire-and-forget AFTER
- **Fix Part 2**: `getMessage()` returns cached copy with `status='archived'` when file is gone but cache entry exists
- **Fix Part 3**: `markMessageAsRead` handles archived-status return with clear message

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 475 passed, 0 failed
- [x] Updated `MessageManager.test.ts` stale cache test: `expect(null)` → `expect(status='archived')`
- [ ] Manual test: send message, force archive race, verify mark_read returns graceful "already archived" instead of "introuvable"

🤖 Generated with [Claude Code](https://claude.com/claude-code)