### PR TITLE
fix(search): #2455 remove blind Phase B fallback in codebase_search

### DIFF
--- a/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
@@ -191,37 +191,29 @@ describe('search-codebase.tool', () => {
 				delete process.env.EMBEDDING_API_KEY;
 			});
 
-			test('falls back to listWorkspaceCollections when no hash variant matches', async () => {
-				// Phase A: all hash variants fail (getCollection rejects for non-fallback names)
-				// Phase B: getCollection succeeds for ws-fallbackcollection
+			test('returns collection_not_found with diagnostic info when no hash variant matches (#2455)', async () => {
+				// #2455: Phase B no longer blindly selects the first ws-* collection.
+				// It returns diagnostic info instead, preventing wrong-workspace results.
 				mockQdrant.getCollection.mockImplementation(async (name: string) => {
 					if (name === 'ws-fallbackcollection') {
-						return { points_count: 5000 };
+						return { points_count: 5000, status: 'green' };
 					}
 					throw new Error('not found');
 				});
 
-				// Phase B: listCollections returns a ws-* collection
+				// Phase B: listCollections returns a ws-* collection (unrelated to workspace)
 				mockQdrant.getCollections.mockResolvedValue({
 					collections: [{ name: 'ws-fallbackcollection' }]
 				});
 
-				// Embedding + search succeed
-				mockEmbeddingCreate.mockResolvedValue({
-					data: [{ embedding: new Array(8).fill(0.1) }]
-				});
-				mockQdrant.query.mockResolvedValue({
-					points: [{
-						score: 0.85,
-						payload: { filePath: 'src/app.ts', codeChunk: 'const x = 1;', startLine: 1, endLine: 5 }
-					}]
-				});
-
 				const result = await handleCodebaseSearch({ query: 'app', workspace: '/ws' });
 				const parsed = JSON.parse(result.content[0].text);
-				expect(parsed.status).toBe('success');
-				expect(parsed.collection).toBe('ws-fallbackcollection');
-				expect(mockQdrant.getCollections).toHaveBeenCalled();
+				// Phase B now returns diagnostic info, NOT results from unrelated collection
+				expect(parsed.status).toBe('collection_not_found');
+				expect(parsed.fallback_list_tried).toBe(true);
+				expect(parsed.existing_collections).toBeDefined();
+				expect(parsed.troubleshooting).toBeDefined();
+				expect(parsed.primary_hash).toMatch(/^ws-[a-f0-9]{16}$/);
 			});
 
 			test('returns collection_not_found with fallback_list_tried when both phases fail', async () => {
@@ -296,7 +288,7 @@ describe('search-codebase.tool', () => {
 
 			const parsed = JSON.parse(result.content[0].text);
 			expect(parsed.status).toBe('collection_not_found');
-			expect(parsed.tried_collections.length).toBeGreaterThan(0);
+			expect(parsed.tried_variants.length).toBeGreaterThan(0);
 		});
 	});
 

--- a/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
@@ -295,36 +295,52 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 		}
 
 
-		// Phase B: Fallback — list all ws-* collections from Qdrant
+		// Phase B: Diagnostic fallback — no blind collection selection (#2455)
 		// #1085: Hash mismatches between Roo (Windows fsPath backslashes) and
 		// Claude Code (Git Bash forward slashes) produce different hashes.
+		// #2455: Previously, Phase B blindly took the first ws-* collection with
+		// points_count > 0, serving results from unrelated workspaces. Now it
+		// returns enriched diagnostic info to help the caller take action.
 		if (!collectionName) {
-			// #1275: Limit to max 5 collections to prevent cascade timeouts
-			const allWsCollections = (await listWorkspaceCollections()).slice(0, 5);
-			for (const wsCol of allWsCollections) {
+			// Collect diagnostic info about existing ws-* collections
+			const allWsCollections = await listWorkspaceCollections();
+			const collectionDiagnostics = [];
+			for (const wsCol of allWsCollections.slice(0, 10)) {
 				try {
 					const info = await qdrant.getCollection(wsCol);
-					if (info && (info as any).points_count > 0) {
-						collectionName = wsCol;
-						break;
-					}
+					collectionDiagnostics.push({
+						collection: wsCol,
+						points_count: (info as any)?.points_count ?? 0,
+						status: info?.status ?? 'unknown'
+					});
 				} catch {
-					continue;
+					collectionDiagnostics.push({
+						collection: wsCol,
+						points_count: -1,
+						status: 'error'
+					});
 				}
 			}
-		}
-		if (!collectionName) {
+
 			return {
 				isError: false,
 				content: [{
 					type: 'text',
 					text: JSON.stringify({
 						status: 'collection_not_found',
-						message: `Collection Qdrant non trouvée pour le workspace "${workspace}".`,
-						hint: 'Le workspace doit être indexé par Roo Code avant de pouvoir effectuer des recherches. Ouvrez le workspace dans VS Code avec Roo activé pour démarrer l\'indexation automatique. Alternativement, exécutez "roosync_indexing" avec action: "rebuild" pour forcer la reconstruction de l\'index.',
-						tried_collections: collectionVariants,
+						message: `No Qdrant collection matching workspace "${workspace}" (primary hash: ${primaryCollectionName}). ${collectionVariants.length} hash variants tried, none matched.`,
+						hint: 'The workspace must be indexed by Roo Code before searching. If already indexed, the path format may differ from what the indexer used. Check the diagnostic info below for existing collections.',
+						tried_variants: collectionVariants,
+						primary_hash: primaryCollectionName,
+						workspace: workspace,
+						workspace_source: workspaceSource,
+						existing_collections: collectionDiagnostics,
 						fallback_list_tried: true,
-						workspace: workspace
+						troubleshooting: {
+							ripgrep_vscode_1122: 'VS Code 1.122+ renamed ripgrep package to @vscode/ripgrep-universal. Roo Code 3.54 cannot find rg.exe → indexing never starts → collection stays empty. Workaround: copy rg.exe from new path to old path.',
+							hash_mismatch: 'Path format differs between indexing (Roo Code fsPath) and search (Claude Code). Common on Windows: backslash vs forward slash, case differences, UNC prefixes.',
+							action: 'Re-index the workspace from this machine via Roo Code, or verify the ripgrep binary is accessible.'
+						}
 					}, null, 2)
 				}]
 			};

--- a/servers/roo-state-manager/tests/unit/tools/search/codebase-search-execution.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/search/codebase-search-execution.test.ts
@@ -153,14 +153,14 @@ describe('codebase_search - handleCodebaseSearch - Collection not found', () => 
 		expect(result.isError).toBe(false);
 		const response = JSON.parse(result.content[0].text);
 		expect(response.status).toBe('collection_not_found');
-		expect(response.tried_collections).toBeDefined();
-		expect(response.tried_collections.length).toBeGreaterThan(0);
+		expect(response.tried_variants).toBeDefined();
+		expect(response.tried_variants.length).toBeGreaterThan(0);
 	});
 
 	it('devrait inclure un hint pour indexer le workspace', async () => {
 		const result = await handleCodebaseSearch({ query: 'test', workspace: 'd:\\test' });
 		const response = JSON.parse(result.content[0].text);
-		expect(response.hint).toContain('indexé par Roo Code');
+		expect(response.hint).toContain('Roo Code');
 	});
 
 	it('devrait inclure le workspace testé', async () => {


### PR DESCRIPTION
## Summary

Fixes #2455 (Phase B fallback component — cause b).

### Problem
Phase B fallback in `codebase_search` blindly selected the first `ws-*` collection with `points_count > 0`, regardless of workspace. On po-2024/web1, this routed searches to `ws-cced6a0374b91fe1` which matched NO known path format variant → wrong-workspace results.

### Changes
- **Phase B no longer blindly selects** — returns enriched diagnostic `collection_not_found` response instead
- Diagnostic response includes: `tried_variants`, `primary_hash`, `existing_collections`, `troubleshooting` hints
- Updated 3 test files to match new behavior
- **ai-01 path NOT affected** — ai-01 routes via hash variant matching (Phase A), which this PR does not touch

### Testing
- `npm run build` ✅
- `npx vitest run --config vitest.config.ci.ts` — **9880/9880 passed** (2 skipped unrelated)

### Note on cause (a) — ripgrep
This PR addresses cause (b) only. Cause (a) (ripgrep binary not found after VS Code 1.122 rename) is a Roo Code upstream issue — workaround is to copy `rg.exe` on each machine.