### PR TITLE
fix(indexing): add save_snapshot and trend_report to action validator (#2336)

### DIFF
--- a/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
@@ -273,10 +273,10 @@ export async function handleRooSyncIndexing(
         };
     }
 
-    if (!['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'cleanup', 'garbage_scan', 'cleanup_orphans', 'repair_gaps', 'tool_usage_stats'].includes(args.action)) {
+    if (!['index', 'reset', 'rebuild', 'diagnose', 'archive', 'status', 'cleanup', 'garbage_scan', 'cleanup_orphans', 'repair_gaps', 'tool_usage_stats', 'save_snapshot', 'trend_report'].includes(args.action)) {
         return {
             isError: true,
-            content: [{ type: 'text', text: `Action "${args.action}" invalide. Valeurs possibles: index, reset, rebuild, diagnose, archive, status, cleanup, garbage_scan, cleanup_orphans, repair_gaps, tool_usage_stats` }]
+            content: [{ type: 'text', text: `Action "${args.action}" invalide. Valeurs possibles: index, reset, rebuild, diagnose, archive, status, cleanup, garbage_scan, cleanup_orphans, repair_gaps, tool_usage_stats, save_snapshot, trend_report` }]
         };
     }
 


### PR DESCRIPTION
## Problem
The action validator whitelist in `roosync-indexing.tool.ts` was missing `save_snapshot` and `trend_report` actions, causing them to be rejected as "invalid action" despite being fully implemented in the switch statement and declared in the tool schema.

## Fix
Added `save_snapshot` and `trend_report` to the validator whitelist array and error message.

## Testing
- Build: ✅ (tsc clean)
- Tests: 182/182 pass (3020 tests, CI config)
- Verified: the switch cases at lines 1065 (`save_snapshot`) and 1135 (`trend_report`) are now reachable

## Scope
1 file changed, 2 insertions(+), 2 deletions(-)

Related: #2336 D3/D4 (tool-usage telemetry trend dashboard)