### PR TITLE
fix(orphan-leak): kill-cascade + parent-PID watchdog + stdin-close handler (incident 2026-05-26)

### DIFF
--- a/servers/roo-state-manager/mcp-wrapper.cjs
+++ b/servers/roo-state-manager/mcp-wrapper.cjs
@@ -173,9 +173,65 @@ process.stdin.on('data', (data) => {
     }
 });
 
-process.stdin.on('end', () => {
-    server.stdin.end();
-});
+// --- Orphan-leak fix (incident 2026-05-26, 73 orphans on ai-01) ---
+// Windows has no parent-death signal (no SIGHUP-on-parent-death, no POSIX
+// process groups). When the MCP client (Claude Code / Roo) goes away, its
+// only signal to us is stdin EOF. We previously called only `server.stdin.end()`
+// and waited indefinitely on `server.on('exit')` — but the server's event loop
+// is pinned by `qdrantIndexInterval` + `_gdriveHealthInterval` + Qdrant client,
+// so it never exited. Result: orphan processes accumulate (73 on ai-01,
+// 23.9 GB RAM, 73 parallel embedding loops hammering embeddings.myia.io).
+//
+// Fix: cascade SIGTERM/SIGKILL with timers and a final force-exit; plus a
+// parent-PID liveness watchdog as a belt-and-braces against stdin-EOF being
+// lost through the cmd.exe shim or detached stdio.
+let killCascadeArmed = false;
+function forceKillServerCascade(reason) {
+    if (killCascadeArmed) return;
+    killCascadeArmed = true;
+    console.error(`[MCP-WRAPPER] 🛑 ${reason} — initiating server kill cascade`);
+    try { server.stdin.end(); } catch {}
+    setTimeout(() => {
+        try {
+            console.error('[MCP-WRAPPER] kill-cascade T+5s: SIGTERM');
+            server.kill('SIGTERM');
+        } catch {}
+    }, 5000).unref();
+    setTimeout(() => {
+        try {
+            console.error('[MCP-WRAPPER] kill-cascade T+10s: SIGKILL');
+            server.kill('SIGKILL');
+        } catch {}
+    }, 10000).unref();
+    setTimeout(() => {
+        console.error('[MCP-WRAPPER] kill-cascade T+12s: wrapper force-exit');
+        process.exit(0);
+    }, 12000).unref();
+}
+
+process.stdin.on('end', () => forceKillServerCascade('stdin EOF'));
+process.stdin.on('close', () => forceKillServerCascade('stdin closed'));
+
+// Parent-PID liveness watchdog. Windows doesn't notify children when the
+// parent dies, so we poll every 30s with `process.kill(ppid, 0)` (no-signal
+// liveness probe). If the parent is gone (ESRCH), our wrapper has become an
+// orphan — trigger the kill cascade.
+const initialParentPid = process.ppid;
+if (initialParentPid && initialParentPid !== 0) {
+    const parentWatchdog = setInterval(() => {
+        try {
+            process.kill(initialParentPid, 0);
+        } catch (e) {
+            if (e && e.code === 'ESRCH') {
+                clearInterval(parentWatchdog);
+                forceKillServerCascade(`parent PID ${initialParentPid} no longer exists`);
+            }
+            // EPERM = parent exists but we can't signal it (still alive) — keep watching.
+        }
+    }, 30_000);
+    parentWatchdog.unref();
+    console.error(`[MCP-WRAPPER] 👁  Parent-PID liveness watchdog armed (ppid=${initialParentPid}, 30s poll)`);
+}
 
 // --- stdout: process server → client messages ---
 // Returns string to forward, or null to suppress

--- a/servers/roo-state-manager/src/index.ts
+++ b/servers/roo-state-manager/src/index.ts
@@ -620,6 +620,20 @@ process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
 process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 process.on('SIGHUP', () => gracefulShutdown('SIGHUP'));
 
+// Orphan-leak fix (incident 2026-05-26, 73 orphans on ai-01 hammering embeddings):
+// Windows has no parent-death signal, and the signal handlers above never fire
+// when the MCP client (Claude Code / Roo) just disappears. The only reliable
+// notification is stdin EOF / close from our wrapper (which itself watches for
+// parent death). Without these listeners, qdrantIndexInterval + _gdriveHealthInterval
+// + Qdrant client pin the event loop forever → the server becomes an orphan
+// that keeps emitting embedding requests against embeddings.myia.io.
+process.stdin.on('end', () => {
+    void gracefulShutdown('stdin-end');
+});
+process.stdin.on('close', () => {
+    void gracefulShutdown('stdin-close');
+});
+
 // #1918: Periodic GDrive health check — when sharedPath is degraded,
 // probe every 30s and recover when GDrive comes back online.
 let _gdriveHealthInterval: ReturnType<typeof setInterval> | null = null;

