### PR TITLE
fix(mcp): replace readFileSync with async reads to prevent event loop hangs (#2267)

### DIFF
--- a/servers/roo-state-manager/src/services/roosync/BaselineManager.ts
+++ b/servers/roo-state-manager/src/services/roosync/BaselineManager.ts
@@ -7,7 +7,7 @@
  * - État de synchronisation
  */
 
-import { promises as fs, existsSync, readFileSync, constants } from 'fs';
+import { promises as fs, existsSync, constants } from 'fs';
 import { join } from 'path';
 import { RooSyncConfig } from '../../config/roosync-config.js';
 import { RooSyncServiceError } from '../../types/errors.js';
@@ -62,6 +62,8 @@ export interface RollbackRestoreResult {
 export class BaselineManager {
   private logger = createLogger('BaselineManager');
   private machineRegistry: MachineRegistry;
+  // #2267: registry init promise — avoids blocking constructor on GDrive readFileSync
+  private registryInitPromise: Promise<void>;
 
   constructor(
     private config: RooSyncConfig,
@@ -82,17 +84,28 @@ export class BaselineManager {
       this.logger.warn('NonNominativeBaselineService non disponible');
     }
 
-    // Charger le registre existant s'il y en a un
-    this.loadMachineRegistry();
+    // #2267: Fire-and-forget async registry load — avoids blocking constructor on GDrive FUSE stalls.
+    // Methods that read the registry should await registryInitPromise first.
+    this.registryInitPromise = this.loadMachineRegistry();
+  }
+
+  /**
+   * Wait for the machine registry to be loaded from disk (GDrive).
+   * #2267: Safe to call multiple times — resolves immediately after first load.
+   */
+  async waitForRegistry(): Promise<void> {
+    await this.registryInitPromise;
   }
 
   /**
    * Charger le registre des machines depuis le disque
+   * #2267: Converted from sync to async to avoid blocking Node.js event loop on GDrive reads.
    */
-  private loadMachineRegistry(): void {
+  private async loadMachineRegistry(): Promise<void> {
     try {
       if (existsSync(this.machineRegistry.registryPath)) {
-        const registryContent = readFileSync(this.machineRegistry.registryPath, 'utf-8');
+        // #2267: async read replaces readFileSync — GDrive FUSE stalls no longer block event loop
+        const registryContent = await fs.readFile(this.machineRegistry.registryPath, 'utf-8');
         const registryData = JSON.parse(registryContent);
 
         // Reconstruire la Map depuis les données JSON (normaliser les clés en lowercase)
@@ -248,8 +261,8 @@ export class BaselineManager {
       if (existsSync(dashboardPath)) {
         this.logger.info(`Dashboard existant trouvé, chargement depuis: ${dashboardPath}`);
         try {
-          const dashboardContent = readFileSync(dashboardPath, 'utf-8');
-          const dashboard = JSON.parse(dashboardContent);
+          // #2267: async read avoids blocking Node.js event loop on GDrive FUSE stalls
+          const dashboard = JSON.parse(await fs.readFile(dashboardPath, 'utf-8'));
           this.logger.info('Dashboard chargé avec succès depuis le fichier existant');
 
           // S'assurer que le dashboard a bien la propriété machines
@@ -329,8 +342,8 @@ export class BaselineManager {
     // Si un dashboard existe déjà, l'utiliser et s'assurer que la machine courante est présente
     if (existsSync(dashboardPath)) {
       try {
-        const dashboardContent = readFileSync(dashboardPath, 'utf-8');
-        const existingDashboard = JSON.parse(dashboardContent);
+        // #2267: async read avoids blocking Node.js event loop on GDrive FUSE stalls
+        const existingDashboard = JSON.parse(await fs.readFile(dashboardPath, 'utf-8'));
         this.logger.info('Dashboard existant trouvé, vérification de la machine courante');
 
         if (!existingDashboard.machines) {

--- a/servers/roo-state-manager/src/tools/registry.ts
+++ b/servers/roo-state-manager/src/tools/registry.ts
@@ -68,12 +68,12 @@ const TOOL_TIMEOUTS: Record<string, number> = {
     // been observed (490s for the status leg alone). The prior 60s cap (#453),
     // then 600s, both cancelled legitimate condensations, write-blocking the
     // fleet's main coord channel (regression — dashboards worked before #453).
-    // Each LLM call has its own 1800s internal timeout (see dashboard.ts), so we
-    // align the MCP wrapper to 1800s: the wrapper must never be tighter than the
-    // operation's own timeout + circuit-breaker (#1792), which are the real
-    // hang-protection. The status section size is bounded separately by its own
-    // targeted condensation (condenseTextIfTooLarge).
-    roosync_dashboard: 1_800_000,   // 30 min (parallel LLM condensation; matches internal per-call timeout)
+    // #2267 follow-up: reduced from 1800s to 720s (12 min). The internal per-LLM-call
+    // timeout (CONDENSE_LLM_TIMEOUT_MS, dashboard.ts) was already reduced to 720s.
+    // The wrapper timeout aligns to the internal ceiling + circuit-breaker (#1792).
+    // This ensures a true hang (stuck GDrive, dead transport) fails within 12 min
+    // instead of blocking the MCP connection for 30 min.
+    roosync_dashboard: 720_000,     // 12 min (#2267: reduced from 30 min; aligns to CONDENSE_LLM_TIMEOUT_MS)
     roosync_compare_config: 60_000, // 1 min
     roosync_inventory: 60_000,      // 1 min
 };

--- a/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
@@ -388,6 +388,9 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 		}
 
 		// 5. Effectuer la recherche
+		// #2267: Use native Qdrant timeout (seconds) to prevent indefinite hangs.
+		// Follows #1275 convention used in task-searcher.ts and search-semantic.tool.ts.
+		const searchTimeoutSec = Math.ceil(parseInt(process.env.QDRANT_SEARCH_TIMEOUT_MS || '30000', 10) / 1000);
 		const searchResults = await qdrant.query(collectionName, {
 			query: queryVector,
 			filter: filter,
@@ -397,6 +400,7 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 				hnsw_ef: 256,
 				exact: false
 			},
+			timeout: searchTimeoutSec,
 			with_payload: {
 				include: ['filePath', 'codeChunk', 'startLine', 'endLine', 'pathSegments']
 			}

--- a/servers/roo-state-manager/tests/unit/services/roosync/BaselineManager.gap.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/roosync/BaselineManager.gap.test.ts
@@ -13,7 +13,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BaselineManager } from '../../../../src/services/roosync/BaselineManager.js';
-import { promises as fs, existsSync, readFileSync } from 'fs';
+import { promises as fs, existsSync } from 'fs';
 
 vi.mock('fs', () => ({
   constants: { R_OK: 4, W_OK: 2, F_OK: 0 },
@@ -29,7 +29,6 @@ vi.mock('fs', () => ({
     rm: vi.fn(),
   },
   existsSync: vi.fn(),
-  readFileSync: vi.fn(),
 }));
 
 vi.mock('../../../../src/services/BaselineService.js');
@@ -61,63 +60,66 @@ afterEach(() => {
   console.log = originalLog;
 });
 
-function createManager(overrides: { nonNominative?: any; sharedPath?: string } = {}) {
+async function createManager(overrides: { nonNominative?: any; sharedPath?: string } = {}) {
   const config = {
     machineId: 'test-machine',
     sharedPath: overrides.sharedPath || '/tmp/shared',
   } as any;
   const baselineService = { loadBaseline: vi.fn() };
   const configComparator = { listDiffs: vi.fn() };
-  return new BaselineManager(
+  const mgr = new BaselineManager(
     config,
     baselineService,
     configComparator,
     overrides.nonNominative
   );
+  // #2267: loadMachineRegistry() is now async — await before accessing registry
+  await mgr.waitForRegistry();
+  return mgr;
 }
 
 // ─── Machine Registry ───────────────────────────────────────────────
 
 describe('BaselineManager — Machine Registry', () => {
-  it('loads empty registry when file does not exist', () => {
+  it('loads empty registry when file does not exist', async () => {
     (existsSync as any).mockReturnValue(false);
-    const mgr = createManager();
+    const mgr = await createManager();
     expect(mgr.getKnownMachineIds()).toEqual([]);
   });
 
-  it('loads existing registry from disk', () => {
+  it('loads existing registry from disk', async () => {
     (existsSync as any).mockReturnValue(true);
-    (readFileSync as any).mockReturnValue(JSON.stringify({
+    (fs.readFile as any).mockResolvedValue(JSON.stringify({
       machines: {
         'machine-a': { machineId: 'machine-a', firstSeen: '2026-01-01', lastSeen: '2026-01-02', source: 'dashboard', status: 'online' },
         'machine-b': { machineId: 'machine-b', firstSeen: '2026-01-01', lastSeen: '2026-01-03', source: 'config', status: 'offline' },
       },
     }));
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const ids = mgr.getKnownMachineIds();
     expect(ids).toContain('machine-a');
     expect(ids).toContain('machine-b');
     expect(ids).toHaveLength(2);
   });
 
-  it('handles corrupted registry gracefully (empty result)', () => {
+  it('handles corrupted registry gracefully (empty result)', async () => {
     (existsSync as any).mockReturnValue(true);
-    (readFileSync as any).mockReturnValue('invalid json {{{');
+    (fs.readFile as any).mockResolvedValue('invalid json {{{');
 
-    const mgr = createManager();
+    const mgr = await createManager();
     expect(mgr.getKnownMachineIds()).toEqual([]);
   });
 
-  it('normalizes keys to lowercase when loading', () => {
+  it('normalizes keys to lowercase when loading', async () => {
     (existsSync as any).mockReturnValue(true);
-    (readFileSync as any).mockReturnValue(JSON.stringify({
+    (fs.readFile as any).mockResolvedValue(JSON.stringify({
       machines: {
         'MY-MACHINE': { machineId: 'MY-MACHINE', firstSeen: '2026-01-01', lastSeen: '2026-01-01', source: 'dashboard', status: 'online' },
       },
     }));
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const ids = mgr.getKnownMachineIds();
     expect(ids).toContain('my-machine');
   });
@@ -125,8 +127,9 @@ describe('BaselineManager — Machine Registry', () => {
   it('saves registry after adding a machine', async () => {
     (existsSync as any).mockReturnValue(false);
     (fs.writeFile as any).mockResolvedValue(undefined);
+    (fs.readFile as any).mockResolvedValue('{}');
 
-    const mgr = createManager();
+    const mgr = await createManager();
 
     // Trigger add via loadDashboard with machine not in dashboard
     (existsSync as any).mockImplementation((p: string) => {
@@ -134,11 +137,11 @@ describe('BaselineManager — Machine Registry', () => {
       if (p.includes('sync-dashboard.json')) return true;
       return false;
     });
-    (readFileSync as any).mockImplementation((p: string) => {
+    (fs.readFile as any).mockImplementation((p: string) => {
       if (p.includes('sync-dashboard.json')) {
-        return JSON.stringify({ machines: {} });
+        return Promise.resolve(JSON.stringify({ machines: {} }));
       }
-      return '{}';
+      return Promise.resolve('{}');
     });
     (fs.writeFile as any).mockResolvedValue(undefined);
 
@@ -161,33 +164,33 @@ describe('BaselineManager — Machine Registry', () => {
       if (p.includes('.machine-registry')) return true;
       return false;
     });
-    (readFileSync as any).mockImplementation((p: string) => {
+    (fs.readFile as any).mockImplementation((p: string) => {
       if (p.includes('.machine-registry')) {
-        return JSON.stringify({
+        return Promise.resolve(JSON.stringify({
           machines: {
             'test-machine': { machineId: 'test-machine', firstSeen: '2026-01-01', lastSeen: '2026-01-01', source: 'dashboard', status: 'online' },
           },
-        });
+        }));
       }
-      return '{}';
+      return Promise.resolve('{}');
     });
     (fs.writeFile as any).mockResolvedValue(undefined);
 
-    const mgr = createManager();
+    const mgr = await createManager();
 
     // Load dashboard triggers addMachineToRegistry with same source = dashboard
-    (readFileSync as any).mockImplementation((p: string) => {
+    (fs.readFile as any).mockImplementation((p: string) => {
       if (p.includes('.machine-registry')) {
-        return JSON.stringify({
+        return Promise.resolve(JSON.stringify({
           machines: {
             'test-machine': { machineId: 'test-machine', firstSeen: '2026-01-01', lastSeen: '2026-01-01', source: 'dashboard', status: 'online' },
           },
-        });
+        }));
       }
       if (p.includes('sync-dashboard.json')) {
-        return JSON.stringify({ machines: { 'test-machine': { lastSync: '2026-01-01', status: 'synced', diffsCount: 0, pendingDecisions: 0 } } });
+        return Promise.resolve(JSON.stringify({ machines: { 'test-machine': { lastSync: '2026-01-01', status: 'synced', diffsCount: 0, pendingDecisions: 0 } } }));
       }
-      return '{}';
+      return Promise.resolve('{}');
     });
     (existsSync as any).mockReturnValue(true);
 
@@ -204,22 +207,22 @@ describe('BaselineManager — Machine Registry', () => {
       if (p.includes('sync-dashboard.json')) return true;
       return false;
     });
-    (readFileSync as any).mockImplementation((p: string) => {
+    (fs.readFile as any).mockImplementation((p: string) => {
       if (p.includes('.machine-registry')) {
-        return JSON.stringify({
+        return Promise.resolve(JSON.stringify({
           machines: {
             'test-machine': { machineId: 'test-machine', firstSeen: '2026-01-01', lastSeen: '2026-01-01', source: 'config', status: 'online' },
           },
-        });
+        }));
       }
       if (p.includes('sync-dashboard.json')) {
-        return JSON.stringify({ machines: {} });
+        return Promise.resolve(JSON.stringify({ machines: {} }));
       }
-      return '{}';
+      return Promise.resolve('{}');
     });
     (fs.writeFile as any).mockResolvedValue(undefined);
 
-    const mgr = createManager();
+    const mgr = await createManager();
 
     const cacheCallback = vi.fn().mockImplementation((_key: string, fn: () => Promise<any>) => fn());
     const dashboard = await mgr.loadDashboard(cacheCallback);
@@ -235,7 +238,7 @@ describe('BaselineManager — Machine Registry', () => {
 describe('BaselineManager — listRollbackPoints', () => {
   it('returns empty array when rollback dir does not exist', async () => {
     (existsSync as any).mockReturnValue(false);
-    const mgr = createManager();
+    const mgr = await createManager();
     const points = await mgr.listRollbackPoints();
     expect(points).toEqual([]);
   });
@@ -254,7 +257,7 @@ describe('BaselineManager — listRollbackPoints', () => {
       return Promise.resolve(JSON.stringify({ decisionId: 'decision-2', timestamp: '2026-01-02T12:00:00', machine: 'm2', files: ['f2'] }));
     });
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const points = await mgr.listRollbackPoints();
     expect(points).toHaveLength(2);
     expect(points[0].decisionId).toBe('decision-2'); // Most recent first
@@ -268,7 +271,7 @@ describe('BaselineManager — listRollbackPoints', () => {
     });
     (fs.readdir as any).mockResolvedValue(['decision-1_2026-01-01T10-00-00']);
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const points = await mgr.listRollbackPoints();
     expect(points).toEqual([]);
   });
@@ -277,7 +280,7 @@ describe('BaselineManager — listRollbackPoints', () => {
     (existsSync as any).mockReturnValue(true);
     (fs.readdir as any).mockRejectedValue(new Error('Permission denied'));
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const points = await mgr.listRollbackPoints();
     expect(points).toEqual([]);
   });
@@ -288,7 +291,7 @@ describe('BaselineManager — listRollbackPoints', () => {
 describe('BaselineManager — cleanupOldRollbacks', () => {
   it('returns error when rollback dir does not exist', async () => {
     (existsSync as any).mockReturnValue(false);
-    const mgr = createManager();
+    const mgr = await createManager();
     const result = await mgr.cleanupOldRollbacks();
     expect(result.errors).toContain('Rollback directory not found');
     expect(result.deleted).toEqual([]);
@@ -303,7 +306,7 @@ describe('BaselineManager — cleanupOldRollbacks', () => {
       'decision-1_2026-01-03T14-00-00',
     ]);
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const result = await mgr.cleanupOldRollbacks({ keepPerDecision: 1 });
 
     expect(result.kept).toHaveLength(1);
@@ -318,7 +321,7 @@ describe('BaselineManager — cleanupOldRollbacks', () => {
       'decision-1_2026-01-02T12-00-00',
     ]);
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const result = await mgr.cleanupOldRollbacks({ keepPerDecision: 1, dryRun: true });
 
     expect(result.deleted).toHaveLength(1);
@@ -333,7 +336,7 @@ describe('BaselineManager — cleanupOldRollbacks', () => {
       'decision-1_2026-01-02T12-00-00',
     ]);
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const result = await mgr.cleanupOldRollbacks({ keepPerDecision: 1 });
 
     expect(result.errors.length).toBeGreaterThan(0);
@@ -345,7 +348,7 @@ describe('BaselineManager — cleanupOldRollbacks', () => {
 describe('BaselineManager — validateRollbackPoint', () => {
   it('returns invalid when rollback dir does not exist', async () => {
     (existsSync as any).mockReturnValue(false);
-    const mgr = createManager();
+    const mgr = await createManager();
     const result = await mgr.validateRollbackPoint('decision-1');
     expect(result.isValid).toBe(false);
     expect(result.errors).toContain('Rollback directory not found');
@@ -354,7 +357,7 @@ describe('BaselineManager — validateRollbackPoint', () => {
   it('returns invalid when no matching rollback found', async () => {
     (existsSync as any).mockReturnValue(true);
     (fs.readdir as any).mockResolvedValue(['other-decision_2026-01-01']);
-    const mgr = createManager();
+    const mgr = await createManager();
     const result = await mgr.validateRollbackPoint('decision-1');
     expect(result.isValid).toBe(false);
     expect(result.errors[0]).toContain('No rollback found');
@@ -379,7 +382,7 @@ describe('BaselineManager — validateRollbackPoint', () => {
     });
     (fs.stat as any).mockResolvedValue({ size: 100 });
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const result = await mgr.validateRollbackPoint('decision-1');
     expect(result.isValid).toBe(true);
     expect(result.files).toHaveLength(2);
@@ -405,7 +408,7 @@ describe('BaselineManager — validateRollbackPoint', () => {
     });
     (fs.stat as any).mockResolvedValue({ size: 0 });
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const result = await mgr.validateRollbackPoint('decision-1');
     expect(result.isValid).toBe(false);
     expect(result.errors).toContain('Empty file: empty-file.txt');
@@ -436,7 +439,7 @@ describe('BaselineManager — validateRollbackPoint', () => {
       return Promise.resolve(Buffer.from(''));
     });
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const result = await mgr.validateRollbackPoint('decision-1');
     expect(result.isValid).toBe(false);
     expect(result.errors.some((e: string) => e.includes('File not found'))).toBe(true);
@@ -456,7 +459,7 @@ describe('BaselineManager — createRollbackPoint edge cases', () => {
     (fs.copyFile as any).mockResolvedValue(undefined);
     (fs.writeFile as any).mockResolvedValue(undefined);
 
-    const mgr = createManager();
+    const mgr = await createManager();
     await mgr.createRollbackPoint('decision-x');
 
     // copyFile should be called only for the existing file
@@ -467,7 +470,7 @@ describe('BaselineManager — createRollbackPoint edge cases', () => {
     (existsSync as any).mockReturnValue(false);
     (fs.mkdir as any).mockRejectedValue(new Error('Disk full'));
 
-    const mgr = createManager();
+    const mgr = await createManager();
     await expect(mgr.createRollbackPoint('decision-x')).rejects.toThrow('Échec création rollback point');
   });
 });
@@ -481,12 +484,12 @@ describe('BaselineManager — loadDashboard edge cases', () => {
       if (p.includes('sync-dashboard.json')) return true;
       return false;
     });
-    (readFileSync as any).mockImplementation((p: string) => {
-      if (p.includes('sync-dashboard.json')) return '{ broken json';
-      return '{}';
+    (fs.readFile as any).mockImplementation((p: string) => {
+      if (p.includes('sync-dashboard.json')) return Promise.resolve('{ broken json');
+      return Promise.resolve('{}');
     });
 
-    const mgr = createManager();
+    const mgr = await createManager();
 
     // Mock baseline and comparator for calculateDashboardFromBaseline fallback
     (mgr as any).baselineService.loadBaseline.mockResolvedValue({ machineId: 'test-machine' });
@@ -505,13 +508,13 @@ describe('BaselineManager — loadDashboard edge cases', () => {
       if (p.includes('sync-dashboard.json')) return true;
       return false;
     });
-    (readFileSync as any).mockImplementation((p: string) => {
-      if (p.includes('sync-dashboard.json')) return JSON.stringify({ version: '2.1.0' });
-      return '{}';
+    (fs.readFile as any).mockImplementation((p: string) => {
+      if (p.includes('sync-dashboard.json')) return Promise.resolve(JSON.stringify({ version: '2.1.0' }));
+      return Promise.resolve('{}');
     });
     (fs.writeFile as any).mockResolvedValue(undefined);
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const cacheCallback = vi.fn().mockImplementation((_key: string, fn: () => Promise<any>) => fn());
     const dashboard = await mgr.loadDashboard(cacheCallback);
 
@@ -524,12 +527,12 @@ describe('BaselineManager — loadDashboard edge cases', () => {
 
 describe('BaselineManager — getStatus edge cases', () => {
   it('throws on null dashboard', async () => {
-    const mgr = createManager();
+    const mgr = await createManager();
     await expect(mgr.getStatus(vi.fn().mockResolvedValue(null))).rejects.toThrow('Dashboard invalide');
   });
 
   it('throws on dashboard without machines property', async () => {
-    const mgr = createManager();
+    const mgr = await createManager();
     await expect(mgr.getStatus(vi.fn().mockResolvedValue({ version: '2.1.0' }))).rejects.toThrow('Dashboard invalide');
   });
 });
@@ -540,7 +543,7 @@ describe('BaselineManager — Non-nominative additional methods', () => {
   let mgr: BaselineManager;
   let mockNN: any;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mockNN = {
       createBaseline: vi.fn(),
       getActiveBaseline: vi.fn(),
@@ -549,7 +552,7 @@ describe('BaselineManager — Non-nominative additional methods', () => {
       generateMachineHash: vi.fn(),
       getState: vi.fn(),
     };
-    mgr = createManager({ nonNominative: mockNN });
+    mgr = await createManager({ nonNominative: mockNN });
   });
 
   describe('mapMachineToNonNominativeBaseline', () => {
@@ -573,7 +576,7 @@ describe('BaselineManager — Non-nominative additional methods', () => {
     });
 
     it('throws when non-nominative service unavailable', async () => {
-      const mgrNoNN = createManager();
+      const mgrNoNN = await createManager();
       await expect(mgrNoNN.mapMachineToNonNominativeBaseline('machine-x')).rejects.toThrow('NonNominativeBaselineService non disponible');
     });
   });
@@ -590,7 +593,7 @@ describe('BaselineManager — restoreFromRollbackPoint additional cases', () => 
     (fs.access as any).mockRejectedValue(new Error('EACCES'));
     (fs.stat as any).mockResolvedValue({ size: 100 });
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const result = await mgr.restoreFromRollbackPoint('decision-1', vi.fn());
 
     expect(result.success).toBe(false);
@@ -598,7 +601,7 @@ describe('BaselineManager — restoreFromRollbackPoint additional cases', () => 
 
   it('handles rollback directory not existing', async () => {
     (existsSync as any).mockReturnValue(false);
-    const mgr = createManager();
+    const mgr = await createManager();
     const result = await mgr.restoreFromRollbackPoint('decision-1', vi.fn());
     expect(result.success).toBe(false);
     expect(result.error).toContain('No rollback directory found');
@@ -615,7 +618,7 @@ describe('BaselineManager — restoreFromRollbackPoint additional cases', () => 
 
     const badCallback = vi.fn().mockImplementation(() => { throw new Error('Cache explosion'); });
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const result = await mgr.restoreFromRollbackPoint('decision-1', badCallback);
 
     // Should still succeed — cache error is logged but non-fatal
@@ -635,7 +638,7 @@ describe('BaselineManager — restoreFromRollbackPoint additional cases', () => 
     (fs.stat as any).mockResolvedValue({ size: 100 });
     (fs.unlink as any).mockResolvedValue(undefined);
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const result = await mgr.restoreFromRollbackPoint('decision-1', vi.fn());
 
     // Should use default files and still attempt restore
@@ -645,7 +648,7 @@ describe('BaselineManager — restoreFromRollbackPoint additional cases', () => 
   it('handles critical error in outer try-catch', async () => {
     (existsSync as any).mockImplementation(() => { throw new Error('Unexpected'); });
 
-    const mgr = createManager();
+    const mgr = await createManager();
     const result = await mgr.restoreFromRollbackPoint('decision-1', vi.fn());
 
     expect(result.success).toBe(false);

--- a/servers/roo-state-manager/tests/unit/services/roosync/BaselineManager.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/roosync/BaselineManager.test.ts
@@ -3,7 +3,7 @@ import { BaselineManager } from '../../../../src/services/roosync/BaselineManage
 import { RooSyncConfig } from '../../../../src/config/roosync-config.js';
 import { BaselineService } from '../../../../src/services/BaselineService.js';
 import { ConfigComparator } from '../../../../src/services/roosync/ConfigComparator.js';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync } from 'fs';
 import { promises as fs } from 'fs';
 
 vi.mock('fs', () => ({
@@ -23,7 +23,6 @@ vi.mock('fs', () => ({
         unlink: vi.fn(),
     },
     existsSync: vi.fn(),
-    readFileSync: vi.fn()
 }));
 
 vi.mock('../../../../src/services/BaselineService.js');
@@ -35,7 +34,7 @@ describe('BaselineManager', () => {
     let mockBaselineService: any;
     let mockConfigComparator: any;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         mockConfig = {
             machineId: 'test-machine',
             sharedPath: '/tmp/shared'
@@ -49,17 +48,22 @@ describe('BaselineManager', () => {
             listDiffs: vi.fn()
         };
 
+        // #2267: Default mock for async readFile (registry loading)
+        (fs.readFile as any).mockResolvedValue('{}');
+
         manager = new BaselineManager(
             mockConfig,
             mockBaselineService as unknown as BaselineService,
             mockConfigComparator as unknown as ConfigComparator
         );
+        // #2267: Await async registry init before accessing manager
+        await manager.waitForRegistry();
     });
 
     describe('loadDashboard', () => {
         it('should load existing dashboard', async () => {
             (existsSync as any).mockReturnValue(true);
-            (readFileSync as any).mockReturnValue(JSON.stringify({
+            (fs.readFile as any).mockResolvedValue(JSON.stringify({
                 machines: { 'test-machine': {} }
             }));
 
@@ -238,7 +242,7 @@ describe('BaselineManager', () => {
     describe('NonNominativeBaseline Integration', () => {
         let mockNonNominativeService: any;
 
-        beforeEach(() => {
+        beforeEach(async () => {
             mockNonNominativeService = {
                 createBaseline: vi.fn(),
                 getActiveBaseline: vi.fn(),
@@ -247,12 +251,16 @@ describe('BaselineManager', () => {
                 generateMachineHash: vi.fn()
             };
 
+            (fs.readFile as any).mockResolvedValue('{}');
+
             manager = new BaselineManager(
                 mockConfig,
                 mockBaselineService as unknown as BaselineService,
                 mockConfigComparator as unknown as ConfigComparator,
                 mockNonNominativeService
             );
+            // #2267: Await async registry init
+            await manager.waitForRegistry();
         });
 
         describe('migrateToNonNominative', () => {


### PR DESCRIPTION
## Summary

Fixes #2267 — MCP tool hangs caused by synchronous I/O on GDrive paths during FUSE stalls.

### Root Cause
`readFileSync` on GDrive paths blocks the Node.js event loop indefinitely when FUSE stalls occur. This causes the MCP server to become unresponsive, triggering client-side timeouts.

### Changes

1. **BaselineManager.ts** — Replace `readFileSync` → `async fs.readFile`:
   - `loadMachineRegistry()`: Constructor fires async init; new `waitForRegistry()` public method for callers
   - `loadDashboard()` inner read: `readFileSync` → `await readFile`
   - `calculateDashboardFromBaseline()` inner read: same pattern

2. **search-codebase.tool.ts** — Add native Qdrant query timeout (seconds):
   - Follows #1275 convention (`QDRANT_SEARCH_TIMEOUT_MS` env, default 30s)
   - Prevents indefinite hangs on slow Qdrant queries

3. **registry.ts** — Reduce `roosync_dashboard` tool timeout:
   - 30 min → 12 min (720,000ms), aligns with `CONDENSE_LLM_TIMEOUT_MS`

### Test Changes
- `createManager()` helper now async with `await mgr.waitForRegistry()`
- All registry mocks: `readFileSync` → `promises.readFile` (mockResolvedValue/mockImplementation returning `Promise.resolve()`)
- All test functions using `createManager()` made `async`
- Removed unused `readFileSync` import from both test files

### Validation
- Build: ✅ `tsc` passes
- Tests: ✅ 9894 passed / 0 failed (CI config, 501 suites)
- Files: 5 changed (+116/-88)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>