### PR TITLE
fix(config): expose targetExtension + validate in roosync_config schema (#2543)

### DIFF
--- a/servers/roo-state-manager/src/tools/tool-definitions.ts
+++ b/servers/roo-state-manager/src/tools/tool-definitions.ts
@@ -423,7 +423,9 @@ export const roosyncConfigDefinition = {
             description: { type: 'string', description: 'Required for publish' },
             backup: { type: 'boolean', default: true },
             profileName: { type: 'string', description: 'Required for apply_profile' },
-            sourceMachineId: { type: 'string', description: 'For model-configs.json' }
+            sourceMachineId: { type: 'string', description: 'For model-configs.json' },
+            validate: { type: 'boolean', description: 'Validate config is effectively applied after write (default: false)' },
+            targetExtension: { type: 'string', enum: ['roo', 'zoo'], description: 'Target extension for vscdb writes. "roo" = RooVeterinaryInc.roo-cline, "zoo" = ZooCodeOrganization.zoo-code. Default: "roo" (#2543)' }
         },
         required: ['action'],
         additionalProperties: false


### PR DESCRIPTION
## Problem

The `roosync_config` MCP tool Zod schema (in `config.ts`) already supports:
- `targetExtension` (#2543 Phase 1b) — controls which vscdb key to write to (Roo vs Zoo)
- `validate` (#2413) — post-apply validation flag

But the **JSON inputSchema** in `tool-definitions.ts` was missing both parameters. This made them impossible to pass through the MCP tool interface — the MCP server would reject any call with these parameters.

## Fix

Add `validate` and `targetExtension` to the `roosyncConfigDefinition.inputSchema` in `tool-definitions.ts`.

## Validation

- `npm run build` ✅
- `npx vitest run --config vitest.config.ci.ts` ✅ (499 test files, 9905 tests passed)

## Scope

Single file change, zero logic modification — only exposes already-existing schema fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)