### PR TITLE
feat(config): add --validate flag for applyProfile + apply (#2413)

### DIFF
--- a/servers/roo-state-manager/src/services/ConfigSharingService.ts
+++ b/servers/roo-state-manager/src/services/ConfigSharingService.ts
@@ -30,6 +30,7 @@ import { InventoryService } from './roosync/InventoryService.js';
 import { readJSONFileWithoutBOM } from '../utils/encoding-helpers.js';
 import { RollbackManager } from './RollbackManager.js';
 import { ConfigHealthCheckService, type ConfigType as HealthCheckConfigType } from './ConfigHealthCheckService.js';
+import yaml from 'js-yaml';
 
 export class ConfigSharingService implements IConfigSharingService {
   private logger: Logger;
@@ -666,10 +667,20 @@ export class ConfigSharingService implements IConfigSharingService {
         } as any;
     }
 
+    // #2413 — Validation post-apply optionnelle pour applyConfig
+    let validation: ApplyConfigResult['validation'] = undefined;
+    if (options.validate && errors.length === 0 && appliedFilePaths.length > 0) {
+      validation = await this.validateConfigApplication(appliedFilePaths);
+      if (!validation.success) {
+        this.logger.warn(`Validation post-apply applyConfig: drift détecté`);
+      }
+    }
+
     return {
       success: errors.length === 0,
       filesApplied,
-      errors
+      errors,
+      validation
     };
   }
 
@@ -864,6 +875,18 @@ export class ConfigSharingService implements IConfigSharingService {
         }
       }
 
+      // 6. Validation post-apply (#2413) — vérifie que le profil est effectivement déployé
+      let validation: ApplyProfileResult['validation'] = undefined;
+      if (options.validate && !options.dryRun) {
+        const roomodesPath = join(inventory.paths.rooExtensions, '.roomodes');
+        validation = await this.validateProfileApplication(profile, newModeApiConfigs, roomodesPath);
+        if (!validation.success) {
+          this.logger.warn(`Validation post-apply: drift détecté (${validation.drift?.length || 0} entrées)`);
+        } else {
+          this.logger.info('Validation post-apply: OK');
+        }
+      }
+
       return {
         success: true,
         profileName: profile.name,
@@ -875,7 +898,8 @@ export class ConfigSharingService implements IConfigSharingService {
           modeApiConfigs: newModeApiConfigs,
           profileThresholds: newThresholds
         },
-        errors: errors.length > 0 ? errors : undefined
+        errors: errors.length > 0 ? errors : undefined,
+        validation
       };
 
     } catch (err: any) {
@@ -893,6 +917,175 @@ export class ConfigSharingService implements IConfigSharingService {
         errors
       };
     }
