### PR TITLE
fix(indexing): re-scan Qdrant index after skeleton cache loads (#2165)

### DIFF
--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -613,15 +613,19 @@ export async function initializeBackgroundServices(state: ServerState): Promise<
                 `— Total: ${stats.total}`
             );
 
-            // #2165 fix: Re-scan for outdated Qdrant index now that skeleton cache is populated.
-            // The initial scan in initializeQdrantIndexingService may have run on an empty cache
-            // (race condition: both are fire-and-forget). This re-scan ensures tasks are queued.
-            if (state.conversationCache.size > 0 && state.isQdrantIndexingEnabled) {
+            // #2165 ARCHITECTURE NOTE:
+            // Both loadSkeletonsFromDisk and initializeQdrantIndexingService are fire-and-forget
+            // at startup (see lines ~598 and ~640). If scanForOutdatedQdrantIndex runs before
+            // the skeleton cache populates, totalTasks stays at 0 and indexing stalls forever.
+            // This conditional re-scan only fires when the initial scan missed the cache,
+            // avoiding unnecessary double-scans on every startup.
+            if (state.conversationCache.size > 0 && state.isQdrantIndexingEnabled
+                && state.indexingMetrics.totalTasks === 0) {
                 try {
                     await scanForOutdatedQdrantIndex(state);
-                    console.log(`[Post-Load] Re-scanned ${state.indexingMetrics.totalTasks} skeletons for Qdrant indexing`);
+                    console.log(`[Post-Load] Re-scanned ${state.indexingMetrics.totalTasks} skeletons for Qdrant indexing (initial scan missed cache)`);
                 } catch (error: any) {
-                    console.warn('[Post-Load] Re-scan failed (non-critical):', error?.message || error);
+                    console.error('[Post-Load] Re-scan failed, indexing may be incomplete:', error?.message || error);
                 }
             }
         }).catch((error: any) => {

--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -602,7 +602,7 @@ export async function initializeBackgroundServices(state: ServerState): Promise<
             state.lastSkeletonRefreshAt = Date.now();
             // Once index is loaded, discover Claude sessions too
             return loadClaudeCodeSessions(state.conversationCache);
-        }).then(() => {
+        }).then(async () => {
             // #1747 sub-issue B: Log tier summary after all background loading completes
             const instance = SkeletonCacheService.getInstance();
             const stats = instance.getCacheTierStats();
@@ -612,6 +612,18 @@ export async function initializeBackgroundServices(state: ServerState): Promise<
                 `Tier3(Archives)=${stats.config.enableArchiveTier ? stats.tier3_archives : 'OFF'} ` +
                 `— Total: ${stats.total}`
             );
+
+            // #2165 fix: Re-scan for outdated Qdrant index now that skeleton cache is populated.
+            // The initial scan in initializeQdrantIndexingService may have run on an empty cache
+            // (race condition: both are fire-and-forget). This re-scan ensures tasks are queued.
+            if (state.conversationCache.size > 0 && state.isQdrantIndexingEnabled) {
+                try {
+                    await scanForOutdatedQdrantIndex(state);
+                    console.log(`[Post-Load] Re-scanned ${state.indexingMetrics.totalTasks} skeletons for Qdrant indexing`);
+                } catch (error: any) {
+                    console.warn('[Post-Load] Re-scan failed (non-critical):', error?.message || error);
+                }
+            }
         }).catch((error: any) => {
             console.warn('[Startup] Background skeleton/Claude load failed (non-blocking):', error?.message || error);
         });


### PR DESCRIPTION
## Summary
- Fix race condition where `scanForOutdatedQdrantIndex` runs before `loadSkeletonsFromDisk` completes (both fire-and-forget at startup)
- When the scan runs on empty `conversationCache`, `totalTasks=0` and indexing stalls indefinitely at current collection size
- Adds a re-scan in the `.then()` chain after skeleton loading completes, populating the queue with tasks needing indexing

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 480 passed, 0 failed, 9627 tests
- [ ] Post-merge: restart VS Code on po-2026 and verify `total_tasks > 0` in `roosync_indexing(action: "status")`
- [ ] Verify indexing traffic increases from ~1.85 req/min

🤖 Generated with [Claude Code](https://claude.com/claude-code)