### PR TITLE
feat(zoo-code): storage detector + source attribution (#2429)

### DIFF
--- a/servers/roo-state-manager/src/__tests__/types/unified-task.test.ts
+++ b/servers/roo-state-manager/src/__tests__/types/unified-task.test.ts
@@ -137,8 +137,8 @@ describe('UnifiedTaskSchema', () => {
 // ─── Enums ────────────────────────────────────────────────────────────────────
 
 describe('Task enums', () => {
-  test('TaskSource has exactly 2 values', () => {
-    expect(TaskSource.options).toEqual(['roo', 'claude-code']);
+  test('TaskSource has expected values', () => {
+    expect(TaskSource.options).toEqual(['roo', 'claude-code', 'zoo-code']);
   });
 
   test('TaskStatus has expected values', () => {

--- a/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
+++ b/servers/roo-state-manager/src/tools/conversation/list-conversations.tool.ts
@@ -78,7 +78,7 @@ interface ApiMessage {
 interface ConversationSummary {
     taskId: string;
     /** #883 / #1244 Couche 3.2 — 'roo' or 'claude'. Prefer metadata.source over taskId prefix. */
-    source?: 'roo' | 'claude';
+    source?: 'roo' | 'claude' | 'zoo';
     /** #1244 Couche 3.2 — 'local' (hot tier 1/2) or 'archive' (cold tier 3 GDrive). */
     tier?: 'local' | 'archive';
     parentTaskId?: string;
@@ -252,12 +252,15 @@ function toConversationSummary(node: SkeletonNode, _depth = 0): Record<string, u
     // Build summary — always include key fields for readability
     const summary: Record<string, unknown> = { taskId: node.taskId };
 
-    // #883: Always show source type (roo/claude)
+    // #883: Always show source type (roo/claude/zoo)
     // #1244 Couche 3.2 — Prefer metadata.source (set by SkeletonCacheService Tier 2/3)
     // before falling back to taskId prefix detection.
+    // #2429 — Added 'zoo-code' source attribution.
     const metaSource = (node.metadata as any)?.source;
     if (metaSource === 'claude-code' || metaSource === 'claude') {
         summary.source = 'claude';
+    } else if (metaSource === 'zoo-code') {
+        summary.source = 'zoo';
     } else if (metaSource === 'roo') {
         summary.source = 'roo';
     } else {

--- a/servers/roo-state-manager/src/tools/storage/__tests__/storage-info.test.ts
+++ b/servers/roo-state-manager/src/tools/storage/__tests__/storage-info.test.ts
@@ -1,5 +1,6 @@
 /**
  * Tests pour l'outil consolidé storage_info (CONS-13)
+ * Updated for #2429: Zoo-Code storage stats alongside Roo.
  */
 
 import { describe, test, expect, vi, beforeEach } from 'vitest';
@@ -8,12 +9,22 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 const mockDetectRooStorage = vi.fn();
 const mockGetStorageStats = vi.fn();
 const mockGetWorkspaceBreakdown = vi.fn();
+const mockZooDetectStorageLocations = vi.fn();
+const mockZooGetStorageStats = vi.fn();
 
 vi.mock('../../../utils/roo-storage-detector.js', () => ({
     RooStorageDetector: {
         detectRooStorage: mockDetectRooStorage,
         getStorageStats: mockGetStorageStats,
         getWorkspaceBreakdown: mockGetWorkspaceBreakdown
+    }
+}));
+
+vi.mock('../../../utils/zoo-storage-detector.js', () => ({
+    ZOO_CODE_EXTENSION_ID: 'zoocodeorganization.zoo-code',
+    ZooStorageDetector: {
+        detectStorageLocations: mockZooDetectStorageLocations,
+        getStorageStats: mockZooGetStorageStats,
     }
 }));
 
@@ -31,11 +42,20 @@ describe('storage_info tool (CONS-13)', () => {
         });
         mockGetStorageStats.mockResolvedValue({
             totalSize: 1024000,
-            totalConversations: 10
+            totalConversations: 10,
+            totalLocations: 1
         });
         mockGetWorkspaceBreakdown.mockResolvedValue({
             '/workspace/a': { conversations: 5, size: 512000 },
             '/workspace/b': { conversations: 5, size: 512000 }
+        });
+
+        // Zoo-Code: no storage by default
+        mockZooDetectStorageLocations.mockResolvedValue([]);
+        mockZooGetStorageStats.mockResolvedValue({
+            totalLocations: 0,
+            totalConversations: 0,
+            totalSize: 0
         });
 
         const mod = await import('../storage-info.js');
@@ -91,10 +111,37 @@ describe('storage_info tool (CONS-13)', () => {
             expect(mockGetWorkspaceBreakdown).toHaveBeenCalled();
 
             const data = JSON.parse((result.content[0] as any).text);
+            // Flat top-level backward compatible keys
             expect(data.totalSize).toBe(1024000);
             expect(data.totalConversations).toBe(10);
+            // Nested roo stats
+            expect(data.roo).toBeDefined();
+            expect(data.roo.totalSize).toBe(1024000);
+            expect(data.roo.totalConversations).toBe(10);
             expect(data.workspaceBreakdown).toBeDefined();
             expect(data.totalWorkspaces).toBe(2);
+        });
+
+        test('should not include zooCode when no Zoo storage present', async () => {
+            const result = await handleStorageInfo({ action: 'stats' });
+            const data = JSON.parse((result.content[0] as any).text);
+
+            expect(data.zooCode).toBeUndefined();
+        });
+
+        test('should include zooCode when Zoo storage is present', async () => {
+            mockZooGetStorageStats.mockResolvedValue({
+                totalLocations: 1,
+                totalConversations: 360,
+                totalSize: 2048000
+            });
+
+            const result = await handleStorageInfo({ action: 'stats' });
+            const data = JSON.parse((result.content[0] as any).text);
+
+            expect(data.zooCode).toBeDefined();
+            expect(data.zooCode.totalConversations).toBe(360);
+            expect(data.zooCode.totalSize).toBe(2048000);
         });
 
         test('should include workspace breakdown details', async () => {

--- a/servers/roo-state-manager/src/tools/storage/storage-info.ts
+++ b/servers/roo-state-manager/src/tools/storage/storage-info.ts
@@ -6,13 +6,16 @@
  *   - detect_roo_storage
  *   - get_storage_stats
  *
+ * #2429: Added Zoo-Code storage stats alongside Roo.
+ *
  * @module tools/storage/storage-info
- * @version 1.0.0
+ * @version 1.1.0
  * @since CONS-13
  */
 
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { RooStorageDetector } from '../../utils/roo-storage-detector.js';
+import { ZooStorageDetector } from '../../utils/zoo-storage-detector.js';
 import { Tool } from '../../types/tool-definitions.js';
 
 /**
@@ -34,7 +37,7 @@ export interface StorageInfoArgs {
 export const storageInfoTool: Tool<StorageInfoArgs> = {
     definition: {
         name: 'storage_info',
-        description: 'Informations sur le stockage Roo. action=detect pour localiser, action=stats pour les statistiques.',
+        description: 'Informations sur le stockage Roo et Zoo-Code. action=detect pour localiser, action=stats pour les statistiques.',
         inputSchema: {
             type: 'object',
             properties: {
@@ -87,15 +90,22 @@ async function handleDetect(): Promise<CallToolResult> {
 
 /**
  * Calcule les statistiques de stockage (ex get_storage_stats)
+ * #2429: Includes Zoo-Code storage stats when present.
  */
 async function handleStats(): Promise<CallToolResult> {
-    const stats = await RooStorageDetector.getStorageStats();
+    const rooStats = await RooStorageDetector.getStorageStats();
+    const zooStats = await ZooStorageDetector.getStorageStats();
 
     // FIX CRITIQUE: Calculer breakdown cohérent avec le total
     const workspaceBreakdown = await RooStorageDetector.getWorkspaceBreakdown();
 
+    // Keep flat top-level keys for backward compatibility + nest under 'roo'
     const enhancedStats = {
-        ...stats,
+        totalLocations: rooStats.totalLocations,
+        totalConversations: rooStats.totalConversations,
+        totalSize: rooStats.totalSize,
+        roo: rooStats,
+        ...(zooStats.totalLocations > 0 ? { zooCode: zooStats } : {}),
         workspaceBreakdown,
         totalWorkspaces: Object.keys(workspaceBreakdown).length
     };

--- a/servers/roo-state-manager/src/tools/task/disk-scanner.ts
+++ b/servers/roo-state-manager/src/tools/task/disk-scanner.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import os from 'os';
 import { ConversationSkeleton, SkeletonHeader } from '../../types/conversation.js';
 import { RooStorageDetector } from '../../utils/roo-storage-detector.js';
+import { detectSourceFromPath } from '../../utils/extension-paths.js';
 
 /**
  * Read task_metadata.json for a task (small file, ~200 bytes).
@@ -40,6 +41,9 @@ async function quickAnalyze(
     // Read task_metadata.json for workspace, totalSize, accurate counts
     const taskMeta = await readTaskMetadata(taskPath);
 
+    // #2429: Detect source from storage path (zoo-code vs roo)
+    const source = detectSourceFromPath(taskPath);
+
     const uiPath = path.join(taskPath, 'ui_messages.json');
 
     try {
@@ -62,6 +66,7 @@ async function quickAnalyze(
                 totalSize: taskMeta.totalSize || 0,
                 workspace: taskMeta.workspace || '',
                 machineId: os.hostname(),
+                source,
             },
             parentTaskId: undefined,
             sequence: []
@@ -80,6 +85,7 @@ async function quickAnalyze(
                 totalSize: taskMeta.totalSize || 0,
                 workspace: taskMeta.workspace || '',
                 machineId: os.hostname(),
+                source,
             },
             parentTaskId: undefined,
             sequence: []

--- a/servers/roo-state-manager/src/types/conversation.ts
+++ b/servers/roo-state-manager/src/types/conversation.ts
@@ -50,7 +50,7 @@ export interface SkeletonMetadata {
     machineId?: string;
     qdrantIndexedAt?: string; // DEPRECATED - utiliser indexingState.lastIndexedAt
     dataSource?: string;
-    source?: 'roo' | 'claude-code';
+    source?: 'roo' | 'claude-code' | 'zoo-code';
     parentTaskId?: string;
     indexingState?: IndexingState;
     synthesis?: import('../models/synthesis/SynthesisModels.js').SynthesisMetadata;

--- a/servers/roo-state-manager/src/types/unified-task.ts
+++ b/servers/roo-state-manager/src/types/unified-task.ts
@@ -2,11 +2,11 @@
  * UnifiedTask — Schema unifié pour les tâches Roo et Claude Code
  *
  * @module types/unified-task
- * @issue #1391 (#1360-1)
- * @version 1.0.0
+ * @issue #1391 (#1360-1), #2429 (zoo-code source)
+ * @version 1.1.0
  *
  * Représente une tâche (conversation/session) de N'IMPORTE QUELLE source
- * (Roo Code ou Claude Code) dans un format commun, permettant la recherche
+ * (Roo Code, Zoo-Code, ou Claude Code) dans un format commun, permettant la recherche
  * cross-source, le reporting unifié et le stockage partagé.
  */
 
@@ -14,7 +14,7 @@ import { z } from 'zod';
 
 // ─── Enums ────────────────────────────────────────────────────────────────────
 
-export const TaskSource = z.enum(['roo', 'claude-code']);
+export const TaskSource = z.enum(['roo', 'claude-code', 'zoo-code']);
 export type TaskSource = z.infer<typeof TaskSource>;
 
 export const TaskStatus = z.enum(['active', 'completed', 'abandoned', 'stuck', 'unknown']);
@@ -31,7 +31,7 @@ export type StorageTier = z.infer<typeof StorageTier>;
 export const UnifiedTaskSchema = z.object({
   id: z.string().describe('Unique task identifier (taskId from source system)'),
 
-  source: TaskSource.describe('Origin system: Roo Code or Claude Code'),
+  source: TaskSource.describe('Origin system: Roo Code, Zoo-Code, or Claude Code'),
 
   parentId: z.string().optional().describe('Parent task ID for sub-task relationships'),
 
@@ -93,7 +93,7 @@ interface SourceTaskLike {
     workspace?: string;
     machineId?: string;
     qdrantIndexedAt?: string;
-    source?: 'roo' | 'claude-code';
+    source?: 'roo' | 'claude-code' | 'zoo-code';
     parentTaskId?: string;
   };
   truncatedInstruction?: string;

--- a/servers/roo-state-manager/src/utils/extension-paths.ts
+++ b/servers/roo-state-manager/src/utils/extension-paths.ts
@@ -5,6 +5,7 @@
  * (`zoocodeorganization.zoo-code`) via the `ROO_EXTENSION_ID` env-var override.
  *
  * #2134 — Zoo-Code migration compatibility.
+ * #2429 — Zoo-Code storage detection + source attribution.
  */
 
 import * as path from 'path';
@@ -74,6 +75,24 @@ export function getTasksPath(): string {
 /** Path: `...globalStorage/<extensionId>/settings/` */
 export function getSettingsPath(): string {
 	return path.join(getGlobalStoragePath(), 'settings');
+}
+
+// ── Source detection from storage path (#2429) ─────────────────────────
+
+/**
+ * Determine the task source ('roo', 'zoo-code', or 'claude-code') from a
+ * storage path. Used when attributing tasks discovered by RooStorageDetector
+ * or scanClaudeSessions to the correct source system.
+ *
+ * @param storagePath - The globalStorage directory path or dataSource field
+ * @returns The source identifier
+ */
+export function detectSourceFromPath(storagePath: string | undefined): 'roo' | 'zoo-code' | 'claude-code' {
+	if (!storagePath) return 'roo';
+	const normalized = storagePath.replace(/\\/g, '/').toLowerCase();
+	if (normalized.includes('zoocodeorganization.zoo-code')) return 'zoo-code';
+	if (normalized.includes('.claude/projects') || normalized.startsWith('claude-')) return 'claude-code';
+	return 'roo';
 }
 
 

--- a/servers/roo-state-manager/src/utils/roo-storage-detector.ts
+++ b/servers/roo-state-manager/src/utils/roo-storage-detector.ts
@@ -30,7 +30,7 @@ import { HierarchyReconstructionEngine } from './hierarchy-reconstruction-engine
 import { SkeletonComparator } from './skeleton-comparator.js';
 import { getParsingConfig, isComparisonMode, shouldUseNewParsing } from './parsing-config.js';
 import { WorkspaceDetector } from './workspace-detector.js';
-import { isZooCode } from './extension-paths.js';
+import { isZooCode, detectSourceFromPath } from './extension-paths.js';
 
 export class RooStorageDetector {
   private static readonly MAX_CONVERSATION_FILE_SIZE = 10 * 1024 * 1024; // 10MB — prevents OOM on traces >40MB
@@ -684,6 +684,7 @@ export class RooStorageDetector {
                 totalSize,
                 workspace: extractedWorkspace || rawMetadata.workspace,
                 dataSource: taskPath, // ✅ CRITIQUE: Chemin pour que HierarchyEngine trouve ui_messages.json
+                source: detectSourceFromPath(taskPath), // #2429: 'zoo-code' vs 'roo'
                 ...(oversizedFiles.length > 0 ? { oversizedFiles } : {}),
             },
             childTaskInstructionPrefixes: childTaskInstructionPrefixes.length > 0 ? childTaskInstructionPrefixes : undefined,
@@ -735,6 +736,7 @@ export class RooStorageDetector {
                         actionCount: 0,
                         totalSize: 0,
                         workspace: 'unknown',
+                        source: detectSourceFromPath(taskPath),
                     },
                 };
             } else {

--- a/servers/roo-state-manager/src/utils/zoo-storage-detector.ts
+++ b/servers/roo-state-manager/src/utils/zoo-storage-detector.ts
@@ -1,0 +1,165 @@
+/**
+ * Zoo-Code Storage Detector
+ *
+ * Detects and scans Zoo-Code globalStorage (`zoocodeorganization.zoo-code`).
+ * Zoo-Code is a Roo/Cline fork with identical storage format:
+ *   - tasks/{uuid}/task_metadata.json
+ *   - tasks/{uuid}/ui_messages.json
+ *   - tasks/{uuid}/history_item.json
+ *   - tasks/_index.json
+ *
+ * This detector identifies Zoo-Code specific storage locations so that tasks
+ * can be correctly attributed to source 'zoo-code' rather than 'roo'.
+ *
+ * @module utils/zoo-storage-detector
+ * @issue #2429
+ */
+
+import * as fs from 'fs/promises';
+import { existsSync } from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+    StorageStats,
+} from '../types/conversation.js';
+import { globalCacheManager } from './cache-manager.js';
+
+/** Zoo-Code extension publisher directory name */
+export const ZOO_CODE_EXTENSION_ID = 'zoocodeorganization.zoo-code';
+
+/**
+ * Lightweight detector for Zoo-Code storage locations.
+ *
+ * Zoo-Code shares the same on-disk format as Roo Code (it's a fork).
+ * The difference is purely in the extension ID / directory name.
+ * This class handles detection and attribution; actual parsing is
+ * delegated to RooStorageDetector since the format is identical.
+ */
+export class ZooStorageDetector {
+    private static readonly CACHE_KEY = 'zoo_storage_locations';
+
+    private static readonly COMMON_GLOBAL_STORAGE_PATHS = [
+        path.join(os.homedir(), 'AppData', 'Roaming', 'Code', 'User', 'globalStorage'),
+        path.join(os.homedir(), 'AppData', 'Roaming', 'Code - Insiders', 'User', 'globalStorage'),
+        path.join(os.homedir(), '.config', 'Code', 'User', 'globalStorage'),
+        path.join(os.homedir(), 'Library', 'Application Support', 'Code', 'User', 'globalStorage'),
+    ];
+
+    /**
+     * Detect Zoo-Code storage locations on this machine.
+     * Returns paths to the extension's globalStorage directory that contain a 'tasks' subdirectory.
+     */
+    public static async detectStorageLocations(): Promise<string[]> {
+        // Check cache
+        const cached = await globalCacheManager.get<string[]>(ZooStorageDetector.CACHE_KEY);
+        if (cached) {
+            return cached;
+        }
+
+        const locations: string[] = [];
+
+        for (const basePath of ZooStorageDetector.COMMON_GLOBAL_STORAGE_PATHS) {
+            const zooPath = path.join(basePath, ZOO_CODE_EXTENSION_ID);
+            if (existsSync(zooPath)) {
+                const tasksPath = path.join(zooPath, 'tasks');
+                if (existsSync(tasksPath)) {
+                    locations.push(zooPath);
+                }
+            }
+        }
+
+        // Cache results
+        await globalCacheManager.set(ZooStorageDetector.CACHE_KEY, locations);
+
+        return locations;
+    }
+
+    /**
+     * Get stats for a Zoo-Code storage path.
+     * Reuses the same stat approach as RooStorageDetector.
+     */
+    public static async getStatsForPath(storagePath: string): Promise<StorageStats> {
+        let count = 0;
+        let totalSize = 0;
+        let lastActivity: Date | null = null;
+
+        const tasksPath = path.join(storagePath, 'tasks');
+        const entries = await fs.readdir(tasksPath, { withFileTypes: true });
+
+        if (!entries || !Array.isArray(entries)) {
+            return { conversationCount: 0, totalSize: 0, fileTypes: {} };
+        }
+
+        for (const entry of entries) {
+            if (!entry.isDirectory() || entry.name === '_index.json') continue;
+            const taskPath = path.join(tasksPath, entry.name);
+            try {
+                let dirSize = 0;
+                let dirMtime: Date | null = null;
+                const files = await fs.readdir(taskPath);
+                for (const file of files) {
+                    try {
+                        const fileStat = await fs.stat(path.join(taskPath, file));
+                        if (fileStat.isFile()) dirSize += fileStat.size;
+                        if (!dirMtime || fileStat.mtime > dirMtime) dirMtime = fileStat.mtime;
+                    } catch { /* skip */ }
+                }
+                count++;
+                totalSize += dirSize;
+                if (dirMtime && (!lastActivity || dirMtime > lastActivity)) {
+                    lastActivity = dirMtime;
+                }
+            } catch { /* skip */ }
+        }
+
+        return { conversationCount: count, totalSize, fileTypes: {} };
+    }
+
+    /**
+     * Get overall storage stats for Zoo-Code on this machine.
+     */
+    public static async getStorageStats(): Promise<{
+        totalLocations: number;
+        totalConversations: number;
+        totalSize: number;
+    }> {
+        const locations = await ZooStorageDetector.detectStorageLocations();
+        let totalConversations = 0;
+        let totalSize = 0;
+
+        for (const loc of locations) {
+            const stats = await ZooStorageDetector.getStatsForPath(loc);
+            totalConversations += stats.conversationCount;
+            totalSize += stats.totalSize;
+        }
+
+        return {
+            totalLocations: locations.length,
+            totalConversations,
+            totalSize,
+        };
+    }
+
+    /**
+     * Check whether a given storage path belongs to Zoo-Code.
+     * Used to distinguish Zoo tasks from Roo tasks when both are found
+     * by RooStorageDetector's glob patterns.
+     */
+    public static isZooCodePath(storagePath: string): boolean {
+        const normalized = storagePath.replace(/\\/g, '/').toLowerCase();
+        return normalized.includes('zoocodeorganization.zoo-code');
+    }
+
+    /**
+     * Validate a custom path as a Zoo-Code storage location.
+     */
+    public static async validateCustomPath(customPath: string): Promise<boolean> {
+        try {
+            const normalizedPath = path.resolve(customPath);
+            const tasksPath = path.join(normalizedPath, 'tasks');
+            return existsSync(tasksPath);
+        } catch {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds Zoo-Code storage detection and source attribution for #2429.

### Changes

**New file:**
- `zoo-storage-detector.ts` — Lightweight detector for Zoo-Code (`zoocodeorganization.zoo-code`) globalStorage. Detects locations, computes stats. Same on-disk format as Roo (fork), so no separate parser needed.

**Source attribution:**
- `extension-paths.ts` — Added `detectSourceFromPath()` utility
- `disk-scanner.ts` — Source attribution in `quickAnalyze()`
- `roo-storage-detector.ts` — Source attribution in skeleton metadata
- `unified-task.ts` — Added `zoo-code` to `TaskSource` enum (3 values: roo, claude-code, zoo-code)
- `conversation.ts` — Extended `SkeletonMetadata.source` to include `zoo-code`

**Tool changes:**
- `storage-info.ts` — `action=stats` now includes `zooCode` stats when present, flat top-level keys preserved for backward compat
- `list-conversations.tool.ts` — Shows `source: "zoo"` for Zoo-Code attributed tasks

**Tests:**
- Updated `unified-task.test.ts` for 3-value TaskSource
- Updated `storage-info.test.ts` with ZooStorageDetector mock + zooCode assertions
- Integration tests pass with backward-compatible flat keys

### Test Results

- Build: ✅ clean
- Tests: ✅ 9654 passed, 0 failed (CI config)
- No platform-dependent tests affected

### Context

web1 has both Zoo (360 tasks) and Roo (324 tasks) installed — ideal test bench. Zoo-Code shares identical storage format with Roo since it is a fork.