### PR TITLE
fix(services): W1 PID filter, W2 startArgs array, W3 bidirectional apply

### DIFF
--- a/servers/roo-state-manager/src/services/ServicesConfigService.ts
+++ b/servers/roo-state-manager/src/services/ServicesConfigService.ts
@@ -385,14 +385,20 @@ export class ServicesConfigService {
    * Apply an operation to specified service targets.
    * Enforces ownership: refuses if current machine ≠ designated owner.
    *
+   * W3: Reconciliation is bidirectional — start AND stop. If a `desiredStatus`
+   *     is provided for each target, the operation is auto-determined from
+   *     current vs desired state. Otherwise the explicit `operation` is used.
+   *
    * @param targets - Service names with operation (e.g. ['vllm'])
    * @param operation - 'start' | 'stop' | 'restart'
    * @param dryRun - If true, only report what would be done
+   * @param desiredStatuses - Optional map of target name → desired status for bidirectional reconciliation
    */
   async apply(
     targets: string[],
     operation: 'start' | 'stop' | 'restart',
-    dryRun?: boolean
+    dryRun?: boolean,
+    desiredStatuses?: Record<string, string>
   ): Promise<ServicesApplyResult> {
     const changes: AppliedChange[] = [];
     const errors: string[] = [];
@@ -411,6 +417,13 @@ export class ServicesConfigService {
         continue;
       }
 
+      // W3: Determine effective operation from desired state if provided
+      let effectiveOp = operation;
+      let needsReconciliation = false;
+      if (desiredStatuses && desiredStatuses[name]) {
+        needsReconciliation = true;
+      }
+
       if (dryRun) {
         changes.push({
           name,
@@ -425,9 +438,35 @@ export class ServicesConfigService {
         // Collect before state
         const before = await this.collectSingle(regEntry);
         const beforeStatus = before.status;
+        const beforePid = before.pid;
+
+        // W3: If reconciliation mode, determine operation from current vs desired
+        if (needsReconciliation && desiredStatuses) {
+          const desired = desiredStatuses[name];
+          const isRunning = ['Running', 'OK'].includes(beforeStatus);
+          const shouldBeRunning = ['Running', 'OK'].includes(desired);
+
+          if (isRunning && !shouldBeRunning) {
+            effectiveOp = 'stop';
+            this.logger.info(`Reconciliation: ${name} is ${beforeStatus}, should be ${desired} → stopping`);
+          } else if (!isRunning && shouldBeRunning) {
+            effectiveOp = 'start';
+            this.logger.info(`Reconciliation: ${name} is ${beforeStatus}, should be ${desired} → starting`);
+          } else {
+            // Already in desired state, skip
+            this.logger.info(`Reconciliation: ${name} already in desired state (${beforeStatus})`);
+            changes.push({
+              name,
+              action: effectiveOp,
+              before: beforeStatus,
+              after: beforeStatus,
+            });
+            continue;
+          }
+        }
 
         // Execute the operation
-        await this.applySingle(regEntry, operation);
+        await this.applySingle(regEntry, effectiveOp, beforePid);
 
         // Wait a moment for the service to stabilize
         await new Promise(resolve => setTimeout(resolve, 2000));
@@ -436,18 +475,19 @@ export class ServicesConfigService {
         const after = await this.collectSingle(regEntry);
         const afterStatus = after.status;
 
-        // Health check
+        // Health check (only for start/restart)
         let healthAfter: ServiceHealth | undefined;
-        if (regEntry.healthEndpoint) {
+        if (regEntry.healthEndpoint && (effectiveOp === 'start' || effectiveOp === 'restart')) {
           healthAfter = await this.probeHealth(regEntry.healthEndpoint);
         }
 
         // Rollback if health check fails on start/restart
-        if ((operation === 'start' || operation === 'restart') && healthAfter && !healthAfter.healthy) {
-          this.logger.warn(`Health check failed for ${name} after ${operation}. Rolling back.`);
+        if ((effectiveOp === 'start' || effectiveOp === 'restart') && healthAfter && !healthAfter.healthy) {
+          this.logger.warn(`Health check failed for ${name} after ${effectiveOp}. Rolling back.`);
           // Best-effort rollback: stop what we just started
           try {
-            await this.applySingle(regEntry, 'stop');
+            const afterRollback = await this.collectSingle(regEntry);
+            await this.applySingle(regEntry, 'stop', afterRollback.pid);
             rollbackPerformed = true;
           } catch (rollbackErr) {
             this.logger.error(`Rollback failed for ${name}: ${rollbackErr}`);
@@ -456,7 +496,7 @@ export class ServicesConfigService {
 
         changes.push({
           name,
-          action: operation,
+          action: effectiveOp,
           before: beforeStatus,
           after: afterStatus,
           healthAfter,
@@ -474,7 +514,19 @@ export class ServicesConfigService {
     };
   }
 
-  private async applySingle(entry: ServiceRegistryEntry, operation: 'start' | 'stop' | 'restart'): Promise<void> {
+  /**
+   * Apply an operation to a single registry entry.
+   *
+   * W1: Process stop uses PID filter (or CommandLine fallback) instead of
+   *     `Stop-Process -Name` which kills ALL processes with that name.
+   * W2: startArgs is passed as a PowerShell array `@('arg1','arg2')`
+   *     instead of a flat joined string.
+   */
+  private async applySingle(
+    entry: ServiceRegistryEntry,
+    operation: 'start' | 'stop' | 'restart',
+    collectedPid?: number
+  ): Promise<void> {
     const opVerb = operation === 'start' ? 'Start' : operation === 'stop' ? 'Stop' : 'Restart';
 
     switch (entry.kind) {
@@ -489,8 +541,7 @@ export class ServicesConfigService {
       }
       case 'process': {
         if (operation === 'stop' || operation === 'restart') {
-          const killScript = `Get-Process -Name '${entry.processName}' -ErrorAction SilentlyContinue | Stop-Process -Force`;
-          await this.executor.executeScript('', ['-Command', killScript], { timeout: 15000 });
+          await this.stopProcess(entry, collectedPid);
           if (operation === 'stop') break;
           // For restart, wait for process to die
           await new Promise(resolve => setTimeout(resolve, 1000));
@@ -499,11 +550,15 @@ export class ServicesConfigService {
           if (!entry.startCommand) {
             throw new Error(`No startCommand defined for process target: ${entry.name}`);
           }
+          // W2: Build PowerShell array for ArgumentList instead of flat join
+          const argsFragment = entry.startArgs?.length
+            ? `-ArgumentList @(${entry.startArgs.map(a => `'${a.replace(/'/g, "''")}'`).join(',')})`
+            : '';
           const startScript = [
             'Start-Process',
-            `-FilePath '${entry.startCommand}'`,
-            ...(entry.startArgs?.length ? [`-ArgumentList '${entry.startArgs.join(' ')}'`] : []),
-            ...(entry.startCwd ? [`-WorkingDirectory '${entry.startCwd}'`] : []),
+            `-FilePath '${entry.startCommand.replace(/'/g, "''")}'`,
+            ...(argsFragment ? [argsFragment] : []),
+            ...(entry.startCwd ? [`-WorkingDirectory '${entry.startCwd.replace(/'/g, "''")}'`] : []),
             '-WindowStyle Hidden',
           ].join(' ');
           const result = await this.executor.executeScript('', ['-Command', startScript], { timeout: 15000 });
@@ -525,6 +580,36 @@ export class ServicesConfigService {
         break;
       }
     }
+  }
+
+  /**
+   * W1: Stop a process target safely — prefers PID, then CommandLine filter,
+   *     falls back to name-based kill with a warning.
+   */
+  private async stopProcess(entry: ServiceRegistryEntry, collectedPid?: number): Promise<void> {
+    // Strategy 1: PID-based kill (most precise)
+    if (collectedPid) {
+      const killScript = `Stop-Process -Id ${collectedPid} -Force -ErrorAction SilentlyContinue`;
+      await this.executor.executeScript('', ['-Command', killScript], { timeout: 15000 });
+      return;
+    }
+
+    // Strategy 2: CommandLine filter (narrower than name)
+    if (entry.processName && entry.startCommand) {
+      const safeName = entry.processName.replace(/'/g, "''");
+      const safeCmd = entry.startCommand.replace(/'/g, "''");
+      const killScript = `
+$procs = Get-CimInstance -ClassName Win32_Process -Filter "Name='${safeName}.exe'" -ErrorAction SilentlyContinue
+$target = $procs | Where-Object { $_.CommandLine -like '*${safeCmd}*' }
+if ($target) { $target | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue } }`.trim();
+      await this.executor.executeScript('', ['-Command', killScript], { timeout: 15000 });
+      return;
+    }
+
+    // Strategy 3: Last resort — name-based kill (broad, logs warning)
+    this.logger.warn(`Broad stop for ${entry.name}: no PID or startCommand filter, using name '${entry.processName}'`);
+    const fallbackScript = `Stop-Process -Name '${entry.processName}' -Force -ErrorAction SilentlyContinue`;
+    await this.executor.executeScript('', ['-Command', fallbackScript], { timeout: 15000 });
   }
 
   // ── Health probe ───────────────────────────────

--- a/servers/roo-state-manager/tests/unit/services/ServicesConfigService.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/ServicesConfigService.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Unit tests for ServicesConfigService — W1/W2/W3 follow-ups
+ *
+ * W1: Stop-Process PID filter (no longer kills ALL processes with same name)
+ * W2: startArgs array (PowerShell @() array instead of flat join)
+ * W3: Bidirectional apply reconciliation (start AND stop via desiredStatuses)
+ *
+ * @module tests/unit/services/ServicesConfigService
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// --- Hoisted mocks ---
+const { mockExecuteScript } = vi.hoisted(() => ({
+  mockExecuteScript: vi.fn(),
+}));
+
+// Mock PowerShellExecutor module — provide both instance method and static method
+vi.mock('../../../src/services/PowerShellExecutor.js', () => {
+  return {
+    PowerShellExecutor: class MockPowerShellExecutor {
+      executeScript = mockExecuteScript;
+      static parseJsonOutput = (input: string) => {
+        try { return JSON.parse(input); } catch { return {}; }
+      };
+    },
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('os', () => ({
+  hostname: () => 'myia-ai-01',
+}));
+
+// Import AFTER mocks
+import {
+  ServicesConfigService,
+  SERVICE_REGISTRY,
+} from '../../../src/services/ServicesConfigService.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createService(): ServicesConfigService {
+  // Inject mock executor via constructor DI
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mockExecutor: any = { executeScript: mockExecuteScript };
+  const svc = new ServicesConfigService(mockExecutor);
+  // Force machineId to match vllm owner for ownership tests
+  Object.defineProperty(svc, 'machineId', { value: 'myia-ai-01', writable: true });
+  return svc;
+}
+
+/** Default successful executor response */
+function successResponse(stdout = '{}') {
+  return Promise.resolve({ success: true as const, stdout, stderr: '', exitCode: 0 });
+}
+
+/** Collect response for a running process with PID */
+function runningProcessResponse(pid: number, ports: number[] = []) {
+  const data: Record<string, unknown> = { Status: 'Running', Pids: [pid] };
+  if (ports.length > 0) data.ListeningPorts = ports;
+  return successResponse(JSON.stringify(data));
+}
+
+/** Collect response for a stopped process */
+function stoppedProcessResponse() {
+  return successResponse(JSON.stringify({ Status: 'Stopped' }));
+}
+
+/** Collect response for a running Windows service */
+function runningServiceResponse(pid?: number) {
+  const data: Record<string, unknown> = { Status: 'Running', StartType: 'Automatic', DisplayName: 'Test Service' };
+  if (pid) data.Pid = pid;
+  return successResponse(JSON.stringify(data));
+}
+
+// ---------------------------------------------------------------------------
+// W1: Stop-Process PID filter
+// ---------------------------------------------------------------------------
+
+describe('W1: Stop-Process PID filter', () => {
+  let service: ServicesConfigService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = createService();
+  });
+
+  it('should use PID-based kill when PID is available', async () => {
+    mockExecuteScript
+      .mockResolvedValueOnce(runningProcessResponse(12345)) // collect before
+      .mockResolvedValueOnce(successResponse())             // stop by PID
+      .mockResolvedValueOnce(stoppedProcessResponse())      // collect after
+    ;
+
+    const result = await service.apply(['vllm'], 'stop');
+
+    expect(result.errors).toEqual([]);
+    expect(mockExecuteScript.mock.calls.length).toBe(3);
+
+    // Call 1 is the stop — should use PID
+    const stopCallScript = mockExecuteScript.mock.calls[1][1][1] as string;
+    expect(stopCallScript).toContain('Stop-Process -Id 12345');
+    expect(result.success).toBe(true);
+  });
+
+  it('should NOT use broad Stop-Process -Name when PID is available', async () => {
+    mockExecuteScript
+      .mockResolvedValueOnce(runningProcessResponse(99999))
+      .mockResolvedValueOnce(successResponse())
+      .mockResolvedValueOnce(stoppedProcessResponse())
+    ;
+
+    await service.apply(['vllm'], 'stop');
+
+    // Only check the stop call (call index 1), not the collect calls which legitimately use Get-Process
+    const stopCallScript = mockExecuteScript.mock.calls[1]?.[1]?.[1] as string;
+    expect(stopCallScript).not.toContain("Stop-Process -Name 'python'");
+    expect(stopCallScript).not.toContain("Get-Process -Name 'python'");
+    expect(stopCallScript).toContain('Stop-Process -Id 99999');
+  });
+
+  it('should fallback to CommandLine filter when no PID is available', async () => {
+    // Process is stopped (no PID) → restart calls stop then start
+    mockExecuteScript
+      .mockResolvedValueOnce(stoppedProcessResponse())    // collect before (Stopped, no PID)
+      .mockResolvedValueOnce(successResponse())           // CommandLine-based stop
+      .mockResolvedValueOnce(successResponse())           // start
+      .mockResolvedValueOnce(runningProcessResponse(555)) // collect after
+    ;
+
+    const result = await service.apply(['vllm'], 'restart');
+
+    // The stop call (call 1) should use Win32_Process filter
+    const stopCallScript = mockExecuteScript.mock.calls[1][1][1] as string;
+    expect(stopCallScript).toContain('Win32_Process');
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// W2: startArgs array
+// ---------------------------------------------------------------------------
+
+describe('W2: startArgs PowerShell array', () => {
+  let service: ServicesConfigService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = createService();
+  });
+
+  it('should generate PowerShell @() array for ArgumentList', async () => {
+    mockExecuteScript
+      .mockResolvedValueOnce(stoppedProcessResponse())
+      .mockResolvedValueOnce(successResponse())
+      .mockResolvedValueOnce(runningProcessResponse(789))
+    ;
+
+    await service.apply(['vllm'], 'start');
+
+    // Call 1 is the start script
+    const startScript = mockExecuteScript.mock.calls[1][1][1] as string;
+    expect(startScript).toMatch(/@\(.*'-m'.*\)/);
+    expect(startScript).not.toMatch(/-ArgumentList '-m vllm/);
+  });
+
+  it('should properly quote each argument individually', async () => {
+    mockExecuteScript
+      .mockResolvedValueOnce(stoppedProcessResponse())
+      .mockResolvedValueOnce(successResponse())
+      .mockResolvedValueOnce(runningProcessResponse(789))
+    ;
+
+    await service.apply(['vllm'], 'start');
+
+    const startScript = mockExecuteScript.mock.calls[1][1][1] as string;
+    expect(startScript).toContain("'--port'");
+    expect(startScript).toContain("'5002'");
+  });
+
+  it('should handle service kind (no startArgs)', async () => {
+    mockExecuteScript
+      .mockResolvedValueOnce(runningServiceResponse(100))
+      .mockResolvedValueOnce(successResponse())          // stop service
+      .mockResolvedValueOnce(successResponse())          // start service
+      .mockResolvedValueOnce(runningServiceResponse(100))
+    ;
+
+    const result = await service.apply(['qdrant'], 'restart');
+    expect(result.success).toBe(true);
+    expect(result.changes[0].action).toBe('restart');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// W3: Bidirectional apply reconciliation
+// ---------------------------------------------------------------------------
+
+describe('W3: Bidirectional reconciliation', () => {
+  let service: ServicesConfigService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = createService();
+  });
+
+  it('should start a stopped service when desiredStatus is Running', async () => {
+    mockExecuteScript
+      .mockResolvedValueOnce(stoppedProcessResponse())
+      .mockResolvedValueOnce(successResponse())
+      .mockResolvedValueOnce(runningProcessResponse(456))
+    ;
+
+    const result = await service.apply(
+      ['vllm'],
+      'start',
+      false,
+      { vllm: 'Running' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.changes[0].action).toBe('start');
+  });
+
+  it('should stop a running service when desiredStatus is Stopped', async () => {
+    mockExecuteScript
+      .mockResolvedValueOnce(runningProcessResponse(789))
+      .mockResolvedValueOnce(successResponse())
+      .mockResolvedValueOnce(stoppedProcessResponse())
+    ;
+
+    const result = await service.apply(
+      ['vllm'],
+      'start', // overridden by reconciliation
+      false,
+      { vllm: 'Stopped' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.changes[0].action).toBe('stop');
+  });
+
+  it('should skip when current state matches desired state', async () => {
+    mockExecuteScript
+      .mockResolvedValueOnce(runningProcessResponse(999))
+    ;
+
+    const result = await service.apply(
+      ['vllm'],
+      'start',
+      false,
+      { vllm: 'Running' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.changes[0].before).toBe('Running');
+    expect(mockExecuteScript.mock.calls.length).toBe(1);
+  });
+
+  it('should pass collected PID to stop during reconciliation', async () => {
+    mockExecuteScript
+      .mockResolvedValueOnce(runningProcessResponse(42))
+      .mockResolvedValueOnce(successResponse())
+      .mockResolvedValueOnce(stoppedProcessResponse())
+    ;
+
+    await service.apply(
+      ['vllm'],
+      'start',
+      false,
+      { vllm: 'Stopped' }
+    );
+
+    const stopCallScript = mockExecuteScript.mock.calls[1][1][1] as string;
+    expect(stopCallScript).toContain('Stop-Process -Id 42');
+  });
+
+  it('should use explicit operation when no desiredStatuses provided', async () => {
+    mockExecuteScript
+      .mockResolvedValueOnce(runningProcessResponse(111))
+      .mockResolvedValueOnce(successResponse())
+      .mockResolvedValueOnce(stoppedProcessResponse())
+    ;
+
+    const result = await service.apply(['vllm'], 'stop');
+
+    expect(result.success).toBe(true);
+    expect(result.changes[0].action).toBe('stop');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registry helpers
+// ---------------------------------------------------------------------------
+
+describe('Registry helpers', () => {
+  it('should parse services: target', () => {
+    expect(ServicesConfigService.parseServiceTarget('services:vllm')).toBe('vllm');
+    expect(ServicesConfigService.parseServiceTarget('config:modes')).toBeNull();
+  });
+
+  it('should validate service names', () => {
+    expect(ServicesConfigService.isValidServiceName('vllm')).toBe(true);
+    expect(ServicesConfigService.isValidServiceName('nonexistent')).toBe(false);
+  });
+
+  it('should list all registered names', () => {
+    const names = ServicesConfigService.getRegisteredNames();
+    expect(names).toContain('vllm');
+    expect(names).toContain('qdrant');
+    expect(names).toContain('iis');
+    expect(names).toContain('sk-agent');
+  });
+});


### PR DESCRIPTION
## ServicesConfigService Follow-ups (W1/W2/W3)

Fixes coordinator dispatch (2026-05-30 03:09Z) for po-2024.

### Changes

**W1: PID-based Stop-Process** (critical safety fix)
- `Stop-Process -Name python` killed ALL python processes on the machine
- Now uses 3-tier strategy: PID → CommandLine filter (Win32_Process) → name-based (last resort, with warning)
- PID is collected during `collectSingle()` and propagated to `applySingle()`

**W2: PowerShell array for startArgs**
- `startArgs.join(" ")` produced a single quoted string instead of individual arguments
- Now generates `@('-m','vllm.entrypoints.openai.api_server',...)` PowerShell array syntax
- Each argument individually quoted, single quotes escaped

**W3: Bidirectional apply reconciliation**
- `apply()` was start-only — could not stop services running when they should be stopped
- New optional `desiredStatuses` parameter: `Record<string, string>` mapping target name → desired status
- When current ≠ desired: auto-determines start or stop
- No-op when already in desired state
- Backward compatible: without `desiredStatuses`, uses explicit `operation` as before

**I3: Unit tests**
- 14 tests: W1 (3), W2 (3), W3 (5), registry helpers (3)
- Full mock of PowerShellExecutor via constructor DI
- CI test suite: 483 files, 9668 tests passing

### Files Changed
- `src/services/ServicesConfigService.ts` — W1/W2/W3 implementation
- `tests/unit/services/ServicesConfigService.test.ts` — 14 new unit tests

### Testing
```
npx vitest run --config vitest.config.ci.ts
# 483 passed, 9668 tests, 0 failures
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>