### PR TITLE
feat(extraction): add ZooTaskExtractor for zoo-code source (#2429)

### DIFF
--- a/servers/roo-state-manager/src/services/extraction/__tests__/zoo-task-extractor.test.ts
+++ b/servers/roo-state-manager/src/services/extraction/__tests__/zoo-task-extractor.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for ZooTaskExtractor — #2429
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+// Use vi.hoisted to create mocks that can be referenced inside vi.mock factories
+const { mockReaddir, mockReadFile, mockStat } = vi.hoisted(() => ({
+  mockReaddir: vi.fn(),
+  mockReadFile: vi.fn(),
+  mockStat: vi.fn(),
+}));
+
+// Mock fs/promises before importing anything that uses it
+vi.mock('fs/promises', () => ({
+  readdir: mockReaddir,
+  readFile: mockReadFile,
+  stat: mockStat,
+}));
+
+// Mock ZooStorageDetector before importing the extractor
+vi.mock('../../../utils/zoo-storage-detector.js', () => ({
+  ZooStorageDetector: {
+    detectStorageLocations: vi.fn(),
+    getStatsForPath: vi.fn(),
+    getStorageStats: vi.fn(),
+    isZooCodePath: vi.fn(),
+    validateCustomPath: vi.fn(),
+  },
+}));
+
+// Mock RooStorageDetector (format-identical parsing delegation)
+vi.mock('../../../utils/roo-storage-detector.js', () => ({
+  RooStorageDetector: {
+    analyzeConversation: vi.fn(),
+  },
+}));
+
+// Don't mock unified-task.js — keep real implementation for toUnifiedTask and computeStorageTier
+
+import { ZooTaskExtractor } from '../zoo-task-extractor.js';
+import { ZooStorageDetector } from '../../../utils/zoo-storage-detector.js';
+import { RooStorageDetector } from '../../../utils/roo-storage-detector.js';
+
+const mockZoo = vi.mocked(ZooStorageDetector);
+const mockRoo = vi.mocked(RooStorageDetector);
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const ZOO_LOCATION = 'C:/Users/test/AppData/Roaming/Code/User/globalStorage/zoocodeorganization.zoo-code';
+
+const makeTaskMetadata = (overrides: Record<string, any> = {}) => ({
+  messageCount: 42,
+  dataSource: `${ZOO_LOCATION}/tasks/019d20bb-b7b7-721a-9306-7412f23e85aa`,
+  lastActivity: '2026-03-24T16:48:00.039Z',
+  workspace: 'd:/Dev/roo-extensions',
+  actionCount: 5,
+  totalSize: 98252,
+  createdAt: '2026-03-24T16:44:26.446Z',
+  ...overrides,
+});
+
+const makeHistoryItem = (overrides: Record<string, any> = {}) => ({
+  number: 1,
+  task: 'Lis le fichier et corrige le bug',
+  id: '019d20bb-b7b7-721a-9306-7412f23e85aa',
+  ts: 1775689528719,
+  ...overrides,
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ZooTaskExtractor', () => {
+  let extractor: ZooTaskExtractor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    extractor = new ZooTaskExtractor();
+  });
+
+  test('has sourceName "zoo-code"', () => {
+    expect(extractor.sourceName).toBe('zoo-code');
+  });
+
+  describe('isAvailable', () => {
+    test('returns true when Zoo locations exist', async () => {
+      mockZoo.detectStorageLocations.mockResolvedValue([ZOO_LOCATION]);
+      await expect(extractor.isAvailable()).resolves.toBe(true);
+    });
+
+    test('returns false when no locations', async () => {
+      mockZoo.detectStorageLocations.mockResolvedValue([]);
+      await expect(extractor.isAvailable()).resolves.toBe(false);
+    });
+
+    test('returns false on error', async () => {
+      mockZoo.detectStorageLocations.mockRejectedValue(new Error('fail'));
+      await expect(extractor.isAvailable()).resolves.toBe(false);
+    });
+  });
+
+  describe('extractAll', () => {
+    test('extracts tasks from Zoo storage locations', async () => {
+      const taskId = '019d20bb-b7b7-721a-9306-7412f23e85aa';
+      mockZoo.detectStorageLocations.mockResolvedValue([ZOO_LOCATION]);
+
+      // Mock fs.readdir to return task directories
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: taskId, isDirectory: () => true } as any,
+        ] as any)
+        .mockResolvedValueOnce([] as any); // files inside task dir (unused)
+
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(makeTaskMetadata())) // task_metadata.json
+        .mockResolvedValueOnce(JSON.stringify(makeHistoryItem())); // history_item.json
+
+      mockRoo.analyzeConversation.mockResolvedValue(null); // No enrichment
+
+      const result = await extractor.extractAll();
+
+      expect(result.source).toBe('zoo-code');
+      expect(result.tasks).toHaveLength(1);
+      expect(result.tasks[0].id).toBe(taskId);
+      expect(result.tasks[0].source).toBe('zoo-code');
+      expect(result.tasks[0].messageCount).toBe(42);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    test('normalizes empty workspace to undefined', async () => {
+      const taskId = '019d20bb-b7b7-721a-9306-7412f23e85aa';
+      mockZoo.detectStorageLocations.mockResolvedValue([ZOO_LOCATION]);
+
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: taskId, isDirectory: () => true } as any,
+        ] as any)
+        .mockResolvedValueOnce([] as any);
+
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(makeTaskMetadata({ workspace: '' })))
+        .mockResolvedValueOnce(JSON.stringify(makeHistoryItem()));
+
+      mockRoo.analyzeConversation.mockResolvedValue(null);
+
+      const result = await extractor.extractAll();
+      expect(result.tasks[0].workspace).toBeUndefined();
+    });
+
+    test('skips tasks with missing metadata', async () => {
+      const taskId = '019d20bb-b7b7-721a-9306-7412f23e85aa';
+      mockZoo.detectStorageLocations.mockResolvedValue([ZOO_LOCATION]);
+
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: taskId, isDirectory: () => true } as any,
+        ] as any)
+        .mockResolvedValueOnce([] as any);
+
+      mockReadFile.mockRejectedValue(new Error('ENOENT'));
+
+      const result = await extractor.extractAll();
+      expect(result.tasks).toHaveLength(0);
+      expect(result.errors).toHaveLength(0); // Skipped silently
+    });
+
+    test('handles top-level failure gracefully', async () => {
+      mockZoo.detectStorageLocations.mockRejectedValue(new Error('disk error'));
+
+      const result = await extractor.extractAll();
+      expect(result.tasks).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('Zoo extraction failed');
+    });
+
+    test('applies machineId option', async () => {
+      const taskId = '019d20bb-b7b7-721a-9306-7412f23e85aa';
+      mockZoo.detectStorageLocations.mockResolvedValue([ZOO_LOCATION]);
+
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: taskId, isDirectory: () => true } as any,
+        ] as any)
+        .mockResolvedValueOnce([] as any);
+
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(makeTaskMetadata()))
+        .mockResolvedValueOnce(JSON.stringify(makeHistoryItem()));
+
+      mockRoo.analyzeConversation.mockResolvedValue(null);
+
+      const result = await extractor.extractAll({ machineId: 'test-machine' });
+      expect(result.tasks[0].machineId).toBe('test-machine');
+    });
+
+    test('applies includeComputedFields option', async () => {
+      const taskId = '019d20bb-b7b7-721a-9306-7412f23e85aa';
+      mockZoo.detectStorageLocations.mockResolvedValue([ZOO_LOCATION]);
+
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: taskId, isDirectory: () => true } as any,
+        ] as any)
+        .mockResolvedValueOnce([] as any);
+
+      // Use a recent date so the real computeStorageTier returns 'hot'
+      const recentDate = new Date().toISOString();
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(makeTaskMetadata({ lastActivity: recentDate, createdAt: recentDate })))
+        .mockResolvedValueOnce(JSON.stringify(makeHistoryItem()));
+
+      mockRoo.analyzeConversation.mockResolvedValue(null);
+
+      const result = await extractor.extractAll({ includeComputedFields: true });
+      // With a recent date, real computeStorageTier returns 'hot' (≤7 days)
+      expect(result.tasks[0].storageTier).toBe('hot');
+    });
+
+    test('enriches with RooStorageDetector skeleton when available', async () => {
+      const taskId = '019d20bb-b7b7-721a-9306-7412f23e85aa';
+      mockZoo.detectStorageLocations.mockResolvedValue([ZOO_LOCATION]);
+
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: taskId, isDirectory: () => true } as any,
+        ] as any)
+        .mockResolvedValueOnce([] as any);
+
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(makeTaskMetadata()))
+        .mockResolvedValueOnce(JSON.stringify(makeHistoryItem()));
+
+      mockRoo.analyzeConversation.mockResolvedValue({
+        taskId,
+        metadata: {
+          title: 'Enriched title from skeleton',
+          lastActivity: '2026-03-24T16:48:00.039Z',
+        },
+        truncatedInstruction: 'Full instruction from API history',
+        parentTaskId: 'parent-task-uuid',
+        isCompleted: true,
+      } as any);
+
+      const result = await extractor.extractAll();
+      expect(result.tasks[0].title).toBe('Enriched title from skeleton');
+      expect(result.tasks[0].instruction).toBe('Full instruction from API history');
+      expect(result.tasks[0].parentId).toBe('parent-task-uuid');
+      expect(result.tasks[0].status).toBe('completed');
+    });
+  });
+
+  describe('extractById', () => {
+    test('returns task when found', async () => {
+      const taskId = '019d20bb-b7b7-721a-9306-7412f23e85aa';
+      mockZoo.detectStorageLocations.mockResolvedValue([ZOO_LOCATION]);
+
+      mockStat.mockResolvedValue({ isDirectory: () => true } as any);
+      mockReaddir.mockResolvedValue([] as any);
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(makeTaskMetadata()))
+        .mockResolvedValueOnce(JSON.stringify(makeHistoryItem()));
+
+      mockRoo.analyzeConversation.mockResolvedValue(null);
+
+      const task = await extractor.extractById(taskId);
+      expect(task).not.toBeNull();
+      expect(task!.id).toBe(taskId);
+      expect(task!.source).toBe('zoo-code');
+    });
+
+    test('returns null when not found in any location', async () => {
+      const taskId = 'nonexistent-task-id';
+      mockZoo.detectStorageLocations.mockResolvedValue([ZOO_LOCATION]);
+      mockStat.mockRejectedValue(new Error('ENOENT'));
+
+      const task = await extractor.extractById(taskId);
+      expect(task).toBeNull();
+    });
+
+    test('returns null on error', async () => {
+      mockZoo.detectStorageLocations.mockRejectedValue(new Error('fail'));
+
+      const task = await extractor.extractById('any-id');
+      expect(task).toBeNull();
+    });
+  });
+});

