### PR TITLE
fix(condensation): cap max_tokens 12000→4096 to prevent vLLM slot exhaustion (#2557)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -136,14 +136,20 @@ const CONDENSE_LLM_TIMEOUT_MS = Number(process.env.CONDENSE_LLM_TIMEOUT_MS) || 7
 
 // Max tokens for every condensation LLM call (summary, status, text-condense).
 //
+// #2557: Capped from 12000 → 4096. A dashboard condensation is a concise summary
+// (system prompts explicitly ask for ≤20 lines / <5KB). At 4096 tokens the model
+// has ample room for a complete summary (~1500-3000 tokens observed) while keeping
+// the vLLM slot occupied for only ~40s at 100 tok/s instead of ~3 min at 12000.
+// This prevents the condensation loop observed 2026-06-11 where 14 identical
+// requests burned GPU time in tight retry cycles because each 15K-token generation
+// took 3 min → client timeout → retry.
+//
 // 2026-05-26: thinking mode disabled at every call site (see chat_template_kwargs
 // below). Per user mandate "passe la condensation en non thinking, vue la situation
 // catastrophique du cluster ce sera un moindre mal" — Qwen3.6 thinking-loop hang
 // was bringing the whole dashboard channel down during the orphan-leak crisis.
 // With thinking off, generation is direct markdown output (~4000 tokens), well
-// under the gateway; the 12000 cap (sized to the 600s IIS → vLLM gateway at
-// ~37 tok/s) is retained as a runaway-guard if the model ever flips back into
-// a long output.
+// under the gateway; the 4096 cap is now sized to actual need, not runaway-guard.
 //
 // History (kept for context — apply *with* enable_thinking=false now):
 // 2026-05-23: regression fix. Commit 9beb7e93 (2026-04-20) bumped this 10000 →
@@ -152,7 +158,7 @@ const CONDENSE_LLM_TIMEOUT_MS = Number(process.env.CONDENSE_LLM_TIMEOUT_MS) || 7
 // repetition failure mode (vLLM+Qwen) where a runaway generation walks all the way
 // to max_tokens. 30000 tokens × ~37 tok/s = ~810s, > 600s gateway = HTTP 502.
 // Bounding at 12000 caps a runaway at ~325s, comfortably under the gateway.
-const CONDENSE_LLM_MAX_TOKENS = 12000;
+const CONDENSE_LLM_MAX_TOKENS = 4096;
 
 // #2426 Phase C+ follow-up: Detect LLM provider for thinking-mode control.
 // vLLM (local) supports chat_template_kwargs; z.ai and other remote APIs reject it (400).


### PR DESCRIPTION
## Problem (#2557)

Dashboard condensation LLM calls use `max_tokens=12000`, causing each condensation to generate up to 15K tokens (~3 min at 100 tok/s). When multiple dashboards condense concurrently or the client retries on timeout, this creates a tight loop of GPU-bound requests:

- 14 identical requests observed between 06:44 and 09:48 UTC on 2026-06-11
- Each request: ~30KB prompt + 15K tokens output
- At batch 4096/16 (Genesis-TQ kernel ceiling), concurrent condensation + real traffic = degraded throughput for ALL users

## Fix

Cap `CONDENSE_LLM_MAX_TOKENS` from **12000 → 4096**.

Dashboard condensations are concise summaries (system prompts explicitly ask for ≤20 lines / <5KB). 4096 tokens is ample (~1500-3000 tokens observed in prod) and reduces:
- Slot occupation: **~3 min → ~40s** at 100 tok/s
- Likelihood of client timeout before completion
- GPU contention with real user traffic

The `CONDENSE_LLM_TIMEOUT_MS` (720s) is already correct — with `max_tokens=4096` the actual generation time is ~40s, well under the timeout and the 600s IIS→vLLM gateway.

## Testing

- Build: ✅ `tsc` clean
- 525 test suites pass (1 pre-existing flaky: `EnvRotationService.test.ts` timing — unrelated)
- No tests hardcode the old `12000` value

## Impact

All fleet machines with workspace dashboards that auto-condense (ai-01, po-2023/24/25/26, web1). After deployment, each condensation takes ~40s instead of ~3 min, freeing GPU capacity.

Fixes #2557 (Priority 2)