--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -135,24 +135,22 @@ const CONDENSE_LLM_TIMEOUT_MS = Number(process.env.CONDENSE_LLM_TIMEOUT_MS) || 7
 
 // Max tokens for every condensation LLM call (summary, status, text-condense).
 //
+// 2026-05-26: thinking mode disabled at every call site (see chat_template_kwargs
+// below). Per user mandate "passe la condensation en non thinking, vue la situation
+// catastrophique du cluster ce sera un moindre mal" — Qwen3.6 thinking-loop hang
+// was bringing the whole dashboard channel down during the orphan-leak crisis.
+// With thinking off, generation is direct markdown output (~4000 tokens), well
+// under the gateway; the 12000 cap (sized to the 600s IIS → vLLM gateway at
+// ~37 tok/s) is retained as a runaway-guard if the model ever flips back into
+// a long output.
+//
+// History (kept for context — apply *with* enable_thinking=false now):
 // 2026-05-23: regression fix. Commit 9beb7e93 (2026-04-20) bumped this 10000 →
 // 30000 to "give Qwen3.6 thinking room". That was the bug behind "la condensation
 // n'aboutit plus d'elle-même quand on poste": qwen3.6 has a known thinking-loop
 // repetition failure mode (vLLM+Qwen) where a runaway generation walks all the way
-// to max_tokens. At ~37 tok/s, 30000 tokens = ~810s of generation, which exceeds
-// the ~600s reverse-proxy (IIS → vLLM) gateway timeout → the request dies with
-// HTTP 502 mid-thinking, the SDK retries (each ~600s), and after 3 failures the
-// circuit breaker falls back to truncation. The request never "aboutit".
-//
-// Bounding generation at 12000 tokens caps a runaway at ~325s — comfortably UNDER
-// the gateway — so even a runaway returns cleanly (finish_reason=length, null
-// content) and is retried, succeeding stochastically. Legitimate condensations use
-// 3500-4400 total tokens, so 12000 leaves ~3x headroom for a real thinking phase
-// plus the markdown output. Latency is acceptable (user mandate: "qu'elle prenne
-// longtemps ne devrait pas être un problème, mais elle doit aboutir"); completion
-// under the gateway is the requirement. NOT a blind revert to 10000: 12000 is sized
-// to the gateway constraint, leaving the status call (largest legit output ~4000
-// tokens + thinking) genuine room.
+// to max_tokens. 30000 tokens × ~37 tok/s = ~810s, > 600s gateway = HTTP 502.
+// Bounding at 12000 caps a runaway at ~325s, comfortably under the gateway.
 const CONDENSE_LLM_MAX_TOKENS = 12000;
 
 // Dedup window for [ERROR] CONDENSATION CANCELLED system messages (prevent loop
@@ -926,7 +924,13 @@ FORMAT :
         // before the ~600s reverse-proxy gateway timeout (502) — lets condensation
         // actually complete instead of dying mid-thinking and falling to truncation.
         max_tokens: CONDENSE_LLM_MAX_TOKENS,
-        temperature: 0.3
+        temperature: 0.3,
+        // Disable Qwen3.6 thinking mode (user mandate 2026-05-26): thinking-loop
+        // runaway repetition causes null content (finish_reason=length) and chains
+        // of retries that hang the dashboard append. Non-thinking trades nuance for
+        // reliability — "moindre mal" while the cluster is in crisis.
+        // @ts-expect-error vLLM-specific OpenAI-compatible extension
+        chat_template_kwargs: { enable_thinking: false }
       }, {
         timeout: timeoutMs
       });
@@ -1122,7 +1126,10 @@ Mets à jour le statut en intégrant les informations des messages [SERA ARCHIV�
         ],
         // Bounded under the ~600s gateway timeout (see CONDENSE_LLM_MAX_TOKENS).
         max_tokens: CONDENSE_LLM_MAX_TOKENS,
-        temperature: 0.3
+        temperature: 0.3,
+        // Disable Qwen3.6 thinking mode (user mandate 2026-05-26).
+        // @ts-expect-error vLLM-specific OpenAI-compatible extension
+        chat_template_kwargs: { enable_thinking: false }
       }, {
         timeout: timeoutMs
       });
@@ -1230,7 +1237,10 @@ RÈGLES :
       ],
       // Bounded under the ~600s gateway timeout (see CONDENSE_LLM_MAX_TOKENS).
       max_tokens: CONDENSE_LLM_MAX_TOKENS,
