### PR TITLE
test(unified-store): 35 unit tests for writer + reader (#2426 Phase 2)

### DIFF
--- a/servers/roo-state-manager/src/services/unified-store/__tests__/unified-store-reader.test.ts
+++ b/servers/roo-state-manager/src/services/unified-store/__tests__/unified-store-reader.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Tests for PgUnifiedStoreReader — Postgres-backed unified store reader (2-step search)
+ *
+ * #2426 Phase 2: Tests for the 2-step read path (Qdrant ANN → Postgres JOIN).
+ * Uses mocked pg.Pool to avoid real DB dependency.
+ *
+ * @module services/unified-store/__tests__/unified-store-reader.test
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { PgUnifiedStoreReader } from '../PgUnifiedStoreReader.js';
+import type { UnifiedStoreSearchFilters } from '../types.js';
+
+// ─── Mock pg module ──────────────────────────────────────────────────
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn();
+const mockEnd = vi.fn();
+
+const mockClient = {
+  query: mockQuery,
+  release: vi.fn(),
+};
+
+const mockPoolQuery = vi.fn();
+
+const mockPool = {
+  connect: mockConnect,
+  query: mockPoolQuery,
+  end: mockEnd,
+};
+
+vi.mock('pg', () => ({
+  default: {
+    Pool: vi.fn(() => mockPool),
+  },
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function createReader(): PgUnifiedStoreReader {
+  return new PgUnifiedStoreReader({
+    connectionString: 'postgres://test:test@localhost:5432/unified_store',
+    poolMax: 2,
+    statementTimeoutMs: 3000,
+  });
+}
+
+function makeConversationRow(overrides: Record<string, unknown> = {}) {
+  return {
+    task_id: 'task-123',
+    machine_id: 'myia-po-2023',
+    harness: 'claude',
+    workspace: '/test/workspace',
+    parent_task_id: null,
+    title: 'Test Task',
+    first_ts: '2026-06-01T10:00:00Z',
+    last_ts: '2026-06-01T11:00:00Z',
+    msg_count: 10,
+    metadata: null,
+    ingested_at: '2026-06-01T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeMessageRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    task_id: 'task-123',
+    message_id: null,
+    seq: 0,
+    role: 'user',
+    content: 'Hello world',
+    tool_calls: null,
+    ts: '2026-06-01T10:00:00Z',
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+describe('PgUnifiedStoreReader', () => {
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConnect.mockResolvedValue(mockClient);
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    mockEnd.mockResolvedValue(undefined);
+    mockClient.release.mockReset();
+  });
+
+  // ─── Lifecycle ──────────────────────────────────────────────────
+
+  describe('lifecycle', () => {
+    test('init connects and verifies', async () => {
+      const reader = createReader();
+      await reader.init();
+
+      expect(mockQuery).toHaveBeenCalledWith('SELECT 1');
+    });
+
+    test('close drains the pool', async () => {
+      const reader = createReader();
+      await reader.init();
+      await reader.close();
+
+      expect(mockEnd).toHaveBeenCalled();
+    });
+
+    test('ping returns true when pool is healthy', async () => {
+      const reader = createReader();
+      await reader.init();
+      expect(await reader.ping()).toBe(true);
+    });
+
+    test('ping returns false when pool throws', async () => {
+      mockConnect.mockRejectedValue(new Error('Connection refused'));
+      const reader = createReader();
+      await reader.init().catch(() => {});
+      mockConnect.mockResolvedValue(mockClient);
+      mockQuery.mockRejectedValue(new Error('DB down'));
+
+      expect(await reader.ping()).toBe(false);
+    });
+
+    test('isNull returns false', async () => {
+      const reader = createReader();
+      expect(reader.isNull()).toBe(false);
+    });
+  });
+
+  // ─── getConversation ────────────────────────────────────────────
+
+  describe('getConversation', () => {
+    test('returns conversation when found', async () => {
+      const row = makeConversationRow();
+      mockPoolQuery.mockResolvedValue({ rows: [row], rowCount: 1 });
+
+      const reader = createReader();
+      await reader.init();
+      const result = await reader.getConversation('task-123');
+
+      expect(result).not.toBeNull();
+      expect(result!.task_id).toBe('task-123');
+      expect(result!.machine_id).toBe('myia-po-2023');
+      expect(result!.harness).toBe('claude');
+    });
+
+    test('returns null when not found', async () => {
+      mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+      const reader = createReader();
+      await reader.init();
+      const result = await reader.getConversation('nonexistent');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ─── getMessages ────────────────────────────────────────────────
+
+  describe('getMessages', () => {
+    test('returns messages ordered by seq', async () => {
+      const rows = [
+        makeMessageRow({ seq: 0, role: 'user' }),
+        makeMessageRow({ seq: 1, role: 'assistant' }),
+      ];
+      mockPoolQuery.mockResolvedValue({ rows, rowCount: 2 });
+
+      const reader = createReader();
+      await reader.init();
+      const result = await reader.getMessages('task-123');
+
+      expect(result.length).toBe(2);
+      expect(result[0].seq).toBe(0);
+      expect(result[1].seq).toBe(1);
+
+      // Verify ORDER BY seq ASC
+      const queryCall = mockPoolQuery.mock.calls.find(
+        c => typeof c[0] === 'string' && c[0].includes('ORDER BY seq')
+      );
+      expect(queryCall).toBeDefined();
+    });
+
+    test('respects limit and offset', async () => {
+      mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+      const reader = createReader();
+      await reader.init();
+      await reader.getMessages('task-123', { limit: 50, offset: 10 });
+
+      const queryCall = mockPoolQuery.mock.calls.find(
+        c => c[0].includes('LIMIT') && c[0].includes('OFFSET')
+      );
+      expect(queryCall).toBeDefined();
+      expect(queryCall![1]).toEqual(['task-123', 50, 10]);
+    });
+
+    test('uses default limit=1000 when not specified', async () => {
+      mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+      const reader = createReader();
+      await reader.init();
+      await reader.getMessages('task-123');
+
+      const queryCall = mockPoolQuery.mock.calls.find(
+        c => Array.isArray(c[1]) && c[1][1] === 1000
+      );
+      expect(queryCall).toBeDefined();
+    });
+  });
+
+  // ─── joinFromQdrant (2-step search) ─────────────────────────────
+
+  describe('joinFromQdrant', () => {
+    test('returns empty array when no hits', async () => {
+      const reader = createReader();
+      await reader.init();
+      const result = await reader.joinFromQdrant([]);
+
+      expect(result).toEqual([]);
+    });
+
+    test('maps Qdrant hits to search results with scores', async () => {
+      const convRow = makeConversationRow({ task_id: 'task-1' });
+      const convRow2 = makeConversationRow({ task_id: 'task-2' });
+
+      // Mock the JOIN query at pool level
+      mockPoolQuery.mockImplementation((sql: string) => {
+        if (sql.includes('FROM conversations')) {
+          return Promise.resolve({ rows: [convRow, convRow2], rowCount: 2 });
+        }
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      });
+
+      const reader = createReader();
+      await reader.init();
+
+      const qdrantHits = [
+        { task_id: 'task-1', score: 0.95 },
+        { task_id: 'task-2', score: 0.80 },
+      ];
+
+      const result = await reader.joinFromQdrant(qdrantHits);
+
+      expect(result.length).toBe(2);
+      // Sorted by score DESC
+      expect(result[0].score).toBe(0.95);
+      expect(result[1].score).toBe(0.80);
+      expect(result[0].task_id).toBe('task-1');
+      expect(result[1].task_id).toBe('task-2');
+    });
+
+    test('applies machine_id filter', async () => {
+      mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+      const reader = createReader();
+      await reader.init();
+
+      const filters: UnifiedStoreSearchFilters = { machine_id: 'myia-po-2023' };
+      await reader.joinFromQdrant(
+        [{ task_id: 'task-1', score: 0.9 }],
+        filters,
+      );
+
+      const queryCall = mockPoolQuery.mock.calls.find(
+        c => typeof c[0] === 'string' && c[0].includes('machine_id')
+      );
+      expect(queryCall).toBeDefined();
+    });
+
+    test('applies workspace filter', async () => {
+      mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+      const reader = createReader();
+      await reader.init();
+
+      const filters: UnifiedStoreSearchFilters = { workspace: '/test/workspace' };
+      await reader.joinFromQdrant(
+        [{ task_id: 'task-1', score: 0.9 }],
+        filters,
+      );
+
+      const queryCall = mockPoolQuery.mock.calls.find(
+        c => typeof c[0] === 'string' && c[0].includes('workspace')
+      );
+      expect(queryCall).toBeDefined();
+    });
+
+    test('applies date range filters', async () => {
+      mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+      const reader = createReader();
+      await reader.init();
+
+      const filters: UnifiedStoreSearchFilters = {
+        since: '2026-05-01T00:00:00Z',
+        until: '2026-06-01T00:00:00Z',
+      };
+      await reader.joinFromQdrant(
+        [{ task_id: 'task-1', score: 0.9 }],
+        filters,
+      );
+
+      const queryCall = mockPoolQuery.mock.calls.find(
+        c => typeof c[0] === 'string' && c[0].includes('last_ts')
+      );
+      expect(queryCall).toBeDefined();
+    });
+
+    test('joins messages when tool_name filter is specified', async () => {
+      const convRow = makeConversationRow({ task_id: 'task-1' });
+      const msgRow = makeMessageRow({
+        task_id: 'task-1',
+        tool_calls: [{ name: 'read_file', arguments: { path: '/test.ts' } }],
+      });
+
+      mockPoolQuery.mockImplementation((sql: string) => {
+        if (sql.includes('JOIN messages')) {
+          return Promise.resolve({ rows: [convRow], rowCount: 1 });
+        }
+        if (sql.includes('tool_calls @>')) {
+          return Promise.resolve({ rows: [msgRow], rowCount: 1 });
+        }
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      });
+
+      const reader = createReader();
+      await reader.init();
+
+      const filters: UnifiedStoreSearchFilters = { tool_name: 'read_file' };
+      const result = await reader.joinFromQdrant(
+        [{ task_id: 'task-1', score: 0.9 }],
+        filters,
+      );
+
+      expect(result.length).toBe(1);
+      // Should have matched messages because tool_name filter was applied
+      expect(result[0].matched_messages).toBeDefined();
+    });
+
+    test('uses GIN @> operator for tool_calls JSONB filter', async () => {
+      mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+      const reader = createReader();
+      await reader.init();
+
+      const filters: UnifiedStoreSearchFilters = { tool_name: 'write_to_file' };
+      await reader.joinFromQdrant(
+        [{ task_id: 'task-1', score: 0.9 }],
+        filters,
+      );
+
+      // Find the query that uses GIN @> containment
+      const queryCall = mockPoolQuery.mock.calls.find(
+        c => typeof c[0] === 'string' && c[0].includes('@>')
+      );
+      expect(queryCall).toBeDefined();
+    });
+
+    test('preserves Qdrant ANN ranking (sort by score DESC)', async () => {
+      const convA = makeConversationRow({ task_id: 'task-a' });
+      const convB = makeConversationRow({ task_id: 'task-b' });
+      const convC = makeConversationRow({ task_id: 'task-c' });
+
+      // Return in DB order (arbitrary), not score order
+      mockPoolQuery.mockResolvedValue({ rows: [convB, convA, convC], rowCount: 3 });
+
+      const reader = createReader();
+      await reader.init();
+
+      const result = await reader.joinFromQdrant([
+        { task_id: 'task-c', score: 0.99 },
+        { task_id: 'task-a', score: 0.85 },
+        { task_id: 'task-b', score: 0.70 },
+      ]);
+
+      // Should be sorted by Qdrant score DESC
+      expect(result[0].task_id).toBe('task-c');
+      expect(result[0].score).toBe(0.99);
+      expect(result[1].task_id).toBe('task-a');
+      expect(result[1].score).toBe(0.85);
+      expect(result[2].task_id).toBe('task-b');
+      expect(result[2].score).toBe(0.70);
+    });
+  });
+});

--- a/servers/roo-state-manager/src/services/unified-store/__tests__/unified-store-writer.test.ts
+++ b/servers/roo-state-manager/src/services/unified-store/__tests__/unified-store-writer.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Tests for PgUnifiedStoreWriter — Postgres-backed unified store writer
+ *
+ * #2426 Phase 2: Tests for the dual-write writer with circuit-breaker + retry.
+ * Uses mocked pg.Pool to avoid real DB dependency.
+ *
+ * @module services/unified-store/__tests__/unified-store-writer.test
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PgUnifiedStoreWriter } from '../PgUnifiedStoreWriter.js';
+import type { ConversationBundle, ConversationRow, MessageRow } from '../types.js';
+
+// ─── Mock pg module ──────────────────────────────────────────────────
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn();
+const mockEnd = vi.fn();
+
+const mockClient = {
+  query: mockQuery,
+  release: vi.fn(),
+};
+
+const mockPoolQuery = vi.fn();
+
+const mockPool = {
+  connect: mockConnect,
+  query: mockPoolQuery,
+  end: mockEnd,
+};
+
+vi.mock('pg', () => ({
+  default: {
+    Pool: vi.fn(() => mockPool),
+  },
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function createWriter(): PgUnifiedStoreWriter {
+  return new PgUnifiedStoreWriter({
+    connectionString: 'postgres://test:test@localhost:5432/unified_store',
+    poolMax: 2,
+    statementTimeoutMs: 3000,
+  });
+}
+
+function createConversationRow(overrides?: Partial<ConversationRow>): ConversationRow {
+  return {
+    task_id: 'task-123',
+    machine_id: 'myia-po-2023',
+    harness: 'claude',
+    workspace: '/test/workspace',
+    parent_task_id: null,
+    title: 'Test Task',
+    first_ts: '2026-06-01T10:00:00Z',
+    last_ts: '2026-06-01T11:00:00Z',
+    msg_count: 10,
+    metadata: null,
+    ...overrides,
+  };
+}
+
+function createMessageRow(overrides?: Partial<MessageRow>): MessageRow {
+  return {
+    id: 1,
+    task_id: 'task-123',
+    message_id: null,
+    seq: 0,
+    role: 'user',
+    content: 'Hello world',
+    tool_calls: null,
+    ts: '2026-06-01T10:00:00Z',
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+describe('PgUnifiedStoreWriter', () => {
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConnect.mockResolvedValue(mockClient);
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    mockEnd.mockResolvedValue(undefined);
+    mockClient.release.mockReset();
+  });
+
+  // ─── Lifecycle ──────────────────────────────────────────────────
+
+  describe('lifecycle', () => {
+    test('init connects to pool and verifies connectivity', async () => {
+      const writer = createWriter();
+      await writer.init();
+
+      expect(mockConnect).toHaveBeenCalledTimes(1); // connect for SELECT 1 verification
+      expect(mockQuery).toHaveBeenCalledWith('SELECT 1');
+    });
+
+    test('init is idempotent', async () => {
+      const writer = createWriter();
+      await writer.init();
+      await writer.init();
+
+      // SELECT 1 called only once (second init early-returns)
+      const select1Calls = mockQuery.mock.calls.filter(c => c[0] === 'SELECT 1');
+      expect(select1Calls.length).toBe(1);
+    });
+
+    test('close drains the pool', async () => {
+      const writer = createWriter();
+      await writer.init();
+      await writer.close();
+
+      expect(mockEnd).toHaveBeenCalledTimes(1);
+    });
+
+    test('ping returns true when pool is healthy', async () => {
+      const writer = createWriter();
+      await writer.init();
+      const result = await writer.ping();
+
+      expect(result).toBe(true);
+    });
+
+    test('ping returns false when pool throws', async () => {
+      mockConnect.mockRejectedValue(new Error('Connection refused'));
+      // Need to bypass init's connect
+      const writer = createWriter();
+      await writer.init().catch(() => {});
+      mockConnect.mockResolvedValue(mockClient);
+      mockQuery.mockRejectedValue(new Error('DB down'));
+
+      const result = await writer.ping();
+      expect(result).toBe(false);
+    });
+  });
+
+  // ─── Upsert Conversation ────────────────────────────────────────
+
+  describe('upsertConversation', () => {
+    test('inserts conversation + messages in a transaction', async () => {
+      const writer = createWriter();
+      await writer.init();
+
+      const bundle: ConversationBundle = {
+        conversation: createConversationRow(),
+        messages: [
+          createMessageRow({ seq: 0, role: 'user' }),
+          createMessageRow({ seq: 1, role: 'assistant' }),
+        ],
+      };
+
+      await writer.upsertConversation(bundle);
+
+      // BEGIN, upsert conversation, upsert messages (UNNEST), COMMIT
+      expect(mockQuery).toHaveBeenCalledWith('BEGIN');
+      expect(mockQuery).toHaveBeenCalledWith('COMMIT');
+      expect(mockClient.release).toHaveBeenCalled();
+    });
+
+    test('rolls back on error', async () => {
+      const writer = createWriter();
+      await writer.init();
+
+      // Make the conversation INSERT fail
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('INSERT INTO conversations')) {
+          throw new Error('Unique violation');
+        }
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      });
+
+      const bundle: ConversationBundle = {
+        conversation: createConversationRow(),
+        messages: [],
+      };
+
+      // Should not throw (best-effort with retry)
+      await writer.upsertConversation(bundle);
+
+      // ROLLBACK should be called
+      expect(mockQuery).toHaveBeenCalledWith('ROLLBACK');
+    });
+
+    test('skips messages when bundle has no messages', async () => {
+      const writer = createWriter();
+      await writer.init();
+
+      const bundle: ConversationBundle = {
+        conversation: createConversationRow(),
+        messages: [],
+      };
+
+      await writer.upsertConversation(bundle);
+
+      // Only BEGIN, INSERT conversation, COMMIT — no UNNEST
+      const unnestCalls = mockQuery.mock.calls.filter(
+        c => typeof c[0] === 'string' && c[0].includes('UNNEST')
+      );
+      expect(unnestCalls.length).toBe(0);
+    });
+  });
+
+  // ─── Upsert Conversation Only ───────────────────────────────────
+
+  describe('upsertConversationOnly', () => {
+    test('inserts conversation without transaction', async () => {
+      const writer = createWriter();
+      await writer.init();
+
+      await writer.upsertConversationOnly(createConversationRow());
+
+      // Should NOT call BEGIN/COMMIT (single statement)
+      const beginCalls = mockQuery.mock.calls.filter(c => c[0] === 'BEGIN');
+      expect(beginCalls.length).toBe(0);
+
+      // Should call INSERT INTO conversations
+      const insertCalls = mockQuery.mock.calls.filter(
+        c => typeof c[0] === 'string' && c[0].includes('INSERT INTO conversations')
+      );
+      expect(insertCalls.length).toBe(1);
+    });
+  });
+
+  // ─── Upsert Messages ────────────────────────────────────────────
+
+  describe('upsertMessages', () => {
+    test('uses UNNEST for batch insert', async () => {
+      const writer = createWriter();
+      await writer.init();
+
+      const messages = [
+        createMessageRow({ seq: 0 }),
+        createMessageRow({ seq: 1 }),
+        createMessageRow({ seq: 2 }),
+      ];
+
+      await writer.upsertMessages(messages);
+
+      const unnestCalls = mockQuery.mock.calls.filter(
+        c => typeof c[0] === 'string' && c[0].includes('UNNEST')
+      );
+      expect(unnestCalls.length).toBe(1);
+    });
+
+    test('is no-op when rows is empty', async () => {
+      const writer = createWriter();
+      await writer.init();
+
+      const queryCountBefore = mockQuery.mock.calls.length;
+
+      await writer.upsertMessages([]);
+
+      // No additional queries should be made (early return)
+      expect(mockQuery.mock.calls.length).toBe(queryCountBefore);
+    });
+
+    test('handles tool_calls JSON serialization safely', async () => {
+      const writer = createWriter();
+      await writer.init();
+
+      const messages = [
+        createMessageRow({
+          seq: 0,
+          tool_calls: [{ name: 'read_file', arguments: { path: '/test.ts' } }],
+        }),
+      ];
+
+      await writer.upsertMessages(messages);
+
+      // The UNNEST query should have been called with JSON-stringified tool_calls
+      const unnestCall = mockQuery.mock.calls.find(
+        c => typeof c[0] === 'string' && c[0].includes('UNNEST')
+      );
+      expect(unnestCall).toBeDefined();
+      // tool_calls array should be ['{"name":"read_file",...}']
+      const toolCallsParam = unnestCall![1][5]; // $6::jsonb[]
+      expect(toolCallsParam[0]).toContain('read_file');
+    });
+
+    test('handles non-serializable tool_calls gracefully (stores null)', async () => {
+      const writer = createWriter();
+      await writer.init();
+
+      const circular: any = { name: 'test' };
+      circular.self = circular; // circular reference
+
+      const messages = [
+        createMessageRow({ seq: 0, tool_calls: circular }),
+      ];
+
+      // Should not throw
+      await writer.upsertMessages(messages);
+
+      const unnestCall = mockQuery.mock.calls.find(
+        c => typeof c[0] === 'string' && c[0].includes('UNNEST')
+      );
+      expect(unnestCall).toBeDefined();
+      // tool_calls should be [null] because JSON.stringify fails on circular
+      const toolCallsParam = unnestCall![1][5];
+      expect(toolCallsParam[0]).toBeNull();
+    });
+  });
+
+  // ─── Retry + Circuit Breaker ────────────────────────────────────
+
+  describe('circuit breaker', () => {
+    test('retries on transient failure', async () => {
+      const writer = createWriter();
+      await writer.init();
+
+      let callCount = 0;
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('INSERT INTO conversations')) {
+          callCount++;
+          if (callCount <= 1) throw new Error('Transient error');
+          return { rows: [], rowCount: 0 };
+        }
+        if (sql === 'BEGIN' || sql === 'COMMIT') return { rows: [], rowCount: 0 };
+        return { rows: [], rowCount: 0 };
+      });
+
+      await writer.upsertConversationOnly(createConversationRow());
+
+      // First attempt failed, retry succeeded
+      expect(callCount).toBe(2); // failed once, succeeded on retry
+      const metrics = writer.getMetrics();
+      expect(metrics.upsertsRetried).toBeGreaterThan(0);
+      expect(metrics.upsertsSuccess).toBe(1);
+    });
+
+    test('opens circuit breaker after consecutive failures', async () => {
+      const writer = createWriter();
+      await writer.init();
+
+      // Make all conversation inserts fail
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('INSERT INTO conversations')) {
+          throw new Error('Connection refused');
+        }
+        return { rows: [], rowCount: 0 };
+      });
+
+      // Trigger 3+ failures to open breaker
+      for (let i = 0; i < 4; i++) {
+        await writer.upsertConversationOnly(createConversationRow({ task_id: `task-${i}` }));
+      }
+
+      const state = writer.getBreakerState();
+      expect(state).toBe('OPEN');
+    });
+
+    test('circuit breaker skips calls when OPEN', async () => {
+      const writer = createWriter();
+      await writer.init();
+
+      // Force breaker OPEN by failing repeatedly
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes('INSERT INTO conversations')) {
+          throw new Error('Connection refused');
+        }
+        return { rows: [], rowCount: 0 };
+      });
+
+      for (let i = 0; i < 5; i++) {
+        await writer.upsertConversationOnly(createConversationRow({ task_id: `task-${i}` }));
+      }
+
+      expect(writer.getBreakerState()).toBe('OPEN');
+
+      const metricsBefore = writer.getMetrics();
+      // Another call should be skipped by breaker
+      await writer.upsertConversationOnly(createConversationRow({ task_id: 'task-skipped' }));
+
+      const metricsAfter = writer.getMetrics();
+      // Failed count should increase (breaker blocks the call = counted as failed)
+      expect(metricsAfter.upsertsFailed).toBeGreaterThan(metricsBefore.upsertsFailed);
+    });
+
+    test('metrics are accurate', async () => {
+      const writer = createWriter();
+      await writer.init();
+
+      await writer.upsertConversationOnly(createConversationRow());
+
+      const metrics = writer.getMetrics();
+      expect(metrics.upsertsTotal).toBe(1);
+      expect(metrics.upsertsSuccess).toBe(1);
+      expect(metrics.upsertsFailed).toBe(0);
+      expect(metrics.upsertsRetried).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## #2426 Phase 2 — UnifiedStore Unit Tests

### What
Adds **35 unit tests** covering the Postgres-backed unified store writer and reader, using mocked `pg.Pool` (no real DB dependency).

### Files added
- `servers/roo-state-manager/src/services/unified-store/__tests__/unified-store-writer.test.ts` (17 tests)
- `servers/roo-state-manager/src/services/unified-store/__tests__/unified-store-reader.test.ts` (18 tests)

### Writer tests (17)
- **Lifecycle**: init/connect, idempotent init, close/drain, ping healthy/down
- **Upsert conversation**: transaction (BEGIN/INSERT/COMMIT), rollback on error, skip empty messages
- **Upsert conversation only**: single statement without transaction
- **Upsert messages**: UNNEST batch insert, empty array no-op, JSON tool_calls serialization, circular ref graceful null
- **Circuit breaker**: retry on transient failure, opens after 3 consecutive failures, skips when OPEN, metrics accuracy

### Reader tests (18)
- **Lifecycle**: init/connect, close/drain, ping, isNull=false
- **getConversation**: found (mapped row), not found (null)
- **getMessages**: ordered by seq, limit/offset params, default limit=1000
- **joinFromQdrant (2-step search)**: empty hits, score mapping + sort DESC, machine_id filter, workspace filter, date range (since/until), tool_name JOIN with GIN @> operator, Qdrant ANN ranking preservation

### CI
- `npx vitest run --config vitest.config.ci.ts`: **9857 passed / 1 pre-existing failure** (scrypt perf timeout, unrelated)
- Build: `tsc --noEmit` clean

### Context
- Phases A/B/C/C+ already merged (#563, #568, #569, #571): interfaces, concrete writer/reader, factories, hook
- Zero tests existed for these components — this PR fills that gap
- Part of #2426 Phase 2 prototype (Epic #2191, ADR 010)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>