### PR TITLE
fix(messages): skip inbox files whose name ≠ internal id (phantom inbox bug)

### DIFF
--- a/servers/roo-state-manager/src/services/MessageManager.ts
+++ b/servers/roo-state-manager/src/services/MessageManager.ts
@@ -326,6 +326,17 @@ export class MessageManager {
         const result = results[r];
         if (result.status === 'fulfilled') {
           const message = result.value;
+          // Phantom-message guard: the inbox is LISTED by each file's internal `id`,
+          // but every mutation (getMessage/markAsRead/archiveMessage/destroyMessage)
+          // locates the file by reconstructing `inbox/${id}.json`. A file whose name
+          // does not match its `id` is therefore listed forever yet can never be
+          // opened, marked read, or archived — a silent un-actionable phantom.
+          // Skip such files from the listing and warn so the operator can archive/rename.
+          const fileName = chunk[r];
+          if (fileName !== `${message.id}.json`) {
+            logger.warn(`Inbox file name/id mismatch — skipping to avoid phantom listing: file="${fileName}", id="${message.id}" (expected "${message.id}.json"). Archive or rename this file.`);
+            continue;
+          }
           full.set(message.id, message);
           items.push({
             id: message.id,

--- a/servers/roo-state-manager/src/services/__tests__/MessageManager.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/MessageManager.test.ts
@@ -1297,5 +1297,39 @@ describe('MessageManager', () => {
       const inbox = await messageManager.readInbox('machine-a');
       expect(inbox.find(m => m.id === msg.id)).toBeUndefined();
     });
+
+    test('inbox file whose name differs from its internal id is NOT listed (anti-phantom)', async () => {
+      // Regression for the long-standing "message fantôme" bug: a file whose on-disk
+      // name does not match its internal `id` was LISTED forever (ensureInboxCache keys
+      // by `message.id`) yet could never be opened, marked read, or archived — every
+      // mutation reconstructs `inbox/${id}.json`, which does not exist. Real-world
+      // offender: a legacy `roosync-report.json` carrying id `msg-...-po2026-status`.
+      const phantomId = 'msg-20260226T080000-po2026-status';
+      const phantom = {
+        id: phantomId,
+        from: 'machine-b',
+        to: 'machine-a',
+        subject: '[STATUS] Legacy seed report',
+        body: 'Stale status report whose filename does not match its id.',
+        priority: 'LOW',
+        timestamp: '2026-02-26T08:00:00.000Z',
+        status: 'unread',
+        tags: ['status']
+      };
+      // Write with a NON-canonical filename (name !== `${id}.json`).
+      const mismatchedFile = join(testSharedStatePath, 'messages/inbox', 'legacy-report.json');
+      await fs.writeFile(mismatchedFile, JSON.stringify(phantom, null, 2), 'utf-8');
+
+      // File was written outside the manager → force a cache rebuild.
+      messageManager.invalidateCache();
+
+      // The mis-named file must be skipped from the listing (guarded in ensureInboxCache).
+      const inbox = await messageManager.readInbox('machine-a', 'all');
+      expect(inbox.find(m => m.id === phantomId)).toBeUndefined();
+
+      // And it must not inflate the unread count.
+      const counts = await messageManager.getFilteredCount('machine-a', 'all');
+      expect(counts.total).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
## Problem — the "message fantôme"

The inbox is **listed** by each file's internal `id` (`ensureInboxCache` keys the cache by `message.id`), but every **mutation** — `getMessage` / `markAsRead` / `archiveMessage` / `destroyMessage` — **locates** the file by reconstructing `inbox/${id}.json`.

A file whose on-disk name differs from `${id}.json` is therefore:
- ✅ listed in the inbox forever (counts toward unread)
- ❌ impossible to open, mark read, or archive (the reconstructed path doesn't exist)

→ a silent, un-actionable **phantom** inbox entry.

**Real-world offender:** a legacy `roosync-report.json` (Feb 2026 seed) carrying `id: "msg-20260226T080000-po2026-status"`, which haunted the ai-01 inbox for ~3 months. (The on-disk orphan has been separately archived to its canonical name; this PR fixes the *underlying bug* so it can't recur.)

## Fix (surgical)

In `ensureInboxCache`, skip any file whose name `!== \`${message.id}.json\`` and emit a `logger.warn` so an operator can archive/rename it. No method signatures or listing/mutation contracts changed — one guard in the cache-build loop.

## Test

Adds a focused regression test in the existing `phantom message fix` block: writes a mis-named inbox file (name ≠ internal `id`), forces a cache rebuild, and asserts the message is **not** listed and does **not** inflate the unread count.

## Validation

- `npm run build` — clean (tsc)
- `npx vitest run --config vitest.config.ci.ts` — **495 files / 9822 tests passed, 23 skipped, 0 failures**
- `MessageManager.test.ts` — 96 tests passed (incl. the new one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)