### PR TITLE
feat(indexing): persist tool_usage_stats snapshots + trend_report (#2336 D3)

### DIFF
--- a/servers/roo-state-manager/src/tools/indexing/__tests__/roosync-indexing.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/indexing/__tests__/roosync-indexing.tool.test.ts
@@ -82,9 +82,9 @@ describe('roosyncIndexingTool', () => {
 		expect(roosyncIndexingTool.inputSchema.required).toEqual(['action']);
 	});
 
-	test('has action enum with 11 values', () => {
+	test('has action enum with 13 values', () => {
 		const actionProp = (roosyncIndexingTool.inputSchema.properties as any).action;
-		expect(actionProp.enum).toEqual(['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'cleanup', 'garbage_scan', 'cleanup_orphans', 'repair_gaps', 'tool_usage_stats']);
+		expect(actionProp.enum).toEqual(['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'cleanup', 'garbage_scan', 'cleanup_orphans', 'repair_gaps', 'tool_usage_stats', 'save_snapshot', 'trend_report']);
 	});
 
 	// ============================================================

--- a/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
@@ -19,6 +19,7 @@ import { indexTaskSemanticTool } from './index-task.tool.js';
 import { resetQdrantCollectionTool } from './reset-collection.tool.js';
 import { handleDiagnoseSemanticIndex } from './diagnose-index.tool.js';
 import { RooStorageDetector } from '../../utils/roo-storage-detector.js';
+import { getSharedStatePath } from '../../utils/shared-state-path.js';
 
 /** #2336 D1: Convert ISO timestamp to YYYY-WNN week key */
 function getISOWeek(timestamp: string): string {
@@ -35,7 +36,7 @@ function getISOWeek(timestamp: string): string {
  */
 export interface RooSyncIndexingArgs {
     /** Action d'indexation */
-    action: 'index' | 'reset' | 'rebuild' | 'diagnose' | 'archive' | 'status' | 'cleanup' | 'garbage_scan' | 'cleanup_orphans' | 'repair_gaps' | 'tool_usage_stats';
+    action: 'index' | 'reset' | 'rebuild' | 'diagnose' | 'archive' | 'status' | 'cleanup' | 'garbage_scan' | 'cleanup_orphans' | 'repair_gaps' | 'tool_usage_stats' | 'save_snapshot' | 'trend_report';
 
     /** ID de la tâche à indexer (requis pour action=index) */
     task_id?: string;
@@ -118,8 +119,8 @@ export const roosyncIndexingTool: Tool = {
         properties: {
             action: {
                 type: 'string',
-                enum: ['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'cleanup', 'garbage_scan', 'cleanup_orphans', 'repair_gaps', 'tool_usage_stats'],
-                description: 'Action: index (Qdrant), reset (collection), rebuild (SQLite index), diagnose (health check), archive (GDrive), status (metrics), cleanup (old vectors), garbage_scan (detect junk), cleanup_orphans (remove orphaned vectors), repair_gaps (detect and fix missing/stale index entries), tool_usage_stats (fleet-wide tool usage aggregation)'
+                enum: ['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'cleanup', 'garbage_scan', 'cleanup_orphans', 'repair_gaps', 'tool_usage_stats', 'save_snapshot', 'trend_report'],
+                description: 'Action: index (Qdrant), reset (collection), rebuild (SQLite index), diagnose (health check), archive (GDrive), status (metrics), cleanup (old vectors), garbage_scan (detect junk), cleanup_orphans (remove orphaned vectors), repair_gaps (detect and fix missing/stale index entries), tool_usage_stats (fleet-wide tool usage aggregation), save_snapshot (persist weekly stats to shared storage), trend_report (compare snapshots with ↑/↓ arrows)'
             },
             task_id: {
                 type: 'string',
@@ -1056,6 +1057,185 @@ export async function handleRooSyncIndexing(
                 return {
                     isError: true,
                     content: [{ type: 'text', text: `Error during tool_usage_stats: ${error.message}` }]
+                };
+            }
+        }
+
+        // #2336 D3: Persist weekly tool_usage_stats snapshot to shared storage
+        case 'save_snapshot': {
+            const fs = await import('fs/promises');
+            const os = await import('os');
+
+            try {
+                // 1. Compute tool_usage_stats by recursing into the handler
+                const statsResult = await handleRooSyncIndexing(
+                    { action: 'tool_usage_stats', start_date: args.start_date, end_date: args.end_date },
+                    conversationCache, ensureCacheFreshCallback, saveSkeletonCallback, qdrantIndexQueue, setQdrantIndexingEnabled, rebuildHandler, indexingState,
+                );
+                if (statsResult.isError) return statsResult;
+
+                // 2. Determine snapshot path
+                const sharedPath = getSharedStatePath();
+                const snapshotsDir = path.join(sharedPath, 'tool-usage-snapshots');
+                await fs.mkdir(snapshotsDir, { recursive: true });
+
+                const hostname = os.hostname();
+                const now = new Date();
+                const dateStr = now.toISOString().slice(0, 10);
+                const filename = `${hostname}-${dateStr}.json`;
+                const snapshotPath = path.join(snapshotsDir, filename);
+
+                // 3. Enrich with metadata — safely extract text from CallToolResult
+                const textContent = statsResult.content.find((c: any) => c.type === 'text');
+                if (!textContent || !('text' in textContent)) {
+                    return { isError: true, content: [{ type: 'text', text: 'tool_usage_stats returned no text content' }] };
+                }
+                const parsed = JSON.parse((textContent as any).text);
+                const snapshot = {
+                    ...parsed,
+                    snapshot_metadata: {
+                        machine: hostname,
+                        captured_at: now.toISOString(),
+                        snapshot_type: 'weekly_baseline',
+                    },
+                };
+
+                await fs.writeFile(snapshotPath, JSON.stringify(snapshot, null, 2), 'utf-8');
+
+                // 4. List existing snapshots
+                let existingFiles: string[] = [];
+                try { existingFiles = (await fs.readdir(snapshotsDir)).filter(f => f.endsWith('.json')).sort(); } catch { /* empty */ }
+
+                return {
+                    isError: false,
+                    content: [{
+                        type: 'text',
+                        text: JSON.stringify({
+                            action: 'save_snapshot',
+                            status: 'saved',
+                            path: snapshotPath,
+                            filename,
+                            total_tool_calls: parsed.total_tool_calls,
+                            unique_tools: parsed.unique_tools,
+                            date_range: parsed.date_range,
+                            total_snapshots: existingFiles.length,
+                            all_snapshots: existingFiles,
+                        }, null, 2),
+                    }],
+                };
+            } catch (error: any) {
+                return {
+                    isError: true,
+                    content: [{ type: 'text', text: `Error during save_snapshot: ${error.message}` }],
+                };
+            }
+        }
+
+        // #2336 D3: Generate trend report comparing snapshots
+        case 'trend_report': {
+            const fs = await import('fs/promises');
+
+            try {
+                const sharedPath = getSharedStatePath();
+                const snapshotsDir = path.join(sharedPath, 'tool-usage-snapshots');
+
+                // Load all snapshots
+                let files: string[];
+                try { files = (await fs.readdir(snapshotsDir)).filter(f => f.endsWith('.json')).sort(); } catch {
+                    return {
+                        isError: true,
+                        content: [{ type: 'text', text: 'No snapshots found. Run save_snapshot first.' }],
+                    };
+                }
+
+                if (files.length < 1) {
+                    return {
+                        isError: true,
+                        content: [{ type: 'text', text: 'No snapshots found. Run save_snapshot first.' }],
+                    };
+                }
+
+                // Load the 2 most recent snapshots (or 1 if only 1 exists)
+                const toLoad = files.slice(-2);
+                const snapshots: any[] = [];
+                for (const f of toLoad) {
+                    const content = await fs.readFile(path.join(snapshotsDir, f), 'utf-8');
+                    snapshots.push(JSON.parse(content));
+                }
+
+                const latest = snapshots[snapshots.length - 1];
+                const previous = snapshots.length > 1 ? snapshots[snapshots.length - 2] : null;
+
+                // Build trend report as markdown
+                const lines: string[] = [];
+                lines.push(`# Tool Usage Trend Report`);
+                lines.push(``);
+                lines.push(`**Generated:** ${new Date().toISOString().slice(0, 10)}`);
+                lines.push(`**Snapshots:** ${files.length} total, comparing ${toLoad[0]}${previous ? ' → ' + toLoad[1] : ' (baseline only)'}`);
+                lines.push(``);
+
+                // Summary comparison
+                lines.push(`## Summary`);
+                lines.push(``);
+                if (previous) {
+                    const callsDiff = latest.total_tool_calls - previous.total_tool_calls;
+                    const toolsDiff = latest.unique_tools - previous.unique_tools;
+                    const arrow = (n: number) => n > 0 ? `↑+${n}` : n < 0 ? `↓${n}` : `→`;
+                    lines.push(`| Metric | Previous | Latest | Change |`);
+                    lines.push(`|--------|----------|--------|--------|`);
+                    lines.push(`| Total calls | ${previous.total_tool_calls} | ${latest.total_tool_calls} | ${arrow(callsDiff)} |`);
+                    lines.push(`| Unique tools | ${previous.unique_tools} | ${latest.unique_tools} | ${arrow(toolsDiff)} |`);
+                    lines.push(`| Files scanned | ${previous.files_scanned} | ${latest.files_scanned} | ${arrow(latest.files_scanned - previous.files_scanned)} |`);
+                } else {
+                    lines.push(`Baseline snapshot only — no comparison available yet.`);
+                    lines.push(`- Total calls: ${latest.total_tool_calls}`);
+                    lines.push(`- Unique tools: ${latest.unique_tools}`);
+                    lines.push(`- Date range: ${latest.date_range?.start} → ${latest.date_range?.end}`);
+                }
+                lines.push(``);
+
+                // Per-tool trend (top 20)
+                lines.push(`## Per-Tool Trend (Top 20)`);
+                lines.push(``);
+                if (previous) {
+                    const prevMap: Map<string, any> = new Map(previous.tools.map((t: any) => [t.tool_name, t]));
+                    const rows = latest.tools.slice(0, 20).map((t: any) => {
+                        const p: any = prevMap.get(t.tool_name);
+                        const callsArrow = p ? (t.calls > p.calls ? '↑' : t.calls < p.calls ? '↓' : '→') : '🆕';
+                        const errorArrow = p ? (t.error_rate > p.error_rate ? '↑' : t.error_rate < p.error_rate ? '↓' : '→') : '-';
+                        const retryArrow = p ? (t.retry_rate > p.retry_rate ? '↑' : t.retry_rate < p.retry_rate ? '↓' : '→') : '-';
+                        return `| ${t.tool_name} | ${t.calls} | ${callsArrow} | ${t.error_rate}% | ${errorArrow} | ${t.retry_rate}% | ${retryArrow} | ${t.downstream_action_rate ?? '-'}% |`;
+                    });
+                    lines.push(`| Tool | Calls | Trend | Err% | Trend | Retry% | Trend | DwnAct% |`);
+                    lines.push(`|------|-------|-------|------|-------|--------|-------|--------|`);
+                    lines.push(...rows);
+                } else {
+                    lines.push(`| Tool | Calls | Err% | Retry% | DwnAct% |`);
+                    lines.push(`|------|-------|------|--------|---------|`);
+                    for (const t of latest.tools.slice(0, 20)) {
+                        lines.push(`| ${t.tool_name} | ${t.calls} | ${t.error_rate}% | ${t.retry_rate}% | ${t.downstream_action_rate ?? '-'}% |`);
+                    }
+                }
+                lines.push(``);
+
+                // All snapshots
+                lines.push(`## Available Snapshots (${files.length})`);
+                lines.push(``);
+                for (const f of files) {
+                    lines.push(`- ${f}`);
+                }
+
+                return {
+                    isError: false,
+                    content: [{
+                        type: 'text',
+                        text: lines.join('\n'),
+                    }],
+                };
+            } catch (error: any) {
+                return {
+                    isError: true,
+                    content: [{ type: 'text', text: `Error during trend_report: ${error.message}` }],
                 };
             }
         }

--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -145,11 +145,11 @@ export const roosyncSearchDefinition = {
 // ============================================================
 export const roosyncIndexingDefinition = {
     name: 'roosync_indexing',
-    description: "Manage semantic index, cache, and archiving (index, reset, rebuild, diagnose, archive, status, repair_gaps, cleanup, garbage_scan, cleanup_orphans, tool_usage_stats)",
+    description: "Manage semantic index, cache, and archiving (index, reset, rebuild, diagnose, archive, status, repair_gaps, cleanup, garbage_scan, cleanup_orphans, tool_usage_stats, save_snapshot, trend_report)",
     inputSchema: {
         type: 'object',
         properties: {
-            action: { type: 'string', enum: ['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'repair_gaps', 'cleanup', 'garbage_scan', 'cleanup_orphans', 'tool_usage_stats'], description: 'index=Qdrant, reset=clear, rebuild=SQLite, diagnose=health, archive=GDrive, status=metrics, repair_gaps=fix, cleanup=old vectors, garbage_scan=junk detection, cleanup_orphans=purge, tool_usage_stats=usage aggregation' },
+            action: { type: 'string', enum: ['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'repair_gaps', 'cleanup', 'garbage_scan', 'cleanup_orphans', 'tool_usage_stats', 'save_snapshot', 'trend_report'], description: 'index=Qdrant, reset=clear, rebuild=SQLite, diagnose=health, archive=GDrive, status=metrics, repair_gaps=fix, cleanup=old vectors, garbage_scan=junk detection, cleanup_orphans=purge, tool_usage_stats=usage aggregation, save_snapshot=persist weekly stats to shared storage, trend_report=compare snapshots with ↑/↓ trend arrows' },
             task_id: { type: 'string', description: 'Required for action=index' },
             confirm: { type: 'boolean', description: 'Required for action=reset', default: false },
             workspace_filter: { type: 'string', description: 'Workspace filter (for rebuild)' },

--- a/servers/roo-state-manager/tests/unit/tools/indexing/roosync-indexing.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/indexing/roosync-indexing.test.ts
@@ -76,9 +76,9 @@ describe('roosync_indexing - CONS-11', () => {
             expect(roosyncIndexingTool.name).toBe('roosync_indexing');
         });
 
-        it('should have action enum with 11 values', () => {
+        it('should have action enum with 13 values', () => {
             const actionProp = (roosyncIndexingTool.inputSchema as any).properties.action;
-            expect(actionProp.enum).toEqual(['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'cleanup', 'garbage_scan', 'cleanup_orphans', 'repair_gaps', 'tool_usage_stats']);
+            expect(actionProp.enum).toEqual(['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'cleanup', 'garbage_scan', 'cleanup_orphans', 'repair_gaps', 'tool_usage_stats', 'save_snapshot', 'trend_report']);
         });
 
         it('should require action parameter', () => {


### PR DESCRIPTION
## #2336 D3 — Persistent trend dashboard for tool_usage_stats

Implemented by **po-2024** (commit `3f70f48a`), PR created by ai-01 coordinator on its behalf (worker token `jsboigeEpita` → 403 on submod PR create — known blocker).

### What
Two new `roosync_indexing` actions persisting weekly `tool_usage_stats` snapshots so the north-star trend survives cross-session:
- **`save_snapshot`** — runs `tool_usage_stats`, saves JSON to `$ROOSYNC_SHARED_PATH/tool-usage-snapshots/`
- **`trend_report`** — compares latest vs previous snapshot, emits markdown with ↑/↓ arrows

### Files
- `src/tools/roosync-indexing.tool.ts` — 2 new actions
- `src/tools/tool-definitions.ts` — enum count 11→13
- 2 test files (enum/action coverage)

### Validation
- CI vitest: 9821/9844 pass (reported by po-2024 C61)
- D1/D2 already 100% merged (D2 via #591). D3 is additive — no change to existing actions.

### Notes
- North-star baseline captured this cycle: po-2024 = 41,052 calls / 110 tools / 5 weeks.
- Builds on submod main `b1e90e8e` (phantom inbox fix). No overlap with MessageManager.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>