-      temperature: 0.3
+      temperature: 0.3,
+      // Disable Qwen3.6 thinking mode (user mandate 2026-05-26).
+      // @ts-expect-error vLLM-specific OpenAI-compatible extension
+      chat_template_kwargs: { enable_thinking: false }
     }, {
       timeout: CONDENSE_LLM_TIMEOUT_MS  // #2267 follow-up: bounded so a hung endpoint fast-fails (was 900000)
     });


### PR DESCRIPTION
## Stop & Repair — orphan leak + dashboard condensation hang

Two distinct failures rolled into one PR because they share the root scope (`mcps/internal/servers/roo-state-manager`) and both surfaced in the same crisis.

### Failure A: orphan MCP server leak (kill-cascade + parent watchdog + stdin handlers)

73 → 44 orphan `roo-state-manager build/index.js` processes accumulated on ai-01 (23.9 GB RAM at peak). Each runs `qdrantIndexInterval` → parallel embedding loops hammering `embeddings.myia.io` 24/7 for ~1 month. Reported by po-2026 (VectorIndexer over-indexing) and ai-01 (qdrant orphan inventory).

**Three Windows gaps allowed accumulation:**
1. No parent-death signal on Windows (no SIGHUP, no POSIX process groups) — `SIGTERM`/`SIGINT`/`SIGHUP` handlers never fire.
2. Server had no shutdown path on stdin close — `qdrantIndexInterval` + Qdrant client pin the event loop.
3. `mcp-wrapper.cjs` awaited `server.on(''exit'')` indefinitely with no force-kill timeout.

**Fix (commit `7da41fb7`):**
- `mcp-wrapper.cjs`: kill-cascade (`stdin.end()` → `SIGTERM`+5s → `SIGKILL`+10s → wrapper-exit+12s) on stdin EOF/close; parent-PID liveness watchdog (poll `process.kill(ppid, 0)` every 30s, ESRCH → cascade).
- `src/index.ts` L619-621: `process.stdin.on(''end''|''close'')` → existing `gracefulShutdown` (clears `qdrantIndexInterval` + `_gdriveHealthInterval`, closes Qdrant client).

### Failure B: dashboard condensation hangs indefinitely (Qwen3.6 thinking-loop)

User mandate 2026-05-26 during crisis: *"passe la condensation en non thinking, vue la situation catastrophique du cluster ce sera un moindre mal, tout le monde sur le pont !!!"*

Dashboard `roosync_dashboard append` was hanging the entire MCP because Qwen3.6 thinking-mode runaway repetition → `finish_reason=length` → null content → SDK retries on a ~600s gateway → wrapper waits indefinitely. The 2026-05-23 max_tokens 30000→12000 fix bounded gateway crashes but did NOT prevent thinking-loop degenerate output from chaining retries.

**Fix (commit `ac8e2496`):**
- `dashboard.ts` — added `chat_template_kwargs: { enable_thinking: false }` to all 3 condensation LLM call sites:
  - `generateLLMSummary` (intercom condense, L919)
  - `generateStatusUpdate` (status regen, L1117)
  - `condenseTextIfTooLarge` (size-driven condense, L1225)
- The 12000 `max_tokens` cap is retained as a runaway-guard.

vLLM-specific OpenAI-compatible extension `chat_template_kwargs` is the standard mechanism to disable Qwen3.6 thinking via the chat-completions API.

### Validation

- ✅ `npm run build` — clean (TS compiles; `@ts-expect-error` on the 3 `chat_template_kwargs` lines).
- ✅ `npx vitest run --config vitest.config.ci.ts` — **9623 PASS / 23 skipped / 0 FAIL**.
- ✅ CI on commit `ac8e2496`: `roo-state-manager` job SUCCESS. (Pre-existing unrelated failure on `jinavigator-server` — see prior PRs.)

### Deploy notes

- Source merge ≠ live process swap ([[reference_mcp_rebuild_not_process_swap]]). Each machine needs `roosync_mcp_management rebuild` + session restart for the fix to take effect on its live MCP instance.
- The orphan-leak fix prevents future accumulation; it does NOT itself kill existing orphans. ai-01 was killed by hand (44 reaped during crisis); other machines should be inspected.
- VectorIndexer pre-embedding fix (po-2026 report) is **out of scope** of this PR — distinct bug: chunk dedup happens at Qdrant write but embedding is still computed (2.2 pts/req instead of 22-68). Will be a separate fix once po-2026 restarts to activate leader-election #535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)