### PR TITLE
docs(conversation-browser): add rebuild to action list (#2307 Phase 2)

### DIFF
--- a/servers/roo-state-manager/src/tools/conversation/conversation-browser.ts
+++ b/servers/roo-state-manager/src/tools/conversation/conversation-browser.ts
@@ -8,8 +8,9 @@
  * - 'current'   : Tâche actuellement active (anciennement task_browse action=current)
  * - 'view'      : Vue arborescente d'une conversation (anciennement view_conversation_tree)
  * - 'summarize' : Résumé/synthèse de conversation (anciennement roosync_summarize)
+ * - 'rebuild'   : Reconstruction du cache de squelettes (anciennement build_skeleton_cache)
  *
- * Changement tool count : -2 (3 outils → 1 dans ListTools)
+ * Changement tool count : -3 (4 outils → 1 dans ListTools après ajout de rebuild)
  * Backward compat : Les anciens noms restent fonctionnels via CallTool dans registry.ts
  */
 
@@ -481,7 +482,7 @@ export const conversationBrowserTool: Tool = {
 function validateArgs(args: ConversationBrowserArgs): void {
     if (!args.action) {
         throw new StateManagerError(
-            'Le paramètre "action" est requis. Valeurs possibles: "list", "tree", "current", "view", "summarize".',
+            'Le paramètre "action" est requis. Valeurs possibles: "list", "tree", "current", "view", "summarize", "rebuild".',
             'VALIDATION_FAILED',
             'ConversationBrowserTool',
             { providedArgs: Object.keys(args) }


### PR DESCRIPTION
## Summary

Fix doc drift found in #2307 Phase 1 audit (recommendation #5).

## Problem

`conversation_browser` tool supports **6 actions** (list, tree, current, view, summarize, rebuild) per the schema enum (`:184`) and dispatch switch, but the user-facing documentation only listed **5**:

- Header docblock (`:5-13`): listed 5 actions, missing `rebuild`
- `validateArgs` error message (`:484`): when a user omits `action`, the error returned listed only 5 valid values
- Tool-count delta comment (`:12`): said `-2 (3 outils → 1)`, but with `rebuild` consolidation it should be `-3 (4 outils → 1)`

## Fix

- Added `rebuild` to header docblock action list
- Added `rebuild` to `validateArgs` error message (line 484)
- Updated tool-count delta comment from `-2` to `-3`

## Why It Matters

The `validateArgs` error is the **only feedback** an agent receives when omitting the required `action` parameter. If `rebuild` is missing from this list, the agent may not know this action exists, leading to:
- Direct calls to `build_skeleton_cache` (the unconsolidated legacy tool)
- Confusion about cache freshness workflow
- Broken CONS-X consolidation intent

## Testing

- `npm run build` — clean (tsc)
- `npx vitest run src/tools/conversation/__tests__/conversation-browser.test.ts` — 37/37 pass

## References

- Audit report: `docs/reports/2307-phase1-conversation-search-audit.md` (parent repo)
- Issue: #2307 Phase 2
- Related #2307 Phase 1 PRs: #576 (Phase 4), #582 (status truncation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)