### PR TITLE
fix(#498): complete OOM guard — size check in all fallback read paths

### DIFF
--- a/servers/roo-state-manager/src/utils/roo-storage-detector.ts
+++ b/servers/roo-state-manager/src/utils/roo-storage-detector.ts
@@ -1323,10 +1323,13 @@ export class RooStorageDetector {
         if (!existsSync(uiMessagesPath)) {
           return undefined;
         }
+        const stat = await fs.stat(uiMessagesPath);
+        if (stat.size > RooStorageDetector.MAX_CONVERSATION_FILE_SIZE) {
+          return undefined;
+        }
 
         content = await fs.readFile(uiMessagesPath, 'utf-8');
 
-        // Nettoyage BOM
         if (content.charCodeAt(0) === 0xFEFF) {
           content = content.slice(1);
         }
@@ -1392,6 +1395,11 @@ export class RooStorageDetector {
         if (!existsSync(filePath)) {
           return;
         }
+        const stat = await fs.stat(filePath);
+        if (stat.size > RooStorageDetector.MAX_CONVERSATION_FILE_SIZE) {
+          return;
+        }
+
 
         content = await fs.readFile(filePath, 'utf-8');
 
@@ -1660,6 +1668,8 @@ export class RooStorageDetector {
                 content = preloadedContent;
             } else {
                 if (!existsSync(filePath)) return [];
+                const stat = await fs.stat(filePath);
+                if (stat.size > RooStorageDetector.MAX_CONVERSATION_FILE_SIZE) return [];
                 content = await fs.readFile(filePath, 'utf-8');
                 if (content.charCodeAt(0) === 0xFEFF) content = content.slice(1);
             }


### PR DESCRIPTION
## Summary
- Fixes HIGH finding from [AUDIT-MONTH:po-2023]: OOM guard was incomplete
- The preload-phase guard (>10MB skip) only protected the initial read; 3 downstream helpers fell through to unguarded `fs.readFile()` when `preloadedContent` was undefined

## What changed
Added `fs.stat()` size check against `MAX_CONVERSATION_FILE_SIZE` (10MB) in 3 fallback read paths:
1. `extractMainInstructionFromUI` (L1322) — returns `undefined` if oversized
2. `extractFromMessageFile` (L1394) — returns early if oversized  
3. `readJsonFile` closure in `buildSequenceFromFiles` (L1664) — returns `[]` if oversized

## Why
Commit `f77cef9b7` (#498) added a preload-phase size guard but missed that the 3 helpers all have `if (preloadedContent !== undefined) { use it } else { fs.readFile() }` — when preloaded was undefined (file too large), they'd read the full file anyway, defeating the OOM protection.

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 479 passed, 0 failed, 9623 assertions
- [ ] CI green on this PR

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>