### PR TITLE
fix(classifier): remove console.log stdout leak in determineAssistantSubType

### DIFF
--- a/servers/roo-state-manager/src/services/trace-summary/ContentClassifier.ts
+++ b/servers/roo-state-manager/src/services/trace-summary/ContentClassifier.ts
@@ -138,12 +138,10 @@ export class ContentClassifier {
 
         // 1. Messages de completion (priorité haute)
         if (content.includes('<attempt_completion>')) {
-            console.log(`✅ Matched: Completion`);
             return 'Completion';
         }
 
         // 2. Messages d'outils normaux
-        console.log(`❌ No special match, defaulting to ToolCall`);
         return 'ToolCall';
     }
 


### PR DESCRIPTION
## Fix

Remove two `console.log` calls in `ContentClassifier.determineAssistantSubType` (lines 141, 146) that pollute stdout — reserved for JSON-RPC in MCP servers.

### Context
Found during #756 parsing/export audit (Bug #6). The `console.log` calls write to stdout on every assistant message classification, potentially corrupting the JSON-RPC stream and causing MCP protocol errors.

### Change
- Remove `console.log("✅ Matched: Completion")` (line 141)
- Remove `console.log("❌ No special match, defaulting to ToolCall")` (line 146)
- Kept `console.warn` (line 213) — writes to stderr, safe for JSON-RPC

### Testing
- Build: ✅ `tsc` clean
- Tests: 498/501 pass (1 pre-existing failure in EnvRotationService unrelated)
- ContentClassifier.test.ts: 2/2 pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>