### PR TITLE
feat(indexing): #2336 D2 — downstream-action rate in tool_usage_stats

### DIFF
--- a/servers/roo-state-manager/src/tools/indexing/__tests__/tool-usage-stats-errors.test.ts
+++ b/servers/roo-state-manager/src/tools/indexing/__tests__/tool-usage-stats-errors.test.ts
@@ -63,6 +63,156 @@ async function createClaudeSessionFixture(
 	return filePath;
 }
 
+describe('tool_usage_stats — downstream_action_rate (#2336 D2)', () => {
+    const cache = new Map();
+    const ensureFresh = vi.fn().mockResolvedValue(true);
+    const saveSkeleton = vi.fn();
+    const setEnabled = vi.fn();
+    const rebuildHandler = vi.fn();
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        mockDetectStorageLocations.mockResolvedValue([]);
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tus-da-test-'));
+        fakeHomedir = tmpDir;
+    });
+
+    afterEach(async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+        fakeHomedir = realHomedir();
+    });
+
+    test('counts downstream_action when tool_use is followed by non-tool content', async () => {
+        // Bash call → next assistant message has text (non-tool) = downstream action
+        const projDir = path.join(tmpDir, '.claude', 'projects', 'test-project');
+        const entries = [
+            // Assistant: Bash tool_use only (no text)
+            {
+                type: 'assistant',
+                message: { role: 'assistant', content: [
+                    { type: 'tool_use', id: 'toolu_da1', name: 'Bash', input: { command: 'ls' } },
+                ] },
+                timestamp: '2026-05-20T10:00:00Z',
+            },
+            { type: 'user', message: { role: 'user', content: [
+                { type: 'tool_result', tool_use_id: 'toolu_da1', content: 'file1.txt\nfile2.txt' },
+            ] } },
+            // Assistant: text reasoning (non-tool) = downstream action for Bash
+            {
+                type: 'assistant',
+                message: { role: 'assistant', content: [
+                    { type: 'text', text: 'I can see the files. Let me read file1.txt.' },
+                    { type: 'tool_use', id: 'toolu_da2', name: 'Read', input: { file_path: '/file1.txt' } },
+                ] },
+                timestamp: '2026-05-20T10:01:00Z',
+            },
+        ];
+
+        await createClaudeSessionFixture(projDir, 'session-da-001.jsonl', entries);
+
+        const result = await handleRooSyncIndexing(
+            { action: 'tool_usage_stats', start_date: '2026-05-19', end_date: '2026-05-21' },
+            cache, ensureFresh, saveSkeleton, new Set(), setEnabled, rebuildHandler,
+        );
+
+        expect(result.isError).toBe(false);
+        const parsed = JSON.parse(result.content[0].text);
+        const bash = parsed.tools.find((t: any) => t.tool_name === 'Bash');
+        expect(bash).toBeDefined();
+        expect(bash.downstream_actions).toBe(1);
+        expect(bash.downstream_action_rate).toBe(100.0); // 1/1 * 100
+    });
+
+    test('no downstream_action when tool_use is followed by another tool_use only', async () => {
+        // Edit → next assistant message has ONLY another Edit (no text) = no downstream action
+        const projDir = path.join(tmpDir, '.claude', 'projects', 'test-project');
+        const entries = [
+            {
+                type: 'assistant',
+                message: { role: 'assistant', content: [
+                    { type: 'tool_use', id: 'toolu_da10', name: 'Edit', input: {} },
+                ] },
+                timestamp: '2026-05-20T11:00:00Z',
+            },
+            { type: 'user', message: { role: 'user', content: [
+                { type: 'tool_result', tool_use_id: 'toolu_da10', content: 'ok' },
+            ] } },
+            // Next assistant: ONLY tool_use (retry) = no downstream action
+            {
+                type: 'assistant',
+                message: { role: 'assistant', content: [
+                    { type: 'tool_use', id: 'toolu_da11', name: 'Edit', input: {} },
+                ] },
+                timestamp: '2026-05-20T11:01:00Z',
+            },
+        ];
+
+        await createClaudeSessionFixture(projDir, 'session-da-002.jsonl', entries);
+
+        const result = await handleRooSyncIndexing(
+            { action: 'tool_usage_stats', start_date: '2026-05-19', end_date: '2026-05-21' },
+            cache, ensureFresh, saveSkeleton, new Set(), setEnabled, rebuildHandler,
+        );
+
+        const parsed = JSON.parse(result.content[0].text);
+        const edit = parsed.tools.find((t: any) => t.tool_name === 'Edit');
+        expect(edit).toBeDefined();
+        expect(edit.downstream_actions).toBe(0);
+        expect(edit.downstream_action_rate).toBe(0);
+    });
+
+    test('mixed: some tool_uses get downstream actions, others do not', async () => {
+        const projDir = path.join(tmpDir, '.claude', 'projects', 'test-project');
+        const entries = [
+            // Bash → no downstream (next is only tool_use)
+            {
+                type: 'assistant',
+                message: { role: 'assistant', content: [
+                    { type: 'tool_use', id: 'toolu_da20', name: 'Bash', input: {} },
+                ] },
+                timestamp: '2026-05-20T12:00:00Z',
+            },
+            { type: 'user', message: { role: 'user', content: [
+                { type: 'tool_result', tool_use_id: 'toolu_da20', content: 'ok' },
+            ] } },
+            // Assistant: only Bash tool_use = no downstream for first Bash
+            {
+                type: 'assistant',
+                message: { role: 'assistant', content: [
+                    { type: 'tool_use', id: 'toolu_da21', name: 'Bash', input: {} },
+                ] },
+                timestamp: '2026-05-20T12:01:00Z',
+            },
+            { type: 'user', message: { role: 'user', content: [
+                { type: 'tool_result', tool_use_id: 'toolu_da21', content: 'ok' },
+            ] } },
+            // Assistant: text reasoning = downstream for second Bash
+            {
+                type: 'assistant',
+                message: { role: 'assistant', content: [
+                    { type: 'text', text: 'Good, the command worked.' },
+                ] },
+                timestamp: '2026-05-20T12:02:00Z',
+            },
+        ];
+
+        await createClaudeSessionFixture(projDir, 'session-da-003.jsonl', entries);
+
+        const result = await handleRooSyncIndexing(
+            { action: 'tool_usage_stats', start_date: '2026-05-19', end_date: '2026-05-21' },
+            cache, ensureFresh, saveSkeleton, new Set(), setEnabled, rebuildHandler,
+        );
+
+        const parsed = JSON.parse(result.content[0].text);
+        const bash = parsed.tools.find((t: any) => t.tool_name === 'Bash');
+        expect(bash).toBeDefined();
+        expect(bash.calls).toBe(2);
+        expect(bash.downstream_actions).toBe(1);
+        expect(bash.downstream_action_rate).toBe(50.0); // 1/2 * 100
+    });
+});
+
 describe('tool_usage_stats — error_rate and retry_rate extraction (#549)', () => {
 	const cache = new Map();
 	const ensureFresh = vi.fn().mockResolvedValue(true);

--- a/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
@@ -778,6 +778,7 @@ export async function handleRooSyncIndexing(
                 const errorCounts: Record<string, number> = {};
                 const retryCounts: Record<string, number> = {};
                 const sourceCounts: Record<string, number> = {};
+                const downstreamActionCounts: Record<string, number> = {}; // #2336 D2: tool_use followed by non-tool action
                 let totalCalls = 0;
                 let filesScanned = 0;
 
@@ -807,7 +808,14 @@ export async function handleRooSyncIndexing(
                         const localIdMap = new Map<string, string>();
                         let lastToolName = '';
 
-                        for (const msg of messages) {
+                        // #2336 D2: Track tool_use positions for downstream-action detection.
+                        // downstream-action = tool_use followed by an assistant message with non-tool content
+                        // (reasoning, text, edit — NOT another identical tool call).
+                        interface ToolUseRecord { toolName: string; msgIdx: number; }
+                        const toolUseRecords: ToolUseRecord[] = [];
+
+                        for (let i = 0; i < messages.length; i++) {
+                            const msg = messages[i];
                             if (!Array.isArray(msg.content)) continue;
                             const ts = msg.ts ? new Date(msg.ts) : null;
 
@@ -830,6 +838,9 @@ export async function handleRooSyncIndexing(
                                         }
                                         lastToolName = toolName;
 
+                                        // #2336 D2: record position for downstream-action scan
+                                        toolUseRecords.push({ toolName, msgIdx: i });
+
                                         if (ts) {
                                             const weekKey = getISOWeek(ts.toISOString());
                                             if (!weeklyBuckets[weekKey]) weeklyBuckets[weekKey] = {};
@@ -851,6 +862,23 @@ export async function handleRooSyncIndexing(
                                         }
                                     }
                                 }
+                            }
+                        }
+
+                        // #2336 D2: Compute downstream-action rate for Roo conversation.
+                        // For each tool_use, check if the next assistant message has non-tool content.
+                        for (const rec of toolUseRecords) {
+                            for (let j = rec.msgIdx + 1; j < messages.length; j++) {
+                                const nextMsg = messages[j];
+                                if (nextMsg.role !== 'assistant' || !Array.isArray(nextMsg.content)) continue;
+                                // Found the next assistant message — check if it has non-tool_use content
+                                const hasNonToolContent = nextMsg.content.some(
+                                    (b: any) => b.type !== 'tool_use'
+                                );
+                                if (hasNonToolContent) {
+                                    downstreamActionCounts[rec.toolName] = (downstreamActionCounts[rec.toolName] || 0) + 1;
+                                }
+                                break; // Only check the first assistant message after the tool_use
                             }
                         }
                     }
@@ -878,6 +906,11 @@ export async function handleRooSyncIndexing(
                         const localIdMap = new Map<string, string>();
                         let lastToolName = '';
 
+                        // #2336 D2: Track tool_use names from previous assistant message for downstream-action.
+                        // When we see an assistant message with non-tool content, we attribute
+                        // downstream-action to all tool_uses from the previous assistant message.
+                        let prevAssistantToolUses: string[] = [];
+
                         // Read JSONL line-by-line to handle large files
                         const { createReadStream } = await import('fs');
                         const readline = await import('readline');
@@ -895,7 +928,24 @@ export async function handleRooSyncIndexing(
                             if (message.role === 'assistant' && Array.isArray(message.content)) {
                                 const tsRaw = entry.timestamp || message.timestamp;
                                 const ts = tsRaw ? new Date(tsRaw) : null;
-                                if (ts && (ts < startDate || ts > endDate)) continue;
+                                if (ts && (ts < startDate || ts > endDate)) {
+                                    prevAssistantToolUses = [];
+                                    continue;
+                                }
+
+                                // #2336 D2: Check if this assistant message has non-tool content
+                                // (meaning previous tool_uses led to productive action)
+                                const hasNonToolContent = message.content.some(
+                                    (b: any) => b.type !== 'tool_use'
+                                );
+                                if (hasNonToolContent && prevAssistantToolUses.length > 0) {
+                                    for (const prevTool of prevAssistantToolUses) {
+                                        downstreamActionCounts[prevTool] = (downstreamActionCounts[prevTool] || 0) + 1;
+                                    }
+                                }
+
+                                // Collect tool_uses from this message for next-iteration check
+                                const currentToolUses: string[] = [];
 
                                 for (const block of message.content) {
                                     if (block.type === 'tool_use' && block.name) {
@@ -914,12 +964,26 @@ export async function handleRooSyncIndexing(
                                         }
                                         lastToolName = toolName;
 
+                                        currentToolUses.push(toolName);
+
                                         if (ts) {
                                             const weekKey = getISOWeek(ts.toISOString());
                                             if (!weeklyBuckets[weekKey]) weeklyBuckets[weekKey] = {};
                                             weeklyBuckets[weekKey][toolName] = (weeklyBuckets[weekKey][toolName] || 0) + 1;
                                         }
                                     }
+                                }
+
+                                // #2336 D2: If this message has ONLY tool_uses (no text/thinking),
+                                // those tools haven't led to downstream action yet — check next message.
+                                // If this message has BOTH tool_uses AND non-tool content, the
+                                // non-tool content is itself a downstream action for the tool_uses
+                                // in the SAME message (but we only count cross-message to avoid
+                                // inflating counts — same-message is just the agent calling+reasoning).
+                                if (currentToolUses.length > 0 && !hasNonToolContent) {
+                                    prevAssistantToolUses = currentToolUses;
+                                } else {
+                                    prevAssistantToolUses = [];
                                 }
                             } else if (message.role === 'user' && Array.isArray(message.content)) {
                                 // Scan tool_result blocks for error detection
@@ -950,6 +1014,8 @@ export async function handleRooSyncIndexing(
                         error_rate: count > 0 ? +((errorCounts[name] || 0) / count * 100).toFixed(1) : 0,
                         retries: retryCounts[name] || 0,
                         retry_rate: count > 0 ? +((retryCounts[name] || 0) / count * 100).toFixed(1) : 0,
+                        downstream_actions: downstreamActionCounts[name] || 0,
+                        downstream_action_rate: count > 0 ? +((downstreamActionCounts[name] || 0) / count * 100).toFixed(1) : 0,
                     }));
 
                 // Sort weeks chronologically
@@ -982,7 +1048,7 @@ export async function handleRooSyncIndexing(
                             source_distribution: sourceCounts,
                             tools: sortedTools,
                             weekly_trend: sortedWeeks,
-                            summary: `${totalCalls} tool calls across ${Object.keys(toolCounts).length} tools, ${sortedWeeks.length} weeks (${startDate.toISOString().slice(0, 10)} → ${endDate.toISOString().slice(0, 10)}). Errors: ${Object.values(errorCounts).reduce((s, c) => s + c, 0)}, Retries: ${Object.values(retryCounts).reduce((s, c) => s + c, 0)}`,
+                            summary: `${totalCalls} tool calls across ${Object.keys(toolCounts).length} tools, ${sortedWeeks.length} weeks (${startDate.toISOString().slice(0, 10)} → ${endDate.toISOString().slice(0, 10)}). Errors: ${Object.values(errorCounts).reduce((s, c) => s + c, 0)}, Retries: ${Object.values(retryCounts).reduce((s, c) => s + c, 0)}, Downstream actions: ${Object.values(downstreamActionCounts).reduce((s, c) => s + c, 0)}`,
                         }, null, 2)
                     }]
                 };


### PR DESCRIPTION
## #2336 D2 — Downstream-action rate metric

**Auteur du code : myia-po-2024 (GLM-5.1).** PR créée par ai-01 (po-2024 bloqué token 403 sur ce repo).

### Scope
Nouvelle métrique d'**utilité** par outil dans `tool_usage_stats` : `downstream_actions` + `downstream_action_rate`.
- Définition : un `tool_use` suivi d'un message assistant à contenu **non-tool** (raisonnement/texte/edit) = appel productif (downstream action).
- Couvre les 2 sources : Roo (`api_conversation_history.json`) + Claude Code (`*.jsonl` streaming).
- Attribution cross-message (évite l'inflation same-message agent calling+reasoning).

### Tests
- 3 nouveaux tests (`tool-usage-stats-errors.test.ts`) : downstream counted / not counted / mixed.
- po-2024 : 12/12 tool-usage-stats pass, 9819/9842 CI config pass.

### Fichiers
- `roosync-indexing.tool.ts` (+72/-3)
- `tool-usage-stats-errors.test.ts` (+150)

Sert le north-star (#2336 : mesurer utilité des outils, pas juste le volume).