### PR TITLE
fix(summary): replace hardcoded source filename with dataSource-derived label (#795)

### DIFF
--- a/servers/roo-state-manager/src/services/trace-summary/ExportRenderer.ts
+++ b/servers/roo-state-manager/src/services/trace-summary/ExportRenderer.ts
@@ -322,14 +322,17 @@ export class ExportRenderer {
             hour12: false
         }).replace(',', ' a');
 
-        // Note: getOriginalContentSize est dans SummaryGenerator, on peut l'injecter ou le recalculer
-        // Pour simplifier, on utilise une valeur approximative ou on passe la stat
-        // Ici on va utiliser une méthode simplifiée
         const sourceSizeKB = Math.round(conversation.metadata.totalSize / 1024 * 10) / 10;
+
+        // Derive source label from metadata (dataSource path or taskId), not hardcoded
+        const dataSource = conversation.metadata.dataSource as string | undefined;
+        const sourceLabel = dataSource
+            ? dataSource.split('/').pop()!.split('\\').pop()!
+            : conversation.taskId;
 
         return `# RESUME DE TRACE D'ORCHESTRATION ROO
 
-**Fichier source :** roo_task_sep-8-2025_11-11-29-pm.md
+**Fichier source :** ${sourceLabel}
 **Date de generation :** ${dateStr}
 **Taille source :** ${sourceSizeKB} KB`;
     }

--- a/servers/roo-state-manager/src/services/trace-summary/__tests__/ExportRenderer.test.ts
+++ b/servers/roo-state-manager/src/services/trace-summary/__tests__/ExportRenderer.test.ts
@@ -381,6 +381,39 @@ describe('ExportRenderer - generateHeader', () => {
         const header = renderer.generateHeader(conversation, options);
         expect(header).toContain('0.5 KB');
     });
+
+    it('should use dataSource basename as Fichier source when available', () => {
+        const conversation = makeConversation({
+            metadata: {
+                ...makeConversation().metadata,
+                dataSource: 'c:/dev/roo-extensions/tasks/roo_task_may-30_task.md'
+            }
+        });
+        const options = makeDefaultOptions();
+        const header = renderer.generateHeader(conversation, options);
+        expect(header).toContain('roo_task_may-30_task.md');
+        expect(header).not.toContain('roo_task_sep-8-2025');
+    });
+
+    it('should use taskId as Fichier source when no dataSource', () => {
+        const conversation = makeConversation();
+        const options = makeDefaultOptions();
+        const header = renderer.generateHeader(conversation, options);
+        expect(header).toContain('test-task-001');
+        expect(header).not.toContain('roo_task_sep-8-2025');
+    });
+
+    it('should handle Windows-style dataSource path', () => {
+        const conversation = makeConversation({
+            metadata: {
+                ...makeConversation().metadata,
+                dataSource: 'C:\\Users\\test\\.claude\\projects\\abc\\session.jsonl'
+            }
+        });
+        const options = makeDefaultOptions();
+        const header = renderer.generateHeader(conversation, options);
+        expect(header).toContain('session.jsonl');
+    });
 });
 
 describe('ExportRenderer - generateMetadata', () => {


### PR DESCRIPTION
## Fix

ExportRenderer.generateHeader() had a hardcoded literal `roo_task_sep-8-2025_11-11-29-pm.md` as "Fichier source" for ALL trace summaries, regardless of actual conversation source (Roo or Claude).

### Root cause
Leftover test fixture string from commit 75952f0a (2025-12-10). The `generateHeader` method never used the conversation metadata to derive the source filename.

### Fix
Derives the label from `conversation.metadata.dataSource` (basename extraction, handles both `/` and `\` separators) with fallback to `conversation.taskId` when `dataSource` is undefined.

### Test results
- 127/127 ExportRenderer tests pass (3 new assertions added)
- Build clean (tsc)

### Files changed
- `ExportRenderer.ts`: 11 lines changed (+7/-4)
- `ExportRenderer.test.ts`: 33 lines added (3 new test cases)

### Ref
- Found during #795 AUDIT Test profondeur outils MCP (conversation_browser summarize test)
- Refs: #795