### PR TITLE
refactor(test): parameterize extension ID in 2 test files (#2373)

### DIFF
--- a/servers/roo-state-manager/src/tools/conversation/__tests__/conversation-browser.smoke.test.ts
+++ b/servers/roo-state-manager/src/tools/conversation/__tests__/conversation-browser.smoke.test.ts
@@ -15,6 +15,7 @@ import { RooStorageDetector } from '../../../utils/roo-storage-detector.js';
 import { globalCacheManager } from '../../../utils/cache-manager.js';
 import * as fs from 'fs';
 import * as path from 'path';
+import { getExtensionId } from '../../../utils/extension-paths.js';
 
 // Unmock modules that jest.setup.js mocks globally.
 // Smoke tests need real filesystem and real services (not mocks).
@@ -34,7 +35,7 @@ describe('SMOKE: conversation_browser', () => {
     originalEnv = { ...process.env };
 
     // Compute test path after setup-env.ts has redirected APPDATA
-    testTasksPath = path.join(process.env.APPDATA, 'Code', 'User', 'globalStorage', 'rooveterinaryinc.roo-cline', 'tasks');
+    testTasksPath = path.join(process.env.APPDATA, 'Code', 'User', 'globalStorage', getExtensionId(), 'tasks');
 
     // Setup test environment with required env vars
     process.env.ROOSYNC_WORKSPACE_ID = 'roo-extensions';

--- a/servers/roo-state-manager/src/utils/__tests__/touch-mcp-settings.integration.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/touch-mcp-settings.integration.test.ts
@@ -18,6 +18,9 @@ import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import { existsSync, rmSync, mkdirSync, writeFileSync, statSync } from 'fs';
 import { join } from 'path';
 import { handleTouchMcpSettings } from '../server-helpers.js';
+import { getExtensionId } from '../extension-paths.js';
+
+const EXTENSION_ID = getExtensionId();
 
 describe('handleTouchMcpSettings (integration)', () => {
   const originalAppdata = process.env.APPDATA;
@@ -26,11 +29,11 @@ describe('handleTouchMcpSettings (integration)', () => {
 
   beforeEach(() => {
     // Créer la structure de test
-    // %APPDATA%/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json
+    // %APPDATA%/Code/User/globalStorage/<extensionId>/settings/mcp_settings.json
     const codeDir = join(testSettingsBase, 'Code');
     const userDir = join(codeDir, 'User');
     const globalStorageDir = join(userDir, 'globalStorage');
-    const rooDir = join(globalStorageDir, 'rooveterinaryinc.roo-cline');
+    const rooDir = join(globalStorageDir, EXTENSION_ID);
     const settingsDir = join(rooDir, 'settings');
 
     for (const dir of [testSettingsBase, codeDir, userDir, globalStorageDir, rooDir, settingsDir]) {
@@ -63,7 +66,7 @@ describe('handleTouchMcpSettings (integration)', () => {
 
   describe('basic functionality', () => {
     test('should touch the mcp_settings.json file successfully', async () => {
-      const settingsPath = join(testSettingsBase, 'Code', 'User', 'globalStorage', 'rooveterinaryinc.roo-cline', 'settings', 'mcp_settings.json');
+      const settingsPath = join(testSettingsBase, 'Code', 'User', 'globalStorage', EXTENSION_ID, 'settings', 'mcp_settings.json');
 
       // Obtenir le timestamp avant
       const statsBefore = statSync(settingsPath);
@@ -97,7 +100,7 @@ describe('handleTouchMcpSettings (integration)', () => {
 
     test('should return error when mcp_settings.json does not exist', async () => {
       // Supprimer le fichier créé par beforeEach
-      const settingsDir = join(testSettingsBase, 'Code', 'User', 'globalStorage', 'rooveterinaryinc.roo-cline', 'settings');
+      const settingsDir = join(testSettingsBase, 'Code', 'User', 'globalStorage', EXTENSION_ID, 'settings');
       const settingsPath = join(settingsDir, 'mcp_settings.json');
       if (existsSync(settingsPath)) {
         rmSync(settingsPath);
@@ -153,7 +156,7 @@ describe('handleTouchMcpSettings (integration)', () => {
       expect(parsed.path).toContain('Code');
       expect(parsed.path).toContain('User');
       expect(parsed.path).toContain('globalStorage');
-      expect(parsed.path).toContain('rooveterinaryinc.roo-cline');
+      expect(parsed.path).toContain(EXTENSION_ID);
       expect(parsed.path).toContain('settings');
       expect(parsed.path).toContain('mcp_settings.json');
     });
@@ -196,7 +199,7 @@ describe('handleTouchMcpSettings (integration)', () => {
   describe('error handling', () => {
     test('should return isError=true when file not found', async () => {
       // Supprimer le fichier
-      const settingsPath = join(testSettingsBase, 'Code', 'User', 'globalStorage', 'rooveterinaryinc.roo-cline', 'settings', 'mcp_settings.json');
+      const settingsPath = join(testSettingsBase, 'Code', 'User', 'globalStorage', EXTENSION_ID, 'settings', 'mcp_settings.json');
       if (existsSync(settingsPath)) {
         rmSync(settingsPath);
       }
@@ -208,7 +211,7 @@ describe('handleTouchMcpSettings (integration)', () => {
 
     test('should return structured error response', async () => {
       // Supprimer le fichier
-      const settingsPath = join(testSettingsBase, 'Code', 'User', 'globalStorage', 'rooveterinaryinc.roo-cline', 'settings', 'mcp_settings.json');
+      const settingsPath = join(testSettingsBase, 'Code', 'User', 'globalStorage', EXTENSION_ID, 'settings', 'mcp_settings.json');
       if (existsSync(settingsPath)) {
         rmSync(settingsPath);
       }


### PR DESCRIPTION
## Summary
- Replace hardcoded `rooveterinaryinc.roo-cline` with `getExtensionId()` from `extension-paths.ts` in 2 test files
- Files changed: `touch-mcp-settings.integration.test.ts` (7 occurrences) + `conversation-browser.smoke.test.ts` (1 occurrence)
- Ensures tests resolve the correct extension directory under Zoo-Code mode (`ROO_EXTENSION_ID` env-var override)

## Context
EPIC #2373 (Zoo-Code migration). Production code was already parameterized via `extension-paths.ts` (#2134). Test files still had hardcoded strings.

## Remaining work
5 other test files still use hardcoded strings in `vi.hoisted()` blocks or assertion fixtures — these cannot import ESM at hoist time and need a different approach (deferred).

## Test plan
- [x] `npm run build` — clean (tsc, 0 errors)
- [x] `npx vitest run --config vitest.config.ci.ts` — 479 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)