### PR TITLE
fix(export): load full skeleton for task XML export (#2549)

### DIFF
--- a/servers/roo-state-manager/src/tools/export/__tests__/export-data.test.ts
+++ b/servers/roo-state-manager/src/tools/export/__tests__/export-data.test.ts
@@ -261,6 +261,82 @@ describe('export_data - CONS-10', () => {
             expect(result.isError).toBe(true);
             expect(getTextContent(result)).toContain('non trouvée');
         });
+
+        // #2549 regression test: handleTaskXml must load full skeleton from disk,
+        // not use the cache (which only has SkeletonHeader without sequence).
+        test('should load full skeleton via getConversationSkeleton, not cache (#2549)', async () => {
+            // Cache skeleton has NO sequence (like SkeletonHeader in production)
+            const cacheOnlySkeleton = createMockSkeleton('task-123');
+            (cacheOnlySkeleton as any).sequence = undefined;
+            mockCache.set('task-123', cacheOnlySkeleton);
+
+            // Full skeleton loaded from disk HAS sequence
+            const fullSkeleton: ConversationSkeleton = {
+                taskId: 'task-123',
+                metadata: {
+                    title: 'Full Task',
+                    lastActivity: new Date().toISOString(),
+                    createdAt: new Date().toISOString(),
+                    messageCount: 2,
+                    actionCount: 1,
+                    totalSize: 500,
+                    workspace: '/test'
+                },
+                sequence: [
+                    { role: 'user', content: 'Hello', timestamp: new Date().toISOString(), isTruncated: false } as any,
+                    { role: 'assistant', content: 'World', timestamp: new Date().toISOString(), isTruncated: false } as any,
+                ]
+            };
+
+            mockGetSkeleton = vi.fn(async () => fullSkeleton);
+
+            const args: ExportDataArgs = {
+                target: 'task',
+                format: 'xml',
+                taskId: 'task-123'
+            };
+
+            const result = await handleExportData(
+                args,
+                mockCache,
+                mockXmlExporterService as any,
+                mockEnsureCache,
+                mockGetSkeleton
+            );
+
+            // getConversationSkeleton must have been called with the taskId
+            expect(mockGetSkeleton).toHaveBeenCalledWith('task-123');
+
+            // generateTaskXml must have been called with the FULL skeleton (not the cache one)
+            expect(mockXmlExporterService.generateTaskXml).toHaveBeenCalledWith(
+                fullSkeleton,
+                expect.objectContaining({ includeContent: false, prettyPrint: true })
+            );
+
+            expect(result.isError).toBeFalsy();
+        });
+
+        test('should return error when full skeleton cannot be loaded (#2549)', async () => {
+            // Task exists in cache but disk read fails
+            mockGetSkeleton = vi.fn(async () => null);
+
+            const args: ExportDataArgs = {
+                target: 'task',
+                format: 'xml',
+                taskId: 'task-123'
+            };
+
+            const result = await handleExportData(
+                args,
+                mockCache,
+                mockXmlExporterService as any,
+                mockEnsureCache,
+                mockGetSkeleton
+            );
+
+            expect(result.isError).toBe(true);
+            expect(getTextContent(result)).toContain('Impossible de charger le skeleton complet');
+        });
     });
 
     // ============================================================

--- a/servers/roo-state-manager/src/tools/export/export-data.ts
+++ b/servers/roo-state-manager/src/tools/export/export-data.ts
@@ -339,19 +339,24 @@ function validateExportFilePath(filePath: string): void {
 
 /**
  * Handler pour export XML d'une tâche individuelle
+ *
+ * #2549 fix: Uses getConversationSkeleton (loads full skeleton from disk)
+ * instead of conversationCache (which only stores SkeletonHeader without sequence).
+ * The cache is still used to verify the task exists before the expensive disk read.
  */
 async function handleTaskXml(
     args: ExportDataArgs,
     conversationCache: Map<string, ConversationSkeleton>,
     xmlExporterService: XmlExporterService,
-    ensureSkeletonCacheIsFresh: () => Promise<void>
+    ensureSkeletonCacheIsFresh: () => Promise<void>,
+    getConversationSkeleton: (taskId: string) => Promise<ConversationSkeleton | null>
 ): Promise<CallToolResult> {
     const { taskId, filePath, includeContent = false, prettyPrint = true } = args;
 
     await ensureSkeletonCacheIsFresh();
 
-    const skeleton = conversationCache.get(taskId!);
-    if (!skeleton) {
+    // Verify task exists in cache (lightweight check)
+    if (!conversationCache.has(taskId!)) {
         throw new StateManagerError(
             `Tâche avec l'ID '${taskId}' non trouvée dans le cache`,
             'TASK_NOT_FOUND',
@@ -360,7 +365,18 @@ async function handleTaskXml(
         );
     }
 
-    const xmlContent = (xmlExporterService as any).generateTaskXml(skeleton, {
+    // Load full skeleton from disk (includes sequence) — #2549
+    const fullSkeleton = await getConversationSkeleton(taskId!);
+    if (!fullSkeleton) {
+        throw new StateManagerError(
+            `Impossible de charger le skeleton complet pour la tâche '${taskId}'`,
+            'SKELETON_LOAD_FAILED',
+            'ExportDataTool',
+            { taskId }
+        );
+    }
+
+    const xmlContent = xmlExporterService.generateTaskXml(fullSkeleton, {
         includeContent,
         prettyPrint
     });
@@ -734,7 +750,7 @@ export async function handleExportData(
 
         if (target === 'task') {
             if (format === 'xml') {
-                return await handleTaskXml(args, conversationCache, xmlExporterService, ensureSkeletonCacheIsFresh);
+                return await handleTaskXml(args, conversationCache, xmlExporterService, ensureSkeletonCacheIsFresh, getConversationSkeleton);
             }
             if (format === 'debug') {
                 return await handleTaskDebug(args);


### PR DESCRIPTION
## Problem
`export_data(target:task, format:xml)` produces empty `<sequence/>` because `handleTaskXml` reads from `conversationCache` (which stores only `SkeletonHeader` without message sequence) instead of loading the full `ConversationSkeleton` from disk.

JSON/CSV exports work correctly because they already use `getConversationSkeleton`.

## Root Cause
The `conversationCache` (Map<string, ConversationSkeleton>) actually stores `SkeletonHeader` objects (no sequence). `handleTaskXml` used `conversationCache.get(taskId)` to retrieve the skeleton and pass it to `generateTaskXml`, which iterates `skeleton.sequence ?? []` — always empty.

## Fix
- `handleTaskXml` now accepts `getConversationSkeleton` parameter and uses it to load the full skeleton from disk
- Cache is still used for lightweight existence check
- Removed unsafe `(xmlExporterService as any)` cast
- 2 regression tests added

## Testing
- Build: OK
- Tests: 499 pass, 0 fail (CI config)
- New tests: verify `getConversationSkeleton` is called with correct taskId

Fixes #2549