### PR TITLE
fix(search): #2472 codebase_search workspace desc + #2473 roosync_search max_results clamp

### DIFF
--- a/servers/roo-state-manager/src/tools/search/roosync-search.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/roosync-search.tool.ts
@@ -91,7 +91,7 @@ export const roosyncSearchTool: Tool = {
             },
             max_results: {
                 type: 'number',
-                description: 'Max results to return'
+                description: 'Max results to return (default: 10, max: 100)'
             },
             workspace: {
                 type: 'string',
@@ -185,6 +185,9 @@ export async function handleRooSyncSearch(
                 effectiveWorkspace = undefined;
             }
 
+            // #2473: Clamp max_results to [1, 100] to prevent unbounded Qdrant queries
+            const clampedMaxResults = Math.min(Math.max(args.max_results || 10, 1), 100);
+
             // #249: Try semantic with retry (handled inside search-semantic.tool.ts),
             // then auto-fallback to text search if semantic fails, WITH a warning flag.
             // This replaces #1496 strict_mode=true which blocked fallback entirely.
@@ -192,7 +195,7 @@ export async function handleRooSyncSearch(
             const semanticArgs: SearchTasksByContentArgs = {
                 search_query: args.search_query,
                 conversation_id: args.conversation_id,
-                max_results: args.max_results,
+                max_results: clampedMaxResults,
                 workspace: effectiveWorkspace,
                 source: args.source,
                 diagnose_index: false,

--- a/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
@@ -135,7 +135,7 @@ export interface CodebaseSearchArgs {
 	/** Requête de recherche sémantique */
 	query: string;
 
-	/** Chemin absolu du workspace (optionnel — auto-detecte via MCP roots ou WORKSPACE_PATH) */
+	/** Chemin absolu du workspace. Fortement recommande — auto-detection via MCP roots/WORKSPACE_PATH echoue souvent. */
 	workspace: string;
 
 	/** Préfixe de répertoire pour filtrer les résultats */
@@ -170,7 +170,7 @@ export const codebaseSearchTool: Tool = {
 			},
 			workspace: {
 				type: 'string',
-				description: 'Chemin absolu du workspace. Optionnel - auto-detecte via MCP roots ou WORKSPACE_PATH. Passer explicitement si le resultat semble incorrect.'
+				description: 'Chemin absolu du workspace. Fortement recommande — auto-detection via MCP roots/WORKSPACE_PATH echoue souvent. Passer explicitement recommande.'
 			},
 			directory_prefix: {
 				type: 'string',

--- a/servers/roo-state-manager/tests/unit/tools/search/roosync-search.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/search/roosync-search.test.ts
@@ -346,4 +346,50 @@ describe('roosync_search - CONS-11', () => {
             expect(searchCall.filter.must).toContainEqual({ key: 'workspace_name', match: { value: 'test-ws' } });
         });
     });
+
+    // ============================================================
+    // #2473: max_results clamp [1, 100]
+    // ============================================================
+
+    describe('#2473 max_results clamp', () => {
+        it('should clamp max_results > 100 to 100', async () => {
+            const result = await handleRooSyncSearch(
+                { action: 'semantic', search_query: 'test query', max_results: 500, workspace: 'd:\\test-workspace' },
+                conversationCache,
+                ensureCacheFreshCallback,
+                fallbackHandler
+            );
+
+            expect(result.isError).toBeFalsy();
+            const searchCall = mockQdrantClient.search.mock.calls[0][1];
+            expect(searchCall.limit).toBe(100);
+        });
+
+        it('should clamp max_results < 1 to 1', async () => {
+            const result = await handleRooSyncSearch(
+                { action: 'semantic', search_query: 'test query', max_results: 0, workspace: 'd:\\test-workspace' },
+                conversationCache,
+                ensureCacheFreshCallback,
+                fallbackHandler
+            );
+
+            expect(result.isError).toBeFalsy();
+            const searchCall = mockQdrantClient.search.mock.calls[0][1];
+            // max_results=0 is falsy, falls back to default 10 then clamped
+            expect(searchCall.limit).toBe(10);
+        });
+
+        it('should preserve max_results within [1, 100]', async () => {
+            const result = await handleRooSyncSearch(
+                { action: 'semantic', search_query: 'test query', max_results: 50, workspace: 'd:\\test-workspace' },
+                conversationCache,
+                ensureCacheFreshCallback,
+                fallbackHandler
+            );
+
+            expect(result.isError).toBeFalsy();
+            const searchCall = mockQdrantClient.search.mock.calls[0][1];
+            expect(searchCall.limit).toBe(50);
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Addresses #2307 Phase 1 audit recommendations #3 and #4 (po-2023 report).
**Authored by myia-po-2025** (commit `2279fa4d`), PR relay by po-2023 due to token scope (jsboigeEpita not collaborator).

## #2472 — codebase_search workspace description reconciliation

**Problem**: Schema description (search-codebase.tool.ts:173) said `"Optionnel - auto-detecte via MCP roots ou WORKSPACE_PATH"` while:
- Interface comment (:138) said "optionnel"
- Runtime (workspace-resolver.ts:88-95) hard-fails when not resolvable
- CLAUDE.md mandate: "REQUIRED"

→ Agents induced to omit `workspace`, then rejected.

**Fix (subtract-only per audit)**: Do NOT add `workspace` to schema `required` (Roo legitimately uses MCP roots). Rewrite description to: *"Fortement recommande - l'auto-detection (MCP roots / WORKSPACE_PATH) echoue souvent. Passez le chemin explicitement."*

## #2473 — roosync_search max_results clamp

**Problem**: `max_results` passed verbatim to Qdrant as `limit` (`search-semantic.tool.ts:646`). No upper/lower bound → a typo (e.g., 1000000) gets passed through.

**Fix**: Add `Math.min(Math.max(args.max_results || 10, 1), 100)` guard in handler. Schema description updated: *"Max results to return (default: 10, max: 100)"*.

## Testing (by po-2025)
- Build: `tsc` clean
- Tests: 20/20 `roosync-search`, 60/60 search/ all pass
- 3 new tests for `max_results` clamp:
  - `>100` clamped to 100
  - `0` falls back to 10
  - in-range preserved

## Files changed (3 files, +53/-4 LOC)
- `servers/roo-state-manager/src/tools/search/roosync-search.tool.ts`
- `servers/roo-state-manager/src/tools/search/search-codebase.tool.ts`
- `servers/roo-state-manager/tests/unit/tools/search/roosync-search.test.ts`

## References
- Audit report: `docs/reports/2307-phase1-conversation-search-audit.md` (parent repo)
- Phase 1 audit by po-2023
- Fix authored by po-2025, PR relayed by po-2023

🤖 Generated with [Claude Code](https://claude.com/claude-code)