### PR TITLE
fix(compare-config): catch partial-alias typos before misleading CRITICAL

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/compare-config.ts
+++ b/servers/roo-state-manager/src/tools/roosync/compare-config.ts
@@ -203,6 +203,38 @@ export async function roosyncCompareConfig(args: CompareConfigArgs): Promise<Com
           };
       }
 
+    // #alias-validation: catch partial-alias typos before the misleading downstream
+    // "inventory missing" CRITICAL. Only "local-machine" is a recognized alias (L181);
+    // a literal "local"/"remote" resolves to nothing, then getInventory() looks for
+    // inventories/local.json (absent) and returns a generic CRITICAL. This gives the
+    // caller an actionable message instead.
+    const PARTIAL_ALIASES: Record<string, string> = {
+      'local': 'local-machine',
+      'remote': 'remote-machine',
+    };
+    const aliasIssues: string[] = [];
+    if (PARTIAL_ALIASES[sourceMachineId]) {
+      aliasIssues.push(`source "${sourceMachineId}" — vouliez-vous l'alias "${PARTIAL_ALIASES[sourceMachineId]}" ?`);
+    }
+    if (PARTIAL_ALIASES[targetMachineId]) {
+      aliasIssues.push(`target "${targetMachineId}" — vouliez-vous l'alias "${PARTIAL_ALIASES[targetMachineId]}" ?`);
+    }
+    if (aliasIssues.length > 0) {
+      return {
+        source: sourceMachineId,
+        target: targetMachineId,
+        granularity: args.granularity || 'full',
+        differences: [{
+          category: 'validation',
+          severity: 'CRITICAL',
+          path: 'input.machineId',
+          description: `machineId inconnu: ${aliasIssues.join('; ')}. Le seul alias reconnu est "local-machine" (résolu vers la machine locale). Les machines distantes s'adressent par leur machineId (ex: "myia-ai-01", "myia-po-2024").`,
+          action: 'Utiliser "local-machine" pour la machine locale, ou un vrai machineId pour une machine distante.'
+        }],
+        summary: { total: 1, critical: 1, important: 0, warning: 0, info: 0 }
+      };
+    }
+
     // Settings comparison: uses RooSettingsService + GDrive published settings
     if (args.granularity === 'settings') {
       return await compareSettings(sourceMachineId, targetMachineId, service, args.filter);

--- a/servers/roo-state-manager/tests/unit/tools/roosync/compare-config.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/compare-config.test.ts
@@ -324,6 +324,72 @@ describe('roosync_compare_config', () => {
     });
   });
 