+  }
+
+  /**
+   * #2413 — Valide qu'un profil de modèle est effectivement appliqué après applyProfile().
+   *
+   * Vérifie deux niveaux :
+   *  1. `.roomodes` déployé : chaque mode listé dans `expectedModeApiConfigs` doit avoir
+   *     l'`apiConfigId` attendu dans `customModes[]`. Supporte les formats YAML et JSON.
+   *  2. `state.vscdb` (via RooSettingsService) : lit `currentApiConfigName` pour signaler
+   *     un éventuel désalignement si VS Code n'a pas été redémarré.
+   *
+   * NOTE : Drift sur `state.vscdb` n'est PAS toujours un échec — c'est attendu tant que
+   * Roo Code/VS Code n'a pas été relancé. C'est exposé comme information, non comme erreur.
+   *
+   * @param profile - Profil source (avec `modeOverrides`, `defaultApiConfig` optionnel)
+   * @param expectedModeApiConfigs - Mode → apiConfigId attendu, déjà fusionné avec defaults
+   * @param roomodesPath - Chemin absolu vers `.roomodes`
+   */
+  private async validateProfileApplication(
+    profile: any,
+    expectedModeApiConfigs: Record<string, string>,
+    roomodesPath: string,
+  ): Promise<NonNullable<ApplyProfileResult['validation']>> {
+    const drift: Array<{ field: string; expected: any; actual: any }> = [];
+
+    // 1. Lire et parser .roomodes (format YAML par défaut sur disque, JSON aussi supporté)
+    let deployedModes: any = null;
+    if (!existsSync(roomodesPath)) {
+      drift.push({ field: '.roomodes', expected: 'existing file', actual: 'missing' });
+    } else {
+      try {
+        const content = await fs.readFile(roomodesPath, 'utf-8');
+        // Try JSON first (generate-modes.js default format), then YAML
+        try {
+          deployedModes = JSON.parse(content);
+        } catch {
+          deployedModes = yaml.load(content);
+        }
+      } catch (e: any) {
+        drift.push({ field: '.roomodes', expected: 'parseable content', actual: `parse error: ${e.message}` });
+      }
+    }
+
+    // 2. Comparer chaque mode du profile.modeOverrides vs .roomodes
+    if (deployedModes && Array.isArray(deployedModes.customModes)) {
+      // Vérifier uniquement les modes explicitement dans modeOverrides du profil
+      // (pas les modes "default" injectés artificiellement par applyProfile)
+      const explicitOverrides = profile?.modeOverrides || {};
+      for (const [modeSlug, expectedApiConfigId] of Object.entries(explicitOverrides)) {
+        const deployedMode = deployedModes.customModes.find((m: any) => m && m.slug === modeSlug);
+        if (!deployedMode) {
+          drift.push({
+            field: `customModes.${modeSlug}`,
+            expected: 'present',
+            actual: 'missing',
+          });
+          continue;
+        }
+        if (deployedMode.apiConfigId !== expectedApiConfigId) {
+          drift.push({
+            field: `customModes.${modeSlug}.apiConfigId`,
+            expected: expectedApiConfigId,
+            actual: deployedMode.apiConfigId ?? null,
+          });
+        }
+      }
+    } else if (deployedModes !== null) {
+      drift.push({
+        field: '.roomodes.customModes',
+        expected: 'array',
+        actual: typeof deployedModes.customModes,
+      });
+    }
+
+    // 3. Lire state.vscdb pour currentApiConfigName via RooSettingsService
+    let activeApiConfigName: string | undefined;
+    let activeApiConfigInSync: boolean | undefined;
+    try {
+      const rooSettings = new RooSettingsService();
+      if (rooSettings.isAvailable()) {
+        const value = await rooSettings.getSetting('currentApiConfigName');
+        activeApiConfigName = typeof value === 'string' ? value : undefined;
+        // Si le profil spécifie un defaultApiConfig, drift si state.vscdb ne le reflète pas.
+        // Sinon (cas courant : profil-by-mode-only), on rapporte juste activeApiConfigName.
+        if (profile?.defaultApiConfig && activeApiConfigName) {
+          if (activeApiConfigName !== profile.defaultApiConfig) {
+            activeApiConfigInSync = false;
+            // state.vscdb drift est INFORMATIF — pas un fail strict (VS Code restart needed)
+            // On le pousse dans drift pour visibilité mais on ne le compte pas comme échec critique.
+            drift.push({
+              field: 'state.vscdb.currentApiConfigName',
+              expected: profile.defaultApiConfig,
+              actual: activeApiConfigName,
+            });
+          } else {
+            activeApiConfigInSync = true;
+          }
+        }
+      } else {
+        // state.vscdb non disponible — non-fatal
+        activeApiConfigInSync = undefined;
+      }
+    } catch (e: any) {
+      this.logger.warn(`Validation: lecture state.vscdb échouée (non-fatal): ${e.message}`);
+      activeApiConfigInSync = undefined;
+    }
+
+    return {
+      performed: true,
+      success: drift.length === 0,
+      drift: drift.length > 0 ? drift : undefined,
+      activeApiConfigName,
+      activeApiConfigInSync,
+    };
+  }
+
+  /**
+   * #2413 — Validation post-apply pour `applyConfig`. Pour chaque target appliqué,
+   * exécute un check basique (`json_valid` / `file_readable`) via `ConfigHealthCheckService`.
+   * Cette version est intentionnellement minimaliste — l'objectif principal de #2413 est
+   * la validation profile/modes (cf. `validateProfileApplication`).
+   */
+  private async validateConfigApplication(
+    appliedFiles: Array<{ path: string; type: string }>,
+  ): Promise<NonNullable<ApplyConfigResult['validation']>> {
+    const healthChecker = new ConfigHealthCheckService(this.logger);
+    const targetValidations: Array<{ target: string; success: boolean; details?: any }> = [];
+
+    for (const { path: filePath, type } of appliedFiles) {
+      // Skip rules (text files, no JSON check)
+      if (type === 'rules_config') {
+        targetValidations.push({ target: filePath, success: true, details: { skipped: 'text file' } });
+        continue;
+      }
+
+      const configTypeMap: Record<string, HealthCheckConfigType> = {
+        'mcp_config': 'mcp_config',
+        'mode_definition': 'mode_definition',
+        'roomodes_config': 'roomodes_config',
+        'model_config': 'model_config',
+        'profile_settings': 'profile_settings',
+        'settings_config': 'settings_config',
+      };
+      const healthConfigType = configTypeMap[type] || 'mcp_config';
+
+      try {
+        const result = await healthChecker.checkHealth(filePath, healthConfigType, {
+          checks: ['file_readable', 'json_valid'],
+        });
+        targetValidations.push({
+          target: filePath,
+          success: result.healthy,
+          details: result.healthy ? undefined : { errors: result.errors },
+        });
+      } catch (err: any) {
+        targetValidations.push({
+          target: filePath,
+          success: false,
+          details: { error: err.message },
+        });
+      }
+    }
+
+    const allSuccess = targetValidations.every((tv) => tv.success);
+    return {
+      performed: true,
+      success: allSuccess,
+      targetValidations,
+    };
   }
 
   /**

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/apply-profile-validate.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/apply-profile-validate.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for roosync_config apply_profile + --validate flag (#2413)
+ *
+ * Validates post-apply behavior :
+ *  - `validate: true` + propre apply -> validation.success === true
+ *  - `validate: true` + .roomodes drift -> validation.success === false + drift array
+ *  - `validate: undefined` -> backwards compat, validation absent
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { ConfigArgsSchema, roosyncConfig } from '../config.js';
+
+const mockApplyProfile = vi.fn();
+const mockApplyConfig = vi.fn();
+const mockCollectConfig = vi.fn();
+const mockPublishConfig = vi.fn();
+const mockGetConfigVersion = vi.fn();
+
+vi.mock('../../../services/RooSyncService.js', () => ({
+  getRooSyncService: () => ({
+    getConfigSharingService: () => ({
+      collectConfig: mockCollectConfig,
+      publishConfig: mockPublishConfig,
+      applyConfig: mockApplyConfig,
+      applyProfile: mockApplyProfile,
+    }),
+    getConfigService: () => ({
+      getConfigVersion: mockGetConfigVersion,
+    }),
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('#2413 — ConfigArgsSchema accepts validate flag', () => {
+  test('apply_profile + validate: true is accepted', () => {
+    const result = ConfigArgsSchema.parse({
+      action: 'apply_profile',
+      profileName: 'Production',
+      validate: true,
+    });
+    expect(result.validate).toBe(true);
+  });
+
+  test('apply + validate: true is accepted', () => {
+    const result = ConfigArgsSchema.parse({
+      action: 'apply',
+      validate: true,
+    });
+    expect(result.validate).toBe(true);
+  });
+
+  test('validate is optional (backwards compat)', () => {
+    const result = ConfigArgsSchema.parse({
+      action: 'apply_profile',
+      profileName: 'Production',
+    });
+    expect(result.validate).toBeUndefined();
+  });
+});
+
+describe('#2413 — apply_profile with validate: true (clean apply)', () => {
+  test('validate: true + clean apply -> status success + validation.success true', async () => {
+    mockApplyProfile.mockResolvedValue({
+      success: true,
+      profileName: 'Production',
+      modesConfigured: 10,
+      apiConfigsCount: 2,
+      roomodesGenerated: true,
+      validation: {
+        performed: true,
+        success: true,
+        activeApiConfigName: 'default',
+        activeApiConfigInSync: undefined,
+      },
+    });
+
+    const result = await roosyncConfig({
+      action: 'apply_profile',
+      profileName: 'Production',
+      validate: true,
+    } as any);
+
+    expect(mockApplyProfile).toHaveBeenCalledWith({
+      profileName: 'Production',
+      sourceMachineId: undefined,
+      backup: true,
+      dryRun: false,
+      validate: true,
+    });
+    expect(result.status).toBe('success');
+    expect(result.validation).toBeDefined();
+    expect(result.validation?.success).toBe(true);
+    expect(result.message).toContain('validation OK');
+  });
+});
+
+describe('#2413 — apply_profile with validate: true (drift detected)', () => {
+  test('validate: true + .roomodes apiConfigId drift -> status drift + validation.success false', async () => {
+    mockApplyProfile.mockResolvedValue({
+      success: true,
+      profileName: 'Production',
+      modesConfigured: 10,
+      apiConfigsCount: 2,
+      roomodesGenerated: true,
+      validation: {
+        performed: true,
+        success: false,
+        drift: [
+          {
+            field: 'customModes.code-simple.apiConfigId',
+            expected: 'simple',
+            actual: 'default',
+          },
+        ],
+      },
+    });
+
+    const result = await roosyncConfig({
+      action: 'apply_profile',
+      profileName: 'Production',
+      validate: true,
+    } as any);
+
+    expect(result.status).toBe('drift');
+    expect(result.validation?.success).toBe(false);
+    expect(result.validation?.drift).toHaveLength(1);
+    expect(result.validation?.drift?.[0]?.field).toContain('apiConfigId');
+    expect(result.message).toContain('drift détecté');
+  });
+});
+
+describe('#2413 — backwards compat (validate undefined)', () => {
+  test('no validate flag -> applyProfile receives validate: undefined, no validation field in result', async () => {
+    mockApplyProfile.mockResolvedValue({
+      success: true,
+      profileName: 'Production',
+      modesConfigured: 10,
+      apiConfigsCount: 2,
+      roomodesGenerated: true,
+      // validation absent — service didn't run it
+    });
+
+    const result = await roosyncConfig({
+      action: 'apply_profile',
+      profileName: 'Production',
+    } as any);
+
+    expect(mockApplyProfile).toHaveBeenCalledWith({
+      profileName: 'Production',
+      sourceMachineId: undefined,
+      backup: true,
+      dryRun: false,
+      validate: undefined,
+    });
+    expect(result.status).toBe('success');
+    expect(result.validation).toBeUndefined();
+    expect(result.message).not.toContain('validation');
+    expect(result.message).not.toContain('drift');
+  });
+});
+
+describe('#2413 — apply with validate: true', () => {
+  test('apply + validate: true + clean -> validation.success true propagated', async () => {
+    mockGetConfigVersion.mockResolvedValue(null);
+    mockApplyConfig.mockResolvedValue({
+      success: true,
+      filesApplied: 3,
+      validation: {
+        performed: true,
+        success: true,
+        targetValidations: [
+          { target: '/tmp/mcp.json', success: true },
+          { target: '/tmp/.roomodes', success: true },
+          { target: '/tmp/profiles.json', success: true },
+        ],
+      },
+    });
+
+    const result = await roosyncConfig({
+      action: 'apply',
+      validate: true,
+    } as any);
+
+    expect(mockApplyConfig).toHaveBeenCalledWith(expect.objectContaining({
+      validate: true,
+    }));
+    expect(result.status).toBe('success');
+    expect(result.validation?.success).toBe(true);
+    expect(result.validation?.targetValidations).toHaveLength(3);
+  });
+
+  test('apply + validate: true + a target fails -> status drift', async () => {
+    mockGetConfigVersion.mockResolvedValue(null);
+    mockApplyConfig.mockResolvedValue({
+      success: true,
+      filesApplied: 2,
+      validation: {
+        performed: true,
+        success: false,
+        targetValidations: [
+          { target: '/tmp/mcp.json', success: true },
+          { target: '/tmp/broken.json', success: false, details: { errors: ['JSON parse error'] } },
+        ],
+      },
+    });
+
+    const result = await roosyncConfig({
+      action: 'apply',
+      validate: true,
+    } as any);
+
+    expect(result.status).toBe('drift');
+    expect(result.validation?.success).toBe(false);
+    expect(result.message).toContain('drift');
+  });
+});

--- a/servers/roo-state-manager/src/tools/roosync/config.ts
+++ b/servers/roo-state-manager/src/tools/roosync/config.ts
@@ -52,6 +52,9 @@ export const ConfigArgsSchema = z.object({
   // Pour apply
   backup: z.boolean().optional().describe('Create local backup before apply (default: true). For apply and apply_profile'),
 
+  // #2413 — Pour apply et apply_profile : validation post-apply
+  validate: z.boolean().optional().describe('Validate config is effectively applied after write (default: false). For apply and apply_profile. Profile validation reads .roomodes and state.vscdb.currentApiConfigName.'),
+
   // Pour apply_profile (#498 Phase 2)
   profileName: z.string().optional().describe('Profile name (required for apply_profile). E.g. "Production (Qwen 3.5 + GLM-5)"'),
   sourceMachineId: z.string().optional().describe('Source machine ID for model-configs.json (default: local file)')
@@ -203,7 +206,7 @@ export async function roosyncConfig(args: ConfigArgs) {
 
       case 'apply': {
         // Action apply: Applique une configuration depuis le stockage
-        const { version, targets, backup = true } = args;
+        const { version, targets, backup = true, validate } = args;
 
         // Vérifier la version de configuration requise
         const configService = rooSyncService.getConfigService();
@@ -238,21 +241,29 @@ export async function roosyncConfig(args: ConfigArgs) {
           targets: parseTargets(targets),
           backup,
           dryRun,
-          scope // Issue #601 - Pass scope to apply
+          scope, // Issue #601 - Pass scope to apply
+          validate // #2413 - Propagate validate flag
         });
 
+        // #2413 — Si validation activée et drift détecté, marquer le statut comme drift
+        const validationFailed = !!result.validation && result.validation.success === false;
+        const overallSuccess = result.success && !validationFailed;
+
         return {
-          status: result.success ? 'success' : 'error',
-          message: result.success ? 'Configuration appliquée avec succès' : 'Échec de l\'application de la configuration',
+          status: overallSuccess ? 'success' : (validationFailed ? 'drift' : 'error'),
+          message: overallSuccess
+            ? (result.validation ? 'Configuration appliquée et validée avec succès' : 'Configuration appliquée avec succès')
+            : (validationFailed ? 'Configuration appliquée mais drift détecté lors de la validation' : 'Échec de l\'application de la configuration'),
           filesApplied: result.filesApplied,
           backupPath: result.backupPath,
-          errors: result.errors
+          errors: result.errors,
+          validation: result.validation
         };
       }
 
       case 'apply_profile': {
         // Action apply_profile: Applique un profil de modèle (#498 Phase 2)
-        const { profileName, sourceMachineId, backup = true } = args;
+        const { profileName, sourceMachineId, backup = true, validate } = args;
 
         if (!profileName) {
           throw new ConfigSharingServiceError(
@@ -266,7 +277,8 @@ export async function roosyncConfig(args: ConfigArgs) {
           profileName,
           sourceMachineId,
           backup,
-          dryRun
+          dryRun,
+          validate // #2413 - Propagate validate flag
         });
 
         const modesMsg = result.roomodesGenerated
@@ -275,10 +287,18 @@ export async function roosyncConfig(args: ConfigArgs) {
             ? ` (⚠️ .roomodes non régénéré)`
             : '';
 
+        // #2413 — Si validation activée et drift détecté, statut "drift" (pas pure error)
+        const validationFailed = !!result.validation && result.validation.success === false;
+        const validationMsg = result.validation
+          ? (result.validation.success ? ' + validation OK' : ` + drift détecté (${result.validation.drift?.length || 0} entrées)`)
+          : '';
+
         return {
-          status: result.success ? 'success' : 'error',
+          status: !result.success
+            ? 'error'
+            : (validationFailed ? 'drift' : 'success'),
           message: result.success
-            ? `Profil '${result.profileName}' appliqué avec succès (${result.modesConfigured} modes, ${result.apiConfigsCount} configs API${modesMsg})`
+            ? `Profil '${result.profileName}' appliqué avec succès (${result.modesConfigured} modes, ${result.apiConfigsCount} configs API${modesMsg}${validationMsg})`
             : `Échec de l'application du profil '${result.profileName}'`,
           profileName: result.profileName,
           modesConfigured: result.modesConfigured,
@@ -286,7 +306,8 @@ export async function roosyncConfig(args: ConfigArgs) {
           backupPath: result.backupPath,
           changes: result.changes,
           roomodesGenerated: result.roomodesGenerated,
-          errors: result.errors
+          errors: result.errors,
+          validation: result.validation
         };
       }
 

--- a/servers/roo-state-manager/src/types/config-sharing.ts
+++ b/servers/roo-state-manager/src/types/config-sharing.ts
@@ -61,6 +61,8 @@ export interface ApplyConfigOptions {
   backup?: boolean; // Défaut: true
   dryRun?: boolean;
   scope?: ClaudeCodeScope; // Issue #601 - Scope Claude Code (user/project/settings)
+  /** #2413 — Vérifier que la configuration est effectivement appliquée et opérationnelle après écriture */
+  validate?: boolean;
 }
 
 export interface ApplyConfigResult {
@@ -68,6 +70,13 @@ export interface ApplyConfigResult {
   filesApplied: number;
   backupPath?: string;
   errors?: string[];
+  /** #2413 — Résultat de la validation post-apply si validate=true */
+  validation?: {
+    performed: boolean;
+    success: boolean;
+    /** Détails par target appliqué */
+    targetValidations?: Array<{ target: string; success: boolean; details?: any }>;
+  };
 }
 
 /**
@@ -85,6 +94,8 @@ export interface ApplyProfileOptions {
   dryRun?: boolean;
   /** Régénérer .roomodes après application du profil (défaut: true). Appelle generate-modes.js --profile --deploy */
   generateModes?: boolean;
+  /** #2413 — Vérifier que le profil est effectivement appliqué (.roomodes + state.vscdb) après écriture */
+  validate?: boolean;
 }
 
 export interface ApplyProfileResult {
@@ -105,6 +116,20 @@ export interface ApplyProfileResult {
     profileThresholds: Record<string, number>;
   };
   errors?: string[];
+  /**
+   * #2413 — Résultat de la validation post-apply si validate=true.
+   *  - success=true => .roomodes aligné avec profile.modeOverrides
+   *  - success=false => drift détecté (liste détaillée dans drift)
+   *  - activeApiConfigInSync indique si state.vscdb.currentApiConfigName correspond
+   *    au profil attendu (undefined si state.vscdb non lisible)
+   */
+  validation?: {
+    performed: boolean;
+    success: boolean;
+    drift?: Array<{ field: string; expected: any; actual: any }>;
+    activeApiConfigName?: string;
+    activeApiConfigInSync?: boolean;
+  };
 }
 
 export interface ConfigChange {


### PR DESCRIPTION
## Summary
- Adds `validate?: boolean` to `ApplyProfileOptions` and `ApplyConfigOptions`
- Implements post-apply validation:
  - **`applyProfile`**: parses `.roomodes` (JSON or YAML via `js-yaml`), compares `customModes[].apiConfigId` vs `profile.modeOverrides`, reads `state.vscdb.currentApiConfigName` via `RooSettingsService.getSetting()` (non-fatal if `state.vscdb` is absent — VS Code may be closed)
  - **`applyConfig`**: per-target `file_readable` + `json_valid` via existing `ConfigHealthCheckService`
- Tool layer `roosync_config(action: "apply" | "apply_profile", validate: true)` propagates the flag and returns `status: "drift"` when `validation.success === false`
- Backwards compat: `validate` undefined => behavior unchanged, no `validation` field in result
- Closes jsboige/roo-extensions#2413

## Test plan
- [x] Build passes (`npm run build`)
- [x] New tests `apply-profile-validate.test.ts` pass (8 scenarios: schema, clean apply, drift, backwards compat, apply action)
- [x] Existing `apply-profile.test.ts` (12 tests) still passes
- [x] Existing `config.test.ts` (37 tests) still passes
- [x] Existing `ConfigSharingService.test.ts` (29 tests) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)