### PR TITLE
fix(condense): explicit errors instead of opaque timeouts

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -874,6 +874,42 @@ function truncateError(msg: string): string {
   return msg.length > 240 ? `${msg.slice(0, 237)}...` : msg;
 }
 
+/** Host[:port] of the condensation LLM endpoint — for explicit error context (host only, no secret). */
+export function condenseEndpointHost(): string {
+  const raw = process.env.OPENAI_BASE_URL || '';
+  try { return new URL(raw).host || '(OPENAI_BASE_URL unset)'; }
+  catch { return raw || '(OPENAI_BASE_URL unset)'; }
+}
+
+/**
+ * Build an EXPLICIT, human-readable failure string for a failed condensation LLM call.
+ *
+ * User mandate 2026-06-01: "le condenser doit exploser avec des erreurs explicites le
+ * cas échéant, pas nous mettre des timeout dont on ne sait ce qu'il y a derrière."
+ * A bare "timeout" tells the operator nothing — this surfaces WHAT failed (HTTP status,
+ * provider body, or a socket hang), against WHICH endpoint/model, and after how long.
+ */
+export function describeLLMError(
+  error: unknown,
+  opts: { isTimeout: boolean; timeoutMs: number; elapsedMs: number; model: string }
+): string {
+  const host = condenseEndpointHost();
+  const provider = isOpenAICompatVLlm() ? 'vLLM' : 'remote';
+  const ctx = `[${provider} ${host} model=${opts.model}]`;
+  if (opts.isTimeout) {
+    return `TIMEOUT after ${Math.round(opts.elapsedMs / 1000)}s (limit ${Math.round(opts.timeoutMs / 1000)}s): `
+      + `no response — socket held open, neither a completion nor an HTTP error. `
+      + `Endpoint likely hung (check vLLM/gateway health). ${ctx}`;
+  }
+  // OpenAI SDK APIError exposes .status (HTTP code) / .code / .error.message
+  const e = error as { status?: number; code?: string; message?: string; error?: { message?: string } };
+  const httpStatus = typeof e?.status === 'number' ? `HTTP ${e.status}` : '';
+  const code = e?.code ? `code=${e.code}` : '';
+  const body = e?.error?.message || e?.message || String(error);
+  const prefix = [httpStatus, code].filter(Boolean).join(' ');
+  return truncateError(`${prefix ? prefix + ': ' : ''}${body} ${ctx}`);
+}
+
 /**
  * Génère un résumé LLM des messages intercom (#858)
  *
@@ -1009,7 +1045,7 @@ FORMAT :
       }
       stats.finalOutcome = isTimeout ? 'timeout' : 'error';
       stats.elapsedMs = Date.now() - callStart;
-      stats.lastError = truncateError(errStr);
+      stats.lastError = describeLLMError(error, { isTimeout, timeoutMs, elapsedMs: stats.elapsedMs, model: modelId });
       return { content: null, stats };
     }
   }
@@ -1206,7 +1242,7 @@ Mets à jour le statut en intégrant les informations des messages [SERA ARCHIV�
       }
       stats.finalOutcome = isTimeout ? 'timeout' : 'error';
       stats.elapsedMs = Date.now() - callStart;
-      stats.lastError = truncateError(errStr);
+      stats.lastError = describeLLMError(error, { isTimeout, timeoutMs, elapsedMs: stats.elapsedMs, model: modelId });
       return { content: null, stats };
     }
   }
@@ -1415,10 +1451,16 @@ ${archiveMessages}
   const totalElapsed = Date.now() - condensationStart;
   let errorDetail = '';
   if (failedCalls) {
-    const s = failedCalls.statusCall;
-    const sm = failedCalls.summaryCall;
-    if (s) errorDetail += `Status: ${s.stats.finalOutcome}. `;
-    if (sm) errorDetail += `Summary: ${sm.stats.finalOutcome}. `;
+    // Surface the EXPLICIT cause (HTTP status / timeout+endpoint), not just the outcome
+    // label — user mandate 2026-06-01: no opaque "timeout" without what's behind it.
+    const fmtFail = (label: string, c?: LLMCallResult): string => {
+      if (!c) return '';
+      const st = c.stats;
+      if (st.finalOutcome === 'ok') return `${label}: ok.\n`;
+      const why = st.lastError ? ` — ${st.lastError}` : '';
+      return `${label}: ${st.finalOutcome} (${st.attempts} attempt${st.attempts === 1 ? '' : 's'}, ${Math.round(st.elapsedMs / 1000)}s)${why}\n`;
+    };
+    errorDetail = fmtFail('Status', failedCalls.statusCall) + fmtFail('Summary', failedCalls.summaryCall);
   }
 
   const noticeMessage: IntercomMessage = {
@@ -2493,24 +2535,30 @@ async function handleAppend(
   // Build a diagnostic suffix for the human message whenever condensation was
   // attempted — so the failure mode is visible in the primary tool result
   // (not just in condenseDiagnostic which some consumers won't inspect).
+  // Surface condensation failures in the PRIMARY tool result regardless of the
+  // `condensed` flag. The truncation fallback archives messages (so condensed=true)
+  // yet the LLM failed — without this, the agent sees "auto-condensation OK" and never
+  // learns the summary was brute-truncated. User mandate 2026-06-01: explicit, not opaque.
   let diagSuffix = '';
-  if (condenseDiagnostics.length > 0 && !condensed) {
-    const failed = condenseDiagnostics.filter(d =>
-      d.outcome === 'llm-failed-dedup' || d.outcome === 'llm-failed-injected'
-    );
-    if (failed.length > 0) {
-      const first = failed[0];
-      const totalS = Math.round(failed.reduce((sum, d) => sum + d.elapsedMs, 0) / 1000);
-      const summary = first.llm?.summary;
-      const status = first.llm?.status;
-      const llmBits: string[] = [];
-      if (summary) llmBits.push(`summary=${summary.finalOutcome}×${summary.attempts}`);
-      if (status) llmBits.push(`status=${status.finalOutcome}×${status.attempts}`);
-      const dedupNote = failed.some(d => d.outcome === 'llm-failed-dedup')
-        ? ' [recent error msg within dedup window → not re-injected]'
-        : '';
-      diagSuffix = ` — LLM échoué (${totalS}s total, ${llmBits.join(', ')})${dedupNote}`;
-    }
+  const failedDiags = condenseDiagnostics.filter(d =>
+    d.outcome === 'llm-failed-dedup' || d.outcome === 'llm-failed-injected' || d.outcome === 'fallback-truncated'
+  );
+  if (failedDiags.length > 0) {
+    const first = failedDiags[0];
+    const totalS = Math.round(failedDiags.reduce((sum, d) => sum + d.elapsedMs, 0) / 1000);
+    const summary = first.llm?.summary;
+    const status = first.llm?.status;
+    const llmBits: string[] = [];
+    if (summary) llmBits.push(`summary=${summary.finalOutcome}×${summary.attempts}`);
+    if (status) llmBits.push(`status=${status.finalOutcome}×${status.attempts}`);
+    // Explicit underlying cause — HTTP status / timeout+endpoint — not just the label.
+    const why = summary?.lastError || status?.lastError || '';
+    const dedupNote = failedDiags.some(d => d.outcome === 'llm-failed-dedup')
+      ? ' [recent error msg within dedup window → not re-injected]' : '';
+    const truncNote = failedDiags.some(d => d.outcome === 'fallback-truncated')
+      ? ' [truncation fallback: messages archived WITHOUT LLM summary]' : '';
+    const head = llmBits.length > 0 ? `LLM échoué (${totalS}s, ${llmBits.join(', ')})` : `condensation dégradée (${totalS}s)`;
+    diagSuffix = ` — ⚠️ ${head}${why ? `: ${why}` : ''}${dedupNote}${truncNote}`;
   }
 
   const totalMs = Date.now() - appendStart;

--- a/servers/roo-state-manager/tests/unit/tools/roosync/condense-error-explicit.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/condense-error-explicit.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describeLLMError, condenseEndpointHost } from '../../../../src/tools/roosync/dashboard.js';
+
+/**
+ * Regression guard for the user mandate (2026-06-01):
+ *   "Le condenser doit exploser avec des erreurs explicites le cas échéant,
+ *    pas nous mettre des timeout dont on ne sait ce qu'il y a derrière."
+ *
+ * A condensation failure must surface WHAT failed, against WHICH endpoint/model,
+ * and after how long — never an opaque, contextless "timeout".
+ */
+describe('condense explicit-error surfacing (describeLLMError)', () => {
+  const ORIG = process.env.OPENAI_BASE_URL;
+
+  beforeEach(() => {
+    process.env.OPENAI_BASE_URL = 'https://api.medium.text-generation-webui.myia.io/v1';
+  });
+  afterEach(() => {
+    if (ORIG === undefined) delete process.env.OPENAI_BASE_URL;
+    else process.env.OPENAI_BASE_URL = ORIG;
+  });
+
+  it('condenseEndpointHost returns the host only (no secret/path)', () => {
+    const host = condenseEndpointHost();
+    expect(host).toBe('api.medium.text-generation-webui.myia.io');
+    expect(host).not.toContain('/v1');
+  });
+
+  it('condenseEndpointHost is robust when OPENAI_BASE_URL is unset or malformed', () => {
+    delete process.env.OPENAI_BASE_URL;
+    expect(condenseEndpointHost()).toBe('(OPENAI_BASE_URL unset)');
+    process.env.OPENAI_BASE_URL = 'not-a-url';
+    expect(condenseEndpointHost()).toBe('not-a-url');
+  });
+
+  it('timeout case: surfaces duration, limit, endpoint host, model and a hang explanation', () => {
+    const msg = describeLLMError(new Error('aborted'), {
+      isTimeout: true,
+      timeoutMs: 720_000,
+      elapsedMs: 723_456,
+      model: 'qwen3.6-35b-a3b',
+    });
+    expect(msg).toContain('TIMEOUT after 723s');
+    expect(msg).toContain('limit 720s');
+    expect(msg).toContain('socket held open');
+    expect(msg).toContain('api.medium.text-generation-webui.myia.io');
+    expect(msg).toContain('model=qwen3.6-35b-a3b');
+    // vLLM endpoint → provider label vLLM
+    expect(msg).toContain('[vLLM ');
+  });
+
+  it('HTTP-error case: surfaces the status code and the provider body', () => {
+    const apiErr = { status: 400, error: { message: 'enable_thinking is not a valid parameter' } };
+    const msg = describeLLMError(apiErr, {
+      isTimeout: false,
+      timeoutMs: 720_000,
+      elapsedMs: 1_200,
+      model: 'glm-5.1',
+    });
+    expect(msg).toContain('HTTP 400');
+    expect(msg).toContain('enable_thinking is not a valid parameter');
+    expect(msg).toContain('model=glm-5.1');
+  });
+
+  it('remote (non-vLLM) endpoint is labelled "remote"', () => {
+    process.env.OPENAI_BASE_URL = 'https://api.z.ai/v1';
+    const msg = describeLLMError(new Error('boom'), {
+      isTimeout: true,
+      timeoutMs: 720_000,
+      elapsedMs: 720_000,
+      model: 'glm-5.1',
+    });
+    expect(msg).toContain('[remote ');
+    expect(msg).toContain('api.z.ai');
+  });
+
+  it('error with code but no status still produces an explicit, bounded string', () => {
+    const netErr = { code: 'ECONNRESET', message: 'socket hang up' };
+    const msg = describeLLMError(netErr, {
+      isTimeout: false,
+      timeoutMs: 720_000,
+      elapsedMs: 5_000,
+      model: 'glm-5.1',
+    });
+    expect(msg).toContain('code=ECONNRESET');
+    expect(msg).toContain('socket hang up');
+    expect(msg.length).toBeLessThanOrEqual(240);
+  });
+});


### PR DESCRIPTION
## Contexte

Mandat utilisateur 2026-06-01 : *« Le condenser doit exploser avec des erreurs explicites le cas échéant, pas nous mettre des timeout dont on ne sait ce qu'il y a derrière. »*

Lors d'un blocage de condensation du dashboard, l'opérateur ne voyait qu'un `timeout` nu, sans contexte — et quand le fallback de troncature (#1792) se déclenchait, le message était carrément trompeur (`(auto-condensation: N messages archivés)`), sans aucun indice d'échec. Impossible de savoir **quoi** a échoué, contre **quel** endpoint/modèle, ni après **combien de temps**.

## Changements (tous sur les chemins d'erreur/diagnostic — happy path et résilience #1792 intacts)

- **`describeLLMError()`** : construit une cause lisible — `HTTP <status>` + body provider pour les erreurs API, ou `TIMEOUT after Ns (limit Ms) — socket held open …` pour les hangs — taguée `[provider host model=…]`.
- **`condenseEndpointHost()`** : libellé endpoint host-only (aucun secret/chemin).
- Les `catch` de **summary** et **status-update** stockent désormais `describeLLMError()` dans `stats.lastError`.
- **`executeTruncationFallback()`** : le message WARN imprime la cause explicite par appel (outcome Status/Summary + attempts + durée + raison).
- **`diagSuffix`** : se déclenche aussi sur `fallback-truncated` (auparavant exclu quand `condensed=true`), faisant remonter la vraie raison avec ⚠️ dans la réponse de l'append.

## Note de cadrage (anti-pendule)

**`CONDENSE_LLM_TIMEOUT_MS` (720s) est INCHANGÉ** délibérément. Le grief utilisateur porte sur l'**opacité**, pas la durée (mandat précédent : *« qu'elle prenne longtemps… mais elle doit aboutir »*). Le fix = **faire remonter** la cause, pas raccourcir le délai.

## Tests

Ajoute `tests/unit/tools/roosync/condense-error-explicit.test.ts` (6 cas : timeout, erreur HTTP, labelling remote vs vLLM, erreur code-only, parsing host). Suite roosync complète : 580 + 6 = 586 verts, build `tsc` clean.

## Déblocage immédiat CoursIA (hors PR)

La régression CoursIA observée = **process MCP stale** (pré-cap 12000 tokens / pré-#575) tournant encore. Le code corrigé est déjà live pour tout process frais → débloquer = **redémarrer le VS Code / extension host Roo de CoursIA**. Cette PR est le durcissement durable pour qu'un futur échec affiche la cause explicite au lieu d'un timeout opaque de 900s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)