### PR TITLE
docs(rsm): add export_data timeout gotcha to description (#2307 Phase 4)

### DIFF
--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -224,7 +224,7 @@ export const readVscodeLogsDefinition = {
 // ============================================================
 export const exportDataDefinition = {
     name: 'export_data',
-    description: 'Export data as XML, JSON, CSV, Markdown, or debug parsing. Targets: task, conversation, project.',
+    description: 'Export data as XML, JSON, CSV, Markdown, or debug parsing. Targets: task, conversation, project. Gotcha: large exports (full conversations/projects) can timeout — prefer filePath output and/or jsonVariant:light + truncationChars for big targets.',
     inputSchema: {
         type: 'object',
         properties: {


### PR DESCRIPTION
## Summary
Complete the last missing gotcha in tool descriptions (#2307 Phase 4).

**Audit result:** 5/6 known gotchas are already embedded in tool descriptions. Only `export_data` was missing its large-export timeout warning.

| Tool | Gotcha | Status |
|------|--------|--------|
| `codebase_search` | workspace required explicitly | Already present |
| `conversation_browser` | list first, synthesis disabled | Already present |
| `roosync_search` | workspace auto-detection unreliable | Already present |
| `roosync_dashboard` | 3 types only, auto-condensation | Already present |
| **`export_data`** | **large exports can timeout** | **Added by this PR** |

No behavior change — description-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)