### PR TITLE
fix(shared-state): remove doubled .shared-state path segment

### DIFF
--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -675,7 +675,7 @@ async function loadNoiseFilterBlacklist(state: ServerState): Promise<void> {
             return;
         }
 
-        const blacklistPath = path.join(sharedPath, '.shared-state', 'qdrant-blacklist.json');
+        const blacklistPath = path.join(sharedPath, 'qdrant-blacklist.json'); // sharedPath already points to .shared-state
         const content = await fs.readFile(blacklistPath, 'utf8');
 
         const cleaned = content.charCodeAt(0) === 0xFEFF ? content.slice(1) : content;

--- a/servers/roo-state-manager/src/tools/roosync/diagnose.ts
+++ b/servers/roo-state-manager/src/tools/roosync/diagnose.ts
@@ -214,7 +214,7 @@ async function handleEnvAction(
 
   const criticalDirs: Array<{ name: string; base: string | null }> = [
     { name: '.', base: process.cwd() },
-    { name: '.shared-state', base: sharedPath },
+    { name: '.', base: sharedPath }, // sharedPath already points to .shared-state directory
     { name: 'roo-config', base: sharedBase },
     { name: 'mcps', base: process.cwd() },
     { name: 'logs', base: sharedBase },


### PR DESCRIPTION
## Fix

Root cause: ROOSYNC_SHARED_PATH already ends with .shared-state. Two locations in the code append .shared-state again, producing paths like .../.shared-state/.shared-state -> ENOENT.

## Changes (2 lines)

1. diagnose.ts:217 - Use name='.' instead of '.shared-state' since sharedPath already IS the .shared-state directory. Impact: roosync_diagnose(env) reports correct paths.

2. background-services.ts:678 - Remove intermediate '.shared-state' segment from qdrant-blacklist.json path. Impact: NoiseFilter blacklist loads correctly -> Qdrant noise filtering re-enabled.

## Verification

- npm run build: OK
- npx vitest run tests/unit/tools/roosync/diagnose.test.ts: 15/15 pass
- SHA: 897a2354

## Investigation credit

Bug identified by po-2026 (cycle 6), corroborated by web1. Fix by po-2025.

## Related

- ai-01 coordinator dispatch R+7 noted this as confirmed bug (2+ machines)
- Impact: skeleton cache 0/3 tiers, indexing degraded on affected machines