### PR TITLE
fix(security): env-rotation findings — IV doc, Windows ACL warn, crypto-constants test (#2410)

### DIFF
--- a/servers/roo-state-manager/src/services/EnvRotationService.ts
+++ b/servers/roo-state-manager/src/services/EnvRotationService.ts
@@ -109,7 +109,7 @@ export class EnvRotationService {
 
   /**
    * Sérialise les données chiffrées au format wire (binary)
-   * Format: [salt(32)][iv(16)][tag(16)][ciphertext(remaining)]
+   * Format: [salt(32)][iv(12)][tag(16)][ciphertext(remaining)]
    */
   serializeEncrypted(encrypted: { ciphertext: Buffer; iv: Buffer; tag: Buffer; salt: Buffer }): Buffer {
     return Buffer.concat([encrypted.salt, encrypted.iv, encrypted.tag, encrypted.ciphertext]);
@@ -193,6 +193,11 @@ export class EnvRotationService {
 
     const encryptedPath = join(envDir, `${version}.enc`);
     await fs.writeFile(encryptedPath, wire, { mode: 0o600 });
+    // #2410: mode:0o600 is Unix-only. On Windows, file permissions are ACL-based.
+    // For production hardening, apply ACL restrictions via icacls or PowerShell.
+    if (process.platform === 'win32') {
+      this.logger.warn(`Windows: mode:0o600 ignored for ${encryptedPath}. Apply ACL manually for production.`);
+    }
 
     const metadataPath = join(envDir, `${version}.json`);
     await fs.writeFile(metadataPath, JSON.stringify(metadata, null, 2), 'utf-8');
@@ -309,6 +314,10 @@ export class EnvRotationService {
       mkdirSync(targetDir, { recursive: true });
     }
     await fs.writeFile(targetEnvPath, envContent, { encoding: 'utf-8', mode: 0o600 });
+    // #2410: mode:0o600 is Unix-only. On Windows, file permissions are ACL-based.
+    if (process.platform === 'win32') {
+      this.logger.warn(`Windows: mode:0o600 ignored for ${targetEnvPath}. Apply ACL manually for production.`);
+    }
 
     this.logger.info(`Applied env ${service} v${latestVersion}`, { keys: keysWritten });
 

--- a/servers/roo-state-manager/tests/unit/services/EnvRotationService.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/EnvRotationService.test.ts
@@ -171,6 +171,22 @@ describe('EnvRotationService', () => {
       expect(wire.length).toBe(32 + 12 + 16 + encrypted.ciphertext.length);
     });
 
+    it('#2410: should use correct header sizes — salt(32) + iv(12) + tag(16)', () => {
+      // Verify cryptographic constants match NIST/OWASP recommendations
+      const plaintext = Buffer.from('A=1\n', 'utf-8');
+      const encrypted = service.encrypt(plaintext);
+
+      // IV must be 12 bytes (96 bits) for AES-GCM — NIST SP 800-38D §5.2.1.1
+      expect(encrypted.iv.length).toBe(12);
+      // Salt must be 32 bytes (256 bits) for scrypt
+      expect(encrypted.salt.length).toBe(32);
+      // Auth tag must be 16 bytes (128 bits)
+      expect(encrypted.tag.length).toBe(16);
+      // Wire header = 32 + 12 + 16 = 60 bytes
+      const wire = service.serializeEncrypted(encrypted);
+      expect(wire.length).toBe(60 + encrypted.ciphertext.length);
+    });
+
     it('should reject invalid wire data (too short)', () => {
       const shortWire = randomBytes(10);
       expect(() => {


### PR DESCRIPTION
## #2410 — Env rotation (`env:<service>`) adversarial-test findings

Implemented by **po-2025** (commit `b741a646`), PR created by ai-01 coordinator on its behalf (worker token `jsboigeEpita` → 403 on submod PR create — known blocker). GO user 2026-05-30.

### Findings fixed
1. **Wire-format doc bug** — comment said `iv(16)` while `IV_LENGTH=12` (NIST SP 800-38D §5.2.1.1). Code was correct; the doc was misleading. Corrected.
2. **Windows ACL** — `mode: 0o600` in `fs.writeFile` is silently ignored on Windows. Added a platform-specific `logger.warn()` so operators know POSIX perms don't apply.
3. **New test** — asserts crypto constants (salt=32, iv=12, tag=16, header=60 bytes) to lock the AES-256-GCM wire format.

### Validation
- po-2025 C44: code delivered, adversarial tests on AES-256-GCM. Builds on submod main `b1e90e8e`.
- No overlap with MessageManager (phantom fix) or D3.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>