### PR TITLE
fix(roosync): validate mention recipients against fleet roster (roo-extensions #2591)

### DIFF
--- a/servers/roo-state-manager/src/utils/__tests__/send-mention-notifications.test.ts
+++ b/servers/roo-state-manager/src/utils/__tests__/send-mention-notifications.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for sendMentionNotificationsAsync — fleet-roster validation (#2591)
+ *
+ * Ensures mention notifications are only sent to real fleet machines, preventing
+ * orphan messages (to: prose tokens / bot names / test leaks) from accumulating
+ * in the shared inbox and causing roosync_messages timeouts.
+ *
+ * @module utils/__tests__/send-mention-notifications
+ * @issue #2591
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Hoisted mocks ───────────────────────────────────────────────────────────
+
+const { mockSendMessage, mockFleetRoster } = vi.hoisted(() => ({
+	mockSendMessage: vi.fn(),
+	// Configurable roster per test (null = ROO_FLEET_ROSTER unset)
+	mockFleetRoster: { value: null as string[] | null }
+}));
+
+vi.mock('../message-helpers.js', () => ({
+	getLocalMachineId: () => 'myia-po-2025'
+}));
+
+vi.mock('../logger.js', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+vi.mock('../server-helpers.js', () => ({
+	getSharedStatePath: () => '/shared-state'
+}));
+
+vi.mock('../../services/MessageManager.js', () => ({
+	getMessageManager: () => ({ sendMessage: mockSendMessage })
+}));
+
+vi.mock('../../config/roosync-config.js', () => ({
+	tryLoadRooSyncConfig: () =>
+		mockFleetRoster.value === null ? null : { fleetRoster: mockFleetRoster.value }
+}));
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('sendMentionNotificationsAsync — fleet roster validation (#2591)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockSendMessage.mockResolvedValue(undefined);
+	});
+
+	it('sends notifications only to fleet-roster machines (skips orphans)', async () => {
+		mockFleetRoster.value = ['myia-ai-01', 'myia-po-2025', 'myia-po-2023'];
+		const { sendMentionNotificationsAsync } = await import('../dashboard-helpers.js');
+
+		await sendMentionNotificationsAsync('msg-1', [
+			{ type: 'machine', target: 'myia-ai-01', pattern: '@myia-ai-01' },     // in roster → sent
+			{ type: 'machine', target: 'NanoClaw', pattern: '@NanoClaw' },          // orphan → skipped
+			{ type: 'machine', target: 'test-machine', pattern: '@test-machine' },  // test leak → skipped
+			{ type: 'machine', target: 'vscode', pattern: 'vscode' },               // prose token → skipped
+			{ type: 'machine', target: 'myia-po-2023', pattern: '@myia-po-2023' }   // in roster → sent
+		], 'workspace-roo-extensions', 'excerpt');
+
+		// Only the 2 fleet machines notified.
+		expect(mockSendMessage).toHaveBeenCalledTimes(2);
+		const recipients = mockSendMessage.mock.calls.map((c: unknown[]) => c[1]);
+		expect(recipients).toEqual(['myia-ai-01', 'myia-po-2023']);
+	});
+
+	it('skips bare alias not present in roster (e.g. "ai-01" vs "myia-ai-01")', async () => {
+		mockFleetRoster.value = ['myia-ai-01'];
+		const { sendMentionNotificationsAsync } = await import('../dashboard-helpers.js');
+
+		await sendMentionNotificationsAsync('msg-2', [
+			{ type: 'machine', target: 'ai-01', pattern: '@ai-01' }  // bare alias → orphan
+		], 'workspace-roo-extensions', 'excerpt');
+
+		expect(mockSendMessage).not.toHaveBeenCalled();
+	});
+
+	it('keeps legacy behavior (sends to all) when roster is null (ROO_FLEET_ROSTER unset)', async () => {
+		mockFleetRoster.value = null;
+		const { sendMentionNotificationsAsync } = await import('../dashboard-helpers.js');
+
+		await sendMentionNotificationsAsync('msg-3', [
+			{ type: 'machine', target: 'myia-ai-01', pattern: '@myia-ai-01' },
+			{ type: 'machine', target: 'NanoClaw', pattern: '@NanoClaw' }
+		], 'workspace-roo-extensions', 'excerpt');
+
+		// Backward compat: no roster → no filtering.
+		expect(mockSendMessage).toHaveBeenCalledTimes(2);
+	});
+
+	it('derives machine id for agent-type mentions and validates against roster', async () => {
+		mockFleetRoster.value = ['myia-ai-01'];
+		const { sendMentionNotificationsAsync } = await import('../dashboard-helpers.js');
+
+		await sendMentionNotificationsAsync('msg-4', [
+			// agent "roo-myia-ai-01" → derived machine "myia-ai-01" → in roster → sent
+			{ type: 'agent', target: 'roo-myia-ai-01', pattern: '@roo-myia-ai-01' },
+			// agent "roo-Hermes" → derived "Hermes" → not in roster → skipped
+			{ type: 'agent', target: 'roo-Hermes', pattern: '@roo-Hermes' }
+		], 'workspace-roo-extensions', 'excerpt');
+
+		expect(mockSendMessage).toHaveBeenCalledTimes(1);
+		expect(mockSendMessage.mock.calls[0][1]).toBe('myia-ai-01');
+	});
+
+	it('does nothing when no machine/agent mentions are present', async () => {
+		mockFleetRoster.value = ['myia-ai-01'];
+		const { sendMentionNotificationsAsync } = await import('../dashboard-helpers.js');
+
+		await sendMentionNotificationsAsync('msg-5', [
+			{ type: 'user', target: 'jsboige', pattern: '@jsboige' },
+			{ type: 'message', target: 'ic-123', pattern: 'ic-123' }
+		], 'workspace-roo-extensions', 'excerpt');
+
+		expect(mockSendMessage).not.toHaveBeenCalled();
+	});
+});

