### PR TITLE
fix(diagnose): add lifecycle action to tool definition schema

### DIFF
--- a/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
@@ -241,6 +241,8 @@ describe('tool-definitions.ts — Schema Validation', () => {
             expect(actions).toContain('debug');
             expect(actions).toContain('reset');
             expect(actions).toContain('test');
+            expect(actions).toContain('health');
+            expect(actions).toContain('lifecycle'); // #1320: re-câblé from standalone tool (#512 arbitrage A)
             expect(actions).toContain('analyze'); // #1935 Cluster D: fused from analyze_roosync_problems
             expect(actions).toContain('best-practices'); // #1935 Cluster D: fused from get_mcp_best_practices
         });
@@ -249,6 +251,18 @@ describe('tool-definitions.ts — Schema Validation', () => {
             const props = roosyncDiagnoseDefinition.inputSchema.properties as Record<string, unknown>;
             expect(props).toHaveProperty('mcp_name');
             expect((props.mcp_name as Record<string, unknown>).description).toContain('best-practices');
+        });
+
+        it('roosync_diagnose should have lifecycle parameters (state, machineId, reason)', () => {
+            const props = roosyncDiagnoseDefinition.inputSchema.properties as Record<string, unknown>;
+            expect(props).toHaveProperty('state');
+            expect(props).toHaveProperty('machineId');
+            expect(props).toHaveProperty('reason');
+            const stateEnum = (props.state as Record<string, unknown>).enum as string[];
+            expect(stateEnum).toContain('BOOTSTRAPPING');
+            expect(stateEnum).toContain('READY');
+            expect(stateEnum).toContain('WORKING');
+            expect(stateEnum).toContain('IDLE');
         });
 
         it('roosync_config should support collect/publish/apply/apply_profile', () => {

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -496,11 +496,11 @@ export const roosyncStorageManagementDefinition = {
 
 export const roosyncDiagnoseDefinition = {
     name: 'roosync_diagnose',
-    description: 'RooSync diagnostics and debug. Actions: env, debug, reset, test, health (skeleton cache), analyze (roadmap), best-practices (MCP guide).',
+    description: 'Diagnostic et debug RooSync. Actions: env, debug, reset, test, health (skeleton cache), lifecycle (agent state #1320), analyze (roadmap), best-practices (MCP guide)',
     inputSchema: {
         type: 'object',
         properties: {
-            action: { type: 'string', enum: ['env', 'debug', 'reset', 'test', 'health', 'analyze', 'best-practices'] },
+            action: { type: 'string', enum: ['env', 'debug', 'reset', 'test', 'health', 'lifecycle', 'analyze', 'best-practices'] },
             checkDiskSpace: { type: 'boolean' },
             verbose: { type: 'boolean' },
             clearCache: { type: 'boolean' },
@@ -508,7 +508,10 @@ export const roosyncDiagnoseDefinition = {
             message: { type: 'string' },
             roadmapPath: { type: 'string', description: 'Auto-detected if omitted' },
             generateReport: { type: 'boolean' },
-            mcp_name: { type: 'string', description: 'MCP name for best-practices action' }
+            mcp_name: { type: 'string', description: 'MCP name for best-practices action' },
+            state: { type: 'string', enum: ['BOOTSTRAPPING', 'READY', 'CLAIMED', 'WORKING', 'REPORTING', 'IDLE', 'ERROR', 'RECOVERING'], description: 'Target lifecycle state (action: lifecycle)' },
+            machineId: { type: 'string', description: 'Machine ID (action: lifecycle, default: hostname)' },
+            reason: { type: 'string', description: 'Reason for lifecycle transition (action: lifecycle)' }
         },
         required: ['action'],
         additionalProperties: false


### PR DESCRIPTION
## Summary
- The `lifecycle` action was added to `diagnose.ts` Zod schema (#512 arbitrage A) but never reflected in the JSON Schema tool definition served via `tools/list`
- LLM agents could not discover the `lifecycle` action or its parameters (`state`, `machineId`, `reason`)
- Adds `lifecycle` to action enum + 3 lifecycle-specific params to `roosyncDiagnoseDefinition.inputSchema`
- Adds 2 tests: action presence + param shape verification

## Test plan
- [x] Build passes (`npm run build`)
- [x] 98 tests pass in `tool-definitions.test.ts` (was 97, +1 new)
- [x] 30 tests pass in `fusions-1863.test.ts` (unchanged)
- [ ] Verify `tools/list` response includes `lifecycle` in `roosync_diagnose` action enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)