### PR TITLE
fix(env): remove override:true from dotenv.config (#560)

### DIFF
--- a/servers/roo-state-manager/src/index.ts
+++ b/servers/roo-state-manager/src/index.ts
@@ -41,7 +41,7 @@ const __dirname = dirname(__filename);
 const envPath = path.join(__dirname, '..', '.env');
 // #1140: quiet: true prevents dotenv v17 from writing to stdout,
 // which would corrupt the MCP JSON-RPC stdio transport.
-const envResult = dotenv.config({ path: envPath, override: true, quiet: true });
+const envResult = dotenv.config({ path: envPath, quiet: true });
 if (envResult.error) {
   console.error('🔧 [DEBUG] dotenv.config error:', envResult.error);
 }


### PR DESCRIPTION
## Problem

Hermes container restore script (`hermes-restore-config.sh`) patches `.env` in-place via rw Docker volume mount. With `override: true` in `dotenv.config()`, the corrupted `.env` values **overwrite** `process.env` vars that were correctly set by Docker `-e` flags or the host environment.

### Impact
- `QDRANT_URL` changed from `https://qdrant.myia.io` to `http://localhost:1`
- `ROOSYNC_SHARED_PATH` changed from Windows GDrive path to `/opt/gdrive/shared-state`
- ~43 dashboards invisible on po-2026 (only 2 in-memory vs 45 from GDrive)
- Cross-machine coordination broken

## Fix

Remove `override: true` from `dotenv.config()` in `index.ts` (L44). Default is `false`, meaning:
- Process env vars and Docker `-e` flags take **precedence** over `.env`
- `.env` is still loaded for vars not already set
- `start.ts` already uses the default (no override) — now `index.ts` matches

## Testing
- `npm run build` ✅ (tsc clean)
- `npx vitest run --config vitest.config.ci.ts` ✅ (495 pass, 0 fail)

## Evidence
- Commit: `06d9724b` on `fix/560-dotenv-no-override`
- Related: jsboige-mcp-servers#560

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>