### PR TITLE
fix(dashboard): byte-budget kept-message window to stop perpetual re-condensation (#2598)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/dashboard.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, rm } from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import { roosyncDashboard, MentionSchema, detectStatusContradictions, resetCondenseCircuitBreaker } from '../dashboard.js';
+import { roosyncDashboard, MentionSchema, detectStatusContradictions, resetCondenseCircuitBreaker, computeKeepCount } from '../dashboard.js';
 import { resolveMentionTarget } from '@/utils/dashboard-helpers';
 import { resetChatOpenAIClient } from '@/services/openai';
 
@@ -784,9 +784,16 @@ describe('roosync_dashboard', () => {
       // Regression: prior behaviour was "single large message protected by
       // CONDENSE_KEEP slice policy → dashboard stays above threshold forever".
       // With per-append split (#1589), a 47KB message becomes ~12 parts (4KB
-      // cap each). After an initial small message + the big one split into
-      // parts, messages.length > CONDENSE_KEEP and the next append correctly
-      // triggers condensation.
+      // cap each) so the bulk becomes archivable rather than protected.
+      //
+      // #2598 sharpened this: the kept window is now byte-budgeted
+      // (computeKeepCount, 16KB) instead of a fixed CONDENSE_KEEP=10. The 12
+      // parts blow past the 16KB keep-budget, so condensation archives the
+      // oldest parts on the *first* append already (previously condenseIntercom
+      // refused to archive the mere 2 messages over keep=10, leaving all 12 and
+      // only condensing on the next append). This is strictly more aggressive
+      // archival of large content — exactly the #1589 anti-"protected forever"
+      // intent — so the post-condense window is bounded by the byte budget.
       mockGetChatClient.mockReturnValue({
         chat: { completions: { create: mockChatCreate } }
       });
@@ -798,9 +805,16 @@ describe('roosync_dashboard', () => {
       const huge = 'Y'.repeat(47 * 1024); // 47 KB single message
       const firstResult = await roosyncDashboard({ action: 'append', type: 'global', content: huge });
 
-      // The 47KB content is split into ~12 parts of 4KB each.
-      expect(firstResult.splitCount).toBeGreaterThan(1);
-      expect(firstResult.messageCount).toBeGreaterThan(10);
+      // The 47KB content is split into ~12 parts of 4KB each (the split itself
+      // is independent of the keep policy — this is the core #1589 behaviour).
+      expect(firstResult.splitCount).toBeGreaterThan(10);
+      // The oversized message is archived (NOT protected forever): condensation
+      // fires and archives the oldest parts, retaining only a byte-budgeted
+      // recent window (#2598) bounded by [CONDENSE_KEEP_MIN=4, CONDENSE_KEEP=10].
+      expect(firstResult.condensed).toBe(true);
+      expect(firstResult.archivedCount).toBeGreaterThan(0);
+      expect(firstResult.messageCount).toBeGreaterThanOrEqual(4);  // CONDENSE_KEEP_MIN
+      expect(firstResult.messageCount).toBeLessThanOrEqual(10);    // CONDENSE_KEEP
 
       const result = await roosyncDashboard({
         action: 'append',
@@ -809,8 +823,7 @@ describe('roosync_dashboard', () => {
       });
 
       expect(result.success).toBe(true);
-      // Now that the big message is multiple parts and count > CONDENSE_KEEP,
-      // preemptive condense fires and LLM is called.
+      // The LLM condense path was exercised (fired on the first append already).
       expect(mockChatCreate).toHaveBeenCalled();
     });
 
@@ -1671,5 +1684,51 @@ describe('roosync_dashboard', () => {
       // Status should still be ≤ 15 KB (not grown back to oversized)
       expect(sizeAfterSecond).toBeLessThanOrEqual(15 * 1024);
     });
+  });
+});
+
+// #2598: byte-budgeted keep window — guards against the perpetual-condensation
+// loop where a fixed keep-count (10) + 15KB status pinned the post-condense
+// floor at ~the 46KB preemptive threshold, re-condensing on nearly every post.
+describe('computeKeepCount (#2598 byte-budgeted keep window)', () => {
+  const CONDENSE_KEEP = 10;
+  const CONDENSE_KEEP_MIN = 4;
+  const KEEP_BUDGET = 16 * 1024;
+  const PREEMPTIVE_THRESHOLD = Math.floor(50 * 1024 * 0.92); // ~46 KB
+  const STATUS_CAP = 15 * 1024;
+
+  const mk = (n: number, sizeBytes: number) =>
+    Array.from({ length: n }, (_, i) => ({ content: 'x'.repeat(sizeBytes) + `#${i}` }));
+  const keptBytes = (msgs: { content: string }[], keep: number) =>
+    msgs.slice(msgs.length - keep).reduce((s, m) => s + Buffer.byteLength(m.content, 'utf8'), 0);
+
+  it('keeps up to CONDENSE_KEEP for small messages (unchanged behaviour)', () => {
+    expect(computeKeepCount(mk(30, 200))).toBe(CONDENSE_KEEP);
+  });
+
+  it('keeps fewer than CONDENSE_KEEP when messages are large (budget-bound)', () => {
+    const msgs = mk(30, 3 * 1024); // ~3 KB each
+    const keep = computeKeepCount(msgs);
+    expect(keep).toBeLessThan(CONDENSE_KEEP);
+    expect(keep).toBeGreaterThanOrEqual(CONDENSE_KEEP_MIN);
+    // kept bytes stay within budget plus at most one over-budget message
+    expect(keptBytes(msgs, keep)).toBeLessThanOrEqual(KEEP_BUDGET + 3 * 1024);
+  });
+
+  it('never keeps fewer than CONDENSE_KEEP_MIN even for huge messages', () => {
+    expect(computeKeepCount(mk(10, 20 * 1024))).toBe(CONDENSE_KEEP_MIN);
+  });
+
+  it('returns 0 for an empty intercom and is bounded by message count', () => {
+    expect(computeKeepCount([])).toBe(0);
+    expect(computeKeepCount(mk(2, 100))).toBe(2);
+  });
+
+  it('post-condense floor (status + kept intercom) stays well below the threshold', () => {
+    // 40 messages of ~3 KB + a 15 KB status: the floor must leave real headroom
+    // under the 46 KB preemptive threshold so posting does not re-condense.
+    const msgs = mk(40, 3 * 1024);
+    const floor = STATUS_CAP + keptBytes(msgs, computeKeepCount(msgs));
+    expect(floor).toBeLessThan(PREEMPTIVE_THRESHOLD - 8 * 1024); // >= 8 KB headroom
   });
 });

--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -99,6 +99,19 @@ const logger: Logger = createLogger('DashboardTool');
 const MAX_DASHBOARD_SIZE_BYTES = 50 * 1024; // 50 KB
 const CONDENSE_KEEP = 10;
 
+// #2598: Byte-budget the kept-message window. The old policy kept a FIXED
+// CONDENSE_KEEP (10) most-recent messages regardless of their byte size.
+// Combined with the 15KB status cap, that pinned the post-condense floor at
+// ~15KB (status) + 10×~3KB (kept messages) ≈ 45KB — essentially equal to the
+// 46KB preemptive threshold. With zero headroom, every subsequent post
+// re-crossed the threshold and re-condensed (observed on workspace-CoursIA:
+// condensation on nearly every append, each a multi-second LLM round-trip).
+// Retaining the most-recent messages up to a byte budget instead caps the
+// intercom contribution to the floor: floor ≈ 15KB status + 16KB intercom
+// = 31KB, ~15KB below the threshold = several posts between condensations.
+const CONDENSE_KEEP_MIN = 4;                       // always keep >= this many recent messages
+const KEEP_INTERCOM_BUDGET_BYTES = 16 * 1024;      // 16 KB target for retained intercom
+
 // #1497: Preemptive condensation threshold (92% of MAX)
 // Triggered BEFORE appending a new message when the dashboard is near-full, so
 // that the condense (which can take ~30s via LLM) completes on smaller data
@@ -1549,6 +1562,37 @@ ${archiveMessages}
 }
 
 /**
+ * #2598: Compute how many of the most-recent intercom messages to retain when
+ * condensing, based on a byte budget rather than a fixed count. Walks from the
+ * newest message backward, accumulating UTF-8 byte size, and keeps messages
+ * while under `budgetBytes` — but never fewer than `minKeep` and never more than
+ * `maxKeep` (default CONDENSE_KEEP). This is always <= the old fixed keep: for
+ * small messages it keeps up to `maxKeep` (unchanged behaviour); for large
+ * messages it keeps fewer, capping the intercom contribution to the
+ * post-condense size floor and preventing the perpetual re-condensation loop.
+ */
+export function computeKeepCount(
+  messages: Pick<IntercomMessage, 'content'>[],
+  maxKeep: number = CONDENSE_KEEP,
+  budgetBytes: number = KEEP_INTERCOM_BUDGET_BYTES,
+  minKeep: number = CONDENSE_KEEP_MIN
+): number {
+  const n = messages.length;
+  if (n === 0) return 0;
+  const minK = Math.min(minKeep, n);
+  let bytes = 0;
+  let kept = 0;
+  for (let i = n - 1; i >= 0 && kept < maxKeep; i--) {
+    const msgBytes = Buffer.byteLength(messages[i].content || '', 'utf8');
+    // Past the guaranteed minimum, stop before exceeding the byte budget.
+    if (kept >= minK && bytes + msgBytes > budgetBytes) break;
+    bytes += msgBytes;
+    kept++;
+  }
+  return kept;
+}
+
+/**
  * Condense les messages intercom : archive les anciens, conserve les récents.
  * Met à jour le statut avec les informations des messages archivés (#858 Phase 2).
  * Si le statut ou le résumé dépasse les limites de taille, auto-condense via LLM.
@@ -2417,15 +2461,20 @@ async function handleAppend(
   // the file with the condensed version. If it fails, the incremental append
   // above is the authoritative state — no message loss.
   const estimatedSize = estimateDashboardSize(updatedDashboard);
+  // #2598: the retained-message window is byte-budgeted (computeKeepCount), not a
+  // fixed CONDENSE_KEEP. Using the same effectiveKeep for the trigger gate, the
+  // #2464 hash payload and the condenseIntercom call keeps all three consistent
+  // with the slice that condenseIntercom will actually perform.
+  const effectiveKeep = computeKeepCount(updatedDashboard.intercom.messages);
   const needsCondense = estimatedSize >= PREEMPTIVE_CONDENSE_THRESHOLD_BYTES
-    && updatedDashboard.intercom.messages.length > CONDENSE_KEEP;
+    && updatedDashboard.intercom.messages.length > effectiveKeep;
 
   if (needsCondense) {
     // #2464: Hash-based skip — if the messages to condense + current status haven't
     // changed since the last successful condensation, skip the LLM calls entirely.
     // This prevents the observed loop where condensation fires 3-4× per 30min on
     // unchanged content, burning ~350KB prompts + 12K output tokens each time.
-    const toArchiveCount = updatedDashboard.intercom.messages.length - CONDENSE_KEEP;
+    const toArchiveCount = updatedDashboard.intercom.messages.length - effectiveKeep;
     const condensePayload = updatedDashboard.intercom.messages
       .slice(0, toArchiveCount)
       .map(m => `${m.timestamp || ''}|${m.content || ''}`)
@@ -2457,7 +2506,7 @@ async function handleAppend(
         const beforeCount = updatedDashboard.intercom.messages.length;
         const condenseDiag = newDiagnostic('post-append');
         const tCondense = Date.now();
-        finalDashboard = await condenseIntercom(key, updatedDashboard, CONDENSE_KEEP, condenseDiag);
+        finalDashboard = await condenseIntercom(key, updatedDashboard, effectiveKeep, condenseDiag);
         preemptiveCondenseMs = Date.now() - tCondense;
         condenseDiagnostics.push(condenseDiag);
         const newlyArchived = beforeCount - finalDashboard.intercom.messages.length;


### PR DESCRIPTION
## Problem

On near-full `workspace` dashboards (acutely on **workspace-CoursIA**), status condensation chained on **almost every `append`** — each a multi-second LLM round-trip. Reported by the user.

The root cause is **arithmetic**, not the LLM path. The post-condense floor is:

```
floor = status (capped ~15KB) + CONDENSE_KEEP(10) kept messages
```

With ~3KB messages: ~15KB + 30KB = **45KB**, essentially equal to the **46KB** preemptive threshold (`floor(50KB × 0.92) = 47104`). **Zero headroom** → the next append re-crosses the threshold and re-condenses, forever.

## Fix (no pendulum)

Keep the most-recent messages up to a **16KB byte budget** instead of a fixed count of 10, bounded by `[CONDENSE_KEEP_MIN=4, CONDENSE_KEEP=10]`. Floor → ~15KB status + 16KB intercom = **31KB**, ~15KB below threshold → several posts between condensations.

The **status size cap is untouched** — no "be short" re-prompt — so CoursIA's legitimate long-term strategic memory is preserved.

### Changes
- `computeKeepCount(messages, maxKeep, budgetBytes, minKeep)` — walks newest→oldest accumulating UTF-8 bytes; **always `<=` the old fixed keep** (identical for small messages, fewer only for large ones).
- `handleAppend` uses `effectiveKeep` at all 3 sites (trigger gate, #2464 hash payload, `condenseIntercom` call) so they stay consistent with the slice condenseIntercom actually performs.
- 5 new unit tests for `computeKeepCount`.
- #1589 test updated faithfully: under the byte budget a 47KB→12-part message is archived on the **first** append (keep window blown) instead of kept whole then condensed on the next — strictly more aggressive archival, the same anti-"protected forever" intent #1589 guards.

## Validation
- `npm run build` clean.
- `vitest --config vitest.config.ci.ts src/tools/roosync/__tests__/dashboard.test.ts` → **95 passed, 1 skipped**.
- Full CI suite: the only failures are 20 pre-existing **semantic-search/qdrant** tests (env-dependent), confirmed identical on the clean baseline with this change stashed — **zero new failures**.

## Deploy note
Running MCP processes on a stale build won't pick this up without restart (deploy-lag). Live wedged dashboards are remediated separately by structural text-surgery (trim to byte budget, archive dropped blocks).

Tracks jsboige/roo-extensions#2598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)