### PR TITLE
feat(unified-store): Phase B writer — PgUnifiedStoreWriter + dual-write hook (#2426)

### DIFF
--- a/servers/roo-state-manager/src/services/skeleton-cache.service.ts
+++ b/servers/roo-state-manager/src/services/skeleton-cache.service.ts
@@ -107,11 +107,57 @@ export class SkeletonCacheService {
     }
 
     /**
-     * Add or update a skeleton in both RAM cache and disk
+     * Add or update a skeleton in both RAM cache and disk.
+     *
+     * #2426 Phase B: also fires a best-effort dual-write to the unified Postgres
+     * store when UNIFIED_STORE_DUAL_WRITE=1 is set. The Postgres write is
+     * fire-and-forget (non-blocking) — failure is absorbed by the writer's
+     * circuit-breaker and never blocks the local cache path.
      */
     public async addOrUpdate(taskId: string, skeleton: ConversationSkeleton): Promise<void> {
         this.cache.set(taskId, skeleton);
         await this.saveSkeleton(taskId, skeleton);
+
+        // #2426 Phase B — dual-write to Postgres (fire-and-forget, env-gated)
+        this.dualWriteToStore(taskId, skeleton).catch(() => {
+          // Intentionally swallowed — writer handles its own errors + circuit breaker
+        });
+    }
+
+    /**
+     * #2426 Phase B: best-effort dual-write to the unified Postgres store.
+     * Maps ConversationSkeleton → ConversationBundle and calls the writer.
+     * The writer's circuit-breaker absorbs transient failures.
+     */
+    private async dualWriteToStore(taskId: string, skeleton: ConversationSkeleton): Promise<void> {
+      try {
+        const { getUnifiedStoreWriter } = await import('./unified-store/writer-factory.js');
+        const writer = getUnifiedStoreWriter();
+
+        // Map skeleton.metadata.source → Harness
+        const source = skeleton.metadata?.source;
+        let harness: 'roo' | 'zoo' | 'claude' = 'roo';
+        if (source === 'claude-code') harness = 'claude';
+        else if (source === 'zoo-code') harness = 'zoo';
+
+        // Map ConversationSkeleton → ConversationRow
+        const conversationRow: import('./unified-store/types.js').ConversationRow = {
+          task_id: taskId,
+          machine_id: skeleton.metadata?.machineId ?? process.env.ROOSYNC_MACHINE_ID ?? process.env.COMPUTERNAME ?? 'unknown',
+          harness,
+          workspace: skeleton.metadata?.workspace ?? null,
+          parent_task_id: skeleton.parentTaskId ?? skeleton.metadata?.parentTaskId ?? null,
+          title: skeleton.metadata?.title ?? null,
+          first_ts: skeleton.metadata?.createdAt ?? null,
+          last_ts: skeleton.metadata?.lastActivity ?? null,
+          msg_count: skeleton.metadata?.messageCount ?? 0,
+          metadata: skeleton.metadata ? { ...skeleton.metadata } as Record<string, unknown> : null,
+        };
+
+        await writer.upsertConversationOnly(conversationRow);
+      } catch {
+        // Swallow all errors — dual-write must never block the caller
+      }
     }
 
     /**

--- a/servers/roo-state-manager/src/services/unified-store/PgUnifiedStoreWriter.ts
+++ b/servers/roo-state-manager/src/services/unified-store/PgUnifiedStoreWriter.ts
@@ -1,0 +1,339 @@
+/**
+ * PgUnifiedStoreWriter — Concrete Postgres writer for the unified store
+ *
+ * @module services/unified-store/PgUnifiedStoreWriter
+ * @issue #2426 Phase B (Epic #2191 unified store)
+ *
+ * Features:
+ *   - pg.Pool connection management (connect once, reuse across calls)
+ *   - Parameterized queries (SQL injection safe)
+ *   - Retry with exponential backoff (transient network/GDrive-lag errors)
+ *   - Circuit breaker (3 consecutive failures → OPEN for 60s, half-open probe)
+ *   - Metrics emitted via log lines (prom-compatible pattern)
+ *
+ * Env-gate: UNIFIED_STORE_DUAL_WRITE=1 activates this writer via the
+ * SkeletonCacheService hook. When unset/false, NullUnifiedStoreWriter is used.
+ *
+ * Connection string: UNIFIED_STORE_PG_URL (required when dual-write is ON)
+ *   e.g. postgres://user:pass@pg.myia.io:5432/unified_store?sslmode=require
+ */
+
+import pg from 'pg';
+import type {
+  ConversationBundle,
+  ConversationRow,
+  MessageRow,
+} from './types.js';
+import type { IUnifiedStoreWriter, UnifiedStoreWriterConfig } from './UnifiedStoreWriter.js';
+
+// ─── Circuit Breaker ───────────────────────────────────────────────
+
+type BreakerState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
+
+class CircuitBreaker {
+  private state: BreakerState = 'CLOSED';
+  private failureCount = 0;
+  private lastFailureTime = 0;
+  private readonly threshold: number;
+  private readonly resetMs: number;
+
+  constructor(threshold = 3, resetMs = 60_000) {
+    this.threshold = threshold;
+    this.resetMs = resetMs;
+  }
+
+  /** Returns true if the call should be allowed through. */
+  allow(): boolean {
+    if (this.state === 'CLOSED') return true;
+    if (this.state === 'OPEN') {
+      if (Date.now() - this.lastFailureTime >= this.resetMs) {
+        this.state = 'HALF_OPEN';
+        return true; // probe
+      }
+      return false; // still open
+    }
+    // HALF_OPEN — allow one probe
+    return true;
+  }
+
+  recordSuccess(): void {
+    this.failureCount = 0;
+    this.state = 'CLOSED';
+  }
+
+  recordFailure(): void {
+    this.failureCount++;
+    this.lastFailureTime = Date.now();
+    if (this.failureCount >= this.threshold) {
+      this.state = 'OPEN';
+    }
+  }
+
+  getState(): BreakerState { return this.state; }
+  getFailureCount(): number { return this.failureCount; }
+}
+
+// ─── Metrics ───────────────────────────────────────────────────────
+
+interface WriterMetrics {
+  upsertsTotal: number;
+  upsertsSuccess: number;
+  upsertsFailed: number;
+  upsertsRetried: number;
+  breakerOpens: number;
+  lastError?: string;
+  lastErrorTs?: string;
+}
+
+// ─── PgUnifiedStoreWriter ──────────────────────────────────────────
+
+export class PgUnifiedStoreWriter implements IUnifiedStoreWriter {
+  private pool: pg.Pool | null = null;
+  private readonly config: UnifiedStoreWriterConfig;
+  private breaker: CircuitBreaker;
+  private metrics: WriterMetrics;
+  private initialized = false;
+
+  // Retry config
+  private readonly maxRetries: number;
+  private readonly baseDelayMs: number;
+
+  constructor(config: UnifiedStoreWriterConfig) {
+    this.config = config;
+    this.breaker = new CircuitBreaker(3, 60_000);
+    this.metrics = {
+      upsertsTotal: 0,
+      upsertsSuccess: 0,
+      upsertsFailed: 0,
+      upsertsRetried: 0,
+      breakerOpens: 0,
+    };
+    this.maxRetries = 2;
+    this.baseDelayMs = 500;
+  }
+
+  // ─── Lifecycle ─────────────────────────────────────────────────
+
+  async init(): Promise<void> {
+    if (this.initialized && this.pool) return;
+
+    this.pool = new pg.Pool({
+      connectionString: this.config.connectionString,
+      max: this.config.poolMax ?? 5,
+      statement_timeout: this.config.statementTimeoutMs ?? 5000,
+      // SSL is configured via the connection string (sslmode=require)
+    });
+
+    // Verify connectivity
+    const client = await this.pool.connect();
+    try {
+      await client.query('SELECT 1');
+    } finally {
+      client.release();
+    }
+
+    this.initialized = true;
+    console.info('[PgUnifiedStoreWriter] Pool initialized and connected');
+  }
+
+  async close(): Promise<void> {
+    if (this.pool) {
+      await this.pool.end();
+      this.pool = null;
+      this.initialized = false;
+      console.info('[PgUnifiedStoreWriter] Pool drained');
+    }
+  }
+
+  async ping(): Promise<boolean> {
+    if (!this.pool) return false;
+    try {
+      const client = await this.pool.connect();
+      try {
+        await client.query('SELECT 1');
+      } finally {
+        client.release();
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // ─── Upsert Operations ────────────────────────────────────────
+
+  async upsertConversation(bundle: ConversationBundle): Promise<void> {
+    await this.withRetry('upsertConversation', async () => {
+      if (!this.pool) throw new Error('Pool not initialized');
+      const client = await this.pool.connect();
+      try {
+        await client.query('BEGIN');
+        await this.upsertConversationRow(client, bundle.conversation);
+        if (bundle.messages.length > 0) {
+          await this.upsertMessagesRows(client, bundle.messages);
+        }
+        await client.query('COMMIT');
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {}); // swallow rollback error
+        throw err;
+      } finally {
+        client.release();
+      }
+    });
+  }
+
+  async upsertConversationOnly(row: ConversationRow): Promise<void> {
+    await this.withRetry('upsertConversationOnly', async () => {
+      if (!this.pool) throw new Error('Pool not initialized');
+      const client = await this.pool.connect();
+      try {
+        await this.upsertConversationRow(client, row);
+      } finally {
+        client.release();
+      }
+    });
+  }
+
+  async upsertMessages(rows: MessageRow[]): Promise<void> {
+    if (rows.length === 0) return;
+
+    await this.withRetry('upsertMessages', async () => {
+      if (!this.pool) throw new Error('Pool not initialized');
+      const client = await this.pool.connect();
+      try {
+        await this.upsertMessagesRows(client, rows);
+      } finally {
+        client.release();
+      }
+    });
+  }
+
+  // ─── Query Helpers ────────────────────────────────────────────
+
+  private async upsertConversationRow(client: pg.PoolClient, row: ConversationRow): Promise<void> {
+    const sql = `
+      INSERT INTO conversations (task_id, machine_id, harness, workspace, parent_task_id, title, first_ts, last_ts, msg_count, metadata)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      ON CONFLICT (task_id) DO UPDATE SET
+        machine_id = EXCLUDED.machine_id,
+        harness = EXCLUDED.harness,
+        workspace = EXCLUDED.workspace,
+        parent_task_id = EXCLUDED.parent_task_id,
+        title = EXCLUDED.title,
+        first_ts = COALESCE(EXCLUDED.first_ts, conversations.first_ts),
+        last_ts = EXCLUDED.last_ts,
+        msg_count = EXCLUDED.msg_count,
+        metadata = COALESCE(EXCLUDED.metadata, conversations.metadata)
+    `;
+    const params = [
+      row.task_id,
+      row.machine_id,
+      row.harness,
+      row.workspace ?? null,
+      row.parent_task_id ?? null,
+      row.title ?? null,
+      row.first_ts ?? null,
+      row.last_ts ?? null,
+      row.msg_count,
+      row.metadata ? JSON.stringify(row.metadata) : null,
+    ];
+    await client.query(sql, params);
+  }
+
+  private async upsertMessagesRows(client: pg.PoolClient, rows: MessageRow[]): Promise<void> {
+    // Batch insert using UNNEST for efficiency (up to 100x faster than individual INSERTs)
+    const taskIds: string[] = [];
+    const messageIds: (string | null)[] = [];
+    const seqs: number[] = [];
+    const roles: string[] = [];
+    const contents: (string | null)[] = [];
+    const toolCalls: (string | null)[] = [];
+    const timestamps: string[] = [];
+
+    for (const row of rows) {
+      taskIds.push(row.task_id);
+      messageIds.push(row.message_id ?? null);
+      seqs.push(row.seq);
+      roles.push(row.role);
+      contents.push(row.content ?? null);
+      toolCalls.push(row.tool_calls ? JSON.stringify(row.tool_calls) : null);
+      timestamps.push(row.ts);
+    }
+
+    const sql = `
+      INSERT INTO messages (task_id, message_id, seq, role, content, tool_calls, ts)
+      SELECT * FROM UNNEST(
+        $1::text[], $2::text[], $3::integer[], $4::text[], $5::text[], $6::jsonb[], $7::timestamptz[]
+      )
+      ON CONFLICT (task_id, seq) DO NOTHING
+    `;
+    await client.query(sql, [
+      taskIds,
+      messageIds,
+      seqs,
+      roles,
+      contents,
+      toolCalls,
+      timestamps,
+    ]);
+  }
+
+  // ─── Retry + Circuit Breaker ──────────────────────────────────
+
+  private async withRetry(label: string, fn: () => Promise<void>): Promise<void> {
+    this.metrics.upsertsTotal++;
+
+    if (!this.breaker.allow()) {
+      this.metrics.upsertsFailed++;
+      const state = this.breaker.getState();
+      console.warn(`[PgUnifiedStoreWriter] Circuit breaker ${state}, skipping ${label}`);
+      return; // best-effort: skip silently (writer failure never blocks caller)
+    }
+
+    let lastError: Error | null = null;
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      try {
+        await fn();
+        this.breaker.recordSuccess();
+        this.metrics.upsertsSuccess++;
+        return;
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+
+        if (attempt < this.maxRetries) {
+          this.metrics.upsertsRetried++;
+          const delay = this.baseDelayMs * Math.pow(2, attempt);
+          console.warn(
+            `[PgUnifiedStoreWriter] ${label} attempt ${attempt + 1}/${this.maxRetries + 1} failed: ${lastError.message}. Retrying in ${delay}ms...`
+          );
+          await new Promise(r => setTimeout(r, delay));
+        }
+      }
+    }
+
+    // All retries exhausted
+    this.breaker.recordFailure();
+    this.metrics.upsertsFailed++;
+    this.metrics.lastError = lastError?.message;
+    this.metrics.lastErrorTs = new Date().toISOString();
+
+    if (this.breaker.getState() === 'OPEN') {
+      this.metrics.breakerOpens++;
+    }
+
+    // Best-effort: log error but do NOT throw (writer failure never blocks caller)
+    console.error(
+      `[PgUnifiedStoreWriter] ${label} failed after ${this.maxRetries + 1} attempts: ${lastError?.message}. Circuit breaker: ${this.breaker.getState()}`
+    );
+  }
+
+  // ─── Observability ────────────────────────────────────────────
+
+  getMetrics(): Readonly<WriterMetrics> {
+    return { ...this.metrics };
+  }
+
+  getBreakerState(): BreakerState {
+    return this.breaker.getState();
+  }
+}

--- a/servers/roo-state-manager/src/services/unified-store/index.ts
+++ b/servers/roo-state-manager/src/services/unified-store/index.ts
@@ -30,5 +30,9 @@ export type {
 export { NullUnifiedStoreWriter } from './UnifiedStoreWriter.js';
 export type { IUnifiedStoreWriter, UnifiedStoreWriterConfig } from './UnifiedStoreWriter.js';
 
+export { PgUnifiedStoreWriter } from './PgUnifiedStoreWriter.js';
+
+export { getUnifiedStoreWriter, resetWriterInstance } from './writer-factory.js';
+
 export { NullUnifiedStoreReader } from './UnifiedStoreReader.js';
 export type { IUnifiedStoreReader, UnifiedStoreReaderConfig } from './UnifiedStoreReader.js';

--- a/servers/roo-state-manager/src/services/unified-store/writer-factory.ts
+++ b/servers/roo-state-manager/src/services/unified-store/writer-factory.ts
@@ -1,0 +1,73 @@
+/**
+ * Writer factory — instantiates the correct UnifiedStoreWriter based on env config
+ *
+ * @module services/unified-store/writer-factory
+ * @issue #2426 Phase B (Epic #2191 unified store)
+ *
+ * Env-gate logic:
+ *   - UNIFIED_STORE_DUAL_WRITE=1 + UNIFIED_STORE_PG_URL set → PgUnifiedStoreWriter
+ *   - Otherwise → NullUnifiedStoreWriter (no-op, zero overhead)
+ *
+ * The factory is idempotent: repeated calls return the same instance
+ * (singleton pattern matching SkeletonCacheService's approach).
+ */
+
+import type { IUnifiedStoreWriter } from './UnifiedStoreWriter.js';
+import { NullUnifiedStoreWriter } from './UnifiedStoreWriter.js';
+import { PgUnifiedStoreWriter } from './PgUnifiedStoreWriter.js';
+
+let instance: IUnifiedStoreWriter | null = null;
+
+/**
+ * Create or return the singleton writer instance.
+ *
+ * Called from SkeletonCacheService (or startup) when the dual-write
+ * env-gate needs to be evaluated. Once created, the instance is reused
+ * for the lifetime of the MCP process.
+ */
+export function getUnifiedStoreWriter(): IUnifiedStoreWriter {
+  if (instance) return instance;
+
+  const dualWrite = process.env.UNIFIED_STORE_DUAL_WRITE;
+  const pgUrl = process.env.UNIFIED_STORE_PG_URL;
+
+  if (dualWrite === '1' && pgUrl) {
+    console.info(
+      `[UnifiedStore] Dual-write ENABLED — connecting to ${maskConnectionString(pgUrl)}`
+    );
+    instance = new PgUnifiedStoreWriter({
+      connectionString: pgUrl,
+      poolMax: parseInt(process.env.UNIFIED_STORE_POOL_MAX ?? '5', 10),
+      statementTimeoutMs: parseInt(process.env.UNIFIED_STORE_TIMEOUT_MS ?? '5000', 10),
+    });
+  } else {
+    console.info('[UnifiedStore] Dual-write DISABLED — using NullUnifiedStoreWriter');
+    instance = new NullUnifiedStoreWriter();
+  }
+
+  return instance;
+}
+
+/**
+ * Reset the singleton (for testing or config hot-reload).
+ * Does NOT close the previous instance — caller must handle lifecycle.
+ */
+export function resetWriterInstance(): void {
+  instance = null;
+}
+
+/**
+ * Mask credentials in connection string for logging.
+ * postgres://user:secret@host/db → postgres://user:***@host/db
+ */
+function maskConnectionString(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.password) {
+      parsed.password = '***';
+    }
+    return parsed.toString();
+  } catch {
+    return '<invalid-url>';
+  }
+}

--- a/servers/roo-state-manager/tests/unit/services/unified-store/PgUnifiedStoreWriter.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/unified-store/PgUnifiedStoreWriter.test.ts
@@ -1,0 +1,286 @@
+/**
+ * PgUnifiedStoreWriter — Phase B unit tests.
+ *
+ * Tests the concrete Postgres writer with mocked pg.Pool.
+ * No live Postgres required.
+ *
+ * @issue #2426 Phase B (Epic #2191)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PgUnifiedStoreWriter } from '../../../../src/services/unified-store/PgUnifiedStoreWriter.js';
+import type {
+  ConversationBundle,
+  ConversationRow,
+  MessageRow,
+} from '../../../../src/services/unified-store/types.js';
+
+// ─── Mock pg module ────────────────────────────────────────────────
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn();
+const mockEnd = vi.fn();
+
+vi.mock('pg', () => ({
+  default: {
+    Pool: vi.fn(() => ({
+      connect: mockConnect,
+      end: mockEnd,
+    })),
+  },
+}));
+
+// Helper to create a mock client with BEGIN/COMMIT/ROLLBACK support
+function mockClient() {
+  return {
+    query: mockQuery,
+    release: vi.fn(),
+  };
+}
+
+// ─── Fixtures ──────────────────────────────────────────────────────
+
+const dummyConv: ConversationRow = {
+  task_id: 't-phase-b',
+  machine_id: 'myia-po-2025',
+  harness: 'roo',
+  workspace: 'roo-extensions',
+  parent_task_id: null,
+  title: 'Phase B test',
+  first_ts: '2026-05-30T10:00:00Z',
+  last_ts: '2026-05-30T10:05:00Z',
+  msg_count: 3,
+  metadata: { mode: 'code-simple' },
+};
+
+const dummyMessages: MessageRow[] = [
+  {
+    task_id: 't-phase-b',
+    message_id: null,
+    seq: 0,
+    role: 'user',
+    content: 'Hello',
+    tool_calls: null,
+    ts: '2026-05-30T10:00:00Z',
+  },
+  {
+    task_id: 't-phase-b',
+    message_id: null,
+    seq: 1,
+    role: 'assistant',
+    content: 'Response',
+    tool_calls: [{ name: 'read_file', args: { path: '/foo.ts' } }],
+    ts: '2026-05-30T10:02:00Z',
+  },
+];
+
+const dummyBundle: ConversationBundle = {
+  conversation: dummyConv,
+  messages: dummyMessages,
+};
+
+// ─── Tests ─────────────────────────────────────────────────────────
+
+describe('PgUnifiedStoreWriter', () => {
+  let writer: PgUnifiedStoreWriter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writer = new PgUnifiedStoreWriter({
+      connectionString: 'postgres://test:test@localhost:5433/unified_store',
+      poolMax: 2,
+      statementTimeoutMs: 3000,
+    });
+    // Default: connect succeeds, query succeeds
+    const client = mockClient();
+    mockConnect.mockResolvedValue(client);
+    mockQuery.mockResolvedValue({ rowCount: 1 });
+    mockEnd.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await writer.close();
+  });
+
+  describe('lifecycle', () => {
+    it('initializes pool and verifies connectivity', async () => {
+      await writer.init();
+      // Pool constructor called + connect for SELECT 1 + release
+      expect(mockConnect).toHaveBeenCalled();
+    });
+
+    it('close drains the pool', async () => {
+      await writer.init();
+      await writer.close();
+      expect(mockEnd).toHaveBeenCalled();
+    });
+
+    it('init is idempotent', async () => {
+      await writer.init();
+      await writer.init();
+      // Pool constructor called once (via vi.fn)
+      await writer.close();
+    });
+  });
+
+  describe('ping', () => {
+    it('returns true when DB is reachable', async () => {
+      await writer.init();
+      const result = await writer.ping();
+      expect(result).toBe(true);
+    });
+
+    it('returns false when DB is unreachable', async () => {
+      // Override mock to reject connections (simulates DB down)
+      mockConnect.mockRejectedValue(new Error('Connection refused'));
+      // ping uses withRetry which catches the error and returns false
+      const result = await writer.ping();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('upsertConversation (atomic)', () => {
+    it('upserts conversation + messages in a transaction', async () => {
+      await writer.init();
+      await writer.upsertConversation(dummyBundle);
+
+      // BEGIN, upsert conv, upsert msgs, COMMIT
+      expect(mockQuery).toHaveBeenCalledWith('BEGIN');
+      expect(mockQuery).toHaveBeenCalledWith('COMMIT');
+      // Conversation upsert query
+      const convQuery = mockQuery.mock.calls.find(c => typeof c[0] === 'string' && c[0].includes('INSERT INTO conversations'));
+      expect(convQuery).toBeDefined();
+      // Messages upsert query
+      const msgQuery = mockQuery.mock.calls.find(c => typeof c[0] === 'string' && c[0].includes('INSERT INTO messages'));
+      expect(msgQuery).toBeDefined();
+    });
+
+    it('rolls back on error', async () => {
+      await writer.init();
+      // Make the conversation INSERT fail
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('INSERT INTO conversations')) {
+          throw new Error('PK violation');
+        }
+        return Promise.resolve({ rowCount: 1 });
+      });
+
+      // Should NOT throw (best-effort, circuit breaker absorbs)
+      await writer.upsertConversation(dummyBundle);
+
+      expect(mockQuery).toHaveBeenCalledWith('ROLLBACK');
+    });
+
+    it('handles empty messages array', async () => {
+      await writer.init();
+      const bundleNoMsgs: ConversationBundle = {
+        conversation: dummyConv,
+        messages: [],
+      };
+      await writer.upsertConversation(bundleNoMsgs);
+
+      // Should still BEGIN/COMMIT but NOT call message insert
+      const msgQuery = mockQuery.mock.calls.find(c => typeof c[0] === 'string' && c[0].includes('INSERT INTO messages'));
+      expect(msgQuery).toBeUndefined();
+    });
+  });
+
+  describe('upsertConversationOnly', () => {
+    it('upserts a single conversation row', async () => {
+      await writer.init();
+      await writer.upsertConversationOnly(dummyConv);
+
+      const convQuery = mockQuery.mock.calls.find(c => typeof c[0] === 'string' && c[0].includes('INSERT INTO conversations'));
+      expect(convQuery).toBeDefined();
+      // Params should match the conversation row
+      expect(convQuery![1][0]).toBe('t-phase-b');
+      expect(convQuery![1][1]).toBe('myia-po-2025');
+    });
+  });
+
+  describe('upsertMessages', () => {
+    it('uses UNNEST for batch insert', async () => {
+      await writer.init();
+      await writer.upsertMessages(dummyMessages);
+
+      const msgQuery = mockQuery.mock.calls.find(c => typeof c[0] === 'string' && c[0].includes('UNNEST'));
+      expect(msgQuery).toBeDefined();
+      // Second param is the array of task_ids
+      expect(msgQuery![1][0]).toEqual(['t-phase-b', 't-phase-b']);
+    });
+
+    it('skips empty array', async () => {
+      await writer.init();
+      await writer.upsertMessages([]);
+      // No query should be issued
+      const msgQuery = mockQuery.mock.calls.find(c => typeof c[0] === 'string' && c[0].includes('INSERT INTO messages'));
+      expect(msgQuery).toBeUndefined();
+    });
+  });
+
+  describe('retry + circuit breaker', () => {
+    it('retries on transient failure', async () => {
+      await writer.init();
+      let callCount = 0;
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('INSERT INTO conversations')) {
+          callCount++;
+          if (callCount === 1) throw new Error('Transient');
+          return Promise.resolve({ rowCount: 1 });
+        }
+        return Promise.resolve({ rowCount: 1 });
+      });
+
+      await writer.upsertConversationOnly(dummyConv);
+
+      // Should have retried
+      const metrics = writer.getMetrics();
+      expect(metrics.upsertsRetried).toBeGreaterThan(0);
+      expect(metrics.upsertsSuccess).toBe(1);
+    });
+
+    it('opens circuit breaker after threshold failures', async () => {
+      await writer.init();
+      mockQuery.mockImplementation(() => {
+        throw new Error('Persistent failure');
+      });
+
+      // Trigger 3 failures to open the breaker
+      await writer.upsertConversationOnly(dummyConv);
+      await writer.upsertConversationOnly(dummyConv);
+      await writer.upsertConversationOnly(dummyConv);
+
+      expect(writer.getBreakerState()).toBe('OPEN');
+      expect(writer.getMetrics().breakerOpens).toBeGreaterThan(0);
+    });
+
+    it('metrics track totals correctly', async () => {
+      await writer.init();
+      await writer.upsertConversationOnly(dummyConv);
+
+      const metrics = writer.getMetrics();
+      expect(metrics.upsertsTotal).toBe(1);
+      expect(metrics.upsertsSuccess).toBe(1);
+      expect(metrics.upsertsFailed).toBe(0);
+    });
+  });
+
+  describe('parameterized queries (SQL injection safety)', () => {
+    it('uses $N placeholders, not string interpolation', async () => {
+      await writer.init();
+      const maliciousConv: ConversationRow = {
+        ...dummyConv,
+        task_id: "'; DROP TABLE conversations; --",
+      };
+      await writer.upsertConversationOnly(maliciousConv);
+
+      const convQuery = mockQuery.mock.calls.find(c => typeof c[0] === 'string' && c[0].includes('INSERT INTO conversations'));
+      expect(convQuery).toBeDefined();
+      // Must use $1, not string interpolation
+      expect(convQuery![0]).toContain('$1');
+      expect(convQuery![0]).not.toContain('DROP TABLE');
+      // The malicious string should be a parameter, not in the query
+      expect(convQuery![1][0]).toBe("'; DROP TABLE conversations; --");
+    });
+  });
+});

--- a/servers/roo-state-manager/tests/unit/services/unified-store/writer-factory.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/unified-store/writer-factory.test.ts
@@ -1,0 +1,71 @@
+/**
+ * writer-factory — Phase B unit tests.
+ *
+ * Tests the factory that creates the correct writer based on env vars.
+ * No live Postgres required.
+ *
+ * @issue #2426 Phase B (Epic #2191)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  getUnifiedStoreWriter,
+  resetWriterInstance,
+} from '../../../../src/services/unified-store/writer-factory.js';
+import { NullUnifiedStoreWriter } from '../../../../src/services/unified-store/UnifiedStoreWriter.js';
+import { PgUnifiedStoreWriter } from '../../../../src/services/unified-store/PgUnifiedStoreWriter.js';
+
+describe('writer-factory', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    resetWriterInstance();
+    // Clear env vars
+    delete process.env.UNIFIED_STORE_DUAL_WRITE;
+    delete process.env.UNIFIED_STORE_PG_URL;
+  });
+
+  afterEach(() => {
+    resetWriterInstance();
+    // Restore env
+    process.env = { ...originalEnv };
+  });
+
+  it('returns NullUnifiedStoreWriter when UNIFIED_STORE_DUAL_WRITE is unset', () => {
+    const writer = getUnifiedStoreWriter();
+    expect(writer).toBeInstanceOf(NullUnifiedStoreWriter);
+  });
+
+  it('returns NullUnifiedStoreWriter when UNIFIED_STORE_DUAL_WRITE is "0"', () => {
+    process.env.UNIFIED_STORE_DUAL_WRITE = '0';
+    const writer = getUnifiedStoreWriter();
+    expect(writer).toBeInstanceOf(NullUnifiedStoreWriter);
+  });
+
+  it('returns NullUnifiedStoreWriter when UNIFIED_STORE_DUAL_WRITE is "1" but no PG URL', () => {
+    process.env.UNIFIED_STORE_DUAL_WRITE = '1';
+    // No UNIFIED_STORE_PG_URL set
+    const writer = getUnifiedStoreWriter();
+    expect(writer).toBeInstanceOf(NullUnifiedStoreWriter);
+  });
+
+  it('returns PgUnifiedStoreWriter when both env vars are set', () => {
+    process.env.UNIFIED_STORE_DUAL_WRITE = '1';
+    process.env.UNIFIED_STORE_PG_URL = 'postgres://user:pass@localhost:5433/unified_store';
+    const writer = getUnifiedStoreWriter();
+    expect(writer).toBeInstanceOf(PgUnifiedStoreWriter);
+  });
+
+  it('returns the same instance on repeated calls (singleton)', () => {
+    const w1 = getUnifiedStoreWriter();
+    const w2 = getUnifiedStoreWriter();
+    expect(w1).toBe(w2);
+  });
+
+  it('resetWriterInstance allows creating a new instance', () => {
+    const w1 = getUnifiedStoreWriter();
+    resetWriterInstance();
+    const w2 = getUnifiedStoreWriter();
+    expect(w1).not.toBe(w2);
+  });
+});


### PR DESCRIPTION
## #2426 Phase B — Postgres Writer Implementation

**Epic:** #2191 (Unified Store) | **ADR:** #2197 (ADR 010 v2.0, Option E / Scenario B)

### What

Concrete Postgres writer for the unified store, with dual-write hook in SkeletonCacheService.

### Changes

| File | Type | LOC |
|------|------|-----|
| `PgUnifiedStoreWriter.ts` | NEW | ~230 |
| `writer-factory.ts` | NEW | ~65 |
| `PgUnifiedStoreWriter.test.ts` | NEW | ~190 |
| `writer-factory.test.ts` | NEW | ~60 |
| `skeleton-cache.service.ts` | MOD | +40 |
| `index.ts` | MOD | +2 exports |

**Total: ~820 LOC added**

### Features

- **pg.Pool** connection management (connect once, reuse across calls)
- **Parameterized queries** ($N placeholders — SQL injection safe)
- **Retry with exponential backoff** (2 retries, 500ms base delay)
- **Circuit breaker** (3 consecutive failures → OPEN for 60s, half-open probe)
- **Batch UNNEST insert** for messages (O(1) query instead of N individual INSERTs)
- **Env-gate**: `UNIFIED_STORE_DUAL_WRITE=1` + `UNIFIED_STORE_PG_URL` → active writer
- **Fire-and-forget**: dual-write in `addOrUpdate()` never blocks local cache

### Tests (29 total)

- 15 PgUnifiedStoreWriter (lifecycle, upsert, retry, circuit breaker, SQL injection safety)
- 6 writer-factory (env-gate, singleton, reset)
- 3 NullUnifiedStoreWriter (Phase A)
- 5 NullUnifiedStoreReader (Phase A)

### Build + CI

- `npm run build` — clean
- `npx vitest run --config vitest.config.ci.ts` — 487/487 pass, 9709 tests

### Backward Compatibility

- 100% backward compatible — env-gate defaults to OFF (NullUnifiedStoreWriter)
- Existing SkeletonCacheService behavior unchanged when UNIFIED_STORE_DUAL_WRITE is unset

### Acceptance Criteria Progress

- [x] Schéma + migration Postgres (Phase A — `migrations/001_init_unified_store.sql`)
- [ ] Exposition via sous-domaine dédié (ops — not this PR)
- [ ] Prototype fonctionnel (latence < 500ms lecture, < 2s écriture) — needs DB
- [ ] Recherche 2-temps validée (Phase C — reader not yet implemented)
- [x] Backward compat skeleton-cache local (env-gate OFF = unchanged)