### PR TITLE
feat(indexing): populate tool_interaction chunks from tool_use blocks (#2336 D2 étape B)

### DIFF
--- a/servers/roo-state-manager/src/services/task-indexer/ChunkExtractor.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/ChunkExtractor.ts
@@ -299,7 +299,7 @@ export async function extractChunksFromTask(taskId: string, taskPath: string): P
                         chunk_type: 'tool_interaction',
                         sequence_order: seq,
                         timestamp: msg.timestamp || new Date().toISOString(),
-                        indexed: false, // #2336 D2: metadata-only (filterable, not embedded) — prevents embedding explosion
+                        indexed: true, // #2247: tool interactions are valuable search targets
                         content: toolContent,
                         tool_details: {
                             tool_name: toolCall.function.name,
@@ -573,7 +573,7 @@ export async function extractChunksFromClaudeSession(
                                 chunk_type: 'tool_interaction',
                                 sequence_order: toolSeq,
                                 timestamp: entry.timestamp || new Date().toISOString(),
-                                indexed: false, // Metadata-only: filterable but not embedded (#2336 explosion guard)
+                                indexed: true, // #2247: tool interactions are valuable search targets
                                 content: toolContent,
                                 tool_details: {
                                     tool_name: toolName,

--- a/servers/roo-state-manager/src/services/task-indexer/ChunkExtractor.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/ChunkExtractor.ts
@@ -213,6 +213,24 @@ export async function extractChunksFromTask(taskId: string, taskPath: string): P
                         })
                         .join(' ')
                         .trim();
+
+                    // #2336 D2 étape B: Extract tool_use blocks (Anthropic format) → populate msg.tool_calls
+                    // so the existing handler below (line ~260) can emit tool_interaction chunks.
+                    if (!msg.tool_calls) {
+                        const toolUseBlocks = (msg.content as any[]).filter(
+                            (part: any) => part && typeof part === 'object' && part.type === 'tool_use'
+                        );
+                        if (toolUseBlocks.length > 0) {
+                            msg.tool_calls = toolUseBlocks.map((block: any) => ({
+                                function: {
+                                    name: block.name || 'unknown',
+                                    arguments: typeof block.input === 'string'
+                                        ? block.input
+                                        : JSON.stringify(block.input || {}),
+                                },
+                            }));
+                        }
+                    }
                 } else if (msg.content) {
                     // Fallback for any other type, ensuring it becomes a string
                     contentText = String(msg.content);
@@ -281,7 +299,7 @@ export async function extractChunksFromTask(taskId: string, taskPath: string): P
                         chunk_type: 'tool_interaction',
                         sequence_order: seq,
                         timestamp: msg.timestamp || new Date().toISOString(),
-                        indexed: true, // #2247: tool interactions are valuable search targets
+                        indexed: false, // #2336 D2: metadata-only (filterable, not embedded) — prevents embedding explosion
                         content: toolContent,
                         tool_details: {
                             tool_name: toolCall.function.name,
@@ -478,6 +496,7 @@ export async function extractChunksFromClaudeSession(
 
                         // Extract text content (can be string or array of content blocks)
                         let contentText = '';
+                        let claudeToolUseBlocks: any[] = [];
                         if (typeof message.content === 'string') {
                             contentText = message.content;
                         } else if (Array.isArray(message.content)) {
@@ -486,9 +505,14 @@ export async function extractChunksFromClaudeSession(
                                 .map((block: any) => block.text)
                                 .join(' ')
                                 .trim();
+
+                            // #2336 D2 étape B: Collect tool_use blocks for tool_interaction chunks
+                            claudeToolUseBlocks = message.content.filter(
+                                (block: any) => block && typeof block === 'object' && block.type === 'tool_use'
+                            );
                         }
 
-                        if (!contentText.trim()) continue;
+                        if (!contentText.trim() && claudeToolUseBlocks.length === 0) continue;
 
                         // Truncate oversized content to prevent embedding explosion
                         contentText = truncateForIndexing(contentText, `claude-${role}:msg#${messageIndex + 1}`);
@@ -524,6 +548,47 @@ export async function extractChunksFromClaudeSession(
                             model: entry.model || message?.model,
                             has_error: ccHasError || undefined,
                         });
+
+                        // #2336 D2 étape B: Emit tool_interaction chunks for Claude Code tool_use blocks
+                        for (const toolBlock of claudeToolUseBlocks) {
+                            const toolName = toolBlock.name || 'unknown';
+                            let parsedInput: any = {};
+                            try {
+                                parsedInput = typeof toolBlock.input === 'string'
+                                    ? JSON.parse(toolBlock.input)
+                                    : (toolBlock.input || {});
+                            } catch { parsedInput = { raw: toolBlock.input }; }
+
+                            const toolContent = truncateForIndexing(
+                                `Tool call: ${toolName} with args ${JSON.stringify(parsedInput)}`,
+                                `claude-tool:${toolName}`
+                            );
+
+                            const toolSeq = sequenceOrder++;
+                            chunks.push({
+                                chunk_id: computeChunkId(taskId, 'tool_interaction', toolSeq, toolContent),
+                                task_id: taskId,
+                                parent_task_id: null,
+                                root_task_id: null,
+                                chunk_type: 'tool_interaction',
+                                sequence_order: toolSeq,
+                                timestamp: entry.timestamp || new Date().toISOString(),
+                                indexed: false, // Metadata-only: filterable but not embedded (#2336 explosion guard)
+                                content: toolContent,
+                                tool_details: {
+                                    tool_name: toolName,
+                                    parameters: parsedInput,
+                                    status: 'success',
+                                },
+                                tool_name: toolName,
+                                model: entry.model || message?.model,
+                                workspace: metadata?.workspace,
+                                workspace_name: metadata?.workspace ? path.basename(metadata.workspace) : undefined,
+                                task_title: metadata?.title,
+                                host_os: getHostIdentifier(),
+                                source: 'claude-code',
+                            });
+                        }
                     } catch (parseError) {
                         // Skip malformed lines but log for debugging
                         console.warn(`[Claude] Skipping malformed line in ${jsonlFile}: ${parseError}`);

--- a/servers/roo-state-manager/tests/unit/services/task-indexer/ChunkExtractor.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/task-indexer/ChunkExtractor.test.ts
@@ -119,12 +119,12 @@ describe('ChunkExtractor', () => {
       const toolChunks = chunks.filter(c => c.chunk_type === 'tool_interaction');
       expect(toolChunks).toHaveLength(2);
 
-      // Tool interactions should NOT be indexed (explosion guard)
-      expect(toolChunks[0].indexed).toBe(false);
+      // Tool interactions should be indexed (#2247)
+      expect(toolChunks[0].indexed).toBe(true);
       expect(toolChunks[0].tool_details?.tool_name).toBe('execute_command');
       expect(toolChunks[0].tool_details?.parameters).toEqual({ command: 'npm test' });
 
-      expect(toolChunks[1].indexed).toBe(false);
+      expect(toolChunks[1].indexed).toBe(true);
       expect(toolChunks[1].tool_details?.tool_name).toBe('read_file');
       expect(toolChunks[1].tool_details?.parameters).toEqual({ path: '/src/index.ts' });
     });

--- a/servers/roo-state-manager/tests/unit/services/task-indexer/ChunkExtractor.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/task-indexer/ChunkExtractor.test.ts
@@ -86,6 +86,49 @@ describe('ChunkExtractor', () => {
       expect(chunks[0].tool_details?.parameters).toEqual({ arg: 'val' });
     });
 
+    it('should extract tool_interaction from Anthropic tool_use blocks (#2336 D2)', async () => {
+      // Roo stores tool calls as tool_use blocks in the content array (Anthropic format)
+      const metadata = JSON.stringify({});
+      const apiHistory = JSON.stringify([
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'I will run a command' },
+            { type: 'tool_use', id: 'toolu_123', name: 'execute_command', input: { command: 'npm test' } },
+            { type: 'tool_use', id: 'toolu_456', name: 'read_file', input: { path: '/src/index.ts' } }
+          ],
+          timestamp: '2023-01-01T00:00:00Z'
+        }
+      ]);
+
+      vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
+        if (filePath.toString().endsWith('task_metadata.json')) return metadata;
+        if (filePath.toString().endsWith('api_conversation_history.json')) return apiHistory;
+        return '';
+      });
+
+      const chunks = await extractChunksFromTask(taskId, taskPath);
+
+      // 1 message_exchange + 2 tool_interaction chunks
+      expect(chunks).toHaveLength(3);
+
+      const msgChunk = chunks.find(c => c.chunk_type === 'message_exchange');
+      expect(msgChunk).toBeDefined();
+      expect(msgChunk!.content).toBe('I will run a command');
+
+      const toolChunks = chunks.filter(c => c.chunk_type === 'tool_interaction');
+      expect(toolChunks).toHaveLength(2);
+
+      // Tool interactions should NOT be indexed (explosion guard)
+      expect(toolChunks[0].indexed).toBe(false);
+      expect(toolChunks[0].tool_details?.tool_name).toBe('execute_command');
+      expect(toolChunks[0].tool_details?.parameters).toEqual({ command: 'npm test' });
+
+      expect(toolChunks[1].indexed).toBe(false);
+      expect(toolChunks[1].tool_details?.tool_name).toBe('read_file');
+      expect(toolChunks[1].tool_details?.parameters).toEqual({ path: '/src/index.ts' });
+    });
+
     it('should handle ui_messages.json', async () => {
       const metadata = JSON.stringify({});
       const apiHistory = JSON.stringify([]);


### PR DESCRIPTION
## Summary
- Fix `chunk_type: "tool_interaction"` producing 0 results in Qdrant
- Extract `tool_use` blocks (Anthropic format) from content arrays → populate `msg.tool_calls` → existing handler emits `tool_interaction` chunks
- Also emit `tool_interaction` chunks for Claude Code JSONL tool_use blocks
- Restores `roosync_search` filters by `tool_name`/`has_errors` (#636)

## Context
- Coordinator verified: `msg.tool_calls` was declared optional but never assigned
- Roo stores tool calls as `tool_use` blocks in the `content` array (Anthropic format), not as OpenAI-format `tool_calls`
- `tool_usage_stats` (PR #519) works around this via JSONL scanning, but Qdrant-level filters remain broken

## Changes
| File | Change |
|------|--------|
| `ChunkExtractor.ts` | +69 LOC: extract tool_use blocks from content array (Roo + Claude Code paths), emit tool_interaction chunks with `indexed: true` (#2247) |
| `ChunkExtractor.test.ts` | +43 LOC: test Anthropic tool_use extraction (2 tool_use blocks → 2 tool_interaction chunks + 1 message_exchange) |

## Review notes (addressed CHANGES_REQUESTED)
- **v1 had `indexed: false`** — Coordinator review caught that `VectorIndexer.ts` line 836 (`if (chunk.indexed)`) skips non-indexed chunks entirely, so they are NEVER upserted to Qdrant. The claim "stored filterable but not embedded" was incorrect.
- **v2 fix**: Reverted to `indexed: true` (#2247). Tool_interaction chunks will be embedded like message_exchange chunks. This is the honest scope — no explosion guard needed since the existing truncation in `truncateForIndexing` keeps each chunk small.

## Test plan
- [x] Build passes (`npm run build`)
- [x] Full CI suite passes (9553 tests, 475 files)
- [x] New test: Anthropic tool_use blocks → tool_interaction chunks with correct metadata
- [x] Existing test: OpenAI tool_calls still works (backward compatible)
- [x] tool_interaction chunks have `indexed: true` (confirmed by test)
- [ ] Re-index a single task → verify tool_interaction chunks appear in Qdrant
- [ ] `roosync_search(action: "text", chunk_type: "tool_interaction")` returns results

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>