### PR TITLE
fix(cache): make getCacheTierStats() async with ensureFreshCache (#2434)

### DIFF
--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -608,7 +608,7 @@ export async function initializeBackgroundServices(state: ServerState): Promise<
         }).then(async () => {
             // #1747 sub-issue B: Log tier summary after all background loading completes
             const instance = SkeletonCacheService.getInstance();
-            const stats = instance.getCacheTierStats();
+            const stats = await instance.getCacheTierStats();
             console.log(
                 `✅ Skeleton cache loaded: Tier1(Roo)=${stats.tier1_roo} ` +
                 `Tier2(Claude)=${stats.config.enableClaudeTier ? stats.tier2_claude : 'OFF'} ` +

--- a/servers/roo-state-manager/src/services/skeleton-cache.service.ts
+++ b/servers/roo-state-manager/src/services/skeleton-cache.service.ts
@@ -520,13 +520,18 @@ export class SkeletonCacheService {
      *   - 'claude'          → Tier 2 (Claude local)
      *   - 'gdrive-archive'  → Tier 3 (GDrive archives)
      */
-    public getCacheTierStats(): {
+    // #2434: Made async to call ensureFreshCache() before reading cache.
+    // Without this, tier stats could be computed against a stale/cold cache
+    // (unlike every other read path in this class which already awaits ensureFreshCache).
+    public async getCacheTierStats(): Promise<{
         tier1_roo: number;
         tier2_claude: number;
         tier3_archives: number;
         total: number;
         config: { enableClaudeTier: boolean; enableArchiveTier: boolean };
-    } {
+    }> {
+        await this.ensureFreshCache();
+
         let tier1 = 0;
         let tier2 = 0;
         let tier3 = 0;

--- a/servers/roo-state-manager/src/tools/roosync/__tests__/diagnose.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/diagnose.test.ts
@@ -277,7 +277,7 @@ describe('roosync_diagnose', () => {
         config: { enableClaudeTier: true, enableArchiveTier: true },
       };
       vi.spyOn(SkeletonCacheService, 'getInstance').mockReturnValue({
-        getCacheTierStats: vi.fn(() => mockStats),
+        getCacheTierStats: vi.fn(() => Promise.resolve(mockStats)),
       } as any);
 
       const result = await roosyncDiagnose({ action: 'health' });
@@ -305,7 +305,7 @@ describe('roosync_diagnose', () => {
         config: { enableClaudeTier: false, enableArchiveTier: false },
       };
       vi.spyOn(SkeletonCacheService, 'getInstance').mockReturnValue({
-        getCacheTierStats: vi.fn(() => mockStats),
+        getCacheTierStats: vi.fn(() => Promise.resolve(mockStats)),
       } as any);
 
       const result = await roosyncDiagnose({ action: 'health' });
@@ -323,7 +323,7 @@ describe('roosync_diagnose', () => {
         config: { enableClaudeTier: false, enableArchiveTier: false },
       };
       vi.spyOn(SkeletonCacheService, 'getInstance').mockReturnValue({
-        getCacheTierStats: vi.fn(() => mockStats),
+        getCacheTierStats: vi.fn(() => Promise.resolve(mockStats)),
       } as any);
 
       const result = await roosyncDiagnose({ action: 'health' });

--- a/servers/roo-state-manager/src/tools/roosync/diagnose.ts
+++ b/servers/roo-state-manager/src/tools/roosync/diagnose.ts
@@ -413,7 +413,7 @@ async function handleHealthAction(
 ): Promise<DiagnoseResult> {
   const { SkeletonCacheService } = await import('../../services/skeleton-cache.service.js');
   const instance = SkeletonCacheService.getInstance();
-  const stats = instance.getCacheTierStats();
+  const stats = await instance.getCacheTierStats();
 
   const tierSummary =
     `Tier1(Roo): ${stats.tier1_roo} | ` +

--- a/servers/roo-state-manager/tests/unit/tools/roosync/diagnose.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/diagnose.test.ts
@@ -192,7 +192,7 @@ describe('roosync_diagnose tool', () => {
 
     describe('action=health', () => {
         it('returns skeleton cache tier stats', async () => {
-            mockGetCacheTierStats.mockReturnValue({
+            mockGetCacheTierStats.mockResolvedValue({
                 tier1_roo: 100,
                 tier2_claude: 50,
                 tier3_archives: 25,
@@ -208,7 +208,7 @@ describe('roosync_diagnose tool', () => {
         });
 
         it('shows disabled tiers correctly', async () => {
-            mockGetCacheTierStats.mockReturnValue({
+            mockGetCacheTierStats.mockResolvedValue({
                 tier1_roo: 80,
                 tier2_claude: 0,
                 tier3_archives: 0,
@@ -224,9 +224,7 @@ describe('roosync_diagnose tool', () => {
     describe('error handling', () => {
         it('wraps errors with action context', async () => {
             // Force an error in health action
-            mockGetCacheTierStats.mockImplementation(() => {
-                throw new Error('Cache corrupt');
-            });
+            mockGetCacheTierStats.mockRejectedValue(new Error('Cache corrupt'));
             await expect(roosyncDiagnose({ action: 'health' })).rejects.toThrow('health');
             await expect(roosyncDiagnose({ action: 'health' })).rejects.toThrow('Cache corrupt');
         });


### PR DESCRIPTION
## Issue
Closes #2434

## Problem
`getCacheTierStats()` was synchronous and read the cache directly without ensuring it was fresh. This could return stale tier counts.

## Fix
- Made `getCacheTierStats()` async with `await this.ensureFreshCache()` call before reading the cache
- Updated all callers (`background-services.ts`, `diagnose.ts`) to await the now-async method
- Updated all test mocks from sync to async (`mockReturnValue` → `mockResolvedValue`, sync throw → `mockRejectedValue`)

## Files Changed (5)
| File | Change |
|------|--------|
| `skeleton-cache.service.ts` | async + ensureFreshCache() |
| `background-services.ts` | await getCacheTierStats() |
| `diagnose.ts` | await getCacheTierStats() |
| `__tests__/diagnose.test.ts` | mockReturnValue → mockResolvedValue |
| `diagnose.test.ts` (unit) | mockReturnValue → mockResolvedValue, sync throw → mockRejectedValue |

## Validation
- Build: ✅ tsc clean
- Tests: ✅ 498 passed, 0 failed (vitest.config.ci.ts)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>