### PR TITLE
feat(services): ServicesConfigService for declarative Windows services management (#2409)

### DIFF
--- a/servers/roo-state-manager/src/services/ConfigSharingService.ts
+++ b/servers/roo-state-manager/src/services/ConfigSharingService.ts
@@ -345,14 +345,45 @@ export class ConfigSharingService implements IConfigSharingService {
       const servicesTargets = options.targets?.filter(t => typeof t === 'string' && t.startsWith('services:')) as string[] || [];
       if (servicesTargets.length > 0) {
         const serviceNames = servicesTargets.map(t => (t as string).slice(9));
-        // Read services-state.json from the config package for the intended operation
         const servicesStatePath = join(configDir, 'services', 'services-state.json');
         if (existsSync(servicesStatePath)) {
           this.logger.info(`Applying services targets: ${serviceNames.join(', ')}`);
-          // Services apply is a separate flow — collect current state, compare, apply changes
-          // The actual start/stop/restart is handled by ServicesConfigService.apply()
-          // For now, just log that we would apply service changes
-          this.logger.info('Services apply: reading state from package', { servicesStatePath });
+          try {
+            const servicesConfig = new ServicesConfigService();
+            const packageStateRaw = await fs.readFile(servicesStatePath, 'utf-8');
+            const packageState = JSON.parse(packageStateRaw) as { services: Array<{ name: string; status: string }> };
+
+            // Collect current local state
+            const localState = await servicesConfig.collect(serviceNames);
+
+            // Determine operations needed: start services that are stopped in the package state but running in the target
+            const toStart: string[] = [];
+            for (const pkgService of packageState.services) {
+              if (!serviceNames.includes(pkgService.name)) continue;
+              const local = localState.services.find(s => s.name === pkgService.name);
+              if (local && local.status !== pkgService.status) {
+                // If package says Running and local says Stopped → start
+                if (pkgService.status === 'Running' && (local.status === 'Stopped' || local.status === 'NotFound')) {
+                  toStart.push(pkgService.name);
+                }
+              }
+            }
+
+            if (toStart.length > 0) {
+              this.logger.info(`Services to reconcile: ${toStart.join(', ')}`);
+              if (!options.dryRun) {
+                const applyResult = await servicesConfig.apply(toStart, 'start', options.dryRun);
+                if (!applyResult.success) {
+                  errors.push(...(applyResult.errors || []));
+                }
+                filesApplied += toStart.length;
+              }
+            }
+          } catch (svcErr) {
+            errors.push(`Services apply failed: ${svcErr instanceof Error ? svcErr.message : String(svcErr)}`);
+          }
+        } else {
+          this.logger.warn('Services state file not found in package', { servicesStatePath });
         }
       }
 

--- a/servers/roo-state-manager/src/services/ConfigSharingService.ts
+++ b/servers/roo-state-manager/src/services/ConfigSharingService.ts
@@ -30,6 +30,7 @@ import { InventoryService } from './roosync/InventoryService.js';
 import { readJSONFileWithoutBOM } from '../utils/encoding-helpers.js';
 import { RollbackManager } from './RollbackManager.js';
 import { ConfigHealthCheckService, type ConfigType as HealthCheckConfigType } from './ConfigHealthCheckService.js';
+import { ServicesConfigService } from './ServicesConfigService.js';
 import yaml from 'js-yaml';
 
 export class ConfigSharingService implements IConfigSharingService {
@@ -122,6 +123,13 @@ export class ConfigSharingService implements IConfigSharingService {
     if (options.targets.includes('modes-yaml')) {
       const modesYamlFiles = await this.collectModesYaml(tempDir);
       manifest.files.push(...modesYamlFiles);
+    }
+
+    // #2409 — Collecte des services Windows (services:<name>)
+    const servicesTargets = options.targets.filter(t => typeof t === 'string' && t.startsWith('services:'));
+    if (servicesTargets.length > 0) {
+      const servicesFiles = await this.collectServices(tempDir, servicesTargets);
+      manifest.files.push(...servicesFiles);
     }
 
     // Calcul de la taille totale
@@ -332,6 +340,21 @@ export class ConfigSharingService implements IConfigSharingService {
       const hasSettingsTarget = options.targets?.includes('settings') || false;
       const hasClaudeConfigTarget = options.targets?.includes('claude-config') || false;
       const hasModesYamlTarget = options.targets?.includes('modes-yaml') || false;
+
+      // #2409 — Services targets (live management, not file copy)
+      const servicesTargets = options.targets?.filter(t => typeof t === 'string' && t.startsWith('services:')) as string[] || [];
+      if (servicesTargets.length > 0) {
+        const serviceNames = servicesTargets.map(t => (t as string).slice(9));
+        // Read services-state.json from the config package for the intended operation
+        const servicesStatePath = join(configDir, 'services', 'services-state.json');
+        if (existsSync(servicesStatePath)) {
+          this.logger.info(`Applying services targets: ${serviceNames.join(', ')}`);
+          // Services apply is a separate flow — collect current state, compare, apply changes
+          // The actual start/stop/restart is handled by ServicesConfigService.apply()
+          // For now, just log that we would apply service changes
+          this.logger.info('Services apply: reading state from package', { servicesStatePath });
+        }
+      }
 
       // Si aucun target n'est spécifié, tout appliquer par défaut
       const applyAll = options.targets === undefined || options.targets.length === 0;
@@ -1632,6 +1655,48 @@ export class ConfigSharingService implements IConfigSharingService {
       this.logger.info(`Modes YAML collectés depuis: ${yamlPath}`);
     } catch (error) {
       this.logger.error(`Erreur lors de la collecte de custom_modes.yaml: ${error}`);
+    }
+
+    return files;
+  }
+
+  /**
+   * #2409 — Collecte l'état des services Windows
+   */
+  private async collectServices(tempDir: string, serviceTargets: string[]): Promise<ConfigManifestFile[]> {
+    const files: ConfigManifestFile[] = [];
+    const servicesDir = join(tempDir, 'services');
+    await fs.mkdir(servicesDir, { recursive: true });
+
+    try {
+      const serviceNames = serviceTargets.map(t => {
+        const name = (t as string).slice(9); // strip 'services:' prefix
+        if (!ServicesConfigService.isValidServiceName(name)) {
+          this.logger.warn(`Service inconnu dans le registry: ${name}`);
+        }
+        return name;
+      });
+
+      const servicesConfig = new ServicesConfigService();
+      const result = await servicesConfig.collect(serviceNames);
+
+      const destPath = join(servicesDir, 'services-state.json');
+      const content = JSON.stringify(result, null, 2);
+      await fs.writeFile(destPath, content);
+
+      const hash = await this.calculateHash(destPath);
+      const stats = await fs.stat(destPath);
+
+      files.push({
+        path: 'services/services-state.json',
+        hash,
+        type: 'other',
+        size: stats.size,
+      });
+
+      this.logger.info(`Services collectés: ${result.services.length} entrées`);
+    } catch (error) {
+      this.logger.error(`Erreur lors de la collecte des services: ${error}`);
     }
 
     return files;

--- a/servers/roo-state-manager/src/services/ServicesConfigService.ts
+++ b/servers/roo-state-manager/src/services/ServicesConfigService.ts
@@ -1,0 +1,579 @@
+/**
+ * ServicesConfigService - Collect/apply for Windows services and processes
+ *
+ * Target `services:<name>` for roosync_config (#2409 VibeSync Epic).
+ * Manages the lifecycle of critical cluster services (vLLM, Qdrant, IIS, sk-agent).
+ *
+ * Architecture:
+ *   - "service" (Windows service via Get-Service/Set-Service)
+ *   - "process" (managed process via PID tracking + Start-Process)
+ *   - "container" (Docker container via docker CLI)
+ *
+ * Ownership is enforced via static SERVICE_REGISTRY — apply is refused
+ * if the current machine is not the designated owner.
+ *
+ * @module ServicesConfigService
+ * @version 1.0.0
+ */
+
+import { PowerShellExecutor } from './PowerShellExecutor.js';
+import { createLogger, Logger } from '../utils/logger.js';
+import { hostname } from 'os';
+
+// ──────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────
+
+/** The kind of managed entity */
+export type ServiceKind = 'service' | 'process' | 'container';
+
+/** Health status after collect or apply */
+export interface ServiceHealth {
+  /** Whether the endpoint responded */
+  healthy: boolean;
+  /** Latency in ms (if checked) */
+  latencyMs?: number;
+  /** Error message if unhealthy */
+  error?: string;
+}
+
+/** Collected state for a single service target */
+export interface ServiceEntry {
+  /** Logical name (e.g. "vllm", "qdrant") */
+  name: string;
+  /** What kind of entity this is */
+  kind: ServiceKind;
+  /** Running / Stopped / Unknown */
+  status: string;
+  /** PID if applicable */
+  pid?: number;
+  /** Port(s) listening (if detected) */
+  ports?: number[];
+  /** Health probe result */
+  health?: ServiceHealth;
+  /** Machine that owns this service */
+  owner: string;
+}
+
+/** Result of a collect operation */
+export interface ServicesCollectResult {
+  services: ServiceEntry[];
+  collectedAt: string;
+  machineId: string;
+}
+
+/** A single change applied */
+export interface AppliedChange {
+  name: string;
+  action: 'start' | 'stop' | 'restart';
+  before: string;
+  after: string;
+  /** Health check after apply */
+  healthAfter?: ServiceHealth;
+}
+
+/** Result of an apply operation */
+export interface ServicesApplyResult {
+  success: boolean;
+  changes: AppliedChange[];
+  errors: string[];
+  rollbackPerformed: boolean;
+}
+
+/** Registry entry defining a known cluster service */
+export interface ServiceRegistryEntry {
+  /** Logical name */
+  name: string;
+  /** Kind of entity */
+  kind: ServiceKind;
+  /** Designated owner machine ID */
+  owner: string;
+  /** For kind=service: the Windows service name */
+  windowsServiceName?: string;
+  /** For kind=process: the executable name to find/launch */
+  processName?: string;
+  /** For kind=container: the container name */
+  containerName?: string;
+  /** Expected listening port(s) for health check */
+  ports?: number[];
+  /** HTTP health endpoint (GET expected 2xx) */
+  healthEndpoint?: string;
+  /** Startup command (for process kind) */
+  startCommand?: string;
+  /** Startup arguments */
+  startArgs?: string[];
+  /** Working directory for process start */
+  startCwd?: string;
+}
+
+// ──────────────────────────────────────────────────
+// Static registry — cluster infrastructure
+// ──────────────────────────────────────────────────
+
+export const SERVICE_REGISTRY: ServiceRegistryEntry[] = [
+  {
+    name: 'qdrant',
+    kind: 'service',
+    owner: 'myia-ai-01',
+    windowsServiceName: 'Qdrant',
+    ports: [6333],
+    healthEndpoint: 'http://localhost:6333/healthz',
+  },
+  {
+    name: 'iis',
+    kind: 'service',
+    owner: 'myia-po-2023',
+    windowsServiceName: 'W3SVC',
+    ports: [80, 443],
+  },
+  {
+    name: 'vllm',
+    kind: 'process',
+    owner: 'myia-ai-01',
+    processName: 'python',
+    ports: [5002],
+    healthEndpoint: 'http://localhost:5002/v1/models',
+    startCommand: 'python',
+    startArgs: ['-m', 'vllm.entrypoints.openai.api_server', '--port', '5002', '--model', 'qwen3.6-35b-a3b'],
+  },
+  {
+    name: 'sk-agent',
+    kind: 'container',
+    owner: 'myia-ai-01',
+    containerName: 'sk-agent',
+    ports: [8765],
+    healthEndpoint: 'http://localhost:8765/health',
+  },
+];
+
+// ──────────────────────────────────────────────────
+// PowerShell scripts (inline for PowerShellExecutor)
+// ──────────────────────────────────────────────────
+
+const COLLECT_SERVICE_SCRIPT = `
+$ErrorActionPreference = 'Stop'
+$result = @{}
+
+param(
+  [string]$ServiceName,
+  [int[]]$Ports = @()
+)
+
+# Get service info
+try {
+  $svc = Get-Service -Name $ServiceName -ErrorAction Stop
+  $result.Status = $svc.Status.ToString()
+  $result.StartType = $svc.StartType.ToString()
+  $result.DisplayName = $svc.DisplayName
+} catch {
+  $result.Status = 'NotFound'
+  $result.Error = $_.Exception.Message
+}
+
+# Get PID from Win32_Service
+try {
+  $wmi = Get-CimInstance -ClassName Win32_Service -Filter "Name='$ServiceName'" -ErrorAction SilentlyContinue
+  if ($wmi) {
+    $result.Pid = $wmi.ProcessId
+  }
+} catch {}
+
+# Check ports
+if ($Ports.Count -gt 0) {
+  $listeningPorts = @()
+  foreach ($port in $Ports) {
+    $listener = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
+    if ($listener) {
+      $listeningPorts += $port
+    }
+  }
+  $result.ListeningPorts = $listeningPorts
+}
+
+$result | ConvertTo-Json -Depth 5
+`;
+
+const COLLECT_PROCESS_SCRIPT = `
+param(
+  [string]$ProcessName,
+  [int[]]$Ports = @()
+)
+
+$ErrorActionPreference = 'Stop'
+$result = @{}
+
+# Find process
+$procs = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue
+if ($procs) {
+  $result.Status = 'Running'
+  $result.Pids = @($procs | ForEach-Object { $_.Id })
+} else {
+  $result.Status = 'Stopped'
+}
+
+# Check ports
+if ($Ports.Count -gt 0) {
+  $listeningPorts = @()
+  foreach ($port in $Ports) {
+    $listener = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
+    if ($listener) {
+      $listeningPorts += $port
+    }
+  }
+  $result.ListeningPorts = $listeningPorts
+}
+
+$result | ConvertTo-Json -Depth 5
+`;
+
+const COLLECT_CONTAINER_SCRIPT = `
+param(
+  [string]$ContainerName
+)
+
+$ErrorActionPreference = 'Stop'
+$result = @{}
+
+try {
+  $container = docker inspect --format '{{.State.Status}}' $ContainerName 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    $result.Status = $container.Trim()
+  } else {
+    $result.Status = 'NotFound'
+  }
+} catch {
+  $result.Status = 'NotFound'
+  $result.Error = $_.Exception.Message
+}
+
+$result | ConvertTo-Json -Depth 5
+`;
+
+// ──────────────────────────────────────────────────
+// Service class
+// ──────────────────────────────────────────────────
+
+export class ServicesConfigService {
+  private logger: Logger;
+  private executor: PowerShellExecutor;
+  private machineId: string;
+
+  constructor(executor?: PowerShellExecutor) {
+    this.logger = createLogger('ServicesConfigService');
+    this.executor = executor ?? new PowerShellExecutor();
+    this.machineId = process.env.ROOSYNC_MACHINE_ID || hostname().toLowerCase();
+  }
+
+  // ── Collect ────────────────────────────────────
+
+  /**
+   * Collect the state of specified service targets.
+   * @param names - Service names from the registry (e.g. ['qdrant', 'vllm'])
+   * @param dryRun - If true, only report what would be collected
+   */
+  async collect(names: string[], dryRun?: boolean): Promise<ServicesCollectResult> {
+    const entries: ServiceEntry[] = [];
+
+    for (const name of names) {
+      const regEntry = SERVICE_REGISTRY.find(r => r.name === name);
+      if (!regEntry) {
+        this.logger.warn(`Unknown service target: ${name}`);
+        continue;
+      }
+
+      if (dryRun) {
+        entries.push({
+          name: regEntry.name,
+          kind: regEntry.kind,
+          status: 'dry-run',
+          owner: regEntry.owner,
+        });
+        continue;
+      }
+
+      try {
+        const entry = await this.collectSingle(regEntry);
+        entries.push(entry);
+      } catch (err) {
+        this.logger.error(`Failed to collect ${name}: ${err instanceof Error ? err.message : String(err)}`);
+        entries.push({
+          name: regEntry.name,
+          kind: regEntry.kind,
+          status: 'error',
+          owner: regEntry.owner,
+          health: { healthy: false, error: err instanceof Error ? err.message : String(err) },
+        });
+      }
+    }
+
+    return {
+      services: entries,
+      collectedAt: new Date().toISOString(),
+      machineId: this.machineId,
+    };
+  }
+
+  private async collectSingle(entry: ServiceRegistryEntry): Promise<ServiceEntry> {
+    let status = 'Unknown';
+    let pid: number | undefined;
+    let ports: number[] = [];
+
+    switch (entry.kind) {
+      case 'service': {
+        const script = COLLECT_SERVICE_SCRIPT;
+        const result = await this.executor.executeScript(
+          '', // inline script
+          ['-Command', script, '-ServiceName', entry.windowsServiceName || entry.name,
+           ...(entry.ports?.length ? ['-Ports', entry.ports.join(',')] : [])],
+          { timeout: 15000 }
+        );
+        if (result.success) {
+          const parsed = PowerShellExecutor.parseJsonOutput<{
+            Status: string; Pid?: number; ListeningPorts?: number[]
+          }>(result.stdout);
+          status = parsed.Status;
+          pid = parsed.Pid;
+          ports = parsed.ListeningPorts ?? [];
+        }
+        break;
+      }
+      case 'process': {
+        const result = await this.executor.executeScript(
+          '',
+          ['-Command', COLLECT_PROCESS_SCRIPT, '-ProcessName', entry.processName || entry.name,
+           ...(entry.ports?.length ? ['-Ports', entry.ports.join(',')] : [])],
+          { timeout: 15000 }
+        );
+        if (result.success) {
+          const parsed = PowerShellExecutor.parseJsonOutput<{
+            Status: string; Pids?: number[]; ListeningPorts?: number[]
+          }>(result.stdout);
+          status = parsed.Status;
+          if (parsed.Pids?.length) { pid = parsed.Pids[0]; }
+          ports = parsed.ListeningPorts ?? [];
+        }
+        break;
+      }
+      case 'container': {
+        const result = await this.executor.executeScript(
+          '',
+          ['-Command', COLLECT_CONTAINER_SCRIPT, '-ContainerName', entry.containerName || entry.name],
+          { timeout: 15000 }
+        );
+        if (result.success) {
+          const parsed = PowerShellExecutor.parseJsonOutput<{ Status: string }>(result.stdout);
+          status = parsed.Status;
+        }
+        break;
+      }
+    }
+
+    // Health probe
+    let health: ServiceHealth | undefined;
+    if (entry.healthEndpoint && status !== 'Stopped' && status !== 'NotFound') {
+      health = await this.probeHealth(entry.healthEndpoint);
+    }
+
+    return {
+      name: entry.name,
+      kind: entry.kind,
+      status,
+      pid,
+      ports,
+      health,
+      owner: entry.owner,
+    };
+  }
+
+  // ── Apply ──────────────────────────────────────
+
+  /**
+   * Apply an operation to specified service targets.
+   * Enforces ownership: refuses if current machine ≠ designated owner.
+   *
+   * @param targets - Service names with operation (e.g. ['vllm'])
+   * @param operation - 'start' | 'stop' | 'restart'
+   * @param dryRun - If true, only report what would be done
+   */
+  async apply(
+    targets: string[],
+    operation: 'start' | 'stop' | 'restart',
+    dryRun?: boolean
+  ): Promise<ServicesApplyResult> {
+    const changes: AppliedChange[] = [];
+    const errors: string[] = [];
+    let rollbackPerformed = false;
+
+    for (const name of targets) {
+      const regEntry = SERVICE_REGISTRY.find(r => r.name === name);
+      if (!regEntry) {
+        errors.push(`Unknown service target: ${name}`);
+        continue;
+      }
+
+      // Ownership enforcement
+      if (regEntry.owner !== this.machineId) {
+        errors.push(`Ownership violation: ${name} is owned by ${regEntry.owner}, not ${this.machineId}`);
+        continue;
+      }
+
+      if (dryRun) {
+        changes.push({
+          name,
+          action: operation,
+          before: 'dry-run',
+          after: 'dry-run',
+        });
+        continue;
+      }
+
+      try {
+        // Collect before state
+        const before = await this.collectSingle(regEntry);
+        const beforeStatus = before.status;
+
+        // Execute the operation
+        await this.applySingle(regEntry, operation);
+
+        // Wait a moment for the service to stabilize
+        await new Promise(resolve => setTimeout(resolve, 2000));
+
+        // Collect after state
+        const after = await this.collectSingle(regEntry);
+        const afterStatus = after.status;
+
+        // Health check
+        let healthAfter: ServiceHealth | undefined;
+        if (regEntry.healthEndpoint) {
+          healthAfter = await this.probeHealth(regEntry.healthEndpoint);
+        }
+
+        // Rollback if health check fails on start/restart
+        if ((operation === 'start' || operation === 'restart') && healthAfter && !healthAfter.healthy) {
+          this.logger.warn(`Health check failed for ${name} after ${operation}. Rolling back.`);
+          // Best-effort rollback: stop what we just started
+          try {
+            await this.applySingle(regEntry, 'stop');
+            rollbackPerformed = true;
+          } catch (rollbackErr) {
+            this.logger.error(`Rollback failed for ${name}: ${rollbackErr}`);
+          }
+        }
+
+        changes.push({
+          name,
+          action: operation,
+          before: beforeStatus,
+          after: afterStatus,
+          healthAfter,
+        });
+      } catch (err) {
+        errors.push(`${name}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    return {
+      success: errors.length === 0,
+      changes,
+      errors,
+      rollbackPerformed,
+    };
+  }
+
+  private async applySingle(entry: ServiceRegistryEntry, operation: 'start' | 'stop' | 'restart'): Promise<void> {
+    const opVerb = operation === 'start' ? 'Start' : operation === 'stop' ? 'Stop' : 'Restart';
+
+    switch (entry.kind) {
+      case 'service': {
+        const svcName = entry.windowsServiceName || entry.name;
+        const script = `${opVerb}-Service -Name '${svcName}' -ErrorAction Stop`;
+        const result = await this.executor.executeScript('', ['-Command', script], { timeout: 30000 });
+        if (!result.success) {
+          throw new Error(`Service ${opVerb} failed for ${svcName}: ${result.stderr}`);
+        }
+        break;
+      }
+      case 'process': {
+        if (operation === 'stop' || operation === 'restart') {
+          const killScript = `Get-Process -Name '${entry.processName}' -ErrorAction SilentlyContinue | Stop-Process -Force`;
+          await this.executor.executeScript('', ['-Command', killScript], { timeout: 15000 });
+          if (operation === 'stop') break;
+          // For restart, wait for process to die
+          await new Promise(resolve => setTimeout(resolve, 1000));
+        }
+        if (operation === 'start' || operation === 'restart') {
+          if (!entry.startCommand) {
+            throw new Error(`No startCommand defined for process target: ${entry.name}`);
+          }
+          const startScript = [
+            'Start-Process',
+            `-FilePath '${entry.startCommand}'`,
+            ...(entry.startArgs?.length ? [`-ArgumentList '${entry.startArgs.join(' ')}'`] : []),
+            ...(entry.startCwd ? [`-WorkingDirectory '${entry.startCwd}'`] : []),
+            '-WindowStyle Hidden',
+          ].join(' ');
+          const result = await this.executor.executeScript('', ['-Command', startScript], { timeout: 15000 });
+          if (!result.success) {
+            throw new Error(`Process start failed for ${entry.name}: ${result.stderr}`);
+          }
+        }
+        break;
+      }
+      case 'container': {
+        const containerName = entry.containerName || entry.name;
+        const dockerOp = operation === 'restart' ? 'restart' : operation === 'start' ? 'start' : 'stop';
+        const result = await this.executor.executeScript(
+          '', ['-Command', `docker ${dockerOp} ${containerName}`], { timeout: 30000 }
+        );
+        if (!result.success) {
+          throw new Error(`Container ${dockerOp} failed for ${containerName}: ${result.stderr}`);
+        }
+        break;
+      }
+    }
+  }
+
+  // ── Health probe ───────────────────────────────
+
+  private async probeHealth(endpoint: string): Promise<ServiceHealth> {
+    const start = Date.now();
+    try {
+      const response = await fetch(endpoint, {
+        method: 'GET',
+        signal: AbortSignal.timeout(5000),
+      });
+      const latencyMs = Date.now() - start;
+      if (response.ok) {
+        return { healthy: true, latencyMs };
+      }
+      return { healthy: false, latencyMs, error: `HTTP ${response.status}` };
+    } catch (err) {
+      return { healthy: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  // ── Registry helpers ───────────────────────────
+
+  /** Get all registered service names */
+  static getRegisteredNames(): string[] {
+    return SERVICE_REGISTRY.map(r => r.name);
+  }
+
+  /** Get registry entry by name */
+  static getRegistryEntry(name: string): ServiceRegistryEntry | undefined {
+    return SERVICE_REGISTRY.find(r => r.name === name);
+  }
+
+  /** Check if a target name matches the services:<name> pattern */
+  static parseServiceTarget(target: string): string | null {
+    if (target.startsWith('services:')) {
+      return target.slice(9);
+    }
+    return null;
+  }
+
+  /** Validate that a service name exists in the registry */
+  static isValidServiceName(name: string): boolean {
+    return SERVICE_REGISTRY.some(r => r.name === name);
+  }
+}

--- a/servers/roo-state-manager/src/services/ServicesConfigService.ts
+++ b/servers/roo-state-manager/src/services/ServicesConfigService.ts
@@ -150,18 +150,28 @@ export const SERVICE_REGISTRY: ServiceRegistryEntry[] = [
 // PowerShell scripts (inline for PowerShellExecutor)
 // ──────────────────────────────────────────────────
 
-const COLLECT_SERVICE_SCRIPT = `
+/**
+ * Build a PowerShell script to collect Windows service info.
+ * Uses string interpolation (not param()) because PowerShellExecutor
+ * invokes via `-Command` which does not bind param() blocks (#2409 review).
+ */
+function buildCollectServiceScript(serviceName: string, ports: number[]): string {
+  const portCheck = ports.length > 0 ? `
+$Ports = @(${ports.join(',')})
+$listeningPorts = @()
+foreach ($port in $Ports) {
+  $listener = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
+  if ($listener) { $listeningPorts += $port }
+}
+$result.ListeningPorts = $listeningPorts` : '';
+
+  return `
 $ErrorActionPreference = 'Stop'
 $result = @{}
 
-param(
-  [string]$ServiceName,
-  [int[]]$Ports = @()
-)
-
 # Get service info
 try {
-  $svc = Get-Service -Name $ServiceName -ErrorAction Stop
+  $svc = Get-Service -Name '${serviceName}' -ErrorAction Stop
   $result.Status = $svc.Status.ToString()
   $result.StartType = $svc.StartType.ToString()
   $result.DisplayName = $svc.DisplayName
@@ -172,70 +182,50 @@ try {
 
 # Get PID from Win32_Service
 try {
-  $wmi = Get-CimInstance -ClassName Win32_Service -Filter "Name='$ServiceName'" -ErrorAction SilentlyContinue
-  if ($wmi) {
-    $result.Pid = $wmi.ProcessId
-  }
+  $wmi = Get-CimInstance -ClassName Win32_Service -Filter "Name='${serviceName}'" -ErrorAction SilentlyContinue
+  if ($wmi) { $result.Pid = $wmi.ProcessId }
 } catch {}
-
-# Check ports
-if ($Ports.Count -gt 0) {
-  $listeningPorts = @()
-  foreach ($port in $Ports) {
-    $listener = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
-    if ($listener) {
-      $listeningPorts += $port
-    }
-  }
-  $result.ListeningPorts = $listeningPorts
-}
+${portCheck}
 
 $result | ConvertTo-Json -Depth 5
 `;
+}
 
-const COLLECT_PROCESS_SCRIPT = `
-param(
-  [string]$ProcessName,
-  [int[]]$Ports = @()
-)
+function buildCollectProcessScript(processName: string, ports: number[]): string {
+  const portCheck = ports.length > 0 ? `
+$Ports = @(${ports.join(',')})
+$listeningPorts = @()
+foreach ($port in $Ports) {
+  $listener = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
+  if ($listener) { $listeningPorts += $port }
+}
+$result.ListeningPorts = $listeningPorts` : '';
 
+  return `
 $ErrorActionPreference = 'Stop'
 $result = @{}
 
 # Find process
-$procs = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue
+$procs = Get-Process -Name '${processName}' -ErrorAction SilentlyContinue
 if ($procs) {
   $result.Status = 'Running'
   $result.Pids = @($procs | ForEach-Object { $_.Id })
 } else {
   $result.Status = 'Stopped'
 }
-
-# Check ports
-if ($Ports.Count -gt 0) {
-  $listeningPorts = @()
-  foreach ($port in $Ports) {
-    $listener = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
-    if ($listener) {
-      $listeningPorts += $port
-    }
-  }
-  $result.ListeningPorts = $listeningPorts
-}
+${portCheck}
 
 $result | ConvertTo-Json -Depth 5
 `;
+}
 
-const COLLECT_CONTAINER_SCRIPT = `
-param(
-  [string]$ContainerName
-)
-
+function buildCollectContainerScript(containerName: string): string {
+  return `
 $ErrorActionPreference = 'Stop'
 $result = @{}
 
 try {
-  $container = docker inspect --format '{{.State.Status}}' $ContainerName 2>$null
+  $container = docker inspect --format '{{.State.Status}}' '${containerName}' 2>$null
   if ($LASTEXITCODE -eq 0) {
     $result.Status = $container.Trim()
   } else {
@@ -248,6 +238,7 @@ try {
 
 $result | ConvertTo-Json -Depth 5
 `;
+}
 
 // ──────────────────────────────────────────────────
 // Service class
@@ -320,11 +311,12 @@ export class ServicesConfigService {
 
     switch (entry.kind) {
       case 'service': {
-        const script = COLLECT_SERVICE_SCRIPT;
+        const script = buildCollectServiceScript(
+          entry.windowsServiceName || entry.name,
+          entry.ports ?? []
+        );
         const result = await this.executor.executeScript(
-          '', // inline script
-          ['-Command', script, '-ServiceName', entry.windowsServiceName || entry.name,
-           ...(entry.ports?.length ? ['-Ports', entry.ports.join(',')] : [])],
+          '', ['-Command', script],
           { timeout: 15000 }
         );
         if (result.success) {
@@ -338,10 +330,12 @@ export class ServicesConfigService {
         break;
       }
       case 'process': {
+        const script = buildCollectProcessScript(
+          entry.processName || entry.name,
+          entry.ports ?? []
+        );
         const result = await this.executor.executeScript(
-          '',
-          ['-Command', COLLECT_PROCESS_SCRIPT, '-ProcessName', entry.processName || entry.name,
-           ...(entry.ports?.length ? ['-Ports', entry.ports.join(',')] : [])],
+          '', ['-Command', script],
           { timeout: 15000 }
         );
         if (result.success) {
@@ -355,9 +349,9 @@ export class ServicesConfigService {
         break;
       }
       case 'container': {
+        const script = buildCollectContainerScript(entry.containerName || entry.name);
         const result = await this.executor.executeScript(
-          '',
-          ['-Command', COLLECT_CONTAINER_SCRIPT, '-ContainerName', entry.containerName || entry.name],
+          '', ['-Command', script],
           { timeout: 15000 }
         );
         if (result.success) {

--- a/servers/roo-state-manager/src/tools/roosync/config.ts
+++ b/servers/roo-state-manager/src/tools/roosync/config.ts
@@ -36,13 +36,18 @@ export const ConfigArgsSchema = z.object({
           const serverName = target.slice(4);
           return serverName && serverName.trim() !== '';
         }
+        // #2409 — services:<name> target
+        if (target.startsWith('services:')) {
+          const serviceName = target.slice(9);
+          return serviceName && serviceName.trim() !== '';
+        }
         return false;
       });
     },
     {
-      message: "Target invalide. Valeurs acceptées: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, ou mcp:<nomServeur>"
+      message: "Target invalide. Valeurs acceptées: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, mcp:<server>, services:<name>"
     }
-  ).describe('Targets: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, mcp:<server>. Default: ["modes", "mcp"]'),
+  ).describe('Targets: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, mcp:<server>, services:<name>. Default: ["modes", "mcp"]'),
 
   // Pour publish (requiert collect préalable OU packagePath)
   packagePath: z.string().optional().describe('Package path from collect. If omitted with publish+targets, does collect+publish atomically'),
@@ -92,7 +97,7 @@ export type ConfigArgs = z.infer<typeof ConfigArgsSchema>;
  * @returns Liste des targets validés
  * @throws ConfigSharingServiceError si un target est invalide
  */
-function parseTargets(targets?: string[]): ('modes' | 'mcp' | 'profiles' | `mcp:${string}`)[] {
+function parseTargets(targets?: string[]): ('modes' | 'mcp' | 'profiles' | `mcp:${string}` | `services:${string}`)[] {
   if (!targets) return [];
 
   return targets.map(target => {
@@ -108,12 +113,25 @@ function parseTargets(targets?: string[]): ('modes' | 'mcp' | 'profiles' | `mcp:
       return target as `mcp:${string}`;
     }
 
+    // #2409 — services:<name> target
+    if (target.startsWith('services:')) {
+      const serviceName = target.slice(9);
+      if (!serviceName || serviceName.trim() === '') {
+        throw new ConfigSharingServiceError(
+          `Format de target services invalide: '${target}'. Le nom du service ne peut pas être vide.`,
+          ConfigSharingServiceErrorCode.INVALID_TARGET_FORMAT,
+          { target }
+        );
+      }
+      return target as `services:${string}`;
+    }
+
     if (target === 'modes' || target === 'mcp' || target === 'profiles' || target === 'roomodes' || target === 'model-configs' || target === 'rules' || target === 'settings' || target === 'claude-config' || target === 'modes-yaml') {
       return target as any;
     }
 
     throw new ConfigSharingServiceError(
-      `Target invalide: '${target}'. Valeurs acceptées: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, ou mcp:<nomServeur>`,
+      `Target invalide: '${target}'. Valeurs acceptées: modes, mcp, profiles, roomodes, model-configs, rules, settings, claude-config, modes-yaml, mcp:<nomServeur>, services:<nomService>`,
       ConfigSharingServiceErrorCode.INVALID_TARGET_FORMAT,
       { target }
     );

--- a/servers/roo-state-manager/src/types/config-sharing.ts
+++ b/servers/roo-state-manager/src/types/config-sharing.ts
@@ -24,7 +24,7 @@ export interface ConfigManifest {
   files: ConfigManifestFile[];
 }
 
-export type ConfigTarget = 'modes' | 'mcp' | 'profiles' | 'roomodes' | 'model-configs' | 'rules' | 'settings' | 'claude-config' | 'modes-yaml' | `mcp:${string}`;
+export type ConfigTarget = 'modes' | 'mcp' | 'profiles' | 'roomodes' | 'model-configs' | 'rules' | 'settings' | 'claude-config' | 'modes-yaml' | `mcp:${string}` | `services:${string}`;
 
 export interface CollectConfigOptions {
   targets: ConfigTarget[];


### PR DESCRIPTION
## Summary

Adds `services:<name>` target to `roosync_config` for declarative management of critical cluster Windows services (#2409 VibeSync Epic Phase 2).

### New Files
- `ServicesConfigService.ts` (579 LOC) — collect/apply for Windows services

### Changes
- **ConfigTarget type**: Extended with `services:${string}` template literal
- **Zod validation**: `config.ts` now accepts `services:<name>` targets
- **ConfigSharingService**: Integrated `collectServices()` for collect flow

### Architecture
Three entity kinds:
| Kind | Mechanism | Example |
|------|-----------|---------|
| `service` | Get-Service / Set-Service | Qdrant, IIS |
| `process` | PID tracking + Start-Process | vLLM |
| `container` | Docker CLI | sk-agent |

### Safety
- **Ownership enforcement**: apply refused if current machine ≠ designated owner
- **Health probes**: HTTP endpoint check with 5s timeout
- **Rollback**: automatic stop on failed health check after start/restart

### Registry (static, 4 entries)
- `qdrant` — service, owner: ai-01
- `iis` — service, owner: po-2023
- `vllm` — process, owner: ai-01
- `sk-agent` — container, owner: ai-01

### Testing
- Build: clean (tsc)
- Tests: 9654 passed, 0 failed (vitest CI config)
- Unit tests for ServicesConfigService: pending (follow-up PR)

### Part of
Epic #2406 (VibeSync Phase 2), Issue #2409