--- a/servers/roo-state-manager/src/services/extraction/index.ts
+++ b/servers/roo-state-manager/src/services/extraction/index.ts
@@ -1,11 +1,12 @@
 /**
  * Extraction module barrel export
  * @module services/extraction
- * @issue #1392
+ * @issue #1392, #2429 (zoo-code)
  */
 
 export { RooTaskExtractor } from './roo-task-extractor.js';
 export { ClaudeTaskExtractor } from './claude-task-extractor.js';
+export { ZooTaskExtractor } from './zoo-task-extractor.js';
 export { UnifiedTaskExtractor } from './unified-task-extractor.js';
 export type {
   TaskExtractor,

--- a/servers/roo-state-manager/src/services/extraction/task-extractor.ts
+++ b/servers/roo-state-manager/src/services/extraction/task-extractor.ts
@@ -21,17 +21,17 @@ export interface ExtractionOptions {
 /** Result of a single-source extraction */
 export interface ExtractionResult {
   tasks: UnifiedTask[];
-  source: 'roo' | 'claude-code';
+  source: 'roo' | 'claude-code' | 'zoo-code';
   errors: Array<{ taskId?: string; message: string }>;
 }
 
 /**
  * Base interface for task extractors.
- * Each source (Roo, Claude Code) implements this interface.
+ * Each source (Roo, Claude Code, Zoo-Code) implements this interface.
  */
 export interface TaskExtractor {
   /** Human-readable source name */
-  readonly sourceName: 'roo' | 'claude-code';
+  readonly sourceName: 'roo' | 'claude-code' | 'zoo-code';
 
   /** Extract all tasks from this source */
   extractAll(options?: ExtractionOptions): Promise<ExtractionResult>;

--- a/servers/roo-state-manager/src/services/extraction/unified-task-extractor.ts
+++ b/servers/roo-state-manager/src/services/extraction/unified-task-extractor.ts
@@ -2,9 +2,9 @@
  * UnifiedTaskExtractor — Orchestrator for cross-format task extraction
  *
  * @module services/extraction/unified-task-extractor
- * @issue #1392 (#1360-2)
+ * @issue #1392 (#1360-2), #2429 (zoo-code source)
  *
- * Delegates to RooTaskExtractor and ClaudeTaskExtractor,
+ * Delegates to RooTaskExtractor, ClaudeTaskExtractor, and ZooTaskExtractor,
  * merging results into a single unified collection.
  */
 
@@ -16,14 +16,15 @@ import type {
 } from './task-extractor.js';
 import { RooTaskExtractor } from './roo-task-extractor.js';
 import { ClaudeTaskExtractor } from './claude-task-extractor.js';
+import { ZooTaskExtractor } from './zoo-task-extractor.js';
+
+/** Source types supported by the unified extractor */
+type SupportedSource = 'roo' | 'claude-code' | 'zoo-code';
 
 /** Combined result from all extractors */
 export interface UnifiedExtractionResult {
   tasks: UnifiedTask[];
-  bySource: {
-    roo: ExtractionResult;
-    'claude-code': ExtractionResult;
-  };
+  bySource: Record<SupportedSource, ExtractionResult>;
   totalErrors: number;
 }
 
@@ -34,25 +35,26 @@ export class UnifiedTaskExtractor {
     this.extractors = extractors ?? [
       new RooTaskExtractor(),
       new ClaudeTaskExtractor(),
+      new ZooTaskExtractor(),
     ];
   }
 
   /** Extract tasks from all available sources */
   async extractAll(options?: ExtractionOptions): Promise<UnifiedExtractionResult> {
-    const rooResult = await this.extractors[0].extractAll(options);
-    const claudeResult = await this.extractors[1].extractAll(options);
+    const results = await Promise.all(
+      this.extractors.map(ext => ext.extractAll(options)),
+    );
 
-    const allTasks = [...rooResult.tasks, ...claudeResult.tasks];
-    const totalErrors = rooResult.errors.length + claudeResult.errors.length;
+    const allTasks = results.flatMap(r => r.tasks);
+    const totalErrors = results.reduce((sum, r) => sum + r.errors.length, 0);
 
-    return {
-      tasks: allTasks,
-      bySource: {
-        roo: rooResult,
-        'claude-code': claudeResult,
-      },
-      totalErrors,
-    };
+    const bySource = {} as Record<SupportedSource, ExtractionResult>;
+    for (let i = 0; i < this.extractors.length; i++) {
+      const sourceName = this.extractors[i].sourceName as SupportedSource;
+      bySource[sourceName] = results[i];
+    }
+
+    return { tasks: allTasks, bySource, totalErrors };
   }
 
   /** Extract a single task by ID from the appropriate source */
@@ -60,18 +62,17 @@ export class UnifiedTaskExtractor {
     taskId: string,
     options?: ExtractionOptions,
   ): Promise<UnifiedTask | null> {
-    // Determine source from taskId format
     const extractor = this.getExtractorForTask(taskId);
     return extractor.extractById(taskId, options);
   }
 
   /** Check which sources are available */
-  async getAvailableSources(): Promise<Array<'roo' | 'claude-code'>> {
-    const available: Array<'roo' | 'claude-code'> = [];
+  async getAvailableSources(): Promise<SupportedSource[]> {
+    const available: SupportedSource[] = [];
 
     for (const extractor of this.extractors) {
       if (await extractor.isAvailable()) {
-        available.push(extractor.sourceName);
+        available.push(extractor.sourceName as SupportedSource);
       }
     }
 
@@ -83,7 +84,8 @@ export class UnifiedTaskExtractor {
     // Claude tasks use "claude-{projectName}" format
     if (taskId.startsWith('claude-')) {
       return this.extractors.find(e => e.sourceName === 'claude-code')
-        ?? this.extractors[1];
+        ?? this.extractors.find(e => e.sourceName !== 'roo')
+        ?? this.extractors[0];
     }
     // Default to Roo (UUID format or other)
     return this.extractors.find(e => e.sourceName === 'roo')

--- a/servers/roo-state-manager/src/services/extraction/zoo-task-extractor.ts
+++ b/servers/roo-state-manager/src/services/extraction/zoo-task-extractor.ts
@@ -1,0 +1,220 @@
+/**
+ * ZooTaskExtractor — Extracts UnifiedTasks from Zoo-Code storage
+ *
+ * @module services/extraction/zoo-task-extractor
+ * @issue #2429
+ *
+ * Zoo-Code is a Roo/Cline fork with identical on-disk format.
+ * This extractor delegates parsing to RooStorageDetector (format-identical)
+ * but attributes tasks to source 'zoo-code' via ZooStorageDetector for
+ * path detection and source attribution.
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { RooStorageDetector } from '../../utils/roo-storage-detector.js';
+import { ZooStorageDetector } from '../../utils/zoo-storage-detector.js';
+import {
+  toUnifiedTask,
+  computeStorageTier,
+} from '../../types/unified-task.js';
+import type { UnifiedTask } from '../../types/unified-task.js';
+import type {
+  TaskExtractor,
+  ExtractionOptions,
+  ExtractionResult,
+} from './task-extractor.js';
+
+/** Zoo task_metadata.json format */
+interface ZooTaskMetadata {
+  messageCount: number;
+  dataSource: string;
+  lastActivity: string;
+  workspace: string;
+  actionCount: number;
+  totalSize: number;
+  createdAt: string;
+}
+
+/** Zoo history_item.json format */
+interface ZooHistoryItem {
+  number: number;
+  task: string;
+  id: string;
+  ts: number;
+}
+
+export class ZooTaskExtractor implements TaskExtractor {
+  readonly sourceName = 'zoo-code' as const;
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      const locations = await ZooStorageDetector.detectStorageLocations();
+      return locations.length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  async extractAll(options?: ExtractionOptions): Promise<ExtractionResult> {
+    const errors: Array<{ taskId?: string; message: string }> = [];
+    const tasks: UnifiedTask[] = [];
+
+    try {
+      const locations = await ZooStorageDetector.detectStorageLocations();
+
+      for (const locationPath of locations) {
+        const tasksDir = path.join(locationPath, 'tasks');
+        let entries: string[];
+
+        try {
+          const dirents = await fs.readdir(tasksDir, { withFileTypes: true });
+          entries = dirents
+            .filter(d => d.isDirectory() && d.name !== '_index.json')
+            .map(d => d.name);
+        } catch {
+          continue;
+        }
+
+        for (const taskId of entries) {
+          try {
+            const task = await this.extractSingleTask(taskId, tasksDir, options);
+            if (task) tasks.push(task);
+          } catch (err) {
+            errors.push({
+              taskId,
+              message: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+      }
+    } catch (err) {
+      errors.push({
+        message: `Zoo extraction failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+
+    return { tasks, source: 'zoo-code', errors };
+  }
+
+  async extractById(
+    taskId: string,
+    options?: ExtractionOptions,
+  ): Promise<UnifiedTask | null> {
+    try {
+      const locations = await ZooStorageDetector.detectStorageLocations();
+
+      for (const locationPath of locations) {
+        const taskDir = path.join(locationPath, 'tasks', taskId);
+        try {
+          const stat = await fs.stat(taskDir);
+          if (stat.isDirectory()) {
+            return await this.extractSingleTask(taskId, path.join(locationPath, 'tasks'), options);
+          }
+        } catch {
+          continue;
+        }
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Extract a single Zoo task from its directory.
+   *
+   * Strategy: read task_metadata.json for core fields, then delegate
+   * to RooStorageDetector.analyzeConversation for full ConversationSkeleton
+   * parsing (format-identical). Falls back to metadata-only if analyzeConversation
+   * fails (e.g. corrupted api_conversation_history).
+   */
+  private async extractSingleTask(
+    taskId: string,
+    tasksDir: string,
+    options?: ExtractionOptions,
+  ): Promise<UnifiedTask | null> {
+    const taskDir = path.join(tasksDir, taskId);
+
+    // Read task_metadata.json for core fields
+    let metadata: ZooTaskMetadata;
+    try {
+      const raw = await fs.readFile(path.join(taskDir, 'task_metadata.json'), 'utf-8');
+      metadata = JSON.parse(raw) as ZooTaskMetadata;
+    } catch {
+      // No metadata — skip this task
+      return null;
+    }
+
+    // Try to get title from history_item.json (optional)
+    let title: string | undefined;
+    try {
+      const raw = await fs.readFile(path.join(taskDir, 'history_item.json'), 'utf-8');
+      const historyItem = JSON.parse(raw) as ZooHistoryItem;
+      title = historyItem.task?.substring(0, 100) || undefined;
+    } catch {
+      // history_item.json is optional
+    }
+
+    // Normalize workspace: empty string → undefined
+    const workspace = metadata.workspace && metadata.workspace.trim() !== ''
+      ? metadata.workspace.replace(/\\/g, '/')
+      : undefined;
+
+    const input = {
+      taskId,
+      metadata: {
+        title,
+        lastActivity: metadata.lastActivity,
+        createdAt: metadata.createdAt,
+        messageCount: metadata.messageCount || 0,
+        actionCount: metadata.actionCount || 0,
+        totalSize: metadata.totalSize || 0,
+        workspace,
+        source: 'zoo-code' as const,
+        machineId: os.hostname(),
+      },
+      isCompleted: false,
+    };
+
+    const task = toUnifiedTask(input);
+
+    // Try enriching with RooStorageDetector (format-identical parsing)
+    try {
+      const skeleton = await RooStorageDetector.analyzeConversation(taskId, taskDir);
+      if (skeleton) {
+        // Override with richer data from skeleton if available
+        if (skeleton.metadata?.title) {
+          task.title = skeleton.metadata.title;
+        }
+        if (skeleton.truncatedInstruction) {
+          task.instruction = skeleton.truncatedInstruction.length > 500
+            ? skeleton.truncatedInstruction.slice(0, 500) + '...'
+            : skeleton.truncatedInstruction;
+        }
+        if (skeleton.parentTaskId) {
+          task.parentId = skeleton.parentTaskId;
+        }
+        if (skeleton.isCompleted) {
+          task.status = 'completed';
+          task.completedAt = skeleton.metadata?.lastActivity;
+          task.outcome = 'success';
+        }
+      }
+    } catch {
+      // Skeleton enrichment failed — use metadata-only conversion
+    }
+
+    // Apply options
+    if (options?.machineId) {
+      task.machineId = options.machineId;
+    }
+    if (options?.includeComputedFields) {
+      task.storageTier = computeStorageTier(task);
+    }
+
+    return task;
+  }
+}


### PR DESCRIPTION
## Summary

Implements `ZooTaskExtractor` — a `TaskExtractor` for Zoo-Code storage (issue #2429).

### Changes
- **New** `zoo-task-extractor.ts` — Extracts `UnifiedTask` from Zoo-Code `globalStorage` (task_metadata.json + history_item.json)
- **Updated** `task-extractor.ts` — Interface now supports `zoo-code` source
- **Updated** `unified-task-extractor.ts` — Dynamically orchestrates Roo + Claude + Zoo extractors (3 sources)
- **Updated** `index.ts` — Barrel export includes `ZooTaskExtractor`
- **New** `zoo-task-extractor.test.ts` — 14 unit tests covering all paths

### Design Decisions
- Zoo-Code is a Roo/Cline fork with **identical on-disk format**. The extractor delegates deep parsing to `RooStorageDetector.analyzeConversation()` for sequence/hierarchy extraction
- Core metadata comes from `task_metadata.json` (fast, no parsing large files)
- Empty workspace strings (`""`) normalized to `undefined` per Zoo-Code behavior
- Enrichment from `ConversationSkeleton` is optional (title override, instruction, parent hierarchy, completion status)

### Test Results
- 44/44 extraction module tests pass
- 9893/9894 CI suite tests pass (1 pre-existing EnvRotationService perf flake)
- Build: clean (`tsc`)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>