### PR TITLE
fix(indexing): normalize tool_usage_stats keys (#2336)

### DIFF
--- a/servers/roo-state-manager/src/tools/indexing/__tests__/tool-name-normalization.test.ts
+++ b/servers/roo-state-manager/src/tools/indexing/__tests__/tool-name-normalization.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for normalizeToolName — #2336 tool_usage_stats key normalization.
+ *
+ * Bug (reported ai-01 2026-06-10): the same tool was counted under 3 distinct
+ * key variants (`mcp__srv__tool` / `mcp--srv--tool` / bare `tool`), inflating
+ * unique_tools (~103 vs ~15 real) and fragmenting per-tool totals.
+ *
+ * @module tools/indexing/__tests__/tool-name-normalization
+ */
+
+import { describe, test, expect } from 'vitest';
+import { normalizeToolName } from '../roosync-indexing.tool.js';
+
+describe('normalizeToolName (#2336 — canonical tool key)', () => {
+	test('strips Claude Code double-underscore prefix', () => {
+		expect(normalizeToolName('mcp__roo-state-manager__roosync_dashboard')).toBe('roosync_dashboard');
+		expect(normalizeToolName('mcp__playwright__browser_click')).toBe('browser_click');
+	});
+
+	test('strips double-dash variant prefix', () => {
+		expect(normalizeToolName('mcp--roo-state-manager--roosync_dashboard')).toBe('roosync_dashboard');
+		expect(normalizeToolName('mcp--win-cli--execute_command')).toBe('execute_command');
+	});
+
+	test('converges all variants of the same tool to one canonical key', () => {
+		// Regression: before the fix these three counted as distinct tools.
+		const variants = [
+			'mcp__roo-state-manager__roosync_dashboard',
+			'mcp--roo-state-manager--roosync_dashboard',
+			'roosync_dashboard',
+		];
+		const canonical = new Set(variants.map(normalizeToolName));
+		expect(canonical.size).toBe(1);
+		expect([...canonical][0]).toBe('roosync_dashboard');
+	});
+
+	test('handles server names containing the separator char (4_5v_mcp)', () => {
+		// Server `4_5v_mcp` contains underscores — naive `mcp__[^_]+__` regex
+		// would fail; split-and-take-last is robust.
+		expect(normalizeToolName('mcp__4_5v_mcp__analyze_image')).toBe('analyze_image');
+		expect(normalizeToolName('mcp--4_5v_mcp--analyze_image')).toBe('analyze_image');
+	});
+
+	test('passes built-in and bare tool names through unchanged', () => {
+		expect(normalizeToolName('Bash')).toBe('Bash');
+		expect(normalizeToolName('Read')).toBe('Read');
+		expect(normalizeToolName('TodoWrite')).toBe('TodoWrite');
+		expect(normalizeToolName('roosync_search')).toBe('roosync_search');
+	});
+
+	test('trims surrounding whitespace', () => {
+		expect(normalizeToolName('  mcp__searxng__searxng_web_search  ')).toBe('searxng_web_search');
+	});
+
+	test('handles multi-segment server names (roo-state-manager has dashes)', () => {
+		// double-dash split: 'mcp--roo--state--manager--roosync_dashboard'
+		// → last segment is the tool name.
+		expect(normalizeToolName('mcp--roo-state-manager--roosync_messages')).toBe('roosync_messages');
+	});
+
+	test('returns empty string fallback preserves original on malformed input', () => {
+		// 'mcp__' alone → split yields ['mcp', ''] → last is '' → fallback to original
+		expect(normalizeToolName('mcp__')).toBe('mcp__');
+		expect(normalizeToolName('')).toBe('');
+	});
+});

--- a/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
@@ -32,6 +32,34 @@ function getISOWeek(timestamp: string): string {
 }
 
 /**
+ * Normalize a raw tool name from a JSONL tool_use block into a canonical key.
+ *
+ * The same tool is recorded under different prefixes across sources:
+ *   - `mcp__<server>__<tool>` (Claude Code, double-underscore)
+ *   - `mcp--<server>--<tool>` (double-dash variant)
+ *   - `<tool>` (bare name, typically malformed/failed calls)
+ * Without normalization, tool_usage_stats counted each variant as a distinct
+ * tool, fragmenting totals and inflating unique_tools (~103 vs ~15 real).
+ * Fix for #2336 (reported ai-01 2026-06-10).
+ *
+ * Splits on the prefix separator and returns the final segment (the tool name),
+ * which is robust to server names containing the separator char (e.g. `4_5v_mcp`).
+ * Bare names and built-in tools (Bash, Read, …) pass through unchanged.
+ */
+export function normalizeToolName(rawName: string): string {
+    const name = rawName.trim();
+    if (name.startsWith('mcp__')) {
+        const parts = name.split('__');
+        return parts[parts.length - 1] || name;
+    }
+    if (name.startsWith('mcp--')) {
+        const parts = name.split('--');
+        return parts[parts.length - 1] || name;
+    }
+    return name;
+}
+
+/**
  * Arguments du tool roosync_indexing unifié
  */
 export interface RooSyncIndexingArgs {
@@ -826,7 +854,7 @@ export async function handleRooSyncIndexing(
                                 for (const block of msg.content) {
                                     if (block.type === 'tool_use' && block.name) {
                                         totalCalls++;
-                                        const toolName = block.name;
+                                        const toolName = normalizeToolName(block.name);
                                         toolCounts[toolName] = (toolCounts[toolName] || 0) + 1;
                                         sourceCounts['roo'] = (sourceCounts['roo'] || 0) + 1;
 
@@ -951,7 +979,7 @@ export async function handleRooSyncIndexing(
                                 for (const block of message.content) {
                                     if (block.type === 'tool_use' && block.name) {
                                         totalCalls++;
-                                        const toolName = block.name;
+                                        const toolName = normalizeToolName(block.name);
                                         toolCounts[toolName] = (toolCounts[toolName] || 0) + 1;
                                         sourceCounts['claude-code'] = (sourceCounts['claude-code'] || 0) + 1;
 


### PR DESCRIPTION
## What

`tool_usage_stats` counted the **same tool under 3 distinct key variants**, fragmenting per-tool totals and inflating `unique_tools` (~103 reported vs ~15 real tools):

| Variant | Source |
|---------|--------|
| `mcp__<server>__<tool>` | Claude Code (double-underscore) |
| `mcp--<server>--<tool>` | double-dash variant |
| `<tool>` | bare name (malformed/failed calls) |

Reported by ai-01 2026-06-10.

## Fix (#1936 surgical)

New `normalizeToolName(rawName)` helper: splits on the prefix separator (`__` or `--`) and returns the final segment (the tool name). Applied at **both** JSONL scan sites in `tool_usage_stats`:
- Roo conversation scan
- Claude Code conversation scan

Robust to server names containing the separator char (e.g. `4_5v_mcp`). Bare names and built-in tools (`Bash`, `Read`, `TodoWrite`) pass through unchanged.

Only the 2 counting lines changed in the existing source; the truthy guards `if (block.type === 'tool_use' && block.name)` remain raw (correct — they're existence checks, not keys).

## Tests

New dedicated file `__tests__/tool-name-normalization.test.ts` — 8 unit tests covering: double-underscore strip, double-dash strip, all-3-variants-converge regression, `4_5v_mcp` server-with-separator, passthrough of built-ins/bare names, whitespace trim, multi-segment server names (`roo-state-manager`), malformed-input fallback.

## Validation

- `npm run build` (tsc) — clean
- `npx vitest run --config vitest.config.ci.ts` — **501 files passed / 9917 tests passed, 0 failed** (8 new tests included)

Related parent issue: jsboige/roo-extensions#2336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)