### PR TITLE
fix: streaming JSONL read + per-task timeout + test adaptation

### DIFF
--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -426,7 +426,10 @@ export function startSkeletonRefreshWorker(state: ServerState): void {
     state.skeletonRefreshInterval = setInterval(async () => {
         try {
             const startTime = Date.now();
-            const lastCheck = state.lastSkeletonRefreshAt || 0;
+            // #596: ROO_INDEX_FORCE forces a full rescan (bypass mtime incremental filter)
+            // so previously unseen files (e.g., old Claude Code sessions) get discovered.
+            const forceRescan = process.env.ROO_INDEX_FORCE === '1' || process.env.ROO_INDEX_FORCE === 'true';
+            const lastCheck = forceRescan ? 0 : (state.lastSkeletonRefreshAt || 0);
             let updatedCount = 0;
             let newCount = 0;
 
@@ -1105,7 +1108,15 @@ export async function indexTaskInQdrant(taskId: string, state: ServerState): Pro
         }
 
         const taskIndexer = new TaskIndexer();
-        await taskIndexer.indexTask(taskId, source);
+        const TASK_TIMEOUT_MS = parseInt(process.env.INDEX_TASK_TIMEOUT_MS || '300', 10) * 1000;
+        await Promise.race([
+            taskIndexer.indexTask(taskId, source),
+            new Promise((_, reject) =>
+                setTimeout(() => reject(new Error(
+                    `Indexing timeout for ${taskId} after ${TASK_TIMEOUT_MS}ms — session too large or embedding backlog`
+                )), TASK_TIMEOUT_MS).unref()
+            ),
+        ]);
 
         state.indexingDecisionService.markIndexingSuccess(skeleton);
         await saveSkeletonToDisk(skeleton);

--- a/servers/roo-state-manager/src/services/task-indexer/ChunkExtractor.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/ChunkExtractor.ts
@@ -1,7 +1,8 @@
-import { promises as fs } from 'fs';
+import { promises as fs, createReadStream } from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as crypto from 'crypto';
+import * as readline from 'readline';
 import { v5 as uuidv5 } from 'uuid';
 import { StateManagerError } from '../../types/errors.js';
 
@@ -469,16 +470,28 @@ export async function extractChunksFromClaudeSession(
 
         for (const jsonlFile of jsonlFiles) {
             try {
-                const content = await fs.readFile(jsonlFile, 'utf-8');
-                const lines = content.split('\n').filter(line => line.trim());
-                let fileMessageCount = 0;
+                // Stream JSONL instead of loading entire file into memory.
+                // 112 MB files cause 300s+ timeout when read+split all at once.
+                const fileStream = createReadStream(jsonlFile, 'utf-8');
+                const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
 
-                // #1758: Early stop for large JSONL files
-                if (lines.length > MAX_MESSAGES_PER_TASK) {
-                    console.warn(`⚠️ [#1758] Claude session ${taskId} has ${lines.length} lines — exceeding MAX_MESSAGES_PER_TASK=${MAX_MESSAGES_PER_TASK}. Processing first ${MAX_MESSAGES_PER_TASK} only.`);
+                const linesToProcess: string[] = [];
+                let totalLines = 0;
+                for await (const line of rl) {
+                    if (!line.trim()) continue;
+                    totalLines++;
+                    if (linesToProcess.length < MAX_MESSAGES_PER_TASK) {
+                        linesToProcess.push(line);
+                    }
+                }
+                rl.close();
+                fileStream.destroy();
+
+                if (totalLines > MAX_MESSAGES_PER_TASK) {
+                    console.warn(`⚠️ [#1758] Claude session ${taskId} has ${totalLines} lines — processing first ${MAX_MESSAGES_PER_TASK} only.`);
                 }
 
-                const linesToProcess = lines.slice(0, MAX_MESSAGES_PER_TASK);
+                let fileMessageCount = 0;
 
                 for (const line of linesToProcess) {
                     try {

--- a/servers/roo-state-manager/tests/unit/services/task-indexer/ChunkExtractor.claude-session.test.ts
+++ b/servers/roo-state-manager/tests/unit/services/task-indexer/ChunkExtractor.claude-session.test.ts
@@ -13,16 +13,30 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { extractChunksFromClaudeSession } from '../../../../src/services/task-indexer/ChunkExtractor.js';
-import { promises as fs } from 'fs';
+import { promises as fs, createReadStream as realCreateReadStream } from 'fs';
+import { Readable } from 'stream';
 
-// Mock fs/promises — extractChunksFromClaudeSession reads JSONL files
-vi.mock('fs', () => ({
-    promises: {
-        readFile: vi.fn(),
-        stat: vi.fn(),
-        readdir: vi.fn(),
-    }
-}));
+// Mock fs — extractChunksFromClaudeSession reads JSONL files via promises + createReadStream.
+// createReadStream returns a real Readable that emits the JSONL content from a queue.
+vi.mock('fs', () => {
+    const { Readable } = require('stream');
+    const _jsonlQueue: string[] = [];
+    return {
+        promises: {
+            readFile: vi.fn(),
+            stat: vi.fn(),
+            readdir: vi.fn(),
+        },
+        createReadStream: (_path: string, _encoding: string) => {
+            const content = _jsonlQueue.shift();
+            if (content !== undefined) {
+                return Readable.from([content]);
+            }
+            return Readable.from(['']);
+        },
+        __setJsonl: (jsonl: string) => { _jsonlQueue.push(jsonl); },
+    };
+});
 
 // Mock os (hostname used in getHostIdentifier)
 vi.mock('os', () => ({
@@ -41,12 +55,25 @@ const mockReadFile = vi.mocked(fs.readFile);
 const mockStat = vi.mocked(fs.stat);
 const mockReaddir = vi.mocked(fs.readdir);
 
+// Access the fs mock's __setJsonl function for createReadStream side-channel
+import * as fsMock from 'fs';
+const fsMockAny = fsMock as any;
+
 /**
  * Build a Claude Code JSONL string from an array of entries.
  * Each entry becomes one line.
  */
 function buildJsonl(entries: Record<string, any>[]): string {
     return entries.map(e => JSON.stringify(e)).join('\n');
+}
+
+/**
+ * Set the JSONL content for both readFile mock and createReadStream mock.
+ * createReadStream uses __setJsonl to return a Readable with the content.
+ */
+function setJsonlContent(jsonl: string): void {
+    mockReadFile.mockResolvedValue(jsonl);
+    fsMockAny.__setJsonl(jsonl);
 }
 
 /**
@@ -105,7 +132,7 @@ describe('extractChunksFromClaudeSession', () => {
         const jsonl = buildJsonl([
             textEntry('assistant', 'Hello, I can help with that.'),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -120,7 +147,7 @@ describe('extractChunksFromClaudeSession', () => {
         const jsonl = buildJsonl([
             textEntry('user', 'Please run the tests.'),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -137,7 +164,7 @@ describe('extractChunksFromClaudeSession', () => {
             { type: 'system', message: { role: 'system', content: 'System prompt' } },
             textEntry('user', 'Only this should appear'),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -153,7 +180,7 @@ describe('extractChunksFromClaudeSession', () => {
         const jsonl = buildJsonl([
             toolUseEntry('Bash', { command: 'npm test' }),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -177,7 +204,7 @@ describe('extractChunksFromClaudeSession', () => {
                 { type: 'tool_use', id: 'call_bash_001', name: 'Bash', input: { command: 'npm test' } },
             ]),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -203,7 +230,7 @@ describe('extractChunksFromClaudeSession', () => {
                 { type: 'tool_use', id: 'call_1', name: 'Edit', input: '{"file_path":"/a.ts","old":"x","new":"y"}' },
             ]),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -220,7 +247,7 @@ describe('extractChunksFromClaudeSession', () => {
                 { type: 'tool_use', id: 'call_1', name: 'Bash', input: 'not-valid-json{' },
             ]),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -235,7 +262,7 @@ describe('extractChunksFromClaudeSession', () => {
         const jsonl = buildJsonl([
             toolUseEntry('roosync_dashboard', { action: 'read', type: 'workspace' }),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -256,7 +283,7 @@ describe('extractChunksFromClaudeSession', () => {
                 { type: 'tool_result', tool_use_id: 'call_001', content: 'Tests passed. 10/10 tests OK.' },
             ]),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -279,7 +306,7 @@ describe('extractChunksFromClaudeSession', () => {
             ]),
             toolResultEntry('call_bash_001', 'Tests: 10 passed, 0 failed'),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -302,7 +329,7 @@ describe('extractChunksFromClaudeSession', () => {
         const jsonl = buildJsonl([
             textEntry('assistant', 'Hello'),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, {
             workspace: '/dev/roo-extensions',
@@ -319,7 +346,7 @@ describe('extractChunksFromClaudeSession', () => {
             textEntry('user', 'Query'),
             toolUseEntry('Read', { file_path: '/a.ts' }),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -332,7 +359,7 @@ describe('extractChunksFromClaudeSession', () => {
         const jsonl = buildJsonl([
             textEntry('assistant', 'Response', { model: 'claude-sonnet-4-20250514' }),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -346,6 +373,9 @@ describe('extractChunksFromClaudeSession', () => {
     it('scans directory for JSONL files', async () => {
         mockStat.mockResolvedValue({ isDirectory: () => true } as any);
         mockReaddir.mockResolvedValue(['session1.jsonl', 'session2.jsonl', 'notes.txt'] as any);
+        // Queue both JSONL contents for the streaming reader (createReadStream is called per-file)
+        setJsonlContent(buildJsonl([textEntry('user', 'From session 1')]));
+        setJsonlContent(buildJsonl([textEntry('user', 'From session 2')]));
         mockReadFile
             .mockResolvedValueOnce(buildJsonl([textEntry('user', 'From session 1')]))
             .mockResolvedValueOnce(buildJsonl([textEntry('user', 'From session 2')]));
@@ -378,7 +408,7 @@ describe('extractChunksFromClaudeSession', () => {
             JSON.stringify(textEntry('user', 'Hello')),
             '',
         ].join('\n');
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -392,7 +422,7 @@ describe('extractChunksFromClaudeSession', () => {
             JSON.stringify(textEntry('user', 'Valid')),
             '{broken json',
         ].join('\n');
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -405,7 +435,7 @@ describe('extractChunksFromClaudeSession', () => {
             { type: 'assistant', timestamp: '2024-06-15T10:00:00Z', message: { role: 'assistant' } },
             textEntry('user', 'After null'),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -419,7 +449,7 @@ describe('extractChunksFromClaudeSession', () => {
             toolUseEntry('Bash', { command: 'test' }),
             textEntry('assistant', 'Done'),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -435,7 +465,7 @@ describe('extractChunksFromClaudeSession', () => {
                 { type: 'tool_use', id: 'call_1', input: {} }, // no name field
             ]),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 
@@ -450,7 +480,7 @@ describe('extractChunksFromClaudeSession', () => {
                 { type: 'tool_use', id: 'call_1', name: 'Glob' }, // no input field
             ]),
         ]);
-        mockReadFile.mockResolvedValue(jsonl);
+        setJsonlContent(jsonl);
 
         const chunks = await extractChunksFromClaudeSession(taskId, jsonlPath, metadata);
 


### PR DESCRIPTION
## Summary

Two local commits that were on detached HEAD in the submodule, now with fixed tests.

### Changes

1. **Streaming JSONL read** (`ChunkExtractor.ts`): Replace `fs.readFile()` + `split(n)` with `createReadStream` + `readline` streaming. 112 MB files no longer loaded entirely into memory.

2. **Per-task timeout** (`background-services.ts`): Add `Promise.race` timeout wrapper in `indexTaskInQdrant()` — default 300s, configurable via `INDEX_TASK_TIMEOUT_MS` env var. Prevents background worker stalling on large Claude Code sessions.

3. **Restore `ROO_INDEX_FORCE` forceRescan** (`background-services.ts`): The forceRescan bypass was lost during the #610/#611 merge sequence. Without it, the mtime incremental filter skips old Claude Code sessions that haven't been modified since the last scan.

4. **Test adaptation** (`ChunkExtractor.claude-session.test.ts`): Update `createReadStream` mock to use `Readable.from()` for compatibility with the streaming refactor. All 21 Claude session tests pass.

### Test Evidence
- Build: ✅ (tsc clean)
- Tests: ✅ 9893/9894 passed (1 flaky scrypt perf test unrelated to this change)
- `ChunkExtractor.claude-session.test.ts`: 21/21 ✅

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>