--- a/servers/roo-state-manager/src/utils/dashboard-helpers.ts
+++ b/servers/roo-state-manager/src/utils/dashboard-helpers.ts
@@ -14,6 +14,7 @@ import { getSharedStatePath } from './shared-state-path.js';
 import { getLocalMachineId } from './message-helpers.js';
 import { createLogger, Logger } from './logger.js';
 import { getMessageManager } from '../services/MessageManager.js';
+import { tryLoadRooSyncConfig } from '../config/roosync-config.js';
 import type { Mention, UserId } from '../tools/roosync/dashboard.js';
 
 const execAsync = promisify(exec);
@@ -218,7 +219,26 @@ export async function sendMentionNotificationsAsync(
     }
 
     // Construire et envoyer les notifications
+    // Validate recipients against the fleet roster before sending (#2591).
+    // Without this, prose tokens / bot names / test leaks mis-classified as
+    // machine mentions (e.g. "NanoClaw", "vscode", "test-machine", bare "ai-01")
+    // create orphan notifications addressed to non-existent recipients that no
+    // cleanup agent ever processes → shared inbox bloats → roosync_messages timeout.
+    const roster = tryLoadRooSyncConfig()?.fleetRoster ?? null;
+
     for (const [machine, machineMentions] of mentionsByMachine) {
+      // Skip recipients not in the fleet roster (when a roster is configured).
+      // fleetRoster is null when ROO_FLEET_ROSTER is unset — then we keep the
+      // legacy behavior (send to all) for backward compatibility.
+      if (roster && !roster.includes(machine)) {
+        logger.debug('Skipping mention notification to non-fleet recipient (#2591)', {
+          messageId,
+          machine,
+          rosterSize: roster.length
+        });
+        continue;
+      }
+
       const subject = `[MENTION] Nouveau message dashboard mentionnant @${machine}`;
       const mentionList = machineMentions
         .map(m => `- @${m.target}${m.type === 'agent' ? ' (agent)' : ''}`)


### PR DESCRIPTION
## Summary

Fixes the root cause of orphan mention-notification messages accumulating in the shared RooSync inbox, which caused `roosync_messages(inbox)` to time out (120s) fleet-wide.

`sendMentionNotificationsAsync` (`src/utils/dashboard-helpers.ts`) sent a RooSync notification to **any string** extracted from dashboard mentions, without validating it was a real fleet machine. Prose tokens / bot names / test leaks mis-classified as `type:'machine'` mentions produced messages addressed to non-existent recipients that no cleanup agent ever processes.

## Problem (measured)

Forensic on po-2025 (`ROOSYNC_SHARED_PATH/messages/inbox/`):

| `to` recipient | count (~6 weeks) | nature |
|----------------|-----------------:|--------|
| `test-machine` | 1402 | test-suite leak |
| `po-2023` | 230 | real machine, stuck unread |
| `NanoClaw` | 174 | bot name |
| `ai-01` | 172 | bare alias (not `myia-ai-01`) |
| `TAG` | 129 | prose token |
| `vscode` / `playwright` / `anthropic` | 95 | tool/provider names |
| `Emerjesse` | 37 | person name |

- **3,586 orphan files** in a single machine's inbox → filesystem scan on virtualized GDrive FS → `roosync_messages(inbox)` **120s timeout** (#2267)
- The tool's logical view was correct (2 active messages for the querying machine); the **filesystem scan** of all JSONs was the bottleneck
- `roosync_manage(cleanup)` and `bulk_archive` returned "0 messages trouvés" — they operate on logical state, never see orphan files addressed to other recipients
- Bleed rate: **~2,300 orphans/month**

## Fix

Validate the recipient against the fleet roster **before** `sendMessage()`. The roster is already parsed from `ROO_FLEET_ROSTER` in `src/config/roosync-config.ts` (`tryLoadRooSyncConfig()`). When the roster is `null` (env unset), keep the legacy send-to-all behavior for backward compatibility.

```ts
const roster = tryLoadRooSyncConfig()?.fleetRoster ?? null;
for (const [machine, machineMentions] of mentionsByMachine) {
  if (roster && !roster.includes(machine)) {
    logger.debug('Skipping mention notification to non-fleet recipient (#2591)', { ... });
    continue;
  }
  // ...existing sendMessage()...
}
```

This stops the orphan accumulation **at the source** — the 3,586 historical orphans were archived separately (user-approved, move not delete, manifest kept) on po-2025.

## Why this scope (surgical, per #1936)

- **Primary fix (this PR):** roster validation before send — high confidence, ~6 lines, reuses existing source of truth.
- **Secondary (NOT here):** tightening the mention parser to require the `myia-` prefix. More invasive and risky (could break legitimate mentions); the roster check already gates these correctly.
- **Tertiary (separate):** `test-machine` accumulation (1402) suggests tests write to the live shared path — separate test-isolation issue.

## Validation

- `npm run build` ✅ (tsc clean)
- `npx vitest run src/utils/__tests__/send-mention-notifications.test.ts` → **5/5 pass** (new)
  - sends only to fleet-roster machines, skips orphans
  - skips bare aliases (`ai-01` vs `myia-ai-01`)
  - keeps legacy behavior when roster is null
  - validates agent-derived machine ids
  - no-op for user/message mentions
- `npx vitest run src/utils/__tests__/dashboard-helpers.test.ts` → **25/25 pass** (no regression)

Closes jsboige/roo-extensions#2591 (root-cause fix). Parent pointer-bump to follow after merge, per #1799 (post-merge only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
