### PR TITLE
feat(#1985): configurable sanctuary protection via ROO_INDEX_CLAUDE_SESSIONS

### DIFF
--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -1096,8 +1096,11 @@ export async function indexTaskInQdrant(taskId: string, state: ServerState): Pro
         // Manual indexing via roosync_indexing(action: "index") is still allowed.
         // Root cause: Claude Code sessions get new UUIDs on resume/compact, causing
         // 3-4x duplicate vectors (49% of Qdrant storage = duplicates).
-        if (source === 'claude-code') {
-            console.log(`[SKIP] Task ${taskId}: Claude Code session — automatic indexing blocked (#1985 sanctuary protection)`);
+        // #937 mitigation: Per-session taskIds + UUIDv5 deterministic chunk_ids resolve the
+        // duplicate risk. Set ROO_INDEX_CLAUDE_SESSIONS=true to lift sanctuary per-machine.
+        const allowClaudeIndexing = process.env.ROO_INDEX_CLAUDE_SESSIONS === 'true';
+        if (source === 'claude-code' && !allowClaudeIndexing) {
+            console.log(`[SKIP] Task ${taskId}: Claude Code session — automatic indexing blocked (#1985 sanctuary protection). Set ROO_INDEX_CLAUDE_SESSIONS=true to enable.`);
             return;
         }
 


### PR DESCRIPTION
## Problem
The sanctuary protection (#1985) blocks ALL Claude Code session auto-indexing. This was justified by duplicate vectors from resume/compact (3-4x duplicates, 49% of Qdrant storage).

However, per-session taskIds (#937) + UUIDv5 deterministic chunk_ids now resolve this risk. Each session gets a unique taskId, and each chunk has a deterministic ID based on content hash.

## Solution
Add opt-in env var `ROO_INDEX_CLAUDE_SESSIONS=true` to lift the sanctuary per-machine.

- **Default**: sanctuary protection unchanged (safe)
- **Opt-in**: machines with the flag auto-index Claude Code sessions
- **Reversible**: remove the flag to restore protection

## Testing
- TypeScript compilation passes
- Default behavior unchanged (sanctuary active when var not set)

## Related
- #596 — VectorIndexer doesn't index Claude Code conversations
- PR #605 — findConversationById per-session fix (complementary)
- #1985 — Original sanctuary protection
- #937 — Per-session taskId format

Closes #596