### PR TITLE
chore(roosync): remove stale TODO #1843 — ProfileApplicabilityHelper implemented

### DIFF
--- a/servers/roo-state-manager/src/services/roosync/NonNominativeBaselineService.ts
+++ b/servers/roo-state-manager/src/services/roosync/NonNominativeBaselineService.ts
@@ -555,8 +555,8 @@ export class NonNominativeBaselineService {
   }
 
   /**
-   * Vérifie si un profil est applicable à une machine
-   * TODO(#1843): Implement actual applicability rules (OS match, GPU presence, etc.)
+   * Vérifie si un profil est applicable à une machine.
+   * Delegates to ProfileApplicabilityHelper (implemented #1843).
    */
   private isProfileApplicable(profile: ConfigurationProfile, inventory: MachineInventory): boolean {
     return ProfileApplicabilityHelper.isApplicable(profile, inventory);


### PR DESCRIPTION
## Stale TODO Cleanup

Remove obsolete `TODO(#1843)` comment from `NonNominativeBaselineService.ts:559`.

### Context

Issue #1843 is CLOSED. `ProfileApplicabilityHelper.ts` fully implements the applicability rules (OS match, GPU presence, software detection) that the TODO referenced. The method `isProfileApplicable()` delegates to `ProfileApplicabilityHelper.isApplicable()` — the implementation is complete.

The TODO comment was never cleaned up after the implementation.

### Change

```diff
- * TODO(#1843): Implement actual applicability rules (OS match, GPU presence, etc.)
+ * Delegates to ProfileApplicabilityHelper (implemented #1843).
```

### TODO/FIXME Audit (Domain 11, idle catalogue #1417)

Full scan of `src/` found 8 items (7 non-test):

| Status | Count | Details |
|--------|-------|---------|
| TRACKED | 3 | #1315 Phase 3 condensation (NarrativeContextBuilderService ×3) |
| **STALE** | **1** | **This PR** — #1843 resolved but TODO not removed |
| UNTRACKED | 3 | ConfigComparator extraction, ExportConfigManager integration, ContentClassifier XML |

### Verification

- `npx tsc --noEmit` — clean (no type errors)
- Build passes
- No functional change (comment-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)