### PR TITLE
fix(indexing): tool_usage_stats parses JSONL files instead of Qdrant (#2336 D2)

### DIFF
--- a/servers/roo-state-manager/src/tools/indexing/__tests__/roosync-indexing.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/indexing/__tests__/roosync-indexing.tool.test.ts
@@ -9,7 +9,8 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 
 const { mockIndexHandler, mockResetHandler, mockDiagnoseHandler, mockRebuildHandler,
-	mockArchiveTask, mockArchiveClaudeCodeSessions, mockListArchivedTasks, mockFindConversationById
+	mockArchiveTask, mockArchiveClaudeCodeSessions, mockListArchivedTasks, mockFindConversationById,
+	mockDetectStorageLocations, mockFsReadDir, mockFsReadFile, mockFsStat
 } = vi.hoisted(() => ({
 	mockIndexHandler: vi.fn(),
 	mockResetHandler: vi.fn(),
@@ -18,7 +19,11 @@ const { mockIndexHandler, mockResetHandler, mockDiagnoseHandler, mockRebuildHand
 	mockArchiveTask: vi.fn(),
 	mockArchiveClaudeCodeSessions: vi.fn(),
 	mockListArchivedTasks: vi.fn(),
-	mockFindConversationById: vi.fn()
+	mockFindConversationById: vi.fn(),
+	mockDetectStorageLocations: vi.fn(),
+	mockFsReadDir: vi.fn(),
+	mockFsReadFile: vi.fn(),
+	mockFsStat: vi.fn()
 }));
 
 vi.mock('../../../services/task-archiver/index.js', () => ({
@@ -31,7 +36,8 @@ vi.mock('../../../services/task-archiver/index.js', () => ({
 
 vi.mock('../../../utils/roo-storage-detector.js', () => ({
 	RooStorageDetector: {
-		findConversationById: mockFindConversationById
+		findConversationById: mockFindConversationById,
+		detectStorageLocations: mockDetectStorageLocations
 	}
 }));
 

--- a/servers/roo-state-manager/src/tools/indexing/__tests__/tool-usage-stats.test.ts
+++ b/servers/roo-state-manager/src/tools/indexing/__tests__/tool-usage-stats.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for tool_usage_stats action in roosync-indexing.tool.ts
+ * Issue #2336 D2 - Parse tool calls from JSONL files instead of Qdrant
+ *
+ * @module tools/indexing/__tests__/tool-usage-stats
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+const { mockDetectStorageLocations } = vi.hoisted(() => ({
+	mockDetectStorageLocations: vi.fn(),
+}));
+
+vi.mock('../../../utils/roo-storage-detector.js', () => ({
+	RooStorageDetector: {
+		findConversationById: vi.fn(),
+		detectStorageLocations: mockDetectStorageLocations
+	}
+}));
+
+vi.mock('../index-task.tool.js', () => ({
+	indexTaskSemanticTool: { handler: vi.fn() }
+}));
+
+vi.mock('../reset-collection.tool.js', () => ({
+	resetQdrantCollectionTool: { handler: vi.fn() }
+}));
+
+vi.mock('../diagnose-index.tool.js', () => ({
+	handleDiagnoseSemanticIndex: vi.fn()
+}));
+
+import { handleRooSyncIndexing } from '../roosync-indexing.tool.js';
+
+describe('tool_usage_stats action (#2336 D2)', () => {
+	const cache = new Map();
+	const ensureFresh = vi.fn().mockResolvedValue(true);
+	const saveSkeleton = vi.fn();
+	const setEnabled = vi.fn();
+	const rebuildHandler = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockDetectStorageLocations.mockResolvedValue([]);
+	});
+
+	test('returns jsonl_scan method and empty stats when no storage locations', async () => {
+		const result = await handleRooSyncIndexing(
+			{ action: 'tool_usage_stats' },
+			cache, ensureFresh, saveSkeleton, new Set(), setEnabled, rebuildHandler
+		);
+
+		expect(result.isError).toBe(false);
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.method).toBe('jsonl_scan');
+		expect(parsed.total_tool_calls).toBe(0);
+		expect(parsed.unique_tools).toBe(0);
+		expect(parsed.tools).toEqual([]);
+	});
+
+	test('returns error for invalid date format', async () => {
+		const result = await handleRooSyncIndexing(
+			{ action: 'tool_usage_stats', start_date: 'not-a-date', end_date: 'also-invalid' },
+			cache, ensureFresh, saveSkeleton, new Set(), setEnabled, rebuildHandler
+		);
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0].text).toContain('Invalid');
+	});
+
+	test('has correct response structure', async () => {
+		const result = await handleRooSyncIndexing(
+			{ action: 'tool_usage_stats' },
+			cache, ensureFresh, saveSkeleton, new Set(), setEnabled, rebuildHandler
+		);
+
+		expect(result.isError).toBe(false);
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.action).toBe('tool_usage_stats');
+		expect(parsed.method).toBe('jsonl_scan');
+		expect(parsed).toHaveProperty('files_scanned');
+		expect(parsed).toHaveProperty('total_tool_calls');
+		expect(parsed).toHaveProperty('unique_tools');
+		expect(parsed).toHaveProperty('tools');
+		expect(parsed).toHaveProperty('weekly_trend');
+		expect(parsed).toHaveProperty('date_range');
+		expect(parsed).toHaveProperty('source_distribution');
+	});
+
+	test('date range defaults to 28 days (4 weeks)', async () => {
+		const result = await handleRooSyncIndexing(
+			{ action: 'tool_usage_stats' },
+			cache, ensureFresh, saveSkeleton, new Set(), setEnabled, rebuildHandler
+		);
+
+		const parsed = JSON.parse(result.content[0].text);
+		const { start, end } = parsed.date_range;
+		const diffDays = Math.round((new Date(end).getTime() - new Date(start).getTime()) / 86400000);
+		expect(diffDays).toBe(28);
+	});
+
+	test('respects custom date range', async () => {
+		const result = await handleRooSyncIndexing(
+			{ action: 'tool_usage_stats', start_date: '2026-05-01', end_date: '2026-05-14' },
+			cache, ensureFresh, saveSkeleton, new Set(), setEnabled, rebuildHandler
+		);
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.date_range.start).toBe('2026-05-01');
+		expect(parsed.date_range.end).toBe('2026-05-14');
+	});
+});

--- a/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
@@ -18,6 +18,7 @@ import * as path from 'path';
 import { indexTaskSemanticTool } from './index-task.tool.js';
 import { resetQdrantCollectionTool } from './reset-collection.tool.js';
 import { handleDiagnoseSemanticIndex } from './diagnose-index.tool.js';
+import { RooStorageDetector } from '../../utils/roo-storage-detector.js';
 
 /** #2336 D1: Convert ISO timestamp to YYYY-WNN week key */
 function getISOWeek(timestamp: string): string {
@@ -755,13 +756,13 @@ export async function handleRooSyncIndexing(
         }
 
         case 'tool_usage_stats': {
-            // #2336 D1: Fleet-wide tool usage aggregation from conversation index
-            const { getQdrantClient } = await import('../../services/qdrant.js');
-            const collectionName = process.env.QDRANT_COLLECTION_NAME || 'roo_tasks_semantic_index';
+            // #2336 D2: Parse tool calls directly from JSONL files (Roo + Claude Code)
+            // Previous implementation queried Qdrant for chunk_type=tool_interaction which
+            // returned 0 results (ChunkExtractor never populates msg.tool_calls).
+            const fs = await import('fs/promises');
+            const os = await import('os');
 
             try {
-                const qdrant = getQdrantClient();
-
                 // Resolve date range
                 const endDate = args.end_date ? new Date(args.end_date) : new Date();
                 const defaultStart = new Date(endDate);
@@ -772,64 +773,111 @@ export async function handleRooSyncIndexing(
                     return { isError: true, content: [{ type: 'text', text: 'Invalid start_date or end_date format. Use ISO 8601 or YYYY-MM-DD.' }] };
                 }
 
-                // Scroll all tool_interaction chunks in date range
-                const mustConditions: any[] = [
-                    { key: 'chunk_type', match: { value: 'tool_interaction' } },
-                    { key: 'timestamp', range: { gte: startDate.toISOString(), lte: endDate.toISOString() } },
-                ];
-
-                // Per-tool counts
                 const toolCounts: Record<string, number> = {};
-                // Weekly buckets: key = ISO week (YYYY-WNN), value = { tool_name: count }
                 const weeklyBuckets: Record<string, Record<string, number>> = {};
-                // Error counts per tool
                 const errorCounts: Record<string, number> = {};
-                // Per-source counts
                 const sourceCounts: Record<string, number> = {};
-                let totalPoints = 0;
+                let totalCalls = 0;
+                let filesScanned = 0;
 
-                const BATCH_SIZE = 500;
-                let offset: string | undefined = undefined;
+                // --- Scan Roo tasks (api_conversation_history.json) ---
+                const storageLocations = await RooStorageDetector.detectStorageLocations();
+                for (const loc of storageLocations) {
+                    const tasksPath = path.join(loc, 'tasks');
+                    let taskDirs: string[];
+                    try { taskDirs = await fs.readdir(tasksPath); } catch { continue; }
 
-                do {
-                    const scrollResult: any = await qdrant.scroll(collectionName, {
-                        filter: { must: mustConditions },
-                        limit: BATCH_SIZE,
-                        offset,
-                        with_payload: true,
-                        with_vector: false,
-                    });
+                    for (const taskId of taskDirs) {
+                        const apiPath = path.join(tasksPath, taskId, 'api_conversation_history.json');
+                        let content: string;
+                        try {
+                            content = await fs.readFile(apiPath, 'utf-8');
+                            if (content.charCodeAt(0) === 0xFEFF) content = content.slice(1);
+                        } catch { continue; }
 
-                    const points: any[] = Array.isArray(scrollResult)
-                        ? scrollResult
-                        : (scrollResult?.points || []);
+                        filesScanned++;
+                        let messages: any[];
+                        try {
+                            const data = JSON.parse(content);
+                            messages = Array.isArray(data) ? data : (data?.messages || []);
+                        } catch { continue; }
 
-                    for (const point of points) {
-                        const payload = point?.payload || {};
-                        totalPoints++;
+                        for (const msg of messages) {
+                            if (msg.role !== 'assistant' || !Array.isArray(msg.content)) continue;
+                            const ts = msg.ts ? new Date(msg.ts) : null;
+                            if (ts && (ts < startDate || ts > endDate)) continue;
 
-                        const toolName = payload.tool_name || '__unknown__';
-                        toolCounts[toolName] = (toolCounts[toolName] || 0) + 1;
+                            for (const block of msg.content) {
+                                if (block.type === 'tool_use' && block.name) {
+                                    totalCalls++;
+                                    const toolName = block.name;
+                                    toolCounts[toolName] = (toolCounts[toolName] || 0) + 1;
+                                    sourceCounts['roo'] = (sourceCounts['roo'] || 0) + 1;
 
-                        const src = payload.source || '__unknown__';
-                        sourceCounts[src] = (sourceCounts[src] || 0) + 1;
-
-                        if (payload.has_error === true || payload.has_error === 'true') {
-                            errorCounts[toolName] = (errorCounts[toolName] || 0) + 1;
-                        }
-
-                        // Weekly bucket from timestamp
-                        const ts = payload.timestamp;
-                        if (ts) {
-                            const weekKey = getISOWeek(ts);
-                            if (!weeklyBuckets[weekKey]) weeklyBuckets[weekKey] = {};
-                            weeklyBuckets[weekKey][toolName] = (weeklyBuckets[weekKey][toolName] || 0) + 1;
+                                    if (ts) {
+                                        const weekKey = getISOWeek(ts.toISOString());
+                                        if (!weeklyBuckets[weekKey]) weeklyBuckets[weekKey] = {};
+                                        weeklyBuckets[weekKey][toolName] = (weeklyBuckets[weekKey][toolName] || 0) + 1;
+                                    }
+                                }
+                            }
                         }
                     }
+                }
 
-                    offset = scrollResult?.next_page_offset;
-                    if (!offset || points.length === 0) break;
-                } while (true);
+                // --- Scan Claude Code sessions (*.jsonl) ---
+                const claudeBase = path.join(os.homedir(), '.claude', 'projects');
+                let projectDirs: string[];
+                try { projectDirs = await fs.readdir(claudeBase); } catch { projectDirs = []; }
+
+                for (const projDir of projectDirs) {
+                    const projPath = path.join(claudeBase, projDir);
+                    let stat;
+                    try { stat = await fs.stat(projPath); } catch { continue; }
+                    if (!stat.isDirectory()) continue;
+
+                    let jsonlFiles: string[];
+                    try { jsonlFiles = (await fs.readdir(projPath)).filter(f => f.endsWith('.jsonl')); } catch { continue; }
+
+                    for (const jsonlFile of jsonlFiles) {
+                        const jsonlPath = path.join(projPath, jsonlFile);
+                        filesScanned++;
+
+                        // Read JSONL line-by-line to handle large files
+                        const { createReadStream } = await import('fs');
+                        const readline = await import('readline');
+                        const rl = readline.createInterface({ input: createReadStream(jsonlPath, 'utf-8'), crlfDelay: Infinity });
+
+                        for await (const line of rl) {
+                            const trimmed = line.trim();
+                            if (!trimmed) continue;
+                            let entry: any;
+                            try { entry = JSON.parse(trimmed); } catch { continue; }
+
+                            // Claude Code JSONL: each line has { type, message, ... }
+                            const message = entry.message || entry;
+                            if (message.role !== 'assistant' || !Array.isArray(message.content)) continue;
+
+                            const ts = message.timestamp ? new Date(message.timestamp) : null;
+                            if (ts && (ts < startDate || ts > endDate)) continue;
+
+                            for (const block of message.content) {
+                                if (block.type === 'tool_use' && block.name) {
+                                    totalCalls++;
+                                    const toolName = block.name;
+                                    toolCounts[toolName] = (toolCounts[toolName] || 0) + 1;
+                                    sourceCounts['claude-code'] = (sourceCounts['claude-code'] || 0) + 1;
+
+                                    if (ts) {
+                                        const weekKey = getISOWeek(ts.toISOString());
+                                        if (!weeklyBuckets[weekKey]) weeklyBuckets[weekKey] = {};
+                                        weeklyBuckets[weekKey][toolName] = (weeklyBuckets[weekKey][toolName] || 0) + 1;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
 
                 // Sort tools by count descending
                 const sortedTools = Object.entries(toolCounts)
@@ -859,17 +907,19 @@ export async function handleRooSyncIndexing(
                         type: 'text',
                         text: JSON.stringify({
                             action: 'tool_usage_stats',
+                            method: 'jsonl_scan',
                             date_range: {
                                 start: startDate.toISOString().slice(0, 10),
                                 end: endDate.toISOString().slice(0, 10),
                                 weeks: sortedWeeks.length,
                             },
-                            total_tool_calls: totalPoints,
+                            files_scanned: filesScanned,
+                            total_tool_calls: totalCalls,
                             unique_tools: Object.keys(toolCounts).length,
                             source_distribution: sourceCounts,
                             tools: sortedTools,
                             weekly_trend: sortedWeeks,
-                            summary: `${totalPoints} tool calls across ${Object.keys(toolCounts).length} tools, ${sortedWeeks.length} weeks (${startDate.toISOString().slice(0, 10)} → ${endDate.toISOString().slice(0, 10)})`,
+                            summary: `${totalCalls} tool calls across ${Object.keys(toolCounts).length} tools, ${sortedWeeks.length} weeks (${startDate.toISOString().slice(0, 10)} → ${endDate.toISOString().slice(0, 10)})`,
                         }, null, 2)
                     }]
                 };

--- a/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
@@ -854,11 +854,13 @@ export async function handleRooSyncIndexing(
                             let entry: any;
                             try { entry = JSON.parse(trimmed); } catch { continue; }
 
-                            // Claude Code JSONL: each line has { type, message, ... }
+                            // Claude Code JSONL: each line has { type, message, timestamp, ... }
+                            // The timestamp is on the top-level entry, NOT inside message.
                             const message = entry.message || entry;
                             if (message.role !== 'assistant' || !Array.isArray(message.content)) continue;
 
-                            const ts = message.timestamp ? new Date(message.timestamp) : null;
+                            const tsRaw = entry.timestamp || message.timestamp;
+                            const ts = tsRaw ? new Date(tsRaw) : null;
                             if (ts && (ts < startDate || ts > endDate)) continue;
 
                             for (const block of message.content) {


### PR DESCRIPTION
## Summary
- **Root cause**: `tool_usage_stats` queried Qdrant for `chunk_type: "tool_interaction"` which returns 0 results — Roo Code's `ChunkExtractor` never populates `msg.tool_calls`, so `tool_interaction` chunks are never created (verified: 0/462K points match)
- **Fix**: Parse `tool_use` blocks directly from JSONL conversation files:
  - **Roo**: `api_conversation_history.json` — structured `tool_use` blocks with `name` field in assistant messages
  - **Claude Code**: `~/.claude/projects/*/*.jsonl` — same `tool_use` format under `message.content`
- No re-indexing needed, no Qdrant dependency for this action

## Changes
- `roosync-indexing.tool.ts`: Replaced Qdrant scroll with JSONL file scanning
- `roosync-indexing.tool.test.ts`: Updated mock for `RooStorageDetector.detectStorageLocations`
- `tool-usage-stats.test.ts`: New test file (5 tests) for the JSONL-based implementation

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 133 indexing tests pass (9 test files)
- [x] New `tool_usage_stats` tests pass (5/5)
- [ ] Manual test: call `roosync_indexing(action: "tool_usage_stats")` and verify non-zero counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)