### PR TITLE
fix(indexing): correct stale ops/min log message (#2307)

### DIFF
--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -787,8 +787,9 @@ async function scanForOutdatedQdrantIndex(state: ServerState): Promise<void> {
     const totalToProcess = indexCount + retryCount;
     if (totalToProcess > 1000) {
         console.log(`⚠️  Queue importante détectée: ${totalToProcess} tâches à traiter`);
-        console.log(`💡 Traitement progressif avec rate limiting intelligent (200 ops/min)`);
-        console.log(`⏱️  Temps estimé: ${Math.ceil(totalToProcess / 200)} minutes`);
+        const opsPerMin = parseInt(process.env.EMBEDDING_OPS_PER_MINUTE || '30', 10);
+        console.log(`💡 Traitement progressif avec rate limiting intelligent (${opsPerMin} ops/min)`);
+        console.log(`⏱️  Temps estimé: ${Math.ceil(totalToProcess / opsPerMin)} minutes`);
     }
 
     // Estimation de la bande passante économisée


### PR DESCRIPTION
## Summary
- Fix hardcoded "200 ops/min" in queue size warning log to use actual `EMBEDDING_OPS_PER_MINUTE` env var (default 30)
- Accurate time estimates for large queue processing

## Test plan
- [x] `npm run build` clean
- [x] 9611/9611 CI tests pass
- [ ] Visual check: log now shows "30 ops/min" (or configured value) instead of stale "200"

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>