### PR TITLE
chore: gitignore .env backup files (prevent secret leak)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ yarn.lock
 .env.development.local
 .env.test.local
 .env.production.local
+.env.bak*
+.env.old
 
 # Logs
 logs/


### PR DESCRIPTION
## What

Migration/backup scripts create `.env.bak*` files (e.g. `.env.bak-pre-zai-<ts>`) alongside the real `.env`. These backups contain the **same secrets/config as `.env`** but were NOT covered by the existing `.env*` gitignore patterns (which only list `.env.local`, `.env.development.local`, `.env.test.local`, `.env.production.local`).

## Why

Found a stray untracked `.env.bak-pre-zai-20260529-035032` (2331 bytes, secret-bearing) in `servers/roo-state-manager/` that was **NOT gitignored** — a `git add -A` (the worker default commit path) would stage and leak it into a commit.

`git check-ignore` confirmed the gap:
```
$ git check-ignore servers/roo-state-manager/.env.bak-pre-zai-20260529-035032
(empty — NOT ignored)
```

## Fix (#1936 surgical)

Add two lines to `.gitignore`, after the existing `.env.*` patterns:
```
.env.bak*
.env.old
```

Covers backup naming conventions (`.env.bak`, `.env.bak-pre-zai-<ts>`, `.env.old`). Verified:
```
$ git check-ignore servers/roo-state-manager/.env.bak-pre-zai-20260529-035032
servers/roo-state-manager/.env.bak-pre-zai-20260529-035032   ← now ignored
```

## Validation

`.gitignore`-only change — no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)