### PR TITLE
fix(tools): read_vscode_logs falsy bug + raw stack trace (#2307 Phase 4)

### DIFF
--- a/servers/roo-state-manager/src/tools/read-vscode-logs.ts
+++ b/servers/roo-state-manager/src/tools/read-vscode-logs.ts
@@ -55,9 +55,9 @@ export const readVscodeLogs = {
     },
     async handler(args: { lines?: number; filter?: string; maxSessions?: number }): Promise<CallToolResult> {
         const safeArgs = args || {};
-        const lineCount = safeArgs.lines || 100;
+        const lineCount = safeArgs.lines ?? 100;
         const { filter } = safeArgs;
-        const maxSessions = safeArgs.maxSessions || 1;
+        const maxSessions = safeArgs.maxSessions ?? 1;
         const rootLogsPath = path.join(process.env.APPDATA || '', 'Code', 'logs');
         const debugLog: string[] = [`[DEBUG] Smart Log Search starting in: ${rootLogsPath}`];
 
@@ -166,7 +166,7 @@ export const readVscodeLogs = {
         } catch (error) {
             // 🎯 CORRECTION SDDD: Gestion robuste des erreurs de filtrage
             // Si filter est undefined, ne pas essayer de l'utiliser dans le message d'erreur
-            const errorMessage = `Failed to read VS Code logs: ${(error as Error).stack}\n\nDEBUG LOG:\n${debugLog.join('\n')}`;
+            const errorMessage = `Failed to read VS Code logs: ${(error as Error).message}\n\nDEBUG LOG:\n${debugLog.join('\n')}`;
             console.error(errorMessage);
             return { content: [{ type: 'text' as const, text: errorMessage }] };
         }


### PR DESCRIPTION
## Fix

Addresses #2307 Phase 4 P1 item from po-2026 infrastructure audit.

### Changes

1. **`lines: 0` falsy bug** (L58): `safeArgs.lines || 100` → `safeArgs.lines ?? 100`
   - Previously, passing `lines: 0` silently fell back to 100 (0 is falsy)
   - Now correctly uses nullish coalescing

2. **`maxSessions: 0` same bug** (L60): `safeArgs.maxSessions || 1` → `safeArgs.maxSessions ?? 1`

3. **Raw stack trace leak** (L169): `(error as Error).stack` → `(error as Error).message`
   - Avoids leaking raw stack traces to LLM clients in error messages

### Testing
- Build: `npm run build` — clean (tsc OK)
- Tests: 8/8 passing (`src/tools/__tests__/read-vscode-logs.test.ts`)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>