### PR TITLE
fix(export): correct generateProjectXml call signature (#2307)

### DIFF
--- a/servers/roo-state-manager/src/tools/export/export-data.ts
+++ b/servers/roo-state-manager/src/tools/export/export-data.ts
@@ -424,6 +424,10 @@ async function handleProjectXml(
 ): Promise<CallToolResult> {
     const { projectPath, filePath, startDate, endDate, prettyPrint = true } = args;
 
+    if (!projectPath) {
+        return { content: [{ type: 'text', text: 'Error: projectPath is required for project XML export.' }] };
+    }
+
     await ensureSkeletonCacheIsFresh({ workspace: projectPath });
 
     // Filtrer les conversations par workspace et date
@@ -447,8 +451,7 @@ async function handleProjectXml(
         return true;
     });
 
-    const xmlContent = (xmlExporterService as any).generateProjectXml(relevantTasks, {
-        projectPath,
+    const xmlContent = xmlExporterService.generateProjectXml(relevantTasks, projectPath, {
         startDate,
         endDate,
         prettyPrint


### PR DESCRIPTION
## Problem

Bug found by po-2023 during #2307 Phase 1 audit of RSM tools.

In `export-data.ts:450`, the `handleProjectXml` handler calls `generateProjectXml` with **2 arguments**:
```ts
(xmlExporterService as any).generateProjectXml(relevantTasks, { projectPath, startDate, endDate, prettyPrint })
```

But the actual signature is:
```ts
generateProjectXml(skeletons: ConversationSkeleton[], projectPath: string, options?: ProjectExportOptions): string
```

**Effect**: `<projectPath>` in the XML output is serialized as `[object Object]` instead of the actual path string. The `as any` cast suppresses the TypeScript error, and the test mock doesn't validate the argument structure.

## Fix

Align the call with the correct pattern used in `export-project-xml.ts:103`:
```ts
xmlExporterService.generateProjectXml(relevantTasks, projectPath, { startDate, endDate, prettyPrint })
```

Also adds an early-return guard for missing `projectPath` (was undefined before, now string after guard).

## Testing

- Build: ✅ `npm run build` (tsc clean)
- CI tests: ✅ 494 passed, 1 unrelated flaky (EnvRotationService scrypt timeout)
- Export tests: ✅ 12 files, 173 tests passed

## Files changed

- `servers/roo-state-manager/src/tools/export/export-data.ts` (+5/-2)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>