### PR TITLE
fix(#596): findConversationById supports per-session taskId (#937)

### DIFF
--- a/servers/roo-state-manager/src/utils/claude-storage-detector.ts
+++ b/servers/roo-state-manager/src/utils/claude-storage-detector.ts
@@ -530,10 +530,11 @@ export class ClaudeStorageDetector {
         const locations = await this.detectStorageLocations();
 
         // #852: Extract project name from taskId (format: claude-{projectName})
+        // #937: Also handle per-session format: claude-{projectName}--{sessionUuid}
         if (!taskId.startsWith('claude-')) {
             return null;
         }
-        const targetProjectName = taskId.substring(7); // Remove 'claude-' prefix
+        const suffix = taskId.substring(7); // Remove 'claude-' prefix
 
         for (const location of locations) {
             // Chercher dans tous les projets
@@ -541,7 +542,8 @@ export class ClaudeStorageDetector {
 
             for (const projectName of projects) {
                 // #852 FIX: Only check projects that match the taskId
-                if (projectName !== targetProjectName) {
+                // #937 FIX: Match both per-project (exact) and per-session (--{uuid}) formats
+                if (projectName !== suffix && !suffix.startsWith(projectName + '--')) {
                     continue;
                 }
 


### PR DESCRIPTION
## Problem
`findConversationById` in `claude-storage-detector.ts` does not handle per-session taskId format introduced by #937.

### Bug
`taskId.substring(7)` extracts the full suffix including UUID for per-session IDs like `claude-c--Production-Embeddings--58af526e-...`, causing `projectName !== targetProjectName` to always fail.

### Fix
Match both formats:
- Per-project: `claude-{projectName}` → exact match  
- Per-session: `claude-{projectName}--{uuid}` → `suffix.startsWith(projectName + '--')`

### Testing
- TypeScript compilation passes
- Supports both taskId formats

Closes #596 (partial — manual indexing unblocked, sanctuary protection still needs config flag)