### PR TITLE
test(relationship-analyzer): strengthen weak assertions (#833 P1)

### DIFF
--- a/servers/roo-state-manager/tests/unit/services/task-instruction-index.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/task-instruction-index.test.ts
@@ -283,9 +283,8 @@ describe('TaskInstructionIndex', () => {
             expect(results.length).toBeGreaterThan(0);
             const debugMatch = results.find(r => r.taskId === 'task-001');
             expect(debugMatch).toBeDefined();
-            if (debugMatch) {
-                expect(debugMatch.similarityScore).toBeGreaterThan(0.2);
-            }
+            expect(debugMatch!.similarityScore).toBeGreaterThan(0.2);
+            expect(debugMatch!.taskId).toBe('task-001');
         });
 
         it('should respect similarity threshold', async () => {
@@ -310,8 +309,9 @@ describe('TaskInstructionIndex', () => {
             
             const match = results.find(r => r.taskId === 'task-001');
             expect(match).toBeDefined();
-            if (match && match.similarityScore !== undefined && match.similarityScore < 1) {
-                expect(['prefix', 'fuzzy']).toContain(match.matchType);
+            expect(match!.similarityScore).toBeGreaterThan(0);
+            if (match!.similarityScore !== undefined && match!.similarityScore < 1) {
+                expect(['prefix', 'fuzzy']).toContain(match!.matchType);
             }
         });
 
@@ -335,6 +335,7 @@ describe('TaskInstructionIndex', () => {
             // Devrait trouver task-001 car ils partagent des mots significatifs
             const match = results.find(r => r.taskId === 'task-001');
             expect(match).toBeDefined();
+            expect(match!.similarityScore).toBeGreaterThan(0.2);
         });
     });
 
@@ -551,7 +552,7 @@ describe('TaskInstructionIndex', () => {
             
             return index.searchSimilar('!@#$', 0.1).then(results => {
                 // Ne devrait pas crasher
-                expect(results).toBeDefined();
+                expect(results).toBeInstanceOf(Array);
             });
         });
 
@@ -559,7 +560,7 @@ describe('TaskInstructionIndex', () => {
             index.addInstruction('parent-001', '测试中文字符 テスト 🎉');
             
             return index.searchSimilar('测试', 0.1).then(results => {
-                expect(results).toBeDefined();
+                expect(results).toBeInstanceOf(Array);
             });
         });
 
@@ -586,9 +587,8 @@ describe('TaskInstructionIndex', () => {
             
             const match = results.find(r => r.taskId === 'task-001');
             expect(match).toBeDefined();
-            if (match) {
-                expect(match.similarityScore).toBeGreaterThan(0.5);
-            }
+            expect(match!.similarityScore).toBeGreaterThan(0.5);
+            expect(match!.taskId).toBe('task-001');
         });
 
         it('should give low score to different texts', async () => {

--- a/servers/roo-state-manager/tests/unit/utils/relationship-analyzer.test.ts
+++ b/servers/roo-state-manager/tests/unit/utils/relationship-analyzer.test.ts
@@ -490,6 +490,9 @@ describe('RelationshipAnalyzer', () => {
         (r.source === 'se-2' && r.target === 'se-1')
       );
       expect(pairRel).toBeDefined();
+      expect(pairRel!.weight).toBeGreaterThan(0.5);
+      expect(pairRel!.metadata.confidence).toBeGreaterThanOrEqual(0.6);
+      expect(pairRel!.metadata.evidence.length).toBeGreaterThan(0);
     });
 
     it('includes common mode in semantic evidence', async () => {
@@ -516,6 +519,8 @@ describe('RelationshipAnalyzer', () => {
         (r.source === 'sm-2' && r.target === 'sm-1')
       );
       expect(pairRel).toBeDefined();
+      expect(pairRel!.weight).toBeGreaterThan(0.5);
+      expect(pairRel!.metadata.evidence.length).toBeGreaterThan(0);
       // Both conversations share mode 'code'; the SEMANTIC analyzer would
       // include 'Mode commun: code' in evidence. After dedup, the surviving
       // relationship may be FILE_DEPENDENCY instead, so we just verify the pair is linked.
@@ -544,6 +549,8 @@ describe('RelationshipAnalyzer', () => {
         (r.source === 'st-2' && r.target === 'st-1')
       );
       expect(pairRel).toBeDefined();
+      expect(pairRel!.weight).toBeGreaterThan(0.5);
+      expect(pairRel!.metadata.confidence).toBeGreaterThanOrEqual(0.6);
     });
   });
 


### PR DESCRIPTION
## Summary

Strengthens weak assertions in two test files per #833 Phase 4 P1 recommendation.

### Changes

#### 1. `relationship-analyzer.test.ts` (3 assertions strengthened)
- **shared files evidence**: Added weight, confidence, evidence count checks
- **common mode**: Added weight and evidence count checks
- **temporal proximity**: Added weight and confidence checks

#### 2. `task-instruction-index.test.ts` (6 assertions strengthened)
- **debugMatch**: Added score and taskId checks, removed conditional if guard
- **prefix match**: Added score check, use non-null assertion
- **significant words**: Added similarityScore > 0.2
- **special chars**: `toBeInstanceOf(Array)` instead of `toBeDefined()`
- **unicode chars**: `toBeInstanceOf(Array)` instead of `toBeDefined()`
- **high score**: Added score and taskId checks, removed conditional if guard

### Validation
- ✅ All 96 tests pass (45 + 51)
- ✅ CI config validates both files
- ✅ Build succeeds
- ✅ No behavior changes

Ref: #833