### PR TITLE
fix(sk-agent): break circular import sk_conversations<->sk_agent

### DIFF
--- a/servers/sk-agent/sk_conversations.py
+++ b/servers/sk-agent/sk_conversations.py
@@ -30,9 +30,19 @@ from semantic_kernel.agents.strategies import (
 from semantic_kernel.contents import ChatMessageContent, AuthorRole
 
 from sk_agent_config import SKAgentConfig, AgentConfig, ConversationConfig
-from sk_agent import _sanitize_agent_name
 
 log = logging.getLogger("sk-agent.conversations")
+
+# Inlined from sk_agent to avoid circular import when sk_agent.py is the entry
+# point (loaded as __main__, which causes a second import as 'sk_agent' if we
+# reference it here).
+import re as _re
+_INVALID_NAME_CHARS = _re.compile(r"[^0-9A-Za-z_-]")
+
+
+def _sanitize_agent_name(name: str) -> str:
+    sanitized = _INVALID_NAME_CHARS.sub("-", name)
+    return sanitized.strip("-")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix MCP error `-32000: Connection closed` on sk-agent caused by circular
import that crashed the server on cold start.

## Root cause

When `sk_agent.py` is launched as the entry point (`python sk_agent.py`), it's
loaded under the module name `__main__`. The `from sk_conversations import …`
at [sk_agent.py:109](servers/sk-agent/sk_agent.py#L109) triggers
[sk_conversations.py:33](servers/sk-agent/sk_conversations.py#L33) which did
`from sk_agent import _sanitize_agent_name`. Since `sk_agent` is not in
\`sys.modules\` (only `__main__` is), Python attempts a **second** load of
`sk_agent.py` as `sk_agent`, which re-enters the partially-loaded
`sk_conversations` and fails:

\`\`\`
ImportError: cannot import name 'ConversationRunner' from partially
initialized module 'sk_conversations' (most likely due to a circular import)
\`\`\`

Latent since #485 (\`795057b0\`, *robust agent name sanitization*) — exposed
by recent cold start.

## Fix

Inline \`_sanitize_agent_name\` (3 LOC) directly in
\`sk_conversations.py\` so it no longer back-references \`sk_agent\`. Same
pattern already used by [test_mcp_overrides.py:10](servers/sk-agent/test_mcp_overrides.py#L10).
\`sk_agent.py\` is unchanged.

## Test plan

- [x] Standalone Python import: \`import sk_conversations\` succeeds, \`_sanitize_agent_name('glm-4.7') == 'glm-4-7'\`
- [x] sk-agent process startup: no traceback, logs \`Starting sk-agent MCP server v2.0 [stdio]\`
- [x] JSON-RPC \`initialize\` handshake: returns \`serverInfo.name == "sk-agent"\` v1.26.0 with tools/prompts/resources capabilities
- [x] Verified in user's Claude Code session via Reconnect (user confirmed 2026-05-27)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)