### PR TITLE
fix(#527): require state when action=lifecycle via Zod refine

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/diagnose.ts
+++ b/servers/roo-state-manager/src/tools/roosync/diagnose.ts
@@ -69,6 +69,9 @@ export const DiagnoseArgsSchema = z.object({
     .describe('Machine ID (action: lifecycle, default: hostname)'),
   reason: z.string().optional()
     .describe('Reason for lifecycle transition (action: lifecycle)')
+}).refine(data => !(data.action === 'lifecycle' && !data.state), {
+  message: 'state is required when action is "lifecycle"',
+  path: ['state'],
 });
 
 export type DiagnoseArgs = z.infer<typeof DiagnoseArgsSchema>;


### PR DESCRIPTION
## Summary
- Fixes MEDIUM finding from [AUDIT-MONTH:po-2023]: lifecycle action accepted without required `state` param
- `DiagnoseArgsSchema.state` was `.optional()` but lifecycle handler used `args.state!` — runtime crash instead of schema rejection

## What changed
Added `.refine()` to `DiagnoseArgsSchema` requiring `state` when `action === 'lifecycle'`:
```ts
.refine(data => !(data.action === 'lifecycle' && !data.state), {
  message: 'state is required when action is "lifecycle"',
  path: ['state'],
})
```

Now `roosync_diagnose(action: "lifecycle")` without state returns a proper Zod validation error instead of crashing with "Invalid transition: ... → undefined".

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 479 passed, 0 failed
- [ ] CI green on this PR

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>