### PR TITLE
test(extension-id): replace hardcoded extension ID in 5 test files (#533 follow-up)

### DIFF
--- a/servers/roo-state-manager/src/tools/conversation/__tests__/conversation-browser.smoke.test.ts
+++ b/servers/roo-state-manager/src/tools/conversation/__tests__/conversation-browser.smoke.test.ts
@@ -15,6 +15,7 @@ import { RooStorageDetector } from '../../../utils/roo-storage-detector.js';
 import { globalCacheManager } from '../../../utils/cache-manager.js';
 import * as fs from 'fs';
 import * as path from 'path';
+import { getExtensionId } from '../../../utils/extension-paths.js';
 
 // Unmock modules that jest.setup.js mocks globally.
 // Smoke tests need real filesystem and real services (not mocks).
@@ -34,7 +35,7 @@ describe('SMOKE: conversation_browser', () => {
     originalEnv = { ...process.env };
 
     // Compute test path after setup-env.ts has redirected APPDATA
-    testTasksPath = path.join(process.env.APPDATA, 'Code', 'User', 'globalStorage', 'rooveterinaryinc.roo-cline', 'tasks');
+    testTasksPath = path.join(process.env.APPDATA, 'Code', 'User', 'globalStorage', getExtensionId(), 'tasks');
 
     // Setup test environment with required env vars
     process.env.ROOSYNC_WORKSPACE_ID = 'roo-extensions';

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/mcp-management.integration.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/mcp-management.integration.test.ts
@@ -41,9 +41,10 @@ vi.mock('../../../utils/message-helpers.js', async () => {
 // Cannot use `join` from import here (not initialized yet), use require
 const { testAppDataPath, testMcpSettingsDir, testMcpSettingsPath } = vi.hoisted(() => {
   const path = require('path');
+  const extensionId = process.env.ROO_EXTENSION_ID || 'rooveterinaryinc.roo-cline';
   const testAppDataPath = path.join(__dirname, '../../../__test-data__/appdata-mcp-management');
   process.env.APPDATA = testAppDataPath;
-  const testMcpSettingsDir = path.join(testAppDataPath, 'Code', 'User', 'globalStorage', 'rooveterinaryinc.roo-cline', 'settings');
+  const testMcpSettingsDir = path.join(testAppDataPath, 'Code', 'User', 'globalStorage', extensionId, 'settings');
   const testMcpSettingsPath = path.join(testMcpSettingsDir, 'mcp_settings.json');
   return { testAppDataPath, testMcpSettingsDir, testMcpSettingsPath };
 });

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/modes-management.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/modes-management.test.ts
@@ -28,6 +28,7 @@ import {
   type ModesDiff,
   type ModesComparison
 } from '../modes-management';
+import { getExtensionId } from '../../../utils/extension-paths';
 
 const mockedFsPromises = vi.mocked(fsPromises);
 
@@ -68,7 +69,7 @@ describe('modes-management', () => {
     it('should return the correct path on Windows', () => {
       const result = getCustomModesPath();
       expect(result).toContain('custom_modes.yaml');
-      expect(result).toContain('rooveterinaryinc.roo-cline');
+      expect(result).toContain(getExtensionId());
     });
   });
 

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/storage-management.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/storage-management.test.ts
@@ -18,6 +18,7 @@ import { roosyncStorageManagement, type StorageManagementArgs } from '../storage
 import { HeartbeatServiceError } from '../../../services/roosync/HeartbeatService.js';
 import * as storageInfoModule from '../../storage/storage-info.js';
 import * as maintenanceModule from '../../maintenance/maintenance.js';
+import { getExtensionId } from '../../../utils/extension-paths.js';
 
 // Mock des modules
 vi.mock('../../storage/storage-info.js');
@@ -35,7 +36,7 @@ describe('roosyncStorageManagement', () => {
     describe('action: storage - storageAction: detect', () => {
         test('should detect storage successfully', async () => {
             const mockDetectResult = {
-                tasksDir: 'C:\\Users\\Test\\AppData\\Roaming\\Code\\User\\globalStorage\\rooveterinaryinc.roo-cline\\tasks',
+                tasksDir: `C:\\Users\\Test\\AppData\\Roaming\\Code\\User\\globalStorage\\${getExtensionId()}\\tasks`,
                 exists: true,
                 taskCount: 42
             };

--- a/servers/roo-state-manager/src/utils/__tests__/touch-mcp-settings.integration.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/touch-mcp-settings.integration.test.ts
@@ -18,22 +18,22 @@ import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import { existsSync, rmSync, mkdirSync, writeFileSync, statSync } from 'fs';
 import { join } from 'path';
 import { handleTouchMcpSettings } from '../server-helpers.js';
+import { getExtensionId } from '../extension-paths.js';
 
 describe('handleTouchMcpSettings (integration)', () => {
   const originalAppdata = process.env.APPDATA;
+  const extensionId = getExtensionId();
   // APPDATA pointe vers testSettingsBase, l'outil ajoute "Code/User/globalStorage/..."
   const testSettingsBase = join(__dirname, '../../../__test-data__/mcp-settings-integration');
 
   beforeEach(() => {
-    // Créer la structure de test
-    // %APPDATA%/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json
     const codeDir = join(testSettingsBase, 'Code');
     const userDir = join(codeDir, 'User');
     const globalStorageDir = join(userDir, 'globalStorage');
-    const rooDir = join(globalStorageDir, 'rooveterinaryinc.roo-cline');
-    const settingsDir = join(rooDir, 'settings');
+    const extDir = join(globalStorageDir, extensionId);
+    const settingsDir = join(extDir, 'settings');
 
-    for (const dir of [testSettingsBase, codeDir, userDir, globalStorageDir, rooDir, settingsDir]) {
+    for (const dir of [testSettingsBase, codeDir, userDir, globalStorageDir, extDir, settingsDir]) {
       if (!existsSync(dir)) {
         mkdirSync(dir, { recursive: true });
       }
@@ -63,7 +63,7 @@ describe('handleTouchMcpSettings (integration)', () => {
 
   describe('basic functionality', () => {
     test('should touch the mcp_settings.json file successfully', async () => {
-      const settingsPath = join(testSettingsBase, 'Code', 'User', 'globalStorage', 'rooveterinaryinc.roo-cline', 'settings', 'mcp_settings.json');
+      const settingsPath = join(testSettingsBase, 'Code', 'User', 'globalStorage', extensionId, 'settings', 'mcp_settings.json');
 
       // Obtenir le timestamp avant
       const statsBefore = statSync(settingsPath);
@@ -97,7 +97,7 @@ describe('handleTouchMcpSettings (integration)', () => {
 
     test('should return error when mcp_settings.json does not exist', async () => {
       // Supprimer le fichier créé par beforeEach
-      const settingsDir = join(testSettingsBase, 'Code', 'User', 'globalStorage', 'rooveterinaryinc.roo-cline', 'settings');
+      const settingsDir = join(testSettingsBase, 'Code', 'User', 'globalStorage', extensionId, 'settings');
       const settingsPath = join(settingsDir, 'mcp_settings.json');
       if (existsSync(settingsPath)) {
         rmSync(settingsPath);
@@ -153,7 +153,7 @@ describe('handleTouchMcpSettings (integration)', () => {
       expect(parsed.path).toContain('Code');
       expect(parsed.path).toContain('User');
       expect(parsed.path).toContain('globalStorage');
-      expect(parsed.path).toContain('rooveterinaryinc.roo-cline');
+      expect(parsed.path).toContain(extensionId);
       expect(parsed.path).toContain('settings');
       expect(parsed.path).toContain('mcp_settings.json');
     });
@@ -196,7 +196,7 @@ describe('handleTouchMcpSettings (integration)', () => {
   describe('error handling', () => {
     test('should return isError=true when file not found', async () => {
       // Supprimer le fichier
-      const settingsPath = join(testSettingsBase, 'Code', 'User', 'globalStorage', 'rooveterinaryinc.roo-cline', 'settings', 'mcp_settings.json');
+      const settingsPath = join(testSettingsBase, 'Code', 'User', 'globalStorage', extensionId, 'settings', 'mcp_settings.json');
       if (existsSync(settingsPath)) {
         rmSync(settingsPath);
       }
@@ -208,7 +208,7 @@ describe('handleTouchMcpSettings (integration)', () => {
 
     test('should return structured error response', async () => {
       // Supprimer le fichier
-      const settingsPath = join(testSettingsBase, 'Code', 'User', 'globalStorage', 'rooveterinaryinc.roo-cline', 'settings', 'mcp_settings.json');
+      const settingsPath = join(testSettingsBase, 'Code', 'User', 'globalStorage', extensionId, 'settings', 'mcp_settings.json');
       if (existsSync(settingsPath)) {
         rmSync(settingsPath);
       }


### PR DESCRIPTION
## Summary
- Replace hardcoded `'rooveterinaryinc.roo-cline'` string literals with `getExtensionId()` from `extension-paths.ts` in 5 test files (~12 refs total)
- Source files were already migrated by PR #533 — this completes the remaining test coverage

## Files changed
- `conversation-browser.smoke.test.ts` (1 ref) — import + use `getExtensionId()`
- `mcp-management.integration.test.ts` (1 ref) — `vi.hoisted()` context uses `process.env.ROO_EXTENSION_ID` fallback
- `modes-management.test.ts` (1 ref) — import + use `getExtensionId()`
- `storage-management.test.ts` (1 ref) — import + use `getExtensionId()`
- `touch-mcp-settings.integration.test.ts` (7 refs) — import + local variable, all assertions migrated

## Test plan
- [x] Build passes (`npm run build`)
- [x] All CI tests pass (479/479 test files, 9623/9623 tests)
- [ ] Verify no remaining hardcoded `rooveterinaryinc.roo-cline` in test files

Related: jsboige/roo-extensions#2377

🤖 Generated with [Claude Code](https://claude.com/claude-code)