### PR TITLE
fix(roosync): dashboard-derived presence for health-view (#2121 Phase 2)

### DIFF
--- a/servers/roo-state-manager/src/services/roosync/PresenceManager.ts
+++ b/servers/roo-state-manager/src/services/roosync/PresenceManager.ts
@@ -20,7 +20,7 @@ const logger = createLogger('PresenceManager');
  */
 export interface PresenceData {
   id: string;
-  status: 'online' | 'offline' | 'conflict';
+  status: 'online' | 'idle' | 'unknown' | 'offline' | 'conflict';
   lastSeen: string;
   version: string;
   mode: string;
@@ -63,10 +63,11 @@ export class PresenceManager {
   /**
    * Map HeartbeatService status to PresenceData status
    */
+  // #2121 Phase 2: Align with ADR 008 — no 'offline' status, only online/idle/unknown.
   private mapStatus(s: 'online' | 'idle' | 'unknown'): PresenceData['status'] {
     if (s === 'online') return 'online';
-    if (s === 'idle') return 'offline';
-    return 'offline';
+    if (s === 'idle') return 'idle';
+    return 'unknown';
   }
 
   /**

--- a/servers/roo-state-manager/src/tools/roosync/health-view.ts
+++ b/servers/roo-state-manager/src/tools/roosync/health-view.ts
@@ -12,10 +12,10 @@
 import { z } from 'zod';
 import { getServerCapabilities } from '../../utils/server-capabilities.js';
 import { createLogger } from '../../utils/logger.js';
-import { existsSync } from 'fs';
+import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { getSharedStatePath } from '../../utils/shared-state-path.js';
-import { readdirSync, readFileSync } from 'fs';
+import { extractMachineActivity } from '../../utils/dashboard-activity.js';
 import * as os from 'os';
 
 const logger = createLogger('HealthView');
@@ -95,42 +95,58 @@ async function collectSystemHealth(): Promise<{
   totalCount: number;
   flags: string[];
 }> {
+  // #2121 Phase 2: Dashboard-derived presence (ADR 008 Phase 4).
+  // Previously read ghost heartbeat/ files (pre-ADR 008, no longer written).
+  // Now parses dashboard content — the single source of cross-machine presence truth.
   const sharedPath = getSharedStatePath();
   let onlineCount = 0;
   let unknownCount = 0;
   const flags: string[] = [];
+  const now = Date.now();
+  const TWO_HOURS = 2 * 60 * 60 * 1000;
+  const ONE_DAY = 24 * 60 * 60 * 1000;
 
   try {
-    const heartbeatDir = join(sharedPath, 'heartbeat');
-    if (existsSync(heartbeatDir)) {
-      const files = readdirSync(heartbeatDir).filter(f => f.endsWith('.json'));
-      const now = Date.now();
-      const twoHoursAgo = now - 2 * 60 * 60 * 1000;
-      const oneDayAgo = now - 24 * 60 * 60 * 1000;
+    const dashboardsDir = join(sharedPath, 'dashboards');
+    if (!existsSync(dashboardsDir)) {
+      return { onlineCount: 0, unknownCount: 0, totalCount: 0, flags: ['DASHBOARDS_DIR_MISSING'] };
+    }
 
-      for (const file of files) {
-        const machineId = file.replace('.json', '').toLowerCase();
-        if (!isKnownMachine(machineId)) continue;
+    const dashboardFiles = readdirSync(dashboardsDir).filter(f => f.endsWith('.md'));
+    const contents: string[] = [];
+    for (const file of dashboardFiles) {
+      try {
+        contents.push(readFileSync(join(dashboardsDir, file), 'utf-8'));
+      } catch { /* skip unreadable */ }
+    }
 
-        try {
-          const data = JSON.parse(readFileSync(join(heartbeatDir, file), 'utf-8'));
-          const lastSeen = data.lastHeartbeat ? new Date(data.lastHeartbeat).getTime() : 0;
-          if (lastSeen > twoHoursAgo) {
-            onlineCount++;
-          } else {
-            unknownCount++;
-            if (lastSeen > 0 && lastSeen < oneDayAgo) {
-              flags.push(`SYNC_STALE:${machineId}`);
-            }
-          }
-        } catch {
-          unknownCount++;
+    const activity = extractMachineActivity(contents);
+    for (const [machineId, lastSeenStr] of activity) {
+      const id = machineId.toLowerCase();
+      if (!isKnownMachine(id)) continue;
+
+      const lastSeen = new Date(lastSeenStr).getTime();
+      if (now - lastSeen < TWO_HOURS) {
+        onlineCount++;
+      } else {
+        unknownCount++;
+        if (now - lastSeen > ONE_DAY) {
+          flags.push(`SYNC_STALE:${id}`);
         }
       }
     }
+
+    // Flag machines in registry but absent from dashboards
+    const KNOWN_MACHINES = ['myia-ai-01', 'myia-po-2023', 'myia-po-2024', 'myia-po-2025', 'myia-po-2026', 'myia-web1'];
+    for (const m of KNOWN_MACHINES) {
+      if (!activity.has(m)) {
+        flags.push(`SYNC_STALE:${m}`);
+        unknownCount++;
+      }
+    }
   } catch (error) {
-    flags.push('HEALTH_CHECK_FAILED:heartbeat_read_error');
-    logger.warn('Failed to read heartbeat data', { error: (error as Error).message });
+    flags.push('HEALTH_CHECK_FAILED:dashboard_read_error');
+    logger.warn('Failed to derive presence from dashboards', { error: (error as Error).message });
   }
 
   return {


### PR DESCRIPTION
## Summary
- Replace `health-view.ts` ghost heartbeat file reads with dashboard-derived presence via `extractMachineActivity()` (ADR 008 Phase 4)
- Fix `PresenceManager.mapStatus()` to align with ADR 008: `idle→idle`, `unknown→unknown` instead of `idle→offline`
- Widen `PresenceData.status` type to include `'idle' | 'unknown'`

## Context
Since ADR 008 (HeartbeatService v4.0), heartbeat files in `heartbeat/` are no longer written — all presence is passive (every MCP tool call IS the heartbeat, in-memory only). The `collectSystemHealth()` function still read these ghost files, returning stale/empty data.

`get-status.ts` v5.0.0 (#2318) already derives cross-machine presence purely from dashboard content. This PR aligns `health-view.ts` with the same pattern.

## Test plan
- [x] `npm run build` passes
- [x] `npx vitest run --config vitest.config.ci.ts` — 479 passed, 0 failed
- [ ] Verify `roosync_health_view` returns correct machine counts after deploy
- [ ] Confirm `SYNC_STALE` flags appear only for genuinely inactive machines

🤖 Generated with [Claude Code](https://claude.com/claude-code)