### PR TITLE
fix(search): propagate max_results + filters warning to text fallback (#2548)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/config.ts
+++ b/servers/roo-state-manager/src/tools/roosync/config.ts
@@ -409,6 +409,7 @@ export async function roosyncConfig(args: ConfigArgs) {
           backupPath: result.backupPath,
           changes: result.changes,
           roomodesGenerated: result.roomodesGenerated,
+          vscdbWritten: result.vscdbWritten,
           errors: result.errors,
           validation: result.validation
         };

--- a/servers/roo-state-manager/src/tools/search/roosync-search.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/roosync-search.tool.ts
@@ -231,7 +231,15 @@ export async function handleRooSyncSearch(
             const fallbackArgs: SearchFallbackArgs = {
                 query: args.search_query,
                 workspace: effectiveWorkspace,
-                source: args.source
+                source: args.source,
+                // #2548: Propagate max_results to prevent unbounded dumps
+                max_results: clampedMaxResults,
+                // #2548: Signal that advanced filters were requested but can't be applied
+                filters_requested: !!(
+                    args.chunk_type || args.role || args.tool_name ||
+                    args.has_errors || args.model || args.start_date ||
+                    args.end_date || args.exclude_tool_results
+                )
             };
             const textResult = await handleSearchTasksSemanticFallback(fallbackArgs, conversationCache);
 
@@ -271,7 +279,14 @@ export async function handleRooSyncSearch(
             const fallbackArgs: SearchFallbackArgs = {
                 query: args.search_query,
                 workspace: textWorkspace,
-                source: args.source
+                source: args.source,
+                // #2548: Propagate max_results
+                max_results: Math.min(Math.max(args.max_results || 10, 1), 100),
+                filters_requested: !!(
+                    args.chunk_type || args.role || args.tool_name ||
+                    args.has_errors || args.model || args.start_date ||
+                    args.end_date || args.exclude_tool_results
+                )
             };
             return await handleSearchTasksSemanticFallback(fallbackArgs, conversationCache);
         }

--- a/servers/roo-state-manager/src/tools/search/search-fallback.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-fallback.tool.ts
@@ -7,6 +7,10 @@ export interface SearchFallbackArgs {
   workspace?: string;
   /** #604: Filter by conversation source (roo tasks or claude-code sessions) */
   source?: 'roo' | 'claude-code';
+  /** #2548: Max results to return (prevents unbounded dumps) */
+  max_results?: number;
+  /** #2548: Whether advanced filters were requested but not applied */
+  filters_requested?: boolean;
 }
 
 /**
@@ -17,7 +21,7 @@ export async function searchFallbackTool(
   conversationCache: Map<string, ConversationSkeleton>
 ): Promise<CallToolResult> {
   try {
-    const { query, workspace, source } = args;
+    const { query, workspace, source, max_results, filters_requested } = args;
 
     if (!query || query.trim().length === 0) {
       return {
@@ -124,8 +128,22 @@ export async function searchFallbackTool(
       return new Date(b.lastActivity).getTime() - new Date(a.lastActivity).getTime();
     });
 
+    // #2548: Cap results to max_results (prevents unbounded context dumps)
+    const cappedResults = max_results && max_results > 0
+      ? results.slice(0, Math.min(max_results, 100))
+      : results;
+
     // Strip internal _score before returning
-    const cleanResults = results.map(({ _score, ...rest }) => rest);
+    const cleanResults = cappedResults.map(({ _score, ...rest }) => rest);
+
+    // #2548: Build metadata with warnings if filters were requested but not applied
+    const warnings: string[] = [];
+    if (filters_requested) {
+      warnings.push('Advanced filters (chunk_type, role, tool_name, has_errors, model, start_date, end_date, exclude_tool_results) were requested but not applied in text fallback mode. Results are unfiltered.');
+    }
+    if (max_results && results.length > max_results) {
+      warnings.push(`Results capped from ${results.length} to ${max_results}.`);
+    }
 
     return {
       content: [{
@@ -136,6 +154,7 @@ export async function searchFallbackTool(
           query,
           searchType: 'text',
           totalFound: cleanResults.length,
+          ...(warnings.length > 0 && { warnings }),
           metadata: {
             searchMethod: 'text',
             tokenCount: tokens.length,


### PR DESCRIPTION
## Summary

Fixes #2548 — text fallback path in `roosync_search` ignores `max_results` and silently drops advanced #636 filters.

### Changes (3 files, +39/-4)

**`search-fallback.tool.ts`** — Core fix:
- Add `max_results` and `filters_requested` to `SearchFallbackArgs`
- Cap results to `max_results` (default unbounded = context explosion risk)
- Add `warnings` array to response when filters were requested but not applied

**`roosync-search.tool.ts`** — Propagation:
- Pass `max_results` to fallback args in both semantic→text fallback and direct text paths
- Detect if any #636 advanced filter was requested and set `filters_requested: true`

**`config.ts`** — Minor:
- Add missing `vscdbWritten` field to `apply_profile` MCP response

### Validation
- Build: ✅
- Tests: 499 pass, 0 fail (CI config)
- No new tests added (existing fallback tests pass; targeted tests to add in follow-up)

### Before vs After
| Scenario | Before | After |
|----------|--------|-------|
| Semantic fail → text fallback with `max_results: 5` | ~276 KB dump | 5 results max |
| Text search with `role: "user"` filter | Filter silently ignored | Warning: "Advanced filters not applied" |
| `apply_profile` response | No `vscdbWritten` | `vscdbWritten: true/false` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)