### PR TITLE
feat(inventory): rewire health_view as type="health" (#2224)

### DIFF
--- a/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
+++ b/servers/roo-state-manager/src/tools/__tests__/tool-definitions.test.ts
@@ -327,6 +327,16 @@ describe('tool-definitions.ts — Schema Validation', () => {
             expect(roosyncInventoryDefinition.inputSchema.required).toContain('type');
         });
 
+        // #2224: health type re-wired from standalone roosync_health_view
+        it('roosync_inventory should support type="health"', () => {
+            const types = (roosyncInventoryDefinition.inputSchema.properties.type as Record<string, unknown>).enum as string[];
+            expect(types).toContain('health');
+            // Also verify format and includeEnvCheck params for health
+            const props = roosyncInventoryDefinition.inputSchema.properties as Record<string, unknown>;
+            expect(props).toHaveProperty('format');
+            expect(props).toHaveProperty('includeEnvCheck');
+        });
+
         it('export_config should require action', () => {
             expect(exportConfigDefinition.inputSchema.required).toContain('action');
         });

--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -99,6 +99,7 @@ export const TOOL_CAPABILITIES: Record<string, Capability[]> = {
 	roosync_refresh_dashboard: ['sharedPath'],
 	roosync_get_status: ['sharedPath'],
 	roosync_inventory: ['sharedPath'],
+	roosync_health_view: ['sharedPath'], // #2224: backward-compat redirect → inventory(type: "health")
 	roosync_config: ['sharedPath'],
 	roosync_compare_config: ['sharedPath'],
 	// [REMOVED CONS-8 #603] roosync_list_diffs, roosync_decision, roosync_init — dead tools
@@ -499,6 +500,30 @@ export function registerCallToolHandler(
                   const invResult = await m.inventoryTool.execute(redirectArgs, {} as any);
                   if (invResult.success) {
                       result = { content: [{ type: 'text', text: JSON.stringify(invResult.data, null, 2) }] };
+                  } else {
+                      result = { content: [{ type: 'text', text: `Error: ${invResult.error?.message}` }], isError: true };
+                  }
+              } catch (error) {
+                  result = { content: [{ type: 'text', text: `Error: ${(error as Error).message}` }], isError: true };
+              }
+              break;
+          }
+          // #2224: roosync_health_view standalone → redirect to roosync_inventory(type: "health")
+          case 'roosync_health_view': {
+              try {
+                  const m = await import('./roosync/inventory.js');
+                  const legacyArgs = args as Record<string, unknown>;
+                  const redirectArgs = InventoryArgsSchema.parse({
+                      type: 'health',
+                      machineId: legacyArgs.machineId,
+                      includeEnvCheck: legacyArgs.includeEnvCheck,
+                      format: legacyArgs.format,
+                  });
+                  const invResult = await m.inventoryTool.execute(redirectArgs, {} as any);
+                  if (invResult.success) {
+                      const data = invResult.data as any;
+                      const text = data?.markdownContent ?? JSON.stringify(data, null, 2);
+                      result = { content: [{ type: 'text', text }] };
                   } else {
                       result = { content: [{ type: 'text', text: `Error: ${invResult.error?.message}` }], isError: true };
                   }

--- a/servers/roo-state-manager/src/tools/roosync/health-view.ts
+++ b/servers/roo-state-manager/src/tools/roosync/health-view.ts
@@ -1,0 +1,407 @@
+/**
+ * Outil MCP : roosync_health_view
+ *
+ * Vue agrégée de l'état santé du cluster RooSync en un seul appel.
+ * Combine inventory, drift config, env vars critiques, et capability checks.
+ *
+ * #1746-B: Unified config dashboard tool
+ *
+ * @module tools/roosync/health-view
+ */
+
+import { z } from 'zod';
+import { getServerCapabilities } from '../../utils/server-capabilities.js';
+import { createLogger } from '../../utils/logger.js';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { getSharedStatePath } from '../../utils/shared-state-path.js';
+import { readdirSync, readFileSync } from 'fs';
+import * as os from 'os';
+
+const logger = createLogger('HealthView');
+
+const CRITICAL_ENV_VARS = [
+  { name: 'EMBEDDING_MODEL', severity: 'warning' as const },
+  { name: 'EMBEDDING_DIMENSIONS', severity: 'warning' as const },
+  { name: 'EMBEDDING_API_BASE_URL', severity: 'warning' as const },
+  { name: 'EMBEDDING_API_KEY', severity: 'warning' as const },
+  { name: 'QDRANT_URL', severity: 'critical' as const },
+  { name: 'QDRANT_API_KEY', severity: 'critical' as const },
+];
+
+export const HealthViewArgsSchema = z.object({
+  machineId: z.string().optional()
+    .describe('Machine locale (défaut) ou distante pour le drift check'),
+  includeEnvCheck: z.boolean().optional()
+    .describe('Inclure la vérification des env vars critiques (défaut: true)'),
+  format: z.enum(['json', 'markdown']).optional()
+    .describe('Format de sortie (défaut: json)'),
+});
+
+export type HealthViewArgs = z.infer<typeof HealthViewArgsSchema>;
+
+interface DriftItem {
+  category: string;
+  severity: string;
+  path: string;
+  description: string;
+  action?: string;
+}
+
+export interface HealthViewResult {
+  status: 'HEALTHY' | 'WARNING' | 'CRITICAL';
+  score: number;
+  timestamp: string;
+  localMachine: string;
+  systemHealth: {
+    machinesOnline: number;
+    machinesUnknown: number;
+    machinesTotal: number;
+    flags: string[];
+  };
+  capabilities: {
+    sharedPath: boolean;
+    qdrant: boolean;
+    embeddings: boolean;
+  };
+  drift: {
+    checked: boolean;
+    baselineSource: string;
+    critical: number;
+    important: number;
+    warning: number;
+    info: number;
+    items: DriftItem[];
+  };
+  envCheck: {
+    checked: boolean;
+    missing: Array<{ name: string; severity: string }>;
+    present: string[];
+  };
+  recommendations: string[];
+}
+
+function isKnownMachine(machineId: string): boolean {
+  return machineId.toLowerCase().startsWith('myia-');
+}
+
+function getLocalMachineId(): string {
+  return os.hostname().toLowerCase();
+}
+
+async function collectSystemHealth(): Promise<{
+  onlineCount: number;
+  unknownCount: number;
+  totalCount: number;
+  flags: string[];
+}> {
+  const sharedPath = getSharedStatePath();
+  let onlineCount = 0;
+  let unknownCount = 0;
+  const flags: string[] = [];
+
+  try {
+    const heartbeatDir = join(sharedPath, 'heartbeat');
+    if (existsSync(heartbeatDir)) {
+      const files = readdirSync(heartbeatDir).filter(f => f.endsWith('.json'));
+      const now = Date.now();
+      const twoHoursAgo = now - 2 * 60 * 60 * 1000;
+      const oneDayAgo = now - 24 * 60 * 60 * 1000;
+
+      for (const file of files) {
+        const machineId = file.replace('.json', '').toLowerCase();
+        if (!isKnownMachine(machineId)) continue;
+
+        try {
+          const data = JSON.parse(readFileSync(join(heartbeatDir, file), 'utf-8'));
+          const lastSeen = data.lastHeartbeat ? new Date(data.lastHeartbeat).getTime() : 0;
+          if (lastSeen > twoHoursAgo) {
+            onlineCount++;
+          } else {
+            unknownCount++;
+            if (lastSeen > 0 && lastSeen < oneDayAgo) {
+              flags.push(`SYNC_STALE:${machineId}`);
+            }
+          }
+        } catch {
+          unknownCount++;
+        }
+      }
+    }
+  } catch (error) {
+    flags.push('HEALTH_CHECK_FAILED:heartbeat_read_error');
+    logger.warn('Failed to read heartbeat data', { error: (error as Error).message });
+  }
+
+  return {
+    onlineCount,
+    unknownCount,
+    totalCount: onlineCount + unknownCount,
+    flags,
+  };
+}
+
+function collectCapabilities(): {
+  sharedPath: boolean;
+  qdrant: boolean;
+  embeddings: boolean;
+} {
+  const caps = getServerCapabilities();
+  return {
+    sharedPath: caps.isAvailable('sharedPath'),
+    qdrant: caps.isAvailable('qdrant'),
+    embeddings: caps.isAvailable('embeddings'),
+  };
+}
+
+async function collectDrift(
+  localMachineId: string
+): Promise<{
+  checked: boolean;
+  baselineSource: string;
+  critical: number;
+  important: number;
+  warning: number;
+  info: number;
+  items: DriftItem[];
+}> {
+  const empty = {
+    checked: false as const,
+    baselineSource: '',
+    critical: 0, important: 0, warning: 0, info: 0,
+    items: [] as DriftItem[],
+  };
+
+  try {
+    const { roosyncCompareConfig } = await import('./compare-config.js');
+    const result = await roosyncCompareConfig({
+      source: localMachineId,
+      granularity: 'full',
+    });
+
+    return {
+      checked: true,
+      baselineSource: `${result.target} (via GDrive inventory)`,
+      critical: result.summary.critical,
+      important: result.summary.important,
+      warning: result.summary.warning,
+      info: result.summary.info,
+      items: result.differences.map(d => ({
+        category: d.category,
+        severity: d.severity,
+        path: d.path,
+        description: d.description,
+        action: d.action,
+      })),
+    };
+  } catch (error) {
+    const msg = (error as Error).message;
+    logger.warn('Drift collection failed', { error: msg });
+    return { ...empty, baselineSource: `error: ${msg}` };
+  }
+}
+
+function collectEnvCheck(): {
+  checked: boolean;
+  missing: Array<{ name: string; severity: string }>;
+  present: string[];
+} {
+  const missing: Array<{ name: string; severity: string }> = [];
+  const present: string[] = [];
+
+  for (const { name, severity } of CRITICAL_ENV_VARS) {
+    if (process.env[name]) {
+      present.push(name);
+    } else {
+      missing.push({ name, severity });
+    }
+  }
+
+  return { checked: true, missing, present };
+}
+
+function computeScore(
+  onlineCount: number,
+  totalCount: number,
+  capabilities: { sharedPath: boolean; qdrant: boolean; embeddings: boolean },
+  drift: { critical: number; important: number; warning: number },
+  criticalEnvMissing: number
+): number {
+  let score = 100;
+
+  // Machine availability (0-20 points)
+  if (totalCount > 0) {
+    const onlinePct = onlineCount / totalCount;
+    score -= (1 - onlinePct) * 20;
+  }
+
+  // Capabilities (0-30 points)
+  if (!capabilities.sharedPath) score -= 15;
+  if (!capabilities.qdrant) score -= 10;
+  if (!capabilities.embeddings) score -= 5;
+
+  // Drift (0-30 points)
+  score -= Math.min(drift.critical * 10, 20);
+  score -= Math.min(drift.important * 3, 10);
+
+  // Env vars (0-20 points)
+  score -= criticalEnvMissing * 10;
+
+  return Math.max(0, Math.round(score));
+}
+
+function determineStatus(score: number): 'HEALTHY' | 'WARNING' | 'CRITICAL' {
+  if (score >= 80) return 'HEALTHY';
+  if (score >= 50) return 'WARNING';
+  return 'CRITICAL';
+}
+
+function generateRecommendations(
+  onlineCount: number,
+  totalCount: number,
+  capabilities: { sharedPath: boolean; qdrant: boolean; embeddings: boolean },
+  drift: { checked: boolean; critical: number; important: number; items: DriftItem[] },
+  envMissing: Array<{ name: string; severity: string }>
+): string[] {
+  const recs: string[] = [];
+
+  if (!capabilities.sharedPath) {
+    recs.push('ROOSYNC_SHARED_PATH not configured — RooSync features unavailable');
+  }
+  if (!capabilities.qdrant) {
+    recs.push('Qdrant not reachable — semantic search disabled');
+  }
+  if (!capabilities.embeddings) {
+    recs.push('Embedding service not configured — codebase_search disabled');
+  }
+
+  for (const env of envMissing) {
+    recs.push(`Set ${env.name} (severity: ${env.severity})`);
+  }
+
+  if (drift.checked && drift.critical > 0) {
+    recs.push(`${drift.critical} critical config drift(s) detected — run roosync_compare_config for details`);
+  }
+
+  if (totalCount > 0 && onlineCount < totalCount) {
+    const offline = totalCount - onlineCount;
+    recs.push(`${offline} machine(s) offline — check dashboard intercom for [WAKE] signals`);
+  }
+
+  if (recs.length === 0) {
+    recs.push('All systems nominal');
+  }
+
+  return recs;
+}
+
+export function formatMarkdown(result: HealthViewResult): string {
+  const lines: string[] = [];
+  const statusIcon = result.status === 'HEALTHY' ? 'OK' : result.status === 'WARNING' ? 'WARN' : 'CRIT';
+
+  lines.push(`# [${statusIcon}] Cluster Health View — ${result.localMachine}`);
+  lines.push(`**Status:** ${result.status} | **Score:** ${result.score}/100 | **Timestamp:** ${result.timestamp}`);
+  lines.push('');
+
+  lines.push('## System Health');
+  lines.push(`- **Machines:** ${result.systemHealth.machinesOnline}/${result.systemHealth.machinesTotal} online`);
+  if (result.systemHealth.flags.length > 0) {
+    lines.push(`- **Flags:** ${result.systemHealth.flags.join(', ')}`);
+  }
+  lines.push('');
+
+  lines.push('## Capabilities');
+  lines.push(`- SharedPath: ${result.capabilities.sharedPath ? 'OK' : 'MISSING'}`);
+  lines.push(`- Qdrant: ${result.capabilities.qdrant ? 'OK' : 'MISSING'}`);
+  lines.push(`- Embeddings: ${result.capabilities.embeddings ? 'OK' : 'MISSING'}`);
+  lines.push('');
+
+  lines.push('## Config Drift');
+  if (result.drift.checked) {
+    lines.push(`- **Baseline:** ${result.drift.baselineSource}`);
+    lines.push(`- Critical: ${result.drift.critical} | Important: ${result.drift.important} | Warning: ${result.drift.warning} | Info: ${result.drift.info}`);
+    if (result.drift.items.length > 0) {
+      lines.push('');
+      for (const item of result.drift.items.slice(0, 10)) {
+        lines.push(`  - [${item.severity}] ${item.path}: ${item.description}`);
+      }
+      if (result.drift.items.length > 10) {
+        lines.push(`  - ... and ${result.drift.items.length - 10} more`);
+      }
+    }
+  } else {
+    lines.push(`- Not checked (${result.drift.baselineSource})`);
+  }
+  lines.push('');
+
+  if (result.envCheck.checked) {
+    lines.push('## Environment Variables');
+    if (result.envCheck.missing.length > 0) {
+      for (const m of result.envCheck.missing) {
+        lines.push(`- MISSING: ${m.name} (${m.severity})`);
+      }
+    } else {
+      lines.push('- All critical env vars present');
+    }
+    lines.push('');
+  }
+
+  lines.push('## Recommendations');
+  for (const rec of result.recommendations) {
+    lines.push(`- ${rec}`);
+  }
+
+  return lines.join('\n');
+}
+
+export async function roosyncHealthView(args: HealthViewArgs): Promise<HealthViewResult> {
+  const localMachineId = getLocalMachineId();
+  const targetMachine = args.machineId || localMachineId;
+
+  // Collect all data sources in parallel
+  const [systemHealth, capabilities, drift, envCheck] = await Promise.all([
+    collectSystemHealth(),
+    Promise.resolve(collectCapabilities()),
+    collectDrift(targetMachine),
+    args.includeEnvCheck !== false ? Promise.resolve(collectEnvCheck()) : Promise.resolve({
+      checked: false, missing: [], present: [],
+    }),
+  ]);
+
+  const criticalEnvMissing = envCheck.missing.filter(e => e.severity === 'critical').length;
+  const score = computeScore(
+    systemHealth.onlineCount,
+    systemHealth.totalCount,
+    capabilities,
+    drift,
+    criticalEnvMissing
+  );
+  const status = determineStatus(score);
+  const recommendations = generateRecommendations(
+    systemHealth.onlineCount,
+    systemHealth.totalCount,
+    capabilities,
+    drift,
+    envCheck.missing
+  );
+
+  const result: HealthViewResult = {
+    status,
+    score,
+    timestamp: new Date().toISOString(),
+    localMachine: localMachineId,
+    systemHealth: {
+      machinesOnline: systemHealth.onlineCount,
+      machinesUnknown: systemHealth.unknownCount,
+      machinesTotal: systemHealth.totalCount,
+      flags: systemHealth.flags,
+    },
+    capabilities,
+    drift,
+    envCheck,
+    recommendations,
+  };
+
+  logger.info(`Health view computed: ${status} (${score}/100)`);
+  return result;
+}

--- a/servers/roo-state-manager/src/tools/roosync/inventory.ts
+++ b/servers/roo-state-manager/src/tools/roosync/inventory.ts
@@ -23,8 +23,8 @@ import { HeartbeatServiceError } from '../../services/roosync/HeartbeatService.j
  * Schema de validation pour roosync_inventory
  */
 export const InventoryArgsSchema = z.object({
-  type: z.enum(['machine', 'heartbeat', 'all', 'machines', 'status'])
-    .describe('Type d\'inventaire à récupérer. "machines" = unknown/idle machines. "status" = compact system snapshot (fused from roosync_get_status)'),
+  type: z.enum(['machine', 'heartbeat', 'all', 'machines', 'status', 'health'])
+    .describe('Type d\'inventaire à récupérer. "machines" = unknown/idle machines. "status" = compact system snapshot. "health" = unified cluster health view with score (#2224)'),
   machineId: z.string().optional()
     .describe('Identifiant optionnel de la machine (défaut: hostname)'),
   includeHeartbeats: z.boolean().optional()
@@ -40,7 +40,12 @@ export const InventoryArgsSchema = z.object({
   detail: z.enum(['compact', 'full']).optional()
     .describe('Niveau de détail pour type="status". "full" ajoute claims + pipeline stages'),
   resetCache: z.boolean().optional()
-    .describe('Forcer la réinitialisation du cache (type="status" uniquement)')
+    .describe('Forcer la réinitialisation du cache (type="status" uniquement)'),
+  // #2224: health view params (fused from roosync_health_view standalone)
+  format: z.enum(['json', 'markdown']).optional()
+    .describe('Output format for type="health". Default: json'),
+  includeEnvCheck: z.boolean().optional()
+    .describe('Include env var checks in type="health". Default: true')
 });
 
 export type InventoryArgs = z.infer<typeof InventoryArgsSchema>;
@@ -154,6 +159,35 @@ export const inventoryTool: UnifiedToolContract = {
         return {
           success: true,
           data: statusResult,
+          metrics: {
+            executionTime: Date.now() - startTime,
+            processingLevel: ProcessingLevel.IMMEDIATE
+          }
+        };
+      }
+
+      // #2224: type="health" — fused from roosync_health_view standalone (pattern #512 arbitrage A)
+      if (type === 'health') {
+        const { roosyncHealthView, formatMarkdown } = await import('./health-view.js');
+        const healthResult = await roosyncHealthView({
+          machineId,
+          includeEnvCheck: input.includeEnvCheck,
+          format: input.format,
+        });
+        // If markdown format requested, format and return as text
+        if (input.format === 'markdown') {
+          return {
+            success: true,
+            data: { markdownContent: formatMarkdown(healthResult), retrievedAt },
+            metrics: {
+              executionTime: Date.now() - startTime,
+              processingLevel: ProcessingLevel.IMMEDIATE
+            }
+          };
+        }
+        return {
+          success: true,
+          data: healthResult,
           metrics: {
             executionTime: Date.now() - startTime,
             processingLevel: ProcessingLevel.IMMEDIATE

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -434,18 +434,20 @@ export const roosyncConfigDefinition = {
 
 export const roosyncInventoryDefinition = {
     name: 'roosync_inventory',
-    description: 'Machine inventory, heartbeat status, system snapshot. type="status" for compact RooSync status with flags. Gotcha: use includeDetails:true for full metrics including tool usage stats.',
+    description: 'Machine inventory, heartbeat status, system snapshot, cluster health. type="status" for compact RooSync status. type="health" for unified cluster health with score (#2224). Gotcha: use includeDetails:true for full metrics including tool usage stats.',
     inputSchema: {
         type: 'object',
         properties: {
-            type: { type: 'string', enum: ['machine', 'heartbeat', 'all', 'machines', 'status'], description: 'Inventory type to query' },
+            type: { type: 'string', enum: ['machine', 'heartbeat', 'all', 'machines', 'status', 'health'], description: 'Inventory type to query. "health" = unified cluster health view with score (#2224)' },
             machineId: { type: 'string', description: 'Machine ID filter (default: hostname)' },
             includeHeartbeats: { type: 'boolean', description: 'Include heartbeat data' },
             status: { type: 'string', enum: ['unknown', 'idle', 'all'], description: 'Filter by status (type=machines)' },
             includeDetails: { type: 'boolean', description: 'Full details or tool usage stats' },
             detail: { type: 'string', enum: ['compact', 'full'], description: 'compact or full (adds claims + pipeline stages)' },
             resetCache: { type: 'boolean', description: 'Force cache reset (status only)' },
-            summary: { type: 'boolean', description: 'Return compact markdown summary instead of full JSON' }
+            summary: { type: 'boolean', description: 'Return compact markdown summary instead of full JSON' },
+            format: { type: 'string', enum: ['json', 'markdown'], description: 'Output format for type="health". Default: json' },
+            includeEnvCheck: { type: 'boolean', description: 'Include env var checks in type="health". Default: true' }
         },
         required: ['type'],
         additionalProperties: false

--- a/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/fusions-1863.test.ts
@@ -323,6 +323,8 @@ describe('#1863 Cross-cutting: tool count and deprecation markers', () => {
     expect(names).not.toContain('roosync_claim');
     expect(names).not.toContain('roosync_decision');
     expect(names).not.toContain('roosync_list_diffs');
+    // #2224: health_view rewired as inventory(type: "health"), not standalone
+    expect(names).not.toContain('roosync_health_view');
   });
 
   it('canonical tools should not be deprecated', () => {


### PR DESCRIPTION
## Summary

Rewires `roosync_health_view` standalone tool (PR #534, 16th tool) as `roosync_inventory(type: "health")` — pattern #512 arbitrage A. RSM stays at 15 served tools.

### Changes

- **inventory.ts**: Add `'health'` to type enum + `format`/`includeEnvCheck` params. New `type === 'health'` branch dynamically imports `health-view.ts`.
- **tool-definitions.ts**: Add `'health'` to inventory type enum + new params. No new top-level definition.
- **registry.ts**: Backward-compat redirect `roosync_health_view` → `inventory(type: "health")` (same pattern as `roosync_get_status`). TOOL_CAPABILITIES entry added.
- **health-view.ts**: Cherry-picked from PR #534 (handler only, no standalone definition).
- **Tests**: Tool count stays at 15. Health type enum verified. `roosync_health_view` excluded from allToolDefinitions.

### Footprint Impact

- **Served tools**: 15 (unchanged — #512 mandate)
- **New inventory type**: `health` with score/capabilities/drift/env-check
- **Backward compat**: `roosync_health_view` calls still work via redirect

### Test plan

- [x] Build passes (tsc clean)
- [x] 479 test files pass (9623 tests)
- [x] Tool count assertion = 15
- [x] Health type enum in inventory definition
- [x] `roosync_health_view` not in allToolDefinitions