### PR TITLE
feat(indexing): bump INDEX_VERSION_CURRENT 1.1→1.2 (#2455)

### DIFF
--- a/servers/roo-state-manager/src/types/indexing.ts
+++ b/servers/roo-state-manager/src/types/indexing.ts
@@ -32,7 +32,7 @@ export interface IndexingMetrics {
     lastIndexedAt?: string; // ISO datetime of last successful indexing
 }
 
-export const INDEX_VERSION_CURRENT = "1.1";
+export const INDEX_VERSION_CURRENT = "1.2"; // #2455: bump to trigger fleet-wide reindex for workspace_name propagation
 export const DEFAULT_REINDEX_TTL_HOURS = 168; // 7 jours
 export const MAX_RETRY_ATTEMPTS = 3;
 export const RETRY_BACKOFF_BASE_MS = 60000; // 1 minute base


### PR DESCRIPTION
## Purpose

Bump `INDEX_VERSION_CURRENT` from `1.1` to `1.2` to trigger fleet-wide reindexation that propagates the `workspace_name` field to all 683K existing Qdrant points.

## How it works

The index version migration mechanism (`indexing-decision.ts` line 59-69) detects version mismatch between skeleton `indexVersion` and server `INDEX_VERSION_CURRENT`. Each task is marked `action: rebuild`, forcing reindexation through the fixed code from PR #623 that now populates `workspace_name` in Qdrant payloads.

## Context

- Follow-up to PR #623 which fixed the workspace_name propagation bug
- Currently only 9.3% of 683K points have `workspace_name` populated
- Background indexer skips already-indexed tasks (`indexStatus: success`), so a version bump is needed

## Testing

- 24 indexing-decision tests pass
- TypeScript build passes
- No test hardcodes `INDEX_VERSION_CURRENT` value