### PR TITLE
fix(messages): correct broadcast message status display (#2307 Phase 4)

### DIFF
--- a/servers/roo-state-manager/src/services/MessageManager.ts
+++ b/servers/roo-state-manager/src/services/MessageManager.ts
@@ -590,7 +590,17 @@ export class MessageManager {
           }
         }
 
-        filtered.push(item);
+        // #2307 Phase 4: For broadcast messages, adjust status per-machine so
+        // callers (read.ts inbox display) see the correct read/unread state.
+        // Without this, broadcast messages always show "unread" even after being read.
+        const isBroadcast = fullMsg.to === 'all' || fullMsg.to === 'All';
+        if (isBroadcast && fullMsg.read_by) {
+          const readerMachineId = parseMachineWorkspace(machineId).machineId;
+          const hasRead = fullMsg.read_by.includes(readerMachineId);
+          filtered.push({ ...item, status: hasRead ? 'read' : 'unread' });
+        } else {
+          filtered.push(item);
+        }
       }
 
       // Apply pagination (#638)


### PR DESCRIPTION
## Summary
- Broadcast messages (to="all") always showed "unread" in the inbox table even after being read by the local machine
- Root cause: `MessageListItem.status` was copied from the file status (stays "unread" for broadcasts), while per-machine read state is in `message.read_by[]`
- Fix: In `readInbox()`, adjust the status field per-machine for broadcast messages using the same `read_by` logic already used for filtering

## Test plan
- [x] Build passes
- [x] 9580/9580 CI tests pass (0 regressions)
- [x] MessageManager 95/95 tests pass
- [ ] Manual verification: broadcast messages now show "read" status in inbox after being read by the local machine

## Related
- #2307 Phase 4 (phantom message — this fixes the DISPLAY aspect, complementing PR #517 which fixes the race condition)
- Distinct from PR #517 (po-2024): that fixes auto-archive race condition; this fixes broadcast status display

🤖 Generated with [Claude Code](https://claude.com/claude-code)