### PR TITLE
fix(synthesis): raise LLMService max_tokens 4000->16000 for GLM thinking budget

### DIFF
--- a/servers/roo-state-manager/src/services/synthesis/LLMService.ts
+++ b/servers/roo-state-manager/src/services/synthesis/LLMService.ts
@@ -497,12 +497,14 @@ export class LLMService {
             // Configuration de l'appel
             // #954: Prepend /no_think for Qwen 3.5 thinking models — prevents content:null
             // when reasoning tokens consume all max_tokens before generating output
+            // 2026-05-29: GLM-4.7 ignores /no_think and burns 600+ thinking tokens per call;
+            // budget raised from 4000 to 16000 so reasoning + output both fit (vLLM ai-01 DOWN, z.ai fallback active)
             const effectivePrompt = '/no_think\n' + prompt;
             const openaiParams = {
                 model: modelConfig.modelName,
                 messages: [{ role: 'user' as const, content: effectivePrompt }],
                 temperature: 0.1,
-                max_tokens: 4000,
+                max_tokens: 16000,
                 // Ajouter response_format si présent
                 ...(parameters?.response_format ? { response_format: parameters.response_format } : {})
             };


### PR DESCRIPTION
## Context

While vLLM `ai-01` is DOWN, the fleet falls back to z.ai cloud (`glm-4.7-flash` via `https://api.z.ai/api/coding/paas/v4`) for dashboard condensation. Two machines (po-2023, po-2026) already switched their `.env` over yesterday.

But once switched, condensation was still silently failing — the circuit-breaker fallback to truncation kicked in within minutes. Root cause investigation today (user-driven verification):

## Root cause

GLM-4.7-flash **ignores the `/no_think` Qwen prefix** (that's a Qwen 3.5 thinking-model convention, not a GLM one) and unconditionally spends 600+ reasoning tokens per call. With `max_tokens: 4000`, the reasoning phase exhausts the budget before any visible content is generated.

Verified via direct curl against the z.ai endpoint:

| max_tokens | Result |
|------------|--------|
| 80 | `content: ""`, `finish_reason: length`, 80 completion tokens (all thinking) |
| 4000 (current) | empty content under load + 429 rate-limits on shared key |
| **16000** | **HTTP 200, content correct**, reasoning=636, completion=41 on a 3-bullet summarization prompt (48 s) |

## Fix

1-line bump in [`LLMService.ts:506`](servers/roo-state-manager/src/services/synthesis/LLMService.ts#L506): `max_tokens: 4000` → `16000`.

Also adds a 2-line comment documenting *why* the bump exists, so the next agent on this code doesn't revert it as bloat.

## Backwards compatibility

- The Qwen vLLM call site continues to honor `/no_think` and skip reasoning entirely; the extra budget headroom is unused (you're only billed for tokens actually generated).
- The fallback to `message.reasoning` field on line 523 is preserved (still relevant for cases where content is still null despite the larger budget).

## Test plan

- [x] Reproduced empty-content failure with `max_tokens=80` on glm-4.7-flash
- [x] Confirmed `max_tokens=16000` returns correct content on a representative condensation prompt
- [x] `npm run build` clean (tsc exit 0)
- [ ] (post-merge) Pointer-bump parent + restart MCP on po-2023, verify next dashboard auto-condensation uses z.ai successfully

## Related

- `.env` z.ai fallback already deployed on po-2023 (this machine) and po-2026 (cycle 102, 2026-05-28T21:26Z dashboard message)
- Issue #954 — original `/no_think` introduction for Qwen
- vLLM ai-01 DOWN since 2026-05-28T19:20Z (~10h+ at PR creation time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)