### PR TITLE
fix(condense): deterministic status truncation in fallback path (#2463)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -1393,6 +1393,34 @@ export function detectStatusContradictions(status: string): Array<{ entity: stri
  * with a simple template summary (no LLM). Prevents dashboard from growing unbounded
  * during LLM outages.
  */
+/**
+ * Deterministic (non-LLM) truncation: keeps the most recent lines that fit within maxSizeBytes.
+ * Used when LLM condensation fails (#2463 — status should never exceed its cap, even in fallback).
+ */
+function truncateToMaxSize(text: string, maxSizeBytes: number, label: string): string {
+  const sizeBytes = Buffer.byteLength(text, 'utf8');
+  if (sizeBytes <= maxSizeBytes) return text;
+
+  const lines = text.split('\n');
+  // Keep lines from the end (most recent) until we fit
+  let result = '';
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const candidate = lines.slice(i).join('\n');
+    if (Buffer.byteLength(candidate, 'utf8') > maxSizeBytes) break;
+    result = candidate;
+  }
+
+  const truncated = result || lines[lines.length - 1] || '';
+  logger.info(`Deterministic truncation applied to ${label}`, {
+    originalBytes: sizeBytes,
+    truncatedBytes: Buffer.byteLength(truncated, 'utf8'),
+    limitBytes: maxSizeBytes,
+    linesRemoved: lines.length - truncated.split('\n').length,
+  });
+
+  return truncated;
+}
+
 async function executeTruncationFallback(
   key: string,
   dashboard: Dashboard,
@@ -1483,8 +1511,15 @@ ${archiveMessages}
     diagnostic.archivedMessageCount = toArchive.length;
   }
 
+  // #2463: Deterministic status truncation — never let status exceed its cap,
+  // even when LLM is unavailable (the exact scenario where truncation matters most).
+  const truncatedStatus = truncateToMaxSize(
+    dashboard.status.markdown, MAX_STATUS_SIZE_BYTES, 'Status (fallback)'
+  );
+
   return {
     ...dashboard,
+    status: { ...dashboard.status, markdown: truncatedStatus },
     lastModified: now,
     intercom: {
       messages: [noticeMessage, ...toKeep],


### PR DESCRIPTION
## Fix

Dashboard condensation fallback never truncates the status section independently of LLM. When LLM condense fails, status >20KB auto-sustains (#2463).

### Changes
- Added truncateToMaxSize() (29 LOC) deterministic non-LLM truncation, keeps most recent lines within byte limit
- Applied in executeTruncationFallback: status truncated to MAX_STATUS_SIZE_BYTES (15KB) before propagation
- 1 file changed, +35 lines

### Verification
- Build: tsc clean
- Tests: 495/495 pass (0 fail, 23 skip) via vitest.config.ci.ts
- Fix authored by po-2024 (d91d0abf), PR created by po-2023 (token scope workaround)

Closes #2463

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>