### PR TITLE
feat(config): dynamic VSCDB_KEY + listApiConfigMeta write for Zoo (#2543 Phase 1)

### DIFF
--- a/servers/roo-state-manager/src/services/ConfigSharingService.ts
+++ b/servers/roo-state-manager/src/services/ConfigSharingService.ts
@@ -1126,6 +1126,53 @@ export class ConfigSharingService implements IConfigSharingService {
         }
       }
 
+      // 9. #2543 Phase 1(b) — Write listApiConfigMeta + currentApiConfigName to vscdb
+      let vscdbWritten = false;
+      if (!options.dryRun && modelConfigs.apiConfigs) {
+        try {
+          const { RooSettingsService } = await import('./RooSettingsService.js');
+          const settingsService = new RooSettingsService({
+            targetExtension: options.targetExtension || 'roo'
+          });
+
+          if (settingsService.isAvailable()) {
+            // Build listApiConfigMeta from apiConfigs
+            const listApiConfigMeta = Object.entries(modelConfigs.apiConfigs).map(
+              ([id, config]: [string, any]) => ({
+                id,
+                name: config.name || id,
+                apiProvider: config.apiProvider,
+                ...(config.modelId && { modelId: config.modelId }),
+                ...(config.openAiModelId && { openAiModelId: config.openAiModelId }),
+              })
+            );
+
+            // Determine default config name
+            const defaultConfigName = profile.defaultApiConfig || 'default';
+
+            const settingsToInject: Record<string, unknown> = {
+              listApiConfigMeta,
+              currentApiConfigName: defaultConfigName,
+              modeApiConfigs: newModeApiConfigs,
+            };
+
+            const injectResult = await settingsService.injectSettings(settingsToInject, {
+              keys: ['listApiConfigMeta', 'currentApiConfigName', 'modeApiConfigs'],
+            });
+
+            vscdbWritten = true;
+            this.logger.info(`vscdb updated (${options.targetExtension || 'roo'}): ${listApiConfigMeta.length} configs written, default="${defaultConfigName}", applied=${injectResult.applied}`);
+          } else {
+            this.logger.warn('state.vscdb not available for listApiConfigMeta write (non-fatal)');
+          }
+        } catch (vscdbErr: any) {
+          // Non-fatal — apply_profile succeeds even if vscdb write fails
+          const errMsg = `vscdb listApiConfigMeta write failed: ${vscdbErr.message}`;
+          this.logger.warn(errMsg);
+          errors.push(errMsg);
+        }
+      }
+
       return {
         success: true,
         profileName: profile.name,
@@ -1135,6 +1182,7 @@ export class ConfigSharingService implements IConfigSharingService {
         roomodesGenerated,
         schedulesApplied: schedulesApplied > 0 ? schedulesApplied : undefined,
         rulesApplied: rulesApplied > 0 ? rulesApplied : undefined,
+        vscdbWritten,
         changes: {
           modeApiConfigs: newModeApiConfigs,
           profileThresholds: newThresholds,

--- a/servers/roo-state-manager/src/services/RooSettingsService.ts
+++ b/servers/roo-state-manager/src/services/RooSettingsService.ts
@@ -17,10 +17,25 @@ import { join } from 'path';
 import { homedir, tmpdir } from 'os';
 import sqlite3 from 'sqlite3';
 import { createLogger, Logger } from '../utils/logger.js';
-import { getVscdbKey } from '../utils/extension-paths.js';
+import { getVscdbKey, ZOO_CODE_VSCDB_KEY, DEFAULT_VSCDB_KEY } from '../utils/extension-paths.js';
 
-const VSCDB_KEY = getVscdbKey();
+/**
+ * Default VSCDB key resolved at module load (backward compat).
+ * Individual instances can override via constructor option.
+ */
+const DEFAULT_KEY = getVscdbKey();
 const VSCDB_RELATIVE_PATH = join('AppData', 'Roaming', 'Code', 'User', 'globalStorage', 'state.vscdb');
+
+/** Options for RooSettingsService construction (#2543 Phase 1a). */
+export interface RooSettingsServiceOptions {
+  /**
+   * Target extension identity for vscdb operations.
+   * - 'roo' (default) = RooVeterinaryInc.roo-cline
+   * - 'zoo' = ZooCodeOrganization.zoo-code
+   * - Or a raw vscdb key string for advanced usage.
+   */
+  targetExtension?: 'roo' | 'zoo' | string;
+}
 
 /**
  * Settings that should NEVER be exported/synced (machine-specific or sensitive)
@@ -165,9 +180,19 @@ export interface InjectResult {
 
 export class RooSettingsService {
   private logger: Logger;
+  private readonly vscdbKey: string;
 
-  constructor() {
+  constructor(options?: RooSettingsServiceOptions) {
     this.logger = createLogger('RooSettingsService');
+    // Resolve target vscdb key from options, falling back to module-load default
+    if (options?.targetExtension === 'zoo') {
+      this.vscdbKey = ZOO_CODE_VSCDB_KEY;
+    } else if (options?.targetExtension && options.targetExtension !== 'roo') {
+      // Custom raw key
+      this.vscdbKey = options.targetExtension;
+    } else {
+      this.vscdbKey = DEFAULT_KEY;
+    }
   }
 
   /**
@@ -297,9 +322,9 @@ export class RooSettingsService {
 
       const db = await this.openDatabase(tmpPath, sqlite3.OPEN_READONLY);
       try {
-        const row = await this.dbGet(db, `SELECT value FROM ItemTable WHERE key = ?`, [VSCDB_KEY]);
+        const row = await this.dbGet(db, `SELECT value FROM ItemTable WHERE key = ?`, [this.vscdbKey]);
         if (!row) {
-          throw new Error(`Key '${VSCDB_KEY}' not found in state.vscdb`);
+          throw new Error(`Key '${this.vscdbKey}' not found in state.vscdb`);
         }
 
         let value = row.value;
@@ -334,7 +359,7 @@ export class RooSettingsService {
     const db = await this.openDatabase(dbPath, sqlite3.OPEN_READWRITE);
     try {
       const value = JSON.stringify(settings);
-      await this.dbRun(db, `UPDATE ItemTable SET value = ? WHERE key = ?`, [value, VSCDB_KEY]);
+      await this.dbRun(db, `UPDATE ItemTable SET value = ? WHERE key = ?`, [value, this.vscdbKey]);
       this.logger.info('Settings written to state.vscdb');
     } finally {
       await this.closeDatabase(db);

--- a/servers/roo-state-manager/src/tools/roosync/config.ts
+++ b/servers/roo-state-manager/src/tools/roosync/config.ts
@@ -68,7 +68,10 @@ export const ConfigArgsSchema = z.object({
 
   // Pour apply_profile (#498 Phase 2)
   profileName: z.string().optional().describe('Profile name. REQUIRED for action=apply_profile. E.g. "Production (Qwen 3.5 + GLM-5)"'),
-  sourceMachineId: z.string().optional().describe('Source machine ID for model-configs.json (default: local file)')
+  sourceMachineId: z.string().optional().describe('Source machine ID for model-configs.json (default: local file)'),
+
+  // #2543 Phase 1(b) — target extension for vscdb writes
+  targetExtension: z.enum(['roo', 'zoo']).optional().describe('Target extension for vscdb writes. "roo" = RooVeterinaryInc.roo-cline, "zoo" = ZooCodeOrganization.zoo-code. Default: "roo"')
 }).refine(
   (data) => {
     // Validation spécifique par action
@@ -362,7 +365,7 @@ export async function roosyncConfig(args: ConfigArgs) {
 
       case 'apply_profile': {
         // Action apply_profile: Applique un profil de modèle (#498 Phase 2)
-        const { profileName, sourceMachineId, backup = true, validate } = args;
+        const { profileName, sourceMachineId, backup = true, validate, targetExtension } = args;
 
         if (!profileName) {
           throw new ConfigSharingServiceError(
@@ -377,6 +380,7 @@ export async function roosyncConfig(args: ConfigArgs) {
           sourceMachineId,
           backup,
           dryRun,
+          targetExtension,
           validate // #2413 - Propagate validate flag
         });
 

--- a/servers/roo-state-manager/src/types/config-sharing.ts
+++ b/servers/roo-state-manager/src/types/config-sharing.ts
@@ -96,6 +96,8 @@ export interface ApplyProfileOptions {
   generateModes?: boolean;
   /** #2413 — Vérifier que le profil est effectivement appliqué (.roomodes + state.vscdb) après écriture */
   validate?: boolean;
+  /** #2543 Phase 1(b) — Target extension for vscdb writes: 'roo' or 'zoo'. Default: 'roo' */
+  targetExtension?: 'roo' | 'zoo';
 }
 
 export interface ApplyProfileResult {
@@ -124,6 +126,8 @@ export interface ApplyProfileResult {
     rulesSynced?: string[];
   };
   errors?: string[];
+  /** #2543 Phase 1(b) — Whether listApiConfigMeta was written to vscdb */
+  vscdbWritten?: boolean;
   /**
    * #2413 — Résultat de la validation post-apply si validate=true.
    *  - success=true => .roomodes aligné avec profile.modeOverrides

--- a/servers/roo-state-manager/src/utils/extension-paths.ts
+++ b/servers/roo-state-manager/src/utils/extension-paths.ts
@@ -40,6 +40,8 @@ const DEFAULT_VSCDB_KEY = 'RooVeterinaryInc.roo-cline';
 /** Zoo-Code SQLite ItemTable key (case-sensitive). */
 const ZOO_CODE_VSCDB_KEY = 'ZooCodeOrganization.zoo-code';
 
+export { DEFAULT_VSCDB_KEY, ZOO_CODE_VSCDB_KEY };
+
 /**
  * The SQLite ItemTable key for the active extension.
  * Override via `ROO_VSCDB_KEY` env-var, or derived from extension ID.


### PR DESCRIPTION
## Summary

Implements Phase 1 of #2543 — enable `apply_profile` to write provider metadata (`listApiConfigMeta`) into VS Code's `state.vscdb` for both Roo and Zoo Code extensions.

### Phase 1(a): Dynamic VSCDB_KEY resolution
- `RooSettingsService` constructor now accepts `RooSettingsServiceOptions` with `targetExtension: 'roo' | 'zoo' | string`
- `extension-paths.ts` exports `DEFAULT_VSCDB_KEY` and `ZOO_CODE_VSCDB_KEY` constants
- Eliminates module-load-time freeze of VSCDB key — each instance resolves its key dynamically

### Phase 1(b): listApiConfigMeta write in apply_profile
- `applyProfile()` step 9: builds `listApiConfigMeta` from `apiConfigs` and writes to vscdb via `RooSettingsService.injectSettings()`
- Also writes `currentApiConfigName` and `modeApiConfigs` into vscdb
- New `targetExtension` parameter on `apply_profile` action (schema + types)
- Non-fatal: warns on vscdb write failure, apply_profile still succeeds
- `ApplyProfileResult.vscdbWritten` reports write status

## Files changed
- `RooSettingsService.ts`: constructor + instance-level vscdbKey
- `extension-paths.ts`: export key constants
- `ConfigSharingService.ts`: step 9 vscdb write logic
- `config.ts` schema: `targetExtension` param
- `config-sharing.ts` types: `targetExtension` + `vscdbWritten`

## Validation
- Build: ✅ clean
- Tests: ✅ 499 pass, 0 fail (CI config `vitest.config.ci.ts`)

## Usage
```json
{
  "action": "apply_profile",
  "profileName": "Production (Qwen 3.5 + GLM-5)",
  "targetExtension": "zoo"
}
```

## Related
- #2543 (Zoo config as-code)
- #2534 (Zoo scheduler 100% auth failure)
- #2134 (CRITICAL Zoo migration blocker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)