+  describe('partial-alias validation (#alias-validation)', () => {
+    it('devrait détecter source="local" (alias partiel) et suggérer "local-machine"', async () => {
+      const args = {
+        source: 'local',
+        target: 'myia-ai-01',
+        granularity: 'mcp' as const
+      };
+
+      mockRooSyncService.getConfig.mockReturnValue({ machineId: 'myia-po-2024' });
+      // getDefaultTargetMachine is awaited only when target is undefined; here it's set.
+      mockRooSyncService.getInventory.mockResolvedValue({ machineId: 'x', inventory: {} });
+
+      const result = await roosyncCompareConfig(args);
+
+      // Early return: validation CRITICAL, no inventory lookup performed.
+      expect(mockRooSyncService.getInventory).not.toHaveBeenCalled();
+      expect(result.summary.critical).toBe(1);
+      expect(result.differences).toHaveLength(1);
+      expect(result.differences[0].category).toBe('validation');
+      expect(result.differences[0].description).toContain('local-machine');
+      expect(result.differences[0].description).toContain('source "local"');
+    });
+
+    it('devrait détecter target="local" (alias partiel) aussi', async () => {
+      const args = {
+        source: 'myia-ai-01',
+        target: 'local',
+        granularity: 'full' as const
+      };
+
+      mockRooSyncService.getConfig.mockReturnValue({ machineId: 'myia-po-2024' });
+      mockRooSyncService.getInventory.mockResolvedValue({ machineId: 'x', inventory: {} });
+
+      const result = await roosyncCompareConfig(args);
+
+      expect(mockRooSyncService.getInventory).not.toHaveBeenCalled();
+      expect(result.summary.critical).toBe(1);
+      expect(result.differences[0].description).toContain('local-machine');
+      expect(result.differences[0].description).toContain('target "local"');
+    });
+
+    it('ne doit PAS bloquer les vrais machineIds ni l\'alias complet "local-machine"', async () => {
+      // source = local-machine alias (résolu vers config.machineId), target = vrai machineId
+      const args = {
+        source: 'local-machine',
+        target: 'myia-ai-01',
+        granularity: 'full' as const
+      };
+
+      mockRooSyncService.getConfig.mockReturnValue({ machineId: 'myia-po-2024' });
+      mockRooSyncService.getInventory.mockResolvedValue({ machineId: 'x', inventory: {} });
+      mockGranularDiffDetector.compareGranular.mockResolvedValue({
+        reportId: 't', timestamp: new Date().toISOString(),
+        sourceLabel: 'myia-po-2024', targetLabel: 'myia-ai-01',
+        diffs: [], summary: { total: 0, byType: {}, bySeverity: {}, byCategory: {} },
+        performance: { executionTime: 1, nodesCompared: 1 }
+      });
+
+      const result = await roosyncCompareConfig(args);
+
+      // Pas de validation CRITICAL — l'inventaire est bien consulté.
+      expect(mockRooSyncService.getInventory).toHaveBeenCalled();
+      expect(result.differences.every(d => d.category !== 'validation')).toBe(true);
+    });
+  });
+
   describe('error handling with granularity', () => {
     it('devrait retourner un avertissement si inventaire source manquant', async () => {
       const args = {


### PR DESCRIPTION
## Summary

`roosync_compare_config` only resolves the `local-machine` alias. A literal `local` (common typo) resolves to nothing → `getInventory("local")` looks for the absent `inventories/local.json` → returns a generic **CRITICAL "Inventaire manquant: source local"** that misleads the caller into chasing a stale/missing inventory instead of their wrong alias.

## Friction source (real, not theoretical)

During the inventory-automation investigation (ai-01 → po-2024 dispatch, 2026-06-14), an agent ran `compare_config(source:"local", ...)` and got a false CRITICAL. The real issue was the `local` literal vs the `local-machine` alias — verified empirically: the same call with `source:"local-machine"` returns clean diffs (0 CRITICAL, 2 WARNING, 7 INFO).

The CRITICAL wording ("Inventaire manquant") actively misdirects debugging toward inventory freshness/staleness when the actual problem is a one-word alias typo.

## Fix

After resolving source/target machineIds (compare-config.ts:181), validate against a small `PARTIAL_ALIASES` map:

```ts
const PARTIAL_ALIASES: Record<string, string> = {
  'local': 'local-machine',
  'remote': 'remote-machine',
};
```

If a partial alias is detected, return an **actionable** CRITICAL that names the alias to use and how to address remote machines — **before** `getInventory` is called:

> machineId inconnu: source "local" — vouliez-vous l'alias "local-machine" ? Le seul alias reconnu est "local-machine" (résolu vers la machine locale). Les machines distantes s'adressent par leur machineId (ex: "myia-ai-01", "myia-po-2024").

## Why this shape (not a broader validation)

A broader "machineId must exist in the dashboard" check would break every existing test (they use synthetic machineIds `machine-a`, `machine-b`, `local-machine`, `remote-machine`, `profile:dev` without mocking `loadDashboard`). This fix matches **only** the two known partial aliases, so it never fires for a real or synthetic machineId — surgical by construction.

Best-effort: no `loadDashboard` call, no new failure surface, just a dictionary lookup after the existing machineId resolution.

## Tests

3 new unit tests in `tests/unit/tools/roosync/compare-config.test.ts`:
1. `source: "local"` → validation CRITICAL, `getInventory` not called, message contains `local-machine`.
2. `target: "local"` → same.
3. `source: "local-machine"` (full alias) + `target: "myia-ai-01"` → no validation CRITICAL, `getInventory` called normally (no regression).

**Full CI run:** `9925 passed / 0 failed / 23 skipped` (ai-01 baseline was `9902p/20f` — the 20 prior fails were Qdrant-platform tests, unrelated to this change). Build clean (`tsc`).

## Parent pointer-bump

This is the submodule PR only. The parent `roo-extensions` pointer-bump will be a **separate** PR, opened **after** this merges (anti-pointer-bump-premature, per `.claude/rules/pr-mandatory.md`), carrying the squash-merge SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
