### PR TITLE
fix(test): make analyze_problems stale-decision fixtures date-relative

### DIFF
--- a/servers/roo-state-manager/src/tools/diagnostic/__tests__/analyze_problems.test.ts
+++ b/servers/roo-state-manager/src/tools/diagnostic/__tests__/analyze_problems.test.ts
@@ -235,23 +235,27 @@ describe('analyze_problems', () => {
 		// ============================================================
 
 		describe('stale decision cleanup', () => {
+			// Dates are computed relative to "now" so the fixtures never drift across
+			// the STALE_THRESHOLD_DAYS (30j) boundary on a given calendar day.
+			const daysAgo = (n: number) =>
+				new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 			const staleContent = [
 				'<!-- DECISION_BLOCK_START -->',
 				'**ID:** `DEC-STALE-1`',
 				'**Statut:** pending',
-				'**Créé:** 2025-12-01',
+				`**Créé:** ${daysAgo(180)}`,
 				'<!-- DECISION_BLOCK_END -->',
 				'',
 				'<!-- DECISION_BLOCK_START -->',
 				'**ID:** `DEC-FRESH`',
 				'**Statut:** pending',
-				'**Créé:** 2026-05-01',
+				`**Créé:** ${daysAgo(5)}`,
 				'<!-- DECISION_BLOCK_END -->',
 				'',
 				'<!-- DECISION_BLOCK_START -->',
 				'**ID:** `DEC-STALE-2`',
 				'**Statut:** pending',
-				'**Créé:** 2025-11-15',
+				`**Créé:** ${daysAgo(200)}`,
 				'<!-- DECISION_BLOCK_END -->',
 			].join('\n');
 
@@ -286,7 +290,7 @@ describe('analyze_problems', () => {
 					'<!-- DECISION_BLOCK_START -->',
 					'**ID:** `DEC-FRESH`',
 					'**Statut:** pending',
-					'**Créé:** 2026-05-01',
+					`**Créé:** ${daysAgo(5)}`,
 					'<!-- DECISION_BLOCK_END -->',
 				].join('\n');
 				mockStat.mockResolvedValueOnce({ size: 200 });


### PR DESCRIPTION
## Problem

`analyze_problems` "stale decision cleanup" test fixtures hardcoded `**Créé:** 2026-05-01` for `DEC-FRESH`. With `STALE_THRESHOLD_DAYS = 30` and `ageDays = ageMs / 86_400_000` compared as a raw float (`> 30`), the `DEC-FRESH` fixture aged into "stale" **exactly at 2026-05-31** (30 days after 2026-05-01).

This flips `staleDecisions` from 2 → 3 and breaks **3 tests** on every CI run dated `>= 2026-05-31`:
- `detects stale pending decisions` (expected 3 to be 2)
- `cleanupStale removes stale decisions from roadmap` (expected 3 to be 2)
- `cleanupStale with no stale decisions does not write file` (expected 1 to be +0)

It's a **date-bomb** that blocks every `mcps/internal` pointer-bump CI fleet-wide (caught on roo-extensions#2445).

## Why #569's own CI passed but the parent failed

#569 (Phase C Reader) ran its last CI **before** midnight UTC 2026-05-31 (DEC-FRESH was 29 days → fresh → green 6/6). The roo-extensions parent matrix ran at 00:47Z **after** midnight (DEC-FRESH = 30.03 days → stale → red). Same SHA, threshold crossed in between. **Not a Phase C regression.**

## Fix

Replace the hardcoded fixture dates with a `daysAgo(n)` helper so fixtures are always unambiguously stale (180/200d) or fresh (5d) regardless of run date.

- Test-only change; **no production code touched**.
- 17/17 `analyze_problems` tests pass; `npm run build` clean.