### PR TITLE
feat(schtasks): SchtasksConfigService for declarative scheduled task management (#2408)

### DIFF
--- a/servers/roo-state-manager/src/services/ConfigSharingService.ts
+++ b/servers/roo-state-manager/src/services/ConfigSharingService.ts
@@ -32,6 +32,7 @@ import { RollbackManager } from './RollbackManager.js';
 import { ConfigHealthCheckService, type ConfigType as HealthCheckConfigType } from './ConfigHealthCheckService.js';
 import { ServicesConfigService } from './ServicesConfigService.js';
 import yaml from 'js-yaml';
+import { SchtasksConfigService } from './SchtasksConfigService.js';
 
 export class ConfigSharingService implements IConfigSharingService {
   private logger: Logger;
@@ -130,6 +131,12 @@ export class ConfigSharingService implements IConfigSharingService {
     if (servicesTargets.length > 0) {
       const servicesFiles = await this.collectServices(tempDir, servicesTargets);
       manifest.files.push(...servicesFiles);
+    }
+
+    // Collecte des schtasks (tâches planifiées Windows) - #2408 VibeSync Phase 2
+    if (options.targets.includes('schtasks')) {
+      const schtasksFiles = await this.collectSchtasks(tempDir);
+      manifest.files.push(...schtasksFiles);
     }
 
     // Calcul de la taille totale
@@ -1788,5 +1795,41 @@ export class ConfigSharingService implements IConfigSharingService {
   private async calculateHash(filePath: string): Promise<string> {
     const content = await fs.readFile(filePath);
     return createHash('sha256').update(content).digest('hex');
+  }
+
+  /**
+   * Collecte les tâches planifiées Windows via SchtasksConfigService
+   * #2408 VibeSync Phase 2
+   */
+  private async collectSchtasks(tempDir: string): Promise<ConfigManifestFile[]> {
+    const files: ConfigManifestFile[] = [];
+    const schtasksDir = join(tempDir, 'schtasks');
+    await fs.mkdir(schtasksDir, { recursive: true });
+
+    try {
+      const schtasksService = new SchtasksConfigService();
+      const collectResult = await schtasksService.collect();
+
+      const destPath = join(schtasksDir, 'schtasks-inventory.json');
+      const content = JSON.stringify(collectResult, null, 2);
+      await fs.writeFile(destPath, content, 'utf-8');
+
+      const hash = await this.calculateHash(destPath);
+      const stats = await fs.stat(destPath);
+
+      files.push({
+        path: 'schtasks/schtasks-inventory.json',
+        hash,
+        type: 'other',
+        size: stats.size,
+      });
+
+      this.logger.info(`Schtasks collectés: ${collectResult.count} tâches`);
+    } catch (error) {
+      this.logger.warn(`Erreur lors de la collecte des schtasks: ${error}`);
+      // Ne pas faire échouer toute la collecte si les schtasks ne sont pas disponibles
+    }
+
+    return files;
   }
 }

--- a/servers/roo-state-manager/src/services/SchtasksConfigService.ts
+++ b/servers/roo-state-manager/src/services/SchtasksConfigService.ts
@@ -96,62 +96,6 @@ export interface SchtasksApplyResult {
 }
 
 /**
- * PowerShell script to collect scheduled tasks as JSON
- * Filters by name pattern to only get project tasks
- */
-const COLLECT_SCRIPT = `
-$ErrorActionPreference = 'Stop'
-$filterPatterns = '{{FILTER_PATTERNS}}'
-
-$allTasks = Get-ScheduledTask | Where-Object {
-    $_.TaskPath -notlike '\\Microsoft\\*' -and
-    ($filterPatterns | ForEach-Object { $_.TaskName -like $_ } | Where-Object { $_ }).Count -gt 0
-}
-
-$results = @()
-foreach ($task in $allTasks) {
-    $action = $task.Actions | Select-Object -First 1
-    $taskInfo = [ordered]@{
-        taskName = $task.TaskName
-        taskPath = $task.TaskPath
-        execute = if ($action) { $action.Execute } else { '' }
-        arguments = if ($action) { $action.Arguments } else { '' }
-        workingDirectory = if ($action) { $action.WorkingDirectory } else { '' }
-        state = $task.State.ToString()
-        description = $task.Description
-        principal = if ($task.Principal) {
-            @{
-                userId = $task.Principal.UserId
-                logonType = $task.Principal.LogonType.ToString()
-                runLevel = $task.Principal.RunLevel.ToString()
-            }
-        } else { @{} }
-        triggers = @()
-    }
-
-    foreach ($trigger in $task.Triggers) {
-        $schedule = switch ($trigger.CimClass.CimClassName) {
-            'MSFT_TaskTimeTrigger' { "Once at $($trigger.StartBoundary)" }
-            'MSFT_TaskDailyTrigger' { "Daily at $($trigger.StartBoundary)" }
-            'MSFT_TaskWeeklyTrigger' { "Weekly at $($trigger.StartBoundary)" }
-            'MSFT_TaskBootTrigger' { 'At startup' }
-            'MSFT_TaskLogonTrigger' { 'At logon' }
-            default { $trigger.CimClass.CimClassName }
-        }
-        $taskInfo.triggers += @{
-            type = $trigger.CimClass.CimClassName -replace 'MSFT_Task(\\w+)Trigger', '$1'
-            schedule = $schedule
-            enabled = $trigger.Enabled
-        }
-    }
-
-    $results += $taskInfo
-}
-
-$results | ConvertTo-Json -Depth 5 -Compress
-`;
-
-/**
  * PowerShell script to apply a single task configuration
  * Uses Set-ScheduledTask for idempotent updates (preserves triggers and principal)
  */
@@ -241,17 +185,15 @@ export class SchtasksConfigService {
     const patterns = filterPatterns ?? DEFAULT_FILTER_PATTERNS;
     this.logger.info('Collecting scheduled tasks', { patterns });
 
-    const patternsJson = JSON.stringify(patterns);
-    const script = COLLECT_SCRIPT.replace('{{FILTER_PATTERNS}}', patternsJson);
-
     // Write inline script to temp file for PowerShellExecutor
+    // Uses native PowerShell -like operator for safe glob matching (no regex injection)
     const scriptContent = `
 $ErrorActionPreference = 'Stop'
 $filterPatterns = @(${patterns.map(p => `'${p}'`).join(', ')})
 
 $allTasks = Get-ScheduledTask | Where-Object {
-    $_.TaskPath -notlike '\\\\Microsoft\\\\*' -and
-    ($filterPatterns | ForEach-Object { $_ -replace '\\*', '.*' -replace '\\?', '.' } | ForEach-Object { $_.TaskName -match $_ } | Where-Object { $_ }).Count -gt 0
+    $_.TaskPath -notlike '\\Microsoft\\*' -and
+    ($filterPatterns | ForEach-Object { $taskName = $_.TaskName; ($filterPatterns | Where-Object { $taskName -like $_ }).Count -gt 0 })
 }
 
 $results = @()
@@ -370,7 +312,7 @@ if ($results.Count -eq 0) { Write-Output '[]' } else { $results | ConvertTo-Json
   /**
    * Apply a single task configuration
    */
-  private async applySingleTask(task: SchtaskConfig): Promise<{ taskName: string; action: string; details?: string }> {
+  private async applySingleTask(task: SchtaskConfig): Promise<{ taskName: string; action: 'updated' | 'skipped' | 'missing' | 'error'; details?: string }> {
     // Write apply script to temp file
     const tempDir = path.join(os.tmpdir(), `schtasks-apply-${Date.now()}`);
     fs.mkdirSync(tempDir, { recursive: true });
@@ -398,9 +340,17 @@ if ($results.Count -eq 0) { Write-Output '[]' } else { $results | ConvertTo-Json
 
       try {
         const parsed = PowerShellExecutor.parseJsonOutput<{ action: string; taskName: string; changes?: string[]; error?: string }>(result.stdout);
+        // Map action to a known set of values
+        const actionMap: Record<string, 'updated' | 'skipped' | 'missing' | 'error'> = {
+          updated: 'updated',
+          skipped: 'skipped',
+          missing: 'missing',
+          error: 'error',
+        };
+        const mappedAction = actionMap[parsed.action] ?? 'updated';
         return {
           taskName: parsed.taskName || task.taskName,
-          action: parsed.action as any,
+          action: mappedAction,
           details: parsed.changes?.join('; ') || parsed.error,
         };
       } catch {

--- a/servers/roo-state-manager/src/services/SchtasksConfigService.ts
+++ b/servers/roo-state-manager/src/services/SchtasksConfigService.ts
@@ -1,0 +1,456 @@
+/**
+ * SchtasksConfigService - Collect and apply Windows Scheduled Tasks declaratively
+ *
+ * Issue #2408 - Target schtasks pour roosync_config (VibeSync Phase 2)
+ *
+ * Provides collect (inventory), apply (idempotent update), and diff capabilities
+ * for Windows scheduled tasks matching project patterns (Claude-*, Roo-*, RooSync-*).
+ *
+ * Reuses PowerShellExecutor for PowerShell execution.
+ * @module SchtasksConfigService
+ * @version 1.0.0
+ */
+
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import { PowerShellExecutor } from './PowerShellExecutor.js';
+import { createLogger, type Logger } from '../utils/logger.js';
+
+/**
+ * Represents a single scheduled task's declarative config
+ */
+export interface SchtaskConfig {
+  /** Task name (e.g. "Claude-Worker") */
+  taskName: string;
+  /** Task path (e.g. "\" for root) */
+  taskPath: string;
+  /** Executable path */
+  execute: string;
+  /** Arguments string */
+  arguments: string;
+  /** Working directory */
+  workingDirectory?: string;
+  /** Enabled state */
+  state: 'Ready' | 'Disabled' | 'Running' | 'Queued';
+  /** Trigger description (human-readable) */
+  triggers?: SchtaskTrigger[];
+  /** Principal info */
+  principal?: {
+    userId?: string;
+    logonType?: string;
+    runLevel?: string;
+  };
+  /** Description */
+  description?: string;
+}
+
+/**
+ * Simplified trigger representation
+ */
+export interface SchtaskTrigger {
+  /** Trigger type */
+  type: 'Time' | 'Calendar' | 'Boot' | 'Logon' | 'Idle' | 'Registration';
+  /** Human-readable schedule (e.g. "Every 60 min from 00:30") */
+  schedule: string;
+  /** Enabled state */
+  enabled: boolean;
+}
+
+/**
+ * Result of collect operation
+ */
+export interface SchtasksCollectResult {
+  /** Machine ID that was collected */
+  machineId: string;
+  /** Timestamp of collection */
+  timestamp: string;
+  /** Collected tasks */
+  tasks: SchtaskConfig[];
+  /** Filter pattern used */
+  filterPattern: string;
+  /** Task count */
+  count: number;
+}
+
+/**
+ * Result of apply operation
+ */
+export interface SchtasksApplyResult {
+  /** Number of tasks processed */
+  processed: number;
+  /** Number of tasks modified */
+  modified: number;
+  /** Number of tasks skipped (already matching) */
+  skipped: number;
+  /** Number of tasks created (didn't exist) */
+  created: number;
+  /** Errors encountered */
+  errors: string[];
+  /** Detailed changes */
+  changes: Array<{
+    taskName: string;
+    action: 'created' | 'updated' | 'skipped';
+    details?: string;
+  }>;
+}
+
+/**
+ * PowerShell script to collect scheduled tasks as JSON
+ * Filters by name pattern to only get project tasks
+ */
+const COLLECT_SCRIPT = `
+$ErrorActionPreference = 'Stop'
+$filterPatterns = '{{FILTER_PATTERNS}}'
+
+$allTasks = Get-ScheduledTask | Where-Object {
+    $_.TaskPath -notlike '\\Microsoft\\*' -and
+    ($filterPatterns | ForEach-Object { $_.TaskName -like $_ } | Where-Object { $_ }).Count -gt 0
+}
+
+$results = @()
+foreach ($task in $allTasks) {
+    $action = $task.Actions | Select-Object -First 1
+    $taskInfo = [ordered]@{
+        taskName = $task.TaskName
+        taskPath = $task.TaskPath
+        execute = if ($action) { $action.Execute } else { '' }
+        arguments = if ($action) { $action.Arguments } else { '' }
+        workingDirectory = if ($action) { $action.WorkingDirectory } else { '' }
+        state = $task.State.ToString()
+        description = $task.Description
+        principal = if ($task.Principal) {
+            @{
+                userId = $task.Principal.UserId
+                logonType = $task.Principal.LogonType.ToString()
+                runLevel = $task.Principal.RunLevel.ToString()
+            }
+        } else { @{} }
+        triggers = @()
+    }
+
+    foreach ($trigger in $task.Triggers) {
+        $schedule = switch ($trigger.CimClass.CimClassName) {
+            'MSFT_TaskTimeTrigger' { "Once at $($trigger.StartBoundary)" }
+            'MSFT_TaskDailyTrigger' { "Daily at $($trigger.StartBoundary)" }
+            'MSFT_TaskWeeklyTrigger' { "Weekly at $($trigger.StartBoundary)" }
+            'MSFT_TaskBootTrigger' { 'At startup' }
+            'MSFT_TaskLogonTrigger' { 'At logon' }
+            default { $trigger.CimClass.CimClassName }
+        }
+        $taskInfo.triggers += @{
+            type = $trigger.CimClass.CimClassName -replace 'MSFT_Task(\\w+)Trigger', '$1'
+            schedule = $schedule
+            enabled = $trigger.Enabled
+        }
+    }
+
+    $results += $taskInfo
+}
+
+$results | ConvertTo-Json -Depth 5 -Compress
+`;
+
+/**
+ * PowerShell script to apply a single task configuration
+ * Uses Set-ScheduledTask for idempotent updates (preserves triggers and principal)
+ */
+const APPLY_SCRIPT = `
+param(
+    [string]$TaskName,
+    [string]$Execute,
+    [string]$Arguments,
+    [string]$WorkingDirectory,
+    [string]$State
+)
+$ErrorActionPreference = 'Stop'
+
+try {
+    $existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+
+    if ($null -eq $existing) {
+        # Task doesn't exist — cannot create from scratch (requires full definition)
+        @{ action = 'missing'; taskName = $TaskName; error = 'Task not found. Creation from scratch not supported yet.' } | ConvertTo-Json -Compress
+        exit 0
+    }
+
+    $currentExe = $existing.Actions[0].Execute
+    $currentArgs = $existing.Actions[0].Arguments
+    $currentWd = $existing.Actions[0].WorkingDirectory
+
+    $needsUpdate = $false
+    $changes = @()
+
+    if ($currentExe -ne $Execute) {
+        $needsUpdate = $true
+        $changes += "execute: '$currentExe' -> '$Execute'"
+    }
+
+    if ($Arguments -and $currentArgs -ne $Arguments) {
+        $needsUpdate = $true
+        $changes += "arguments updated"
+    }
+
+    if ($WorkingDirectory -and $currentWd -ne $WorkingDirectory) {
+        $needsUpdate = $true
+        $changes += "workingDirectory updated"
+    }
+
+    if ($needsUpdate) {
+        $action = New-ScheduledTaskAction -Execute $Execute -Argument $Arguments -WorkingDirectory $WorkingDirectory
+        Set-ScheduledTask -TaskName $TaskName -Action $action
+        @{ action = 'updated'; taskName = $TaskName; changes = $changes } | ConvertTo-Json -Compress
+    } else {
+        # Check state change
+        if ($State -eq 'Disabled' -and $existing.State -ne 'Disabled') {
+            Disable-ScheduledTask -TaskName $TaskName
+            @{ action = 'updated'; taskName = $TaskName; changes = @('state: disabled') } | ConvertTo-Json -Compress
+        } elseif ($State -eq 'Ready' -and $existing.State -eq 'Disabled') {
+            Enable-ScheduledTask -TaskName $TaskName
+            @{ action = 'updated'; taskName = $TaskName; changes = @('state: enabled') } | ConvertTo-Json -Compress
+        } else {
+            @{ action = 'skipped'; taskName = $TaskName } | ConvertTo-Json -Compress
+        }
+    }
+} catch {
+    @{ action = 'error'; taskName = $TaskName; error = $_.Exception.Message } | ConvertTo-Json -Compress
+}
+`;
+
+/**
+ * Default filter patterns for project scheduled tasks
+ */
+const DEFAULT_FILTER_PATTERNS = ['Claude-*', 'Roo-*', 'RooSync-*'];
+
+export class SchtasksConfigService {
+  private logger: Logger;
+  private executor: PowerShellExecutor;
+
+  constructor(executor?: PowerShellExecutor) {
+    this.logger = createLogger('SchtasksConfigService');
+    this.executor = executor ?? new PowerShellExecutor();
+  }
+
+  /**
+   * Collect scheduled tasks matching project patterns
+   *
+   * @param filterPatterns - Glob patterns for task names (default: Claude-*, Roo-*, RooSync-*)
+   * @returns Collected task configurations
+   */
+  public async collect(filterPatterns?: string[]): Promise<SchtasksCollectResult> {
+    const patterns = filterPatterns ?? DEFAULT_FILTER_PATTERNS;
+    this.logger.info('Collecting scheduled tasks', { patterns });
+
+    const patternsJson = JSON.stringify(patterns);
+    const script = COLLECT_SCRIPT.replace('{{FILTER_PATTERNS}}', patternsJson);
+
+    // Write inline script to temp file for PowerShellExecutor
+    const scriptContent = `
+$ErrorActionPreference = 'Stop'
+$filterPatterns = @(${patterns.map(p => `'${p}'`).join(', ')})
+
+$allTasks = Get-ScheduledTask | Where-Object {
+    $_.TaskPath -notlike '\\\\Microsoft\\\\*' -and
+    ($filterPatterns | ForEach-Object { $_ -replace '\\*', '.*' -replace '\\?', '.' } | ForEach-Object { $_.TaskName -match $_ } | Where-Object { $_ }).Count -gt 0
+}
+
+$results = @()
+foreach ($task in $allTasks) {
+    $action = $task.Actions | Select-Object -First 1
+    $taskInfo = [ordered]@{
+        taskName = $task.TaskName
+        taskPath = $task.TaskPath
+        execute = if ($action) { $action.Execute } else { '' }
+        arguments = if ($action) { $action.Arguments } else { '' }
+        workingDirectory = if ($action) { $action.WorkingDirectory } else { '' }
+        state = $task.State.ToString()
+        description = $task.Description
+    }
+    $results += $taskInfo
+}
+
+if ($results.Count -eq 0) { Write-Output '[]' } else { $results | ConvertTo-Json -Depth 5 -Compress }
+`;
+
+    const tempDir = path.join(os.tmpdir(), `schtasks-collect-${Date.now()}`);
+    fs.mkdirSync(tempDir, { recursive: true });
+    const scriptPath = path.join(tempDir, 'collect-schtasks.ps1');
+    fs.writeFileSync(scriptPath, scriptContent, 'utf-8');
+
+    try {
+      const result = await this.executor.executeScript(scriptPath, [], { timeout: 30000 });
+
+      if (!result.success) {
+        throw new Error(`PowerShell collect failed: ${result.stderr}`);
+      }
+
+      const tasks = this.parseTasksOutput(result.stdout);
+      const collectResult: SchtasksCollectResult = {
+        machineId: process.env.ROOSYNC_MACHINE_ID || process.env.COMPUTERNAME || 'unknown',
+        timestamp: new Date().toISOString(),
+        tasks,
+        filterPattern: patterns.join(','),
+        count: tasks.length,
+      };
+
+      this.logger.info(`Collected ${tasks.length} scheduled tasks`);
+      return collectResult;
+    } finally {
+      // Cleanup temp script
+      try {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+
+  /**
+   * Apply scheduled task configurations idempotently
+   *
+   * @param tasks - Task configurations to apply
+   * @param dryRun - If true, show what would change without modifying
+   * @returns Apply result with changes made
+   */
+  public async apply(tasks: SchtaskConfig[], dryRun?: boolean): Promise<SchtasksApplyResult> {
+    this.logger.info(`Applying ${tasks.length} scheduled task configs`, { dryRun });
+
+    const result: SchtasksApplyResult = {
+      processed: 0,
+      modified: 0,
+      skipped: 0,
+      created: 0,
+      errors: [],
+      changes: [],
+    };
+
+    for (const task of tasks) {
+      result.processed++;
+
+      if (dryRun) {
+        // In dry-run, just report what would happen
+        result.changes.push({
+          taskName: task.taskName,
+          action: 'updated' as const,
+          details: `Would set execute=${task.execute}, arguments=${task.arguments?.substring(0, 50)}...`,
+        });
+        result.modified++;
+        continue;
+      }
+
+      try {
+        const applyResult = await this.applySingleTask(task);
+        result.changes.push({
+          taskName: applyResult.taskName,
+          action: applyResult.action as 'created' | 'updated' | 'skipped',
+          details: applyResult.details,
+        });
+
+        switch (applyResult.action) {
+          case 'updated':
+            result.modified++;
+            break;
+          case 'skipped':
+          case 'missing':
+            // Task doesn't exist — count as skipped for now (creation not supported)
+            result.skipped++;
+            break;
+        }
+      } catch (error) {
+        const errMsg = `Error applying ${task.taskName}: ${error instanceof Error ? error.message : String(error)}`;
+        result.errors.push(errMsg);
+        this.logger.error(errMsg);
+      }
+    }
+
+    this.logger.info(`Apply complete: ${result.modified} modified, ${result.skipped} skipped, ${result.errors.length} errors`);
+    return result;
+  }
+
+  /**
+   * Apply a single task configuration
+   */
+  private async applySingleTask(task: SchtaskConfig): Promise<{ taskName: string; action: string; details?: string }> {
+    // Write apply script to temp file
+    const tempDir = path.join(os.tmpdir(), `schtasks-apply-${Date.now()}`);
+    fs.mkdirSync(tempDir, { recursive: true });
+    const scriptPath = path.join(tempDir, 'apply-schtasks.ps1');
+    fs.writeFileSync(scriptPath, APPLY_SCRIPT, 'utf-8');
+
+    try {
+      const args = [
+        '-TaskName', task.taskName,
+        '-Execute', task.execute || '',
+        '-Arguments', task.arguments || '',
+        '-WorkingDirectory', task.workingDirectory || '',
+        '-State', task.state || 'Ready',
+      ];
+
+      const result = await this.executor.executeScript(scriptPath, args, { timeout: 15000 });
+
+      if (!result.success) {
+        return {
+          taskName: task.taskName,
+          action: 'error',
+          details: result.stderr || `Exit code ${result.exitCode}`,
+        };
+      }
+
+      try {
+        const parsed = PowerShellExecutor.parseJsonOutput<{ action: string; taskName: string; changes?: string[]; error?: string }>(result.stdout);
+        return {
+          taskName: parsed.taskName || task.taskName,
+          action: parsed.action as any,
+          details: parsed.changes?.join('; ') || parsed.error,
+        };
+      } catch {
+        // Fallback: parse the raw output
+        return {
+          taskName: task.taskName,
+          action: 'updated',
+          details: result.stdout.trim(),
+        };
+      }
+    } finally {
+      try {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+
+  /**
+   * Parse the JSON output from the collect script
+   */
+  private parseTasksOutput(stdout: string): SchtaskConfig[] {
+    try {
+      // Try PowerShellExecutor.parseJsonOutput first (handles non-JSON prefixes)
+      const parsed = PowerShellExecutor.parseJsonOutput<SchtaskConfig[] | SchtaskConfig>(stdout);
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+      return [parsed];
+    } catch {
+      // Fallback: direct JSON parse
+      try {
+        const trimmed = stdout.trim();
+        const parsed = JSON.parse(trimmed);
+        if (Array.isArray(parsed)) {
+          return parsed;
+        }
+        return [parsed];
+      } catch {
+        this.logger.warn('Failed to parse schtasks output, returning empty array', { output: stdout.substring(0, 200) });
+        return [];
+      }
+    }
+  }
+
+  /**
+   * Get the default filter patterns
+   */
+  public static getDefaultFilterPatterns(): string[] {
+    return [...DEFAULT_FILTER_PATTERNS];
+  }
+}

--- a/servers/roo-state-manager/src/services/SchtasksConfigService.ts
+++ b/servers/roo-state-manager/src/services/SchtasksConfigService.ts
@@ -193,7 +193,7 @@ $filterPatterns = @(${patterns.map(p => `'${p}'`).join(', ')})
 
 $allTasks = Get-ScheduledTask | Where-Object {
     $_.TaskPath -notlike '\\Microsoft\\*' -and
-    ($filterPatterns | ForEach-Object { $taskName = $_.TaskName; ($filterPatterns | Where-Object { $taskName -like $_ }).Count -gt 0 })
+    ($t = $_; $filterPatterns | Where-Object { $t.TaskName -like $_ }).Count -gt 0
 }
 
 $results = @()

--- a/servers/roo-state-manager/src/services/__tests__/SchtasksConfigService.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/SchtasksConfigService.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SchtasksConfigService, type SchtaskConfig } from '../SchtasksConfigService';
+import type { PowerShellExecutionResult } from '../PowerShellExecutor';
+
+// Mock logger
+vi.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+/**
+ * Create a mock PowerShellExecutor with controllable executeScript
+ */
+function createMockExecutor() {
+  return {
+    executeScript: vi.fn<() => Promise<PowerShellExecutionResult>>(),
+  } as any;
+}
+
+describe('SchtasksConfigService', () => {
+  let service: SchtasksConfigService;
+  let mockExecutor: ReturnType<typeof createMockExecutor>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecutor = createMockExecutor();
+    service = new SchtasksConfigService(mockExecutor);
+  });
+
+  describe('collect', () => {
+    it('should return empty array when no tasks match', async () => {
+      mockExecutor.executeScript.mockResolvedValue({
+        success: true,
+        stdout: '[]',
+        stderr: '',
+        exitCode: 0,
+        executionTime: 100,
+      });
+
+      const result = await service.collect();
+      expect(result.tasks).toEqual([]);
+      expect(result.count).toBe(0);
+      expect(result.machineId).toBeDefined();
+      expect(result.timestamp).toBeDefined();
+    });
+
+    it('should collect and parse scheduled tasks', async () => {
+      const mockTasks = [
+        {
+          taskName: 'Claude-Worker',
+          taskPath: '\\',
+          execute: 'pwsh.exe',
+          arguments: '-File worker.ps1',
+          workingDirectory: '',
+          state: 'Ready',
+          description: 'Claude Worker',
+        },
+        {
+          taskName: 'Roo-Scheduler',
+          taskPath: '\\',
+          execute: 'pwsh.exe',
+          arguments: '-File scheduler.ps1',
+          workingDirectory: '',
+          state: 'Ready',
+          description: 'Roo Scheduler',
+        },
+      ];
+
+      mockExecutor.executeScript.mockResolvedValue({
+        success: true,
+        stdout: JSON.stringify(mockTasks),
+        stderr: '',
+        exitCode: 0,
+        executionTime: 200,
+      });
+
+      const result = await service.collect();
+      expect(result.count).toBe(2);
+      expect(result.tasks[0].taskName).toBe('Claude-Worker');
+      expect(result.tasks[1].taskName).toBe('Roo-Scheduler');
+    });
+
+    it('should handle single task output (non-array)', async () => {
+      const singleTask = {
+        taskName: 'Claude-Coordinator',
+        taskPath: '\\',
+        execute: 'pwsh.exe',
+        arguments: '-File coord.ps1',
+        workingDirectory: '',
+        state: 'Ready',
+      };
+
+      mockExecutor.executeScript.mockResolvedValue({
+        success: true,
+        stdout: JSON.stringify(singleTask),
+        stderr: '',
+        exitCode: 0,
+        executionTime: 100,
+      });
+
+      const result = await service.collect();
+      expect(result.count).toBe(1);
+      expect(result.tasks[0].taskName).toBe('Claude-Coordinator');
+    });
+
+    it('should handle PowerShell execution failure', async () => {
+      mockExecutor.executeScript.mockResolvedValue({
+        success: false,
+        stdout: '',
+        stderr: 'Access denied',
+        exitCode: 1,
+        executionTime: 50,
+      });
+
+      await expect(service.collect()).rejects.toThrow('PowerShell collect failed');
+    });
+
+    it('should accept custom filter patterns', async () => {
+      mockExecutor.executeScript.mockResolvedValue({
+        success: true,
+        stdout: '[]',
+        stderr: '',
+        exitCode: 0,
+        executionTime: 100,
+      });
+
+      await service.collect(['Custom-*']);
+      expect(mockExecutor.executeScript).toHaveBeenCalled();
+    });
+  });
+
+  describe('apply', () => {
+    it('should report dry-run without executing', async () => {
+      const tasks: SchtaskConfig[] = [
+        {
+          taskName: 'Claude-Worker',
+          taskPath: '\\',
+          execute: 'pwsh.exe',
+          arguments: '-File worker.ps1',
+          state: 'Ready',
+        },
+      ];
+
+      const result = await service.apply(tasks, true);
+      expect(result.modified).toBe(1);
+      expect(result.processed).toBe(1);
+      expect(mockExecutor.executeScript).not.toHaveBeenCalled();
+    });
+
+    it('should handle skipped tasks', async () => {
+      mockExecutor.executeScript.mockResolvedValue({
+        success: true,
+        stdout: JSON.stringify({ action: 'skipped', taskName: 'Claude-Worker' }),
+        stderr: '',
+        exitCode: 0,
+        executionTime: 50,
+      });
+
+      const tasks: SchtaskConfig[] = [
+        {
+          taskName: 'Claude-Worker',
+          taskPath: '\\',
+          execute: 'pwsh.exe',
+          arguments: '-File worker.ps1',
+          state: 'Ready',
+        },
+      ];
+
+      const result = await service.apply(tasks);
+      expect(result.skipped).toBe(1);
+      expect(result.modified).toBe(0);
+    });
+
+    it('should handle updated tasks', async () => {
+      mockExecutor.executeScript.mockResolvedValue({
+        success: true,
+        stdout: JSON.stringify({
+          action: 'updated',
+          taskName: 'Claude-Worker',
+          changes: ['execute: powershell.exe -> pwsh.exe'],
+        }),
+        stderr: '',
+        exitCode: 0,
+        executionTime: 100,
+      });
+
+      const tasks: SchtaskConfig[] = [
+        {
+          taskName: 'Claude-Worker',
+          taskPath: '\\',
+          execute: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+          arguments: '-File worker.ps1',
+          state: 'Ready',
+        },
+      ];
+
+      const result = await service.apply(tasks);
+      expect(result.modified).toBe(1);
+      expect(result.changes[0].action).toBe('updated');
+    });
+
+    it('should handle missing tasks gracefully', async () => {
+      mockExecutor.executeScript.mockResolvedValue({
+        success: true,
+        stdout: JSON.stringify({
+          action: 'missing',
+          taskName: 'NonExistent-Task',
+          error: 'Task not found',
+        }),
+        stderr: '',
+        exitCode: 0,
+        executionTime: 50,
+      });
+
+      const tasks: SchtaskConfig[] = [
+        {
+          taskName: 'NonExistent-Task',
+          taskPath: '\\',
+          execute: 'pwsh.exe',
+          arguments: '',
+          state: 'Ready',
+        },
+      ];
+
+      const result = await service.apply(tasks);
+      expect(result.skipped).toBe(1);
+    });
+
+    it('should handle PowerShell execution errors', async () => {
+      mockExecutor.executeScript.mockResolvedValue({
+        success: false,
+        stdout: '',
+        stderr: 'Access is denied',
+        exitCode: 1,
+        executionTime: 50,
+      });
+
+      const tasks: SchtaskConfig[] = [
+        {
+          taskName: 'Claude-Worker',
+          taskPath: '\\',
+          execute: 'pwsh.exe',
+          arguments: '',
+          state: 'Ready',
+        },
+      ];
+
+      const result = await service.apply(tasks);
+      expect(result.changes[0].action).toBe('error');
+    });
+  });
+
+  describe('getDefaultFilterPatterns', () => {
+    it('should return default filter patterns', () => {
+      const patterns = SchtasksConfigService.getDefaultFilterPatterns();
+      expect(patterns).toContain('Claude-*');
+      expect(patterns).toContain('Roo-*');
+      expect(patterns).toContain('RooSync-*');
+      expect(patterns.length).toBe(3);
+    });
+  });
+});

--- a/servers/roo-state-manager/src/tools/roosync/config.ts
+++ b/servers/roo-state-manager/src/tools/roosync/config.ts
@@ -30,7 +30,7 @@ export const ConfigArgsSchema = z.object({
     (targets) => {
       if (!targets) return true;
       return targets.every(target => {
-        if (target === 'modes' || target === 'mcp' || target === 'profiles' || target === 'roomodes' || target === 'model-configs' || target === 'rules' || target === 'settings' || target === 'claude-config' || target === 'modes-yaml') {
+        if (target === 'modes' || target === 'mcp' || target === 'profiles' || target === 'roomodes' || target === 'model-configs' || target === 'rules' || target === 'settings' || target === 'claude-config' || target === 'modes-yaml' || target === 'schtasks') {
           return true;
         }
         if (target.startsWith('mcp:')) {
@@ -51,9 +51,9 @@ export const ConfigArgsSchema = z.object({
       });
     },
     {
-      message: "Target invalide. Valeurs acceptées: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, mcp:<server>, services:<name>, env:<service>"
+      message: "Target invalide. Valeurs acceptées: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, schtasks, mcp:<server>, services:<name>, env:<service>"
     }
-  ).describe('Targets: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, mcp:<server>, services:<name>, env:<service>. Default: ["modes", "mcp"]'),
+  ).describe('Targets: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, schtasks, mcp:<server>, services:<name>, env:<service>. Default: ["modes", "mcp"]'),
 
   // Pour publish (requiert collect préalable OU packagePath)
   packagePath: z.string().optional().describe('Package path from collect. If omitted with publish+targets, does collect+publish atomically'),
@@ -103,7 +103,7 @@ export type ConfigArgs = z.infer<typeof ConfigArgsSchema>;
  * @returns Liste des targets validés
  * @throws ConfigSharingServiceError si un target est invalide
  */
-function parseTargets(targets?: string[]): ('modes' | 'mcp' | 'profiles' | `mcp:${string}` | `services:${string}` | `env:${string}`)[] {
+function parseTargets(targets?: string[]): ('modes' | 'mcp' | 'profiles' | 'schtasks' | `mcp:${string}` | `services:${string}` | `env:${string}`)[] {
   if (!targets) return [];
 
   return targets.map(target => {
@@ -145,12 +145,12 @@ function parseTargets(targets?: string[]): ('modes' | 'mcp' | 'profiles' | `mcp:
       return target as `env:${string}`;
     }
 
-    if (target === 'modes' || target === 'mcp' || target === 'profiles' || target === 'roomodes' || target === 'model-configs' || target === 'rules' || target === 'settings' || target === 'claude-config' || target === 'modes-yaml') {
+    if (target === 'modes' || target === 'mcp' || target === 'profiles' || target === 'roomodes' || target === 'model-configs' || target === 'rules' || target === 'settings' || target === 'claude-config' || target === 'modes-yaml' || target === 'schtasks') {
       return target as any;
     }
 
     throw new ConfigSharingServiceError(
-      `Target invalide: '${target}'. Valeurs acceptées: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, mcp:<nomServeur>, services:<nomService>, env:<nomService>`,
+      `Target invalide: '${target}'. Valeurs acceptées: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, schtasks, mcp:<nomServeur>, services:<nomService>, env:<nomService>`,
       ConfigSharingServiceErrorCode.INVALID_TARGET_FORMAT,
       { target }
     );

--- a/servers/roo-state-manager/src/types/config-sharing.ts
+++ b/servers/roo-state-manager/src/types/config-sharing.ts
@@ -24,7 +24,7 @@ export interface ConfigManifest {
   files: ConfigManifestFile[];
 }
 
-export type ConfigTarget = 'modes' | 'mcp' | 'profiles' | 'roomodes' | 'model-configs' | 'rules' | 'settings' | 'claude-config' | 'modes-yaml' | `mcp:${string}` | `services:${string}` | `env:${string}`;
+export type ConfigTarget = 'modes' | 'mcp' | 'profiles' | 'roomodes' | 'model-configs' | 'rules' | 'settings' | 'claude-config' | 'modes-yaml' | 'schtasks' | `mcp:${string}` | `services:${string}` | `env:${string}`;
 
 export interface CollectConfigOptions {
   targets: ConfigTarget[];


### PR DESCRIPTION
## Summary

Implements `SchtasksConfigService` for VibeSync Phase 2 (#2408 in parent).

### Changes
- **New `SchtasksConfigService`** (`services/SchtasksConfigService.ts`):
  - `collect()`: Inventory project schtasks via PowerShell (`Get-ScheduledTask`)
  - `apply()`: Idempotent updates via `Set-ScheduledTask` (preserves triggers/principal)
  - Filter patterns: `Claude-*`, `Roo-*`, `RooSync-*` (configurable)
  - Uses `PowerShellExecutor` for all PowerShell operations
- **Extended `ConfigTarget`**: Added `schtasks` to type union
- **Extended `ConfigSharingService.collectConfig()`**: New `schtasks` branch
- **Extended Zod validation**: `schtasks` accepted in `targets` array
- **11 unit tests**: All passing (mocked PowerShellExecutor)

### Test Results
```
Build: tsc clean
CI tests: 9655/9655 passed, 0 failed, 23 skipped
New tests: 11/11 passed (SchtasksConfigService.test.ts)
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>