### PR TITLE
feat(config): extend apply_profile with schedules + rules overrides (#2411)

### DIFF
--- a/servers/roo-state-manager/src/services/ConfigSharingService.ts
+++ b/servers/roo-state-manager/src/services/ConfigSharingService.ts
@@ -139,6 +139,12 @@ export class ConfigSharingService implements IConfigSharingService {
       manifest.files.push(...schtasksFiles);
     }
 
+    // #2411 — Collecte des schedules Roo (.roo/schedules.json)
+    if (options.targets.includes('schedules')) {
+      const schedulesFiles = await this.collectSchedules(tempDir);
+      manifest.files.push(...schedulesFiles);
+    }
+
     // Calcul de la taille totale
     for (const file of manifest.files) {
       totalSize += file.size;
@@ -347,6 +353,7 @@ export class ConfigSharingService implements IConfigSharingService {
       const hasSettingsTarget = options.targets?.includes('settings') || false;
       const hasClaudeConfigTarget = options.targets?.includes('claude-config') || false;
       const hasModesYamlTarget = options.targets?.includes('modes-yaml') || false;
+      const hasSchedulesTarget = options.targets?.includes('schedules') || false;
 
       // #2409 — Services targets (live management, not file copy)
       const servicesTargets = options.targets?.filter(t => typeof t === 'string' && t.startsWith('services:')) as string[] || [];
@@ -423,6 +430,48 @@ export class ConfigSharingService implements IConfigSharingService {
         }
       }
 
+      // #2411 — Schedules target apply (ID-based merge into .roo/schedules.json)
+      if (hasSchedulesTarget || applyAll) {
+        const schedulesStatePath = join(configDir, 'schedules', 'schedules.json');
+        if (existsSync(schedulesStatePath)) {
+          this.logger.info('Applying schedules target');
+          try {
+            const inventory2 = await this.inventoryService.getMachineInventory() as any;
+            if (inventory2?.paths?.rooExtensions) {
+              const localSchedulesPath = join(inventory2.paths.rooExtensions, '.roo', 'schedules.json');
+              const packageRaw = await fs.readFile(schedulesStatePath, 'utf-8');
+              const packageData = JSON.parse(packageRaw) as { schedules: any[] };
+
+              // ID-based merge
+              let localSchedules: any[] = [];
+              if (existsSync(localSchedulesPath)) {
+                const localRaw = await fs.readFile(localSchedulesPath, 'utf-8');
+                const localData = JSON.parse(localRaw) as { schedules: any[] };
+                localSchedules = localData.schedules || [];
+              }
+
+              const merged = this.mergeSchedulesById(packageData.schedules || [], localSchedules);
+
+              if (!options.dryRun) {
+                // Backup
+                if (options.backup !== false && existsSync(localSchedulesPath)) {
+                  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+                  const backupSchedPath = `${localSchedulesPath}.backup_${ts}`;
+                  await fs.copyFile(localSchedulesPath, backupSchedPath);
+                  this.logger.info(`Schedules backup: ${backupSchedPath}`);
+                }
+                await fs.mkdir(dirname(localSchedulesPath), { recursive: true });
+                await fs.writeFile(localSchedulesPath, JSON.stringify({ schedules: merged }, null, 2), 'utf-8');
+                filesApplied++;
+                this.logger.info(`Schedules applied: ${merged.length} schedules (merged from ${packageData.schedules?.length || 0} package + ${localSchedules.length} local)`);
+              }
+            }
+          } catch (schedErr) {
+            errors.push(`Schedules apply failed: ${schedErr instanceof Error ? schedErr.message : String(schedErr)}`);
+          }
+        }
+      }
+
       this.logger.info('Targets de configuration', {
         applyAll,
         hasMcpTarget,
@@ -432,6 +481,7 @@ export class ConfigSharingService implements IConfigSharingService {
         hasModelConfigsTarget,
         hasRulesTarget,
         hasSettingsTarget,
+        hasSchedulesTarget,
         mcpServerNames
       });
 
@@ -461,6 +511,8 @@ export class ConfigSharingService implements IConfigSharingService {
             shouldProcess = hasClaudeConfigTarget;
           } else if (file.path.startsWith('modes-yaml/')) {
             shouldProcess = hasModesYamlTarget;
+          } else if (file.path.startsWith('schedules/')) {
+            shouldProcess = hasSchedulesTarget;
           } else if (file.path.startsWith('mcp-settings/')) {
             // #601: Handle all MCP settings files (mcp_settings.json, mcp_user.json, mcp_project.json)
             shouldProcess = hasMcpTarget || hasMcpTargets;
@@ -527,6 +579,9 @@ export class ConfigSharingService implements IConfigSharingService {
           } else if (file.path.startsWith('modes-yaml/')) {
             // modes-yaml/custom_modes.yaml -> %APPDATA%/.../custom_modes.yaml
             destPath = join(getExtensionSettingsPath(), 'custom_modes.yaml');
+          } else if (file.path.startsWith('schedules/')) {
+            // #2411 — schedules/schedules.json -> .roo/schedules.json (skip, handled by merge above)
+            continue;
           } else {
             this.logger.warn(`Type de fichier non supporté ou chemin inconnu: ${file.path}`);
             continue;
@@ -962,7 +1017,104 @@ export class ConfigSharingService implements IConfigSharingService {
         }
       }
 
-      // 6. Validation post-apply (#2413) — vérifie que le profil est effectivement déployé
+      // 6. #2411 — Apply schedules overrides from profile (if present)
+      let schedulesApplied = 0;
+      const schedulesMerged: string[] = [];
+      if (profile.schedulesOverrides && !options.dryRun) {
+        try {
+          const localSchedulesPath = join(inventory.paths.rooExtensions, '.roo', 'schedules.json');
+
+          // Read current local schedules
+          let localSchedules: any[] = [];
+          if (existsSync(localSchedulesPath)) {
+            const localRaw = await fs.readFile(localSchedulesPath, 'utf-8');
+            const localData = JSON.parse(localRaw) as { schedules: any[] };
+            localSchedules = localData.schedules || [];
+          }
+
+          // Merge: profile overrides are the source, local schedules are the base
+          const overridesArray = Array.isArray(profile.schedulesOverrides)
+            ? profile.schedulesOverrides
+            : Object.values(profile.schedulesOverrides);
+          const merged = this.mergeSchedulesById(overridesArray, localSchedules);
+
+          // Track which schedule IDs were affected
+          for (const override of overridesArray) {
+            if (override.id) {
+              schedulesMerged.push(override.id);
+            }
+          }
+          schedulesApplied = overridesArray.length;
+
+          // Backup before write
+          if (options.backup !== false && existsSync(localSchedulesPath)) {
+            const ts = new Date().toISOString().replace(/[:.]/g, '-');
+            await fs.copyFile(localSchedulesPath, `${localSchedulesPath}.backup_${ts}`);
+          }
+
+          await fs.mkdir(dirname(localSchedulesPath), { recursive: true });
+          await fs.writeFile(localSchedulesPath, JSON.stringify({ schedules: merged }, null, 2), 'utf-8');
+          this.logger.info(`Schedules overrides applied: ${schedulesApplied} schedules merged`);
+        } catch (schedErr: any) {
+          errors.push(`Schedules overrides failed: ${schedErr.message}`);
+        }
+      }
+
+      // 7. #2411 — Apply rules overrides from profile (if present)
+      let rulesApplied = 0;
+      const rulesSynced: string[] = [];
+      if (profile.rulesOverrides && !options.dryRun) {
+        try {
+          const rulesDir = join(inventory.paths.rooExtensions, '.roo', 'rules');
+          await fs.mkdir(rulesDir, { recursive: true });
+
+          // Rules source: from roo-config/rules-global/ or inline in profile
+          const rulesSourceDir = join(inventory.paths.rooExtensions, 'roo-config', 'rules-global');
+
+          for (const ruleSpec of profile.rulesOverrides as string[]) {
+            if (ruleSpec.startsWith('+')) {
+              // Add/copy rule
+              const ruleName = ruleSpec.slice(1);
+              const srcPath = join(rulesSourceDir, ruleName);
+              const destPath = join(rulesDir, ruleName);
+              if (existsSync(srcPath)) {
+                await fs.copyFile(srcPath, destPath);
+                rulesApplied++;
+                rulesSynced.push(ruleName);
+              } else {
+                errors.push(`Rule source not found: ${ruleName}`);
+              }
+            } else if (ruleSpec.startsWith('-')) {
+              // Remove rule (preserve *-local.md files)
+              const ruleName = ruleSpec.slice(1);
+              if (ruleName.endsWith('-local.md')) {
+                this.logger.warn(`Skipping removal of local rule: ${ruleName}`);
+                continue;
+              }
+              const destPath = join(rulesDir, ruleName);
+              if (existsSync(destPath)) {
+                await fs.unlink(destPath);
+                rulesApplied++;
+                rulesSynced.push(ruleName);
+              }
+            } else {
+              // Plain name = copy (backward compat)
+              const srcPath = join(rulesSourceDir, ruleSpec);
+              const destPath = join(rulesDir, ruleSpec);
+              if (existsSync(srcPath)) {
+                await fs.copyFile(srcPath, destPath);
+                rulesApplied++;
+                rulesSynced.push(ruleSpec);
+              }
+            }
+          }
+          this.logger.info(`Rules overrides applied: ${rulesApplied} rules synced`);
+        } catch (ruleErr: any) {
+          errors.push(`Rules overrides failed: ${ruleErr.message}`);
+        }
+      }
+
+      // 8. Validation post-apply (#2413) — vérifie que le profil est effectivement déployé
       let validation: ApplyProfileResult['validation'] = undefined;
       if (options.validate && !options.dryRun) {
         const roomodesPath = join(inventory.paths.rooExtensions, '.roomodes');
@@ -981,9 +1133,13 @@ export class ConfigSharingService implements IConfigSharingService {
         apiConfigsCount: Object.keys(modelConfigs.apiConfigs || {}).length,
         backupPath,
         roomodesGenerated,
+        schedulesApplied: schedulesApplied > 0 ? schedulesApplied : undefined,
+        rulesApplied: rulesApplied > 0 ? rulesApplied : undefined,
         changes: {
           modeApiConfigs: newModeApiConfigs,
-          profileThresholds: newThresholds
+          profileThresholds: newThresholds,
+          schedulesMerged: schedulesMerged.length > 0 ? schedulesMerged : undefined,
+          rulesSynced: rulesSynced.length > 0 ? rulesSynced : undefined
         },
         errors: errors.length > 0 ? errors : undefined,
         validation
@@ -1857,5 +2013,81 @@ export class ConfigSharingService implements IConfigSharingService {
     }
 
     return files;
+  }
+
+  /**
+   * #2411 — Collecte les schedules Roo (.roo/schedules.json)
+   */
+  private async collectSchedules(tempDir: string): Promise<ConfigManifestFile[]> {
+    const files: ConfigManifestFile[] = [];
+    const schedulesDir = join(tempDir, 'schedules');
+    await fs.mkdir(schedulesDir, { recursive: true });
+
+    const inventory = await this.inventoryService.getMachineInventory() as any;
+    if (!inventory?.paths?.rooExtensions) {
+      this.logger.warn('Inventaire incomplet: paths.rooExtensions non disponible pour collecter schedules');
+      return files;
+    }
+
+    const schedulesPath = join(inventory.paths.rooExtensions, '.roo', 'schedules.json');
+
+    if (!existsSync(schedulesPath)) {
+      this.logger.warn(`schedules.json non trouvé: ${schedulesPath}`);
+      return files;
+    }
+
+    try {
+      const destPath = join(schedulesDir, 'schedules.json');
+      await fs.copyFile(schedulesPath, destPath);
+
+      const hash = await this.calculateHash(destPath);
+      const stats = await fs.stat(destPath);
+
+      files.push({
+        path: 'schedules/schedules.json',
+        hash,
+        type: 'schedules_config',
+        size: stats.size,
+      });
+
+      this.logger.info(`Schedules collectées depuis: ${schedulesPath}`);
+    } catch (error) {
+      this.logger.error(`Erreur lors de la collecte des schedules: ${error}`);
+    }
+
+    return files;
+  }
+
+  /**
+   * #2411 — Merge schedules by ID (source overrides target where IDs match)
+   *
+   * Strategy:
+   *  - If a schedule in `source` has the same `id` as one in `target`, the source wins (fields override)
+   *  - Schedules in `source` without matching IDs are added
+   *  - Schedules in `target` without matching source IDs are preserved
+   */
+  private mergeSchedulesById(source: any[], target: any[]): any[] {
+    const result = [...target.map(s => ({ ...s }))];
+    const targetIdMap = new Map(result.map((s, i) => [s.id, i]));
+
+    for (const sourceSchedule of source) {
+      if (!sourceSchedule.id) {
+        // Schedule without ID — always add
+        result.push({ ...sourceSchedule });
+        continue;
+      }
+
+      const existingIdx = targetIdMap.get(sourceSchedule.id);
+      if (existingIdx !== undefined) {
+        // ID match — merge: source overrides target fields
+        result[existingIdx] = { ...result[existingIdx], ...sourceSchedule };
+      } else {
+        // New schedule — add
+        result.push({ ...sourceSchedule });
+        targetIdMap.set(sourceSchedule.id, result.length - 1);
+      }
+    }
+
+    return result;
   }
 }

--- a/servers/roo-state-manager/src/types/config-sharing.ts
+++ b/servers/roo-state-manager/src/types/config-sharing.ts
@@ -12,7 +12,7 @@ export type ClaudeCodeScope = 'user' | 'project' | 'settings';
 export interface ConfigManifestFile {
   path: string;
   hash: string;
-  type: 'mode_definition' | 'mcp_config' | 'profile_settings' | 'roomodes_config' | 'model_config' | 'rules_config' | 'roo_settings' | 'claude_config' | 'modes_yaml' | 'other';
+  type: 'mode_definition' | 'mcp_config' | 'profile_settings' | 'roomodes_config' | 'model_config' | 'rules_config' | 'roo_settings' | 'claude_config' | 'modes_yaml' | 'schedules_config' | 'other';
   size: number;
 }
 
@@ -24,7 +24,7 @@ export interface ConfigManifest {
   files: ConfigManifestFile[];
 }
 
-export type ConfigTarget = 'modes' | 'mcp' | 'profiles' | 'roomodes' | 'model-configs' | 'rules' | 'settings' | 'claude-config' | 'modes-yaml' | 'schtasks' | `mcp:${string}` | `services:${string}` | `env:${string}`;
+export type ConfigTarget = 'modes' | 'mcp' | 'profiles' | 'roomodes' | 'model-configs' | 'rules' | 'settings' | 'claude-config' | 'modes-yaml' | 'schtasks' | 'schedules' | `mcp:${string}` | `services:${string}` | `env:${string}`;
 
 export interface CollectConfigOptions {
   targets: ConfigTarget[];
@@ -110,10 +110,18 @@ export interface ApplyProfileResult {
   backupPath?: string;
   /** Indique si .roomodes a été généré et déployé */
   roomodesGenerated?: boolean;
+  /** #2411 — Nombre de schedules appliquées/mergées */
+  schedulesApplied?: number;
+  /** #2411 — Nombre de rules synchronisées */
+  rulesApplied?: number;
   /** Détails des changements */
   changes?: {
     modeApiConfigs: Record<string, string>;
     profileThresholds: Record<string, number>;
+    /** #2411 — Schedule IDs mergées (updated + added) */
+    schedulesMerged?: string[];
+    /** #2411 — Rules filenames synchronisées */
+    rulesSynced?: string[];
   };
   errors?: string[];
   /**

--- a/servers/roo-state-manager/tests/unit/services/SchedulesTarget.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/SchedulesTarget.test.ts
@@ -1,0 +1,539 @@
+/**
+ * #2411 — Tests for schedules target (collect + apply + applyProfile overrides)
+ *
+ * Covers:
+ * - mergeSchedulesById: ID-based merge strategy
+ * - schedules target in applyConfig: ID-based merge with backup
+ * - schedulesOverrides in applyProfile: profile-level schedule overrides
+ * - rulesOverrides in applyProfile: profile-level rules sync
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { existsSync } from 'fs';
+import { ConfigSharingService } from '../../../src/services/ConfigSharingService.js';
+
+// Mock InventoryService
+const mockGetMachineInventory = vi.fn();
+vi.mock('../../../src/services/roosync/InventoryService.js', () => ({
+  InventoryService: {
+    getInstance: () => ({
+      getMachineInventory: mockGetMachineInventory,
+    }),
+  },
+}));
+
+// Mock ConfigService
+const mockGetSharedStatePath = vi.fn();
+const mockConfigService = {
+  getSharedStatePath: mockGetSharedStatePath,
+};
+
+// Mock InventoryCollector
+const mockInventoryCollector = {
+  collectInventory: vi.fn(),
+};
+
+// Helper to create a temp directory
+async function createTempDir(prefix: string): Promise<string> {
+  const tmpDir = path.join(process.cwd(), 'temp', `${prefix}-${Date.now()}`);
+  await fs.mkdir(tmpDir, { recursive: true });
+  return tmpDir;
+}
+
+// Helper to clean up temp directories
+async function cleanupTempDir(dir: string) {
+  try {
+    await fs.rm(dir, { recursive: true, force: true });
+  } catch {}
+}
+
+describe('SchedulesTarget #2411', () => {
+  let service: ConfigSharingService;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetSharedStatePath.mockReturnValue('/tmp/shared-state');
+    mockGetMachineInventory.mockResolvedValue({
+      paths: {
+        rooExtensions: path.join(process.cwd(), 'test-workspace'),
+        mcpSettings: '/tmp/mcp_settings.json',
+      },
+    });
+    service = new ConfigSharingService(
+      mockConfigService as any,
+      mockInventoryCollector as any
+    );
+    tempDir = await createTempDir('sched-test');
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  describe('collectSchedules', () => {
+    it('should collect schedules.json from .roo/', async () => {
+      const workspaceDir = path.join(tempDir, 'workspace');
+      const rooDir = path.join(workspaceDir, '.roo');
+      await fs.mkdir(rooDir, { recursive: true });
+
+      const schedulesData = {
+        schedules: [
+          { id: '123', name: 'Test Schedule', mode: 'code-simple' },
+        ],
+      };
+      await fs.writeFile(
+        path.join(rooDir, 'schedules.json'),
+        JSON.stringify(schedulesData)
+      );
+
+      mockGetMachineInventory.mockResolvedValue({
+        paths: { rooExtensions: workspaceDir },
+      });
+
+      const result = await service.collectConfig({
+        targets: ['schedules'],
+      });
+
+      expect(result.filesCount).toBe(1);
+      expect(result.manifest.files[0].path).toBe('schedules/schedules.json');
+      expect(result.manifest.files[0].type).toBe('schedules_config');
+    });
+
+    it('should handle missing schedules.json gracefully', async () => {
+      const workspaceDir = path.join(tempDir, 'workspace');
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      mockGetMachineInventory.mockResolvedValue({
+        paths: { rooExtensions: workspaceDir },
+      });
+
+      const result = await service.collectConfig({
+        targets: ['schedules'],
+      });
+
+      expect(result.filesCount).toBe(0);
+    });
+  });
+
+  describe('applyConfig with schedules target', () => {
+    it('should merge schedules by ID from package into local', async () => {
+      // Setup shared state with package
+      const configDir = path.join(tempDir, 'configs', 'machine1', 'v1.0-timestamp');
+      const schedulesDir = path.join(configDir, 'schedules');
+      await fs.mkdir(schedulesDir, { recursive: true });
+
+      const packageSchedules = {
+        schedules: [
+          { id: '100', name: 'Updated Schedule', mode: 'code-complex', active: true },
+          { id: '200', name: 'New Schedule', mode: 'debug-simple' },
+        ],
+      };
+      await fs.writeFile(
+        path.join(schedulesDir, 'schedules.json'),
+        JSON.stringify(packageSchedules)
+      );
+
+      // Setup manifest
+      const manifest = {
+        version: '1.0',
+        timestamp: new Date().toISOString(),
+        author: 'test',
+        description: 'test',
+        files: [
+          {
+            path: 'schedules/schedules.json',
+            hash: 'abc',
+            type: 'schedules_config',
+            size: 100,
+          },
+        ],
+      };
+      await fs.writeFile(
+        path.join(configDir, 'manifest.json'),
+        JSON.stringify(manifest)
+      );
+
+      // Setup latest.json
+      const machineDir = path.join(tempDir, 'configs', 'machine1');
+      await fs.writeFile(
+        path.join(machineDir, 'latest.json'),
+        JSON.stringify({ version: '1.0', path: configDir, manifest })
+      );
+
+      // Setup local workspace with existing schedules
+      const workspaceDir = path.join(tempDir, 'workspace');
+      const rooDir = path.join(workspaceDir, '.roo');
+      await fs.mkdir(rooDir, { recursive: true });
+
+      const localSchedules = {
+        schedules: [
+          { id: '100', name: 'Old Schedule', mode: 'code-simple', active: false },
+          { id: '300', name: 'Local Schedule', mode: 'ask-simple' },
+        ],
+      };
+      await fs.writeFile(
+        path.join(rooDir, 'schedules.json'),
+        JSON.stringify(localSchedules)
+      );
+
+      mockGetSharedStatePath.mockReturnValue(path.join(tempDir, 'shared-state'));
+      // Create shared-state path structure
+      const ssDir = path.join(tempDir, 'shared-state', 'configs', 'machine1');
+      await fs.mkdir(ssDir, { recursive: true });
+      await fs.writeFile(
+        path.join(ssDir, 'latest.json'),
+        JSON.stringify({ version: '1.0', path: configDir, manifest })
+      );
+      // Copy config dir into shared-state
+      const ssConfigDir = path.join(tempDir, 'shared-state', 'configs', 'machine1', 'v1.0-timestamp');
+      await fs.mkdir(ssConfigDir, { recursive: true });
+      const ssSchedulesDir = path.join(ssConfigDir, 'schedules');
+      await fs.mkdir(ssSchedulesDir, { recursive: true });
+      await fs.writeFile(
+        path.join(ssSchedulesDir, 'schedules.json'),
+        JSON.stringify(packageSchedules)
+      );
+      await fs.writeFile(
+        path.join(ssConfigDir, 'manifest.json'),
+        JSON.stringify(manifest)
+      );
+
+      mockGetMachineInventory.mockResolvedValue({
+        paths: { rooExtensions: workspaceDir, mcpSettings: '/tmp/mcp.json' },
+      });
+
+      const result = await service.applyConfig({
+        machineId: 'machine1',
+        targets: ['schedules'],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.filesApplied).toBeGreaterThanOrEqual(1);
+
+      // Verify merged result
+      const mergedRaw = await fs.readFile(
+        path.join(rooDir, 'schedules.json'),
+        'utf-8'
+      );
+      const merged = JSON.parse(mergedRaw);
+
+      // Should have 3 schedules: updated 100, new 200, preserved 300
+      expect(merged.schedules).toHaveLength(3);
+
+      const schedule100 = merged.schedules.find((s: any) => s.id === '100');
+      expect(schedule100.name).toBe('Updated Schedule');
+      expect(schedule100.mode).toBe('code-complex');
+
+      const schedule200 = merged.schedules.find((s: any) => s.id === '200');
+      expect(schedule200.name).toBe('New Schedule');
+
+      const schedule300 = merged.schedules.find((s: any) => s.id === '300');
+      expect(schedule300.name).toBe('Local Schedule');
+    });
+
+    it('should create schedules.json if local file does not exist', async () => {
+      // Setup shared state
+      const ssDir = path.join(tempDir, 'shared-state', 'configs', 'machine1');
+      const configDir = path.join(ssDir, 'v1.0-timestamp');
+      const schedulesDir = path.join(configDir, 'schedules');
+      await fs.mkdir(schedulesDir, { recursive: true });
+
+      const packageSchedules = {
+        schedules: [{ id: '400', name: 'Fresh Schedule', mode: 'code-simple' }],
+      };
+      await fs.writeFile(
+        path.join(schedulesDir, 'schedules.json'),
+        JSON.stringify(packageSchedules)
+      );
+
+      const manifest = {
+        version: '1.0',
+        timestamp: new Date().toISOString(),
+        author: 'test',
+        description: 'test',
+        files: [
+          {
+            path: 'schedules/schedules.json',
+            hash: 'abc',
+            type: 'schedules_config',
+            size: 50,
+          },
+        ],
+      };
+      await fs.writeFile(
+        path.join(configDir, 'manifest.json'),
+        JSON.stringify(manifest)
+      );
+      await fs.writeFile(
+        path.join(ssDir, 'latest.json'),
+        JSON.stringify({ version: '1.0', path: configDir, manifest })
+      );
+
+      mockGetSharedStatePath.mockReturnValue(path.join(tempDir, 'shared-state'));
+
+      // Workspace without .roo/schedules.json
+      const workspaceDir = path.join(tempDir, 'workspace');
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      mockGetMachineInventory.mockResolvedValue({
+        paths: { rooExtensions: workspaceDir, mcpSettings: '/tmp/mcp.json' },
+      });
+
+      const result = await service.applyConfig({
+        machineId: 'machine1',
+        targets: ['schedules'],
+      });
+
+      expect(result.success).toBe(true);
+
+      const created = JSON.parse(
+        await fs.readFile(
+          path.join(workspaceDir, '.roo', 'schedules.json'),
+          'utf-8'
+        )
+      );
+      expect(created.schedules).toHaveLength(1);
+      expect(created.schedules[0].id).toBe('400');
+    });
+  });
+
+  describe('applyProfile with schedulesOverrides', () => {
+    it('should merge schedules from profile overrides', async () => {
+      const workspaceDir = path.join(tempDir, 'workspace');
+      const rooConfigDir = path.join(workspaceDir, 'roo-config');
+      const rooDir = path.join(workspaceDir, '.roo');
+      await fs.mkdir(rooConfigDir, { recursive: true });
+      await fs.mkdir(rooDir, { recursive: true });
+
+      // Create model-configs.json with profile containing schedulesOverrides
+      const modelConfigs = {
+        profiles: [
+          {
+            name: 'TestProfile',
+            description: 'Test',
+            modeOverrides: { 'code-simple': 'default' },
+            schedulesOverrides: [
+              { id: '100', name: 'Override Schedule', mode: 'code-complex' },
+              { id: '500', name: 'New Profile Schedule', mode: 'ask-simple' },
+            ],
+          },
+        ],
+        apiConfigs: { default: { id: 'default' } },
+      };
+      await fs.writeFile(
+        path.join(rooConfigDir, 'model-configs.json'),
+        JSON.stringify(modelConfigs)
+      );
+
+      // Create existing schedules
+      const localSchedules = {
+        schedules: [
+          { id: '100', name: 'Old Schedule', mode: 'code-simple' },
+          { id: '300', name: 'Local Only', mode: 'debug-simple' },
+        ],
+      };
+      await fs.writeFile(
+        path.join(rooDir, 'schedules.json'),
+        JSON.stringify(localSchedules)
+      );
+
+      // Create generate-modes.js (mock)
+      const scriptsDir = path.join(rooConfigDir, 'scripts');
+      await fs.mkdir(scriptsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(scriptsDir, 'generate-modes.js'),
+        'console.log("mock");'
+      );
+
+      mockGetMachineInventory.mockResolvedValue({
+        paths: { rooExtensions: workspaceDir },
+      });
+
+      const result = await service.applyProfile({
+        profileName: 'TestProfile',
+        generateModes: false, // Skip modes generation for test
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.schedulesApplied).toBe(2);
+      expect(result.changes?.schedulesMerged).toContain('100');
+      expect(result.changes?.schedulesMerged).toContain('500');
+
+      // Verify merged schedules
+      const merged = JSON.parse(
+        await fs.readFile(path.join(rooDir, 'schedules.json'), 'utf-8')
+      );
+      expect(merged.schedules).toHaveLength(3);
+
+      const s100 = merged.schedules.find((s: any) => s.id === '100');
+      expect(s100.name).toBe('Override Schedule');
+      expect(s100.mode).toBe('code-complex');
+
+      const s500 = merged.schedules.find((s: any) => s.id === '500');
+      expect(s500.name).toBe('New Profile Schedule');
+
+      // Local-only preserved
+      const s300 = merged.schedules.find((s: any) => s.id === '300');
+      expect(s300.name).toBe('Local Only');
+    });
+
+    it('should skip schedules when profile has no schedulesOverrides', async () => {
+      const workspaceDir = path.join(tempDir, 'workspace');
+      const rooConfigDir = path.join(workspaceDir, 'roo-config');
+      await fs.mkdir(rooConfigDir, { recursive: true });
+
+      const modelConfigs = {
+        profiles: [
+          {
+            name: 'NoSchedulesProfile',
+            modeOverrides: { 'code-simple': 'default' },
+            // No schedulesOverrides
+          },
+        ],
+        apiConfigs: { default: { id: 'default' } },
+      };
+      await fs.writeFile(
+        path.join(rooConfigDir, 'model-configs.json'),
+        JSON.stringify(modelConfigs)
+      );
+
+      mockGetMachineInventory.mockResolvedValue({
+        paths: { rooExtensions: workspaceDir },
+      });
+
+      const result = await service.applyProfile({
+        profileName: 'NoSchedulesProfile',
+        generateModes: false,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.schedulesApplied).toBeUndefined();
+    });
+  });
+
+  describe('applyProfile with rulesOverrides', () => {
+    it('should copy rules with + prefix and remove with - prefix', async () => {
+      const workspaceDir = path.join(tempDir, 'workspace');
+      const rooConfigDir = path.join(workspaceDir, 'roo-config');
+      const rooRulesDir = path.join(workspaceDir, '.roo', 'rules');
+      const rulesGlobalDir = path.join(rooConfigDir, 'rules-global');
+      await fs.mkdir(rooConfigDir, { recursive: true });
+      await fs.mkdir(rooRulesDir, { recursive: true });
+      await fs.mkdir(rulesGlobalDir, { recursive: true });
+
+      // Source rules in rules-global
+      await fs.writeFile(
+        path.join(rulesGlobalDir, 'new-rule.md'),
+        '# New Rule\nContent here'
+      );
+
+      // Existing rule to remove
+      await fs.writeFile(
+        path.join(rooRulesDir, 'old-rule.md'),
+        '# Old Rule\nRemove this'
+      );
+
+      // Local rule that should be preserved
+      await fs.writeFile(
+        path.join(rooRulesDir, 'keep-local.md'),
+        '# Keep Me'
+      );
+
+      const modelConfigs = {
+        profiles: [
+          {
+            name: 'RulesProfile',
+            modeOverrides: { 'code-simple': 'default' },
+            rulesOverrides: ['+new-rule.md', '-old-rule.md'],
+          },
+        ],
+        apiConfigs: { default: { id: 'default' } },
+      };
+      await fs.writeFile(
+        path.join(rooConfigDir, 'model-configs.json'),
+        JSON.stringify(modelConfigs)
+      );
+
+      mockGetMachineInventory.mockResolvedValue({
+        paths: { rooExtensions: workspaceDir },
+      });
+
+      const result = await service.applyProfile({
+        profileName: 'RulesProfile',
+        generateModes: false,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.rulesApplied).toBe(2);
+      expect(result.changes?.rulesSynced).toContain('new-rule.md');
+      expect(result.changes?.rulesSynced).toContain('old-rule.md');
+
+      // new-rule.md should exist
+      const newRule = await fs.readFile(
+        path.join(rooRulesDir, 'new-rule.md'),
+        'utf-8'
+      );
+      expect(newRule).toContain('New Rule');
+
+      // old-rule.md should be removed
+      await expect(
+        fs.access(path.join(rooRulesDir, 'old-rule.md'))
+      ).rejects.toThrow();
+
+      // keep-local.md should be preserved
+      const localRule = await fs.readFile(
+        path.join(rooRulesDir, 'keep-local.md'),
+        'utf-8'
+      );
+      expect(localRule).toContain('Keep Me');
+    });
+
+    it('should not remove *-local.md files', async () => {
+      const workspaceDir = path.join(tempDir, 'workspace');
+      const rooConfigDir = path.join(workspaceDir, 'roo-config');
+      const rooRulesDir = path.join(workspaceDir, '.roo', 'rules');
+      await fs.mkdir(rooConfigDir, { recursive: true });
+      await fs.mkdir(rooRulesDir, { recursive: true });
+
+      await fs.writeFile(
+        path.join(rooRulesDir, 'my-local.md'),
+        '# Local Rule'
+      );
+
+      const modelConfigs = {
+        profiles: [
+          {
+            name: 'ProtectLocalProfile',
+            modeOverrides: { 'code-simple': 'default' },
+            rulesOverrides: ['-my-local.md'],
+          },
+        ],
+        apiConfigs: { default: { id: 'default' } },
+      };
+      await fs.writeFile(
+        path.join(rooConfigDir, 'model-configs.json'),
+        JSON.stringify(modelConfigs)
+      );
+
+      mockGetMachineInventory.mockResolvedValue({
+        paths: { rooExtensions: workspaceDir },
+      });
+
+      const result = await service.applyProfile({
+        profileName: 'ProtectLocalProfile',
+        generateModes: false,
+      });
+
+      expect(result.success).toBe(true);
+
+      // my-local.md should still exist (protected)
+      const content = await fs.readFile(
+        path.join(rooRulesDir, 'my-local.md'),
+        'utf-8'
+      );
+      expect(content).toContain('Local Rule');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Extends ConfigSharingService with schedules and rules target support for VibeSync Phase 2.

### Changes
- ConfigTarget: added 'schedules' type
- collectConfig: collects .roo/schedules.json into manifest
- applyConfig: ID-based merge of schedules (preserve local, override matching by ID)
- applyProfile: schedulesOverrides (ID-based merge) + rulesOverrides (+/- prefix sync)
- mergeSchedulesById: source wins on ID match, preserves local-only schedules
- Safety: backup before write, skip *-local.md rules from removal
- Tests: 8 unit tests covering collect, apply, profile overrides, local protection

### Acceptance Criteria (issue #2411)
- [x] Profile accepts schedulesOverrides and rulesOverrides fields
- [x] applyProfile merges schedules by ID (preserve local schedules)
- [x] applyProfile syncs .roo/rules/*.md (+ add, - remove, preserve *-local.md)
- [x] Validation: JSON round-trip before write
- [x] Backward-compat: skips schedules/rules if profile does not define them
- [x] 8 unit tests passing

### Test Results
494 passed | 2 skipped (496 test files)
9804 passed | 23 skipped (9827 tests)

Issue: jsboige/roo-extensions#2411
Epic: jsboige/roo-extensions#2406 (VibeSync Phase 2)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>