### PR TITLE
feat(indexing): hash-based task-space partition for Qdrant indexer (#2352)

### DIFF
--- a/servers/roo-state-manager/src/config/roosync-config.ts
+++ b/servers/roo-state-manager/src/config/roosync-config.ts
@@ -12,6 +12,7 @@
 import { existsSync } from 'fs';
 import { resolve, isAbsolute } from 'path';
 import { createLogger } from '../utils/logger.js';
+import { parseFleetRoster } from '../services/task-partition.js';
 
 const logger = createLogger('RooSyncConfig');
 
@@ -33,6 +34,12 @@ export interface RooSyncConfig {
 
   /** Niveau de verbosité des logs */
   logLevel: 'debug' | 'info' | 'warn' | 'error';
+
+  /**
+   * #2352: Fleet roster for task-space partitioning.
+   * Sorted array of machine IDs. null = partition disabled.
+   */
+  fleetRoster: string[] | null;
 }
 
 /**
@@ -94,7 +101,8 @@ export function loadRooSyncConfig(): RooSyncConfig {
       machineId: process.env.ROOSYNC_MACHINE_ID!.toLowerCase(),
       autoSync,
       conflictStrategy: conflictStrategy as 'manual' | 'auto-local' | 'auto-remote',
-      logLevel: logLevel as 'debug' | 'info' | 'warn' | 'error'
+      logLevel: logLevel as 'debug' | 'info' | 'warn' | 'error',
+      fleetRoster: parseFleetRoster(process.env.ROO_FLEET_ROSTER),
     };
   }
 
@@ -190,13 +198,23 @@ export function loadRooSyncConfig(): RooSyncConfig {
     );
   }
 
-  // 7. Retourner la configuration validée
+  // 7. #2352: Validate optional fleet roster
+  const fleetRoster = parseFleetRoster(process.env.ROO_FLEET_ROSTER);
+  if (fleetRoster && !fleetRoster.includes(machineId)) {
+    throw new RooSyncConfigError(
+      `ROO_FLEET_ROSTER does not include this machine (${machineId}). ` +
+      `Roster: ${fleetRoster.join(', ')}`
+    );
+  }
+
+  // 8. Retourner la configuration validée
   return {
     sharedPath: resolvedPath,
     machineId,
     autoSync,
     conflictStrategy,
-    logLevel
+    logLevel,
+    fleetRoster
   };
 }
 

--- a/servers/roo-state-manager/src/services/__tests__/task-partition.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/task-partition.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { fnv1a32, parseFleetRoster, getTaskOwner, shouldIndexTask } from '../task-partition.js';
+
+describe('task-partition', () => {
+	describe('fnv1a32', () => {
+		it('returns deterministic hash for same input', () => {
+			expect(fnv1a32('task-abc')).toBe(fnv1a32('task-abc'));
+		});
+
+		it('returns different hashes for different inputs', () => {
+			expect(fnv1a32('task-abc')).not.toBe(fnv1a32('task-def'));
+		});
+
+		it('returns unsigned 32-bit integer', () => {
+			const hash = fnv1a32('any-input');
+			expect(hash).toBeGreaterThanOrEqual(0);
+			expect(hash).toBeLessThanOrEqual(0xFFFFFFFF);
+			expect(Number.isInteger(hash)).toBe(true);
+		});
+	});
+
+	describe('parseFleetRoster', () => {
+		it('returns null for undefined', () => {
+			expect(parseFleetRoster(undefined)).toBeNull();
+		});
+
+		it('returns null for empty string', () => {
+			expect(parseFleetRoster('')).toBeNull();
+			expect(parseFleetRoster('   ')).toBeNull();
+		});
+
+		it('parses comma-separated machines', () => {
+			const roster = parseFleetRoster('myia-po-2023,myia-po-2026');
+			expect(roster).toEqual(['myia-po-2023', 'myia-po-2026']);
+		});
+
+		it('sorts alphabetically and deduplicates', () => {
+			const roster = parseFleetRoster('myia-web1,myia-ai-01,myia-web1,myia-po-2023');
+			expect(roster).toEqual(['myia-ai-01', 'myia-po-2023', 'myia-web1']);
+		});
+
+		it('normalizes to lowercase', () => {
+			const roster = parseFleetRoster('MyIA-AI-01,MYIA-WEB1');
+			expect(roster).toEqual(['myia-ai-01', 'myia-web1']);
+		});
+
+		it('trims whitespace', () => {
+			const roster = parseFleetRoster(' myia-ai-01 , myia-web1 ');
+			expect(roster).toEqual(['myia-ai-01', 'myia-web1']);
+		});
+	});
+
+	describe('getTaskOwner', () => {
+		it('returns null for null roster', () => {
+			expect(getTaskOwner('task-123', null)).toBeNull();
+		});
+
+		it('returns null for empty roster', () => {
+			expect(getTaskOwner('task-123', [])).toBeNull();
+		});
+
+		it('returns a machine from the roster', () => {
+			const roster = ['myia-ai-01', 'myia-po-2023', 'myia-po-2026'];
+			const owner = getTaskOwner('task-123', roster);
+			expect(roster).toContain(owner);
+		});
+
+		it('distributes tasks across roster members', () => {
+			const roster = ['myia-ai-01', 'myia-po-2023', 'myia-po-2026', 'myia-web1'];
+			const owners = new Set<string>();
+			for (let i = 0; i < 100; i++) {
+				owners.add(getTaskOwner(`task-${i}`, roster)!);
+			}
+			// With 100 tasks and 4 machines, we expect at least 2 distinct owners
+			expect(owners.size).toBeGreaterThanOrEqual(2);
+		});
+	});
+
+	describe('shouldIndexTask', () => {
+		it('returns true when no roster (partition disabled)', () => {
+			expect(shouldIndexTask('task-123', 'myia-po-2026', null)).toBe(true);
+			expect(shouldIndexTask('task-123', 'myia-po-2026', [])).toBe(true);
+		});
+
+		it('returns true when machine owns the task', () => {
+			const roster = ['myia-ai-01', 'myia-po-2026'];
+			const owner = getTaskOwner('task-123', roster);
+			expect(shouldIndexTask('task-123', owner!, roster)).toBe(true);
+		});
+
+		it('returns false when machine does not own the task', () => {
+			const roster = ['myia-ai-01', 'myia-po-2026'];
+			const owner = getTaskOwner('task-123', roster);
+			const otherMachine = roster.find(m => m !== owner)!;
+			expect(shouldIndexTask('task-123', otherMachine, roster)).toBe(false);
+		});
+
+		it('every task is owned by exactly one machine', () => {
+			const roster = ['myia-ai-01', 'myia-po-2023', 'myia-po-2024', 'myia-po-2025', 'myia-po-2026', 'myia-web1'];
+			for (let i = 0; i < 200; i++) {
+				const taskId = `task-${i}`;
+				let owners = 0;
+				for (const machine of roster) {
+					if (shouldIndexTask(taskId, machine, roster)) owners++;
+				}
+				expect(owners, `Task ${taskId} should have exactly 1 owner`).toBe(1);
+			}
+		});
+	});
+});

--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -16,6 +16,7 @@ import { TaskIndexer, getHostIdentifier } from './task-indexer.js';
 import { getCircuitBreakerState, isCircuitBreakerBlocking, getEmbeddingMetrics } from './task-indexer/VectorIndexer.js';
 import { REBUILD_BACKOFF_MIN_MS_DEFAULT, REBUILD_BACKOFF_MAX_MS_DEFAULT } from '../types/indexing.js';
 import { SkeletonCacheService } from './skeleton-cache.service.js';
+import { shouldIndexTask } from './task-partition.js';
 // REMOVED: import * as toolExports — was unused, added 6s to startup by importing ALL tools
 import { RooStorageDetectorError, RooStorageDetectorErrorCode, GenericErrorCode } from '../types/errors.js';
 // #1140: Lazy import — RooSyncService loads 17 heavy modules (~6s).
@@ -468,7 +469,8 @@ export function startSkeletonRefreshWorker(state: ServerState): void {
                                     // Queue for Qdrant indexation if lastActivity > lastIndexedAt
                                     // #2227: Use newHeader (not skeleton) — skeleton doesn't carry indexingState
                                     const lastIndexed = newHeader.metadata?.indexingState?.lastIndexedAt;
-                                    if (!lastIndexed || new Date(newHeader.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
+                                    if ((!lastIndexed || new Date(newHeader.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime())
+                                        && shouldIndexTask(entry.name, state.machineId, state.fleetRoster)) {
                                         state.qdrantIndexQueue.add(entry.name);
                                     }
                                     if (existingSkeleton) { updatedCount++; } else { newCount++; }
@@ -524,7 +526,8 @@ export function startSkeletonRefreshWorker(state: ServerState): void {
                                         state.conversationCache.set(taskId, newHeader);
                                         // #2227: Use newHeader (not skeleton) — skeleton doesn't carry indexingState
                                         const lastIndexed = newHeader.metadata?.indexingState?.lastIndexedAt;
-                                        if (!lastIndexed || new Date(newHeader.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime()) {
+                                        if ((!lastIndexed || new Date(newHeader.metadata.lastActivity).getTime() > new Date(lastIndexed).getTime())
+                                            && shouldIndexTask(taskId, state.machineId, state.fleetRoster)) {
                                             state.qdrantIndexQueue.add(taskId);
                                         }
                                         if (existingSkeleton) { updatedCount++; } else { newCount++; }
@@ -726,6 +729,12 @@ async function initializeQdrantIndexingService(state: ServerState): Promise<void
         } else {
             console.log(`🔄 [Leader-Election] PID ${process.pid} is follower — will attempt takeover if leader goes stale`);
         }
+        // #2352: Log task-space partition status
+        if (state.fleetRoster && state.fleetRoster.length > 0) {
+            console.log(`🎯 [Partition] Task-space partition enabled: ${state.fleetRoster.length} machines, this=${state.machineId}, shard=~${Math.round(100 / state.fleetRoster.length)}% of tasks`);
+        } else {
+            console.log(`🎯 [Partition] Task-space partition disabled (no ROO_FLEET_ROSTER) — all machines index all tasks`);
+        }
         startQdrantIndexingBackgroundProcess(state);
 
         console.log('✅ Service d\'indexation Qdrant initialisé (indexation en arrière-plan activée)');
@@ -758,6 +767,13 @@ async function scanForOutdatedQdrantIndex(state: ServerState): Promise<void> {
 
     for (const [taskId, skeleton] of state.conversationCache.entries()) {
         state.indexingMetrics.totalTasks++;
+
+        // #2352: Task-space partition — skip tasks owned by other machines
+        if (!shouldIndexTask(taskId, state.machineId, state.fleetRoster)) {
+            skipCount++;
+            state.indexingMetrics.skippedTasks++;
+            continue;
+        }
 
         // Migration automatique des anciens formats
         if (state.indexingDecisionService.migrateLegacyIndexingState(skeleton)) {

--- a/servers/roo-state-manager/src/services/state-manager.service.ts
+++ b/servers/roo-state-manager/src/services/state-manager.service.ts
@@ -12,6 +12,7 @@ import { NarrativeContextBuilderService } from './synthesis/NarrativeContextBuil
 import { SynthesisOrchestratorService } from './synthesis/SynthesisOrchestratorService.js';
 import { IndexingMetrics } from '../types/indexing.js';
 import { ANTI_LEAK_CONFIG } from '../config/server-config.js';
+import { parseFleetRoster } from './task-partition.js';
 
 export interface ServerState {
     conversationCache: Map<string, SkeletonHeader>;
@@ -34,6 +35,9 @@ export interface ServerState {
     isQdrantIndexingEnabled: boolean;
     // #2352: Leader-election — only one MCP instance indexes at a time
     isIndexLeader: boolean;
+    // #2352: Task-space partitioning — null = disabled (all machines index everything)
+    fleetRoster: string[] | null;
+    machineId: string;
 
     // 🛡️ CACHE ANTI-FUITE - Protection contre 220GB de trafic réseau (LEGACY)
     qdrantIndexCache: Map<string, number>;
@@ -113,6 +117,8 @@ export class StateManager {
             qdrantIndexInterval: null,
             isQdrantIndexingEnabled: true,
             isIndexLeader: false,
+            fleetRoster: parseFleetRoster(process.env.ROO_FLEET_ROSTER),
+            machineId: (process.env.ROOSYNC_MACHINE_ID || 'local').toLowerCase(),
             qdrantIndexCache: new Map(),
             lastQdrantConsistencyCheck: 0,
         };

--- a/servers/roo-state-manager/src/services/state-manager.service.ts
+++ b/servers/roo-state-manager/src/services/state-manager.service.ts
@@ -12,7 +12,7 @@ import { NarrativeContextBuilderService } from './synthesis/NarrativeContextBuil
 import { SynthesisOrchestratorService } from './synthesis/SynthesisOrchestratorService.js';
 import { IndexingMetrics } from '../types/indexing.js';
 import { ANTI_LEAK_CONFIG } from '../config/server-config.js';
-import { parseFleetRoster } from './task-partition.js';
+import { tryLoadRooSyncConfig } from '../config/roosync-config.js';
 
 export interface ServerState {
     conversationCache: Map<string, SkeletonHeader>;
@@ -93,6 +93,8 @@ export class StateManager {
             defaultOrchestratorOptions
         );
 
+        const rooSyncCfg = tryLoadRooSyncConfig();
+
         this.state = {
             conversationCache,
             xmlExporterService: new XmlExporterService(),
@@ -117,8 +119,8 @@ export class StateManager {
             qdrantIndexInterval: null,
             isQdrantIndexingEnabled: true,
             isIndexLeader: false,
-            fleetRoster: parseFleetRoster(process.env.ROO_FLEET_ROSTER),
-            machineId: (process.env.ROOSYNC_MACHINE_ID || 'local').toLowerCase(),
+            fleetRoster: rooSyncCfg?.fleetRoster ?? null,
+            machineId: rooSyncCfg?.machineId ?? (process.env.ROOSYNC_MACHINE_ID || 'local').toLowerCase(),
             qdrantIndexCache: new Map(),
             lastQdrantConsistencyCheck: 0,
         };

--- a/servers/roo-state-manager/src/services/task-partition.ts
+++ b/servers/roo-state-manager/src/services/task-partition.ts
@@ -1,0 +1,63 @@
+/**
+ * #2352: Task-space partitioning for Qdrant indexing.
+ *
+ * Hash-based consistent partition: each machine in the fleet is responsible
+ * for only its shard of the task-space, eliminating N× embedding redundancy.
+ *
+ * The fleet roster is configured via the `ROO_FLEET_ROSTER` env var
+ * (comma-separated, sorted alphabetically). Each machine must have the same
+ * roster value — mismatch means some tasks fall through the cracks.
+ */
+
+/**
+ * FNV-1a 32-bit hash — fast, deterministic, good distribution for short strings.
+ * Returns an unsigned 32-bit integer.
+ */
+export function fnv1a32(input: string): number {
+	let hash = 0x811c9dc5; // FNV offset basis
+	for (let i = 0; i < input.length; i++) {
+		hash ^= input.charCodeAt(i);
+		hash = Math.imul(hash, 0x01000193); // FNV prime
+	}
+	return hash >>> 0; // unsigned
+}
+
+/**
+ * Parse the fleet roster from the `ROO_FLEET_ROSTER` env var.
+ * Returns a sorted array of machine IDs, or `null` if not configured
+ * (in which case partition is disabled and every machine indexes everything).
+ */
+export function parseFleetRoster(envValue: string | undefined): string[] | null {
+	if (!envValue || envValue.trim() === '') return null;
+	const machines = envValue
+		.split(',')
+		.map(s => s.trim().toLowerCase())
+		.filter(s => s.length > 0);
+	if (machines.length === 0) return null;
+	return [...new Set(machines)].sort();
+}
+
+/**
+ * Determine which machine in the roster "owns" a given task.
+ * Returns the machine ID from the roster, or `null` if no roster.
+ */
+export function getTaskOwner(taskId: string, roster: string[] | null): string | null {
+	if (!roster || roster.length === 0) return null;
+	const hash = fnv1a32(taskId);
+	return roster[hash % roster.length];
+}
+
+/**
+ * Check whether the current machine should index a given task.
+ * Returns `true` if:
+ *  - no roster is configured (partition disabled — all machines index everything)
+ *  - this machine owns the task's hash bucket
+ */
+export function shouldIndexTask(
+	taskId: string,
+	currentMachineId: string,
+	roster: string[] | null,
+): boolean {
+	if (!roster || roster.length === 0) return true;
+	return getTaskOwner(taskId, roster) === currentMachineId;
+}

--- a/servers/roo-state-manager/src/services/task-partition.ts
+++ b/servers/roo-state-manager/src/services/task-partition.ts
@@ -7,6 +7,16 @@
  * The fleet roster is configured via the `ROO_FLEET_ROSTER` env var
  * (comma-separated, sorted alphabetically). Each machine must have the same
  * roster value — mismatch means some tasks fall through the cracks.
+ *
+ * ## Roster change migration
+ *
+ * Changing `ROO_FLEET_ROSTER` (adding/removing machines) shifts ALL hash
+ * buckets: previously-owned tasks become unowned and vice-versa. After a
+ * roster change, each machine MUST perform a full reindex:
+ * 1. Update ROO_FLEET_ROSTER on ALL machines simultaneously
+ * 2. Restart all MCP instances (new roster takes effect at startup)
+ * 3. Run `roosync_indexing(action: "rebuild")` on each machine — this will
+ *    index the new shard and skip the old one automatically
  */
 
 /**


### PR DESCRIPTION
## Summary
- Implement hash-based task-space partitioning (FNV-1a) to eliminate N× embedding redundancy across the fleet
- Each machine indexes only its shard: `hash(taskId) % roster_size → owner machine`
- **ROO_FLEET_ROSTER** env var (comma-separated machine IDs, optional — when unset, partition is disabled and behavior is unchanged)

## Changes
| File | Change |
|------|--------|
| `services/task-partition.ts` | New module: FNV-1a hash, roster parser, `shouldIndexTask()` gate |
| `services/__tests__/task-partition.test.ts` | 17 tests: hash determinism, distribution, ownership uniqueness |
| `config/roosync-config.ts` | `fleetRoster` field in `RooSyncConfig` + validation (machine must be in roster) |
| `services/background-services.ts` | Partition gates in `scanForOutdatedQdrantIndex` + `startSkeletonRefreshWorker` (both Roo and Claude paths) |
| `services/state-manager.service.ts` | `fleetRoster` and `machineId` in `ServerState` |

## Test plan
- [x] `npm run build` — compiles clean
- [x] `npx vitest run --config vitest.config.ci.ts` — 481/481 files, 9644/9644 tests pass
- [x] 17 new unit tests for partition logic
- [ ] Fleet-wide E2E: set `ROO_FLEET_ROSTER=myia-ai-01,myia-po-2023,myia-po-2024,myia-po-2025,myia-po-2026,myia-web1` on all machines, verify each machine only indexes its shard
- [ ] Verify GPU load reduction from N× to 1/N× on po-2026

## Metrics (expected)
- Current: 6 machines × all tasks = 6× redundant embeddings
- After: 6 machines × 1/6 shard = 1× total (no redundancy)
- GPU load on po-2026: ~83°C continuous → ~83°C ÷ 6 = negligible

Closes #2352

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>