### PR TITLE
fix(dashboard): enforce status cap in condenseTextIfTooLarge (#2598 follow-up, Cause 2)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/condense-cap-enforcement.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/condense-cap-enforcement.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression guard for the #2598 follow-up: Mechanism 2 (the dedicated "status too
+ * big" condenser, condenseTextIfTooLarge) MUST make its byte cap a HARD guarantee.
+ *
+ * Before this fix, condenseTextIfTooLarge was best-effort: on the success path it
+ * returned the LLM output WITHOUT re-checking its size, and on no-client / empty /
+ * exception it returned the oversized original. The 15 KB status cap was decorative,
+ * so a status could grow to ~21 KB (CoursIA-2, 2026-06-15) and wedge the dashboard
+ * at the preemptive condensation threshold — re-condensing on every post.
+ *
+ * These tests assert the invariant the bug violated: every exit path yields
+ * output <= maxSizeBytes, whatever the (mocked) LLM does.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { condenseTextIfTooLarge, truncateToMaxSize } from '../dashboard.js';
+
+// Mirror the LLM-client mock used by dashboard.test.ts.
+const mockChatCreate = vi.fn();
+const mockGetChatClient = vi.fn();
+
+vi.mock('@/services/openai', () => ({
+  getChatOpenAIClient: () => mockGetChatClient(),
+  resetChatOpenAIClient: vi.fn(),
+  getLLMModelId: () => 'test-model',
+}));
+
+const CAP = 2 * 1024; // small cap keeps fixtures tiny; the function takes the cap as a param
+
+// Over-cap, multi-line input so the deterministic floor has real lines to drop.
+const oversizedText = (`${'X'.repeat(100)}\n`).repeat(80); // 80 lines × 101 B ≈ 8 KB
+const oversizedLLMReply = (`${'Y'.repeat(120)}\n`).repeat(80); // still ≈ 9.7 KB > CAP
+const bytes = (s: string) => Buffer.byteLength(s, 'utf8');
+
+beforeEach(() => {
+  mockChatCreate.mockReset();
+  // Default: LLM available, wired to mockChatCreate.
+  mockGetChatClient.mockReset();
+  mockGetChatClient.mockReturnValue({ chat: { completions: { create: mockChatCreate } } });
+  delete process.env.OPENAI_BASE_URL;
+});
+
+describe('truncateToMaxSize (deterministic floor #2463)', () => {
+  it('returns text unchanged when already under cap', () => {
+    const t = 'line1\nline2\nline3';
+    expect(truncateToMaxSize(t, CAP, 'Status')).toBe(t);
+  });
+
+  it('truncates multi-line over-cap text to <= cap', () => {
+    const out = truncateToMaxSize(oversizedText, CAP, 'Status');
+    expect(bytes(out)).toBeLessThanOrEqual(CAP);
+    expect(bytes(out)).toBeGreaterThan(0);
+  });
+
+  it('hard-truncates a single giant line to <= cap', () => {
+    const out = truncateToMaxSize('Z'.repeat(20 * 1024), 1 * 1024, 'Status');
+    expect(bytes(out)).toBeLessThanOrEqual(1 * 1024);
+  });
+});
+
+describe('condenseTextIfTooLarge — cap is a hard guarantee', () => {
+  it('returns input unchanged (no LLM call) when already under cap', async () => {
+    const small = 'already small';
+    const out = await condenseTextIfTooLarge(small, CAP, 'Status');
+    expect(out).toBe(small);
+    expect(mockChatCreate).not.toHaveBeenCalled();
+  });
+
+  it('returns the LLM output when it converges under the cap on attempt 1', async () => {
+    mockChatCreate.mockResolvedValue({ choices: [{ message: { content: 'condensed under cap' } }] });
+    const out = await condenseTextIfTooLarge(oversizedText, CAP, 'Status');
+    expect(out).toBe('condensed under cap');
+    expect(mockChatCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to deterministic truncation when the LLM stays over cap (the #2598 bug)', async () => {
+    mockChatCreate.mockResolvedValue({ choices: [{ message: { content: oversizedLLMReply } }] });
+    const out = await condenseTextIfTooLarge(oversizedText, CAP, 'Status');
+    expect(bytes(out)).toBeLessThanOrEqual(CAP); // never returns the oversized LLM reply
+    expect(mockChatCreate).toHaveBeenCalledTimes(2); // one bounded retry before the floor
+  });
+
+  it('falls back to deterministic truncation when no LLM client is available', async () => {
+    mockGetChatClient.mockImplementation(() => { throw new Error('No chat API key configured'); });
+    const out = await condenseTextIfTooLarge(oversizedText, CAP, 'Status');
+    expect(bytes(out)).toBeLessThanOrEqual(CAP);
+    expect(mockChatCreate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to deterministic truncation when the LLM call throws', async () => {
+    mockChatCreate.mockRejectedValue(new Error('gateway 502'));
+    const out = await condenseTextIfTooLarge(oversizedText, CAP, 'Status');
+    expect(bytes(out)).toBeLessThanOrEqual(CAP);
+    expect(mockChatCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to deterministic truncation when the LLM returns empty content', async () => {
+    mockChatCreate.mockResolvedValue({ choices: [{ message: { content: '' } }] });
+    const out = await condenseTextIfTooLarge(oversizedText, CAP, 'Status');
+    expect(bytes(out)).toBeLessThanOrEqual(CAP);
+    expect(mockChatCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('prefers the smallest over-cap candidate for the floor (retry shrinks but still over)', async () => {
+    // Attempt 1 returns a big reply, attempt 2 a smaller (still over-cap) one — the
+    // floor should run on the smaller candidate, and the result must be <= cap.
+    const bigger = (`${'Y'.repeat(120)}\n`).repeat(80);  // ≈ 9.7 KB
+    const smaller = (`${'Y'.repeat(120)}\n`).repeat(30);  // ≈ 3.6 KB, still > 2 KB cap
+    mockChatCreate
+      .mockResolvedValueOnce({ choices: [{ message: { content: bigger } }] })
+      .mockResolvedValueOnce({ choices: [{ message: { content: smaller } }] });
+    const out = await condenseTextIfTooLarge(oversizedText, CAP, 'Status');
+    expect(bytes(out)).toBeLessThanOrEqual(CAP);
+    expect(mockChatCreate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/servers/roo-state-manager/src/tools/roosync/dashboard.ts
+++ b/servers/roo-state-manager/src/tools/roosync/dashboard.ts
@@ -1279,7 +1279,7 @@ Mets à jour le statut en intégrant les informations des messages [SERA ARCHIV�
  * Uses a dedicated LLM call asking to compress the text while preserving all info.
  * Returns the condensed text, or the original if condensation fails.
  */
-async function condenseTextIfTooLarge(
+export async function condenseTextIfTooLarge(
   text: string,
   maxSizeBytes: number,
   label: string
@@ -1289,18 +1289,37 @@ async function condenseTextIfTooLarge(
 
   logger.info(`${label} exceeds size limit, auto-condensing`, { sizeBytes, limit: maxSizeBytes, sizeKB: `${(sizeBytes / 1024).toFixed(1)}KB` });
 
+  // #2598 follow-up — Mechanism 2 (the dedicated "too big" condenser) is the ONLY
+  // size guardian and MUST make the cap a HARD guarantee, not best-effort. Every
+  // exit below returns <= maxSizeBytes. The LLM is the intelligent primary; the
+  // deterministic truncateToMaxSize floor is the last resort when it can't converge
+  // (no client / empty output / exception / still-over-cap after a bounded retry).
+  // (Status GROWTH is Mechanism 1's business — see generateStatusUpdate; not touched here.)
   let openai: OpenAI;
   try {
     openai = getChatOpenAIClient();
   } catch {
-    logger.warn(`Cannot auto-condense ${label}: no LLM client`);
-    return text;
+    logger.warn(`Cannot auto-condense ${label}: no LLM client — applying deterministic truncation`);
+    return truncateToMaxSize(text, maxSizeBytes, label);
   }
   const modelId = getLLMModelId();
+  const capKb = Math.round(maxSizeBytes / 1024);
 
-  const systemPrompt = `Tu es un expert en synthèse. Le texte suivant dépasse la limite de ${Math.round(maxSizeBytes / 1024)} Ko.
+  // Up to 2 LLM attempts. The 2nd targets a tighter budget (~80% of the cap) with a
+  // stronger instruction, used only if the 1st came back still over the limit.
+  const MAX_ATTEMPTS = 2;
+  let bestCandidate = text;
+  let bestSize = sizeBytes;
 
-MISSION : Condenser ce texte en dessous de ${Math.round(maxSizeBytes / 1024)} Ko tout en préservant TOUTE l'information critique.
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const targetKb = attempt === 1 ? capKb : Math.max(1, Math.floor((maxSizeBytes * 0.8) / 1024));
+    const aggressiveNote = attempt === 1
+      ? ''
+      : `\n\nCRITIQUE : la version précédente dépassait ENCORE la limite. Sois plus agressif — vise ${targetKb} Ko, fusionne/supprime davantage de redondance, SANS perdre aucune décision, métrique chiffrée ni blocage.`;
+
+    const systemPrompt = `Tu es un expert en synthèse. Le texte suivant dépasse la limite de ${capKb} Ko.
+
+MISSION : Condenser ce texte en dessous de ${targetKb} Ko tout en préservant TOUTE l'information critique.
 
 RÈGLES :
 - Préserver les métriques chiffrées exactes
@@ -1312,50 +1331,64 @@ RÈGLES :
 - Le résultat DOIT être plus court que l'original
 - LAST-KNOWN-STATE WINS : pour chaque sujet, ne garder QUE le dernier état connu (#1502)
 - INTERDICTION D'EXTRAPOLER : ne rien afficher qui ne soit pas dans le texte source (#1502)
-- SUPPRIMER les faits contredits par des informations plus récentes dans le texte (#1502)`;
+- SUPPRIMER les faits contredits par des informations plus récentes dans le texte (#1502)${aggressiveNote}`;
 
-  const startTime = Date.now();
-  try {
-    const thinkingCtrl = buildThinkingControl(isOpenAICompatVLlm());
-    const response = await openai.chat.completions.create({
-      model: modelId,
-      messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: thinkingCtrl.promptPrefix + text }
-      ],
-      // Bounded under the ~600s gateway timeout (see CONDENSE_LLM_MAX_TOKENS).
-      max_tokens: CONDENSE_LLM_MAX_TOKENS,
-      temperature: 0.3,
-      // Disable Qwen3.6 thinking mode (user mandate 2026-05-26).
-      ...(thinkingCtrl.chatTemplateKwargs ? { chat_template_kwargs: thinkingCtrl.chatTemplateKwargs } : {})
-    }, {
-      timeout: CONDENSE_LLM_TIMEOUT_MS  // #2267 follow-up: bounded so a hung endpoint fast-fails (was 900000)
-    });
+    const startTime = Date.now();
+    try {
+      const thinkingCtrl = buildThinkingControl(isOpenAICompatVLlm());
+      const response = await openai.chat.completions.create({
+        model: modelId,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: thinkingCtrl.promptPrefix + text }
+        ],
+        // Bounded under the ~600s gateway timeout (see CONDENSE_LLM_MAX_TOKENS).
+        max_tokens: CONDENSE_LLM_MAX_TOKENS,
+        temperature: 0.3,
+        // Disable Qwen3.6 thinking mode (user mandate 2026-05-26).
+        ...(thinkingCtrl.chatTemplateKwargs ? { chat_template_kwargs: thinkingCtrl.chatTemplateKwargs } : {})
+      }, {
+        timeout: CONDENSE_LLM_TIMEOUT_MS  // #2267 follow-up: bounded so a hung endpoint fast-fails (was 900000)
+      });
 
-    const condensed = response.choices[0]?.message?.content;
-    if (!condensed) {
-      logger.warn(`Auto-condense ${label}: LLM returned empty, keeping original`);
-      return text;
+      const condensed = response.choices[0]?.message?.content;
+      const elapsed = Date.now() - startTime;
+      if (!condensed) {
+        logger.warn(`Auto-condense ${label} attempt ${attempt}: LLM returned empty`, { elapsed: `${elapsed}ms` });
+        continue;
+      }
+
+      const newSize = Buffer.byteLength(condensed, 'utf8');
+      logger.info(`Auto-condensed ${label} (attempt ${attempt})`, {
+        elapsed: `${elapsed}ms`,
+        beforeKB: `${(sizeBytes / 1024).toFixed(1)}KB`,
+        afterKB: `${(newSize / 1024).toFixed(1)}KB`,
+        reduction: `${Math.round((1 - newSize / sizeBytes) * 100)}%`,
+        targetKB: targetKb
+      });
+
+      if (newSize <= maxSizeBytes) return condensed;  // converged under cap — done
+
+      // Still over cap: keep the smallest candidate seen, then retry tighter (or fall through).
+      if (newSize < bestSize) { bestCandidate = condensed; bestSize = newSize; }
+      logger.warn(`Auto-condense ${label} attempt ${attempt} still over cap`, {
+        afterKB: `${(newSize / 1024).toFixed(1)}KB`, capKB: `${capKb}KB`
+      });
+    } catch (error) {
+      const elapsed = Date.now() - startTime;
+      logger.warn(`Auto-condense ${label} attempt ${attempt} failed`, {
+        elapsed: `${elapsed}ms`,
+        error: error instanceof Error ? error.message : String(error)
+      });
     }
-
-    const newSize = Buffer.byteLength(condensed, 'utf8');
-    const elapsed = Date.now() - startTime;
-    logger.info(`Auto-condensed ${label}`, {
-      elapsed: `${elapsed}ms`,
-      beforeKB: `${(sizeBytes / 1024).toFixed(1)}KB`,
-      afterKB: `${(newSize / 1024).toFixed(1)}KB`,
-      reduction: `${Math.round((1 - newSize / sizeBytes) * 100)}%`
-    });
-    return condensed;
-
-  } catch (error) {
-    const elapsed = Date.now() - startTime;
-    logger.warn(`Auto-condense ${label} failed, keeping original`, {
-      elapsed: `${elapsed}ms`,
-      error: error instanceof Error ? error.message : String(error)
-    });
-    return text;
   }
+
+  // LLM never converged under the cap (down, empty, or still oversized) → deterministic
+  // backstop on the smallest candidate so ${label} NEVER exceeds its cap (the #2598 bug).
+  logger.warn(`Auto-condense ${label}: LLM did not converge under ${capKb}KB, applying deterministic truncation`, {
+    bestKB: `${(bestSize / 1024).toFixed(1)}KB`
+  });
+  return truncateToMaxSize(bestCandidate, maxSizeBytes, label);
 }
 
 /**
@@ -1419,7 +1452,7 @@ export function detectStatusContradictions(status: string): Array<{ entity: stri
  * Deterministic (non-LLM) truncation: keeps the most recent lines that fit within maxSizeBytes.
  * Used when LLM condensation fails (#2463 — status should never exceed its cap, even in fallback).
  */
-function truncateToMaxSize(text: string, maxSizeBytes: number, label: string): string {
+export function truncateToMaxSize(text: string, maxSizeBytes: number, label: string): string {
   const sizeBytes = Buffer.byteLength(text, 'utf8');
   if (sizeBytes <= maxSizeBytes) return text;
 


### PR DESCRIPTION
## Contexte

Suite du bug **\"condensation à chaque post\"** des dashboards RooSync (#2598, surtout CoursIA). Le fix #2598 / PR #633 (`computeKeepCount`, mergé 2026-06-15) n'a traité que **Cause 1** (wedge arithmétique de la fenêtre intercom). L'utilisateur a constaté qu'un statut faisait toujours **~21 KB** (CoursIA-2) après ce fix → **« ça n'est pas le bon fixe »**.

**Cause 2 (cette PR)** : le **2è mécanisme** de condensation — `condenseTextIfTooLarge`, dédié au statut « trop gros » — était **best-effort sans backstop déterministe** :
- chemin succès : retournait la sortie LLM **sans re-vérifier sa taille** (`newSize` calculé seulement pour le log) ;
- chemins no-client / empty / exception : retournaient l'**original gonflé**.

Le cap `MAX_STATUS_SIZE_BYTES` (15 KB) était donc **décoratif** : si le LLM renvoyait un texte toujours > 15 KB, il était écrit tel quel → dashboard collé au seuil de condensation préemptive → re-condensation à chaque append.

## Fix — le cap devient une garantie DURE

Toute sortie de `condenseTextIfTooLarge` est désormais `≤ maxSizeBytes` :
1. **LLM = condenseur intelligent primaire** (prompt/qualité inchangés).
2. **Re-check** de la taille de sortie ; si encore > cap, **1 retry borné** ciblant ~80 % du cap avec une instruction plus agressive.
3. **Plancher déterministe** `truncateToMaxSize` (déjà utilisé par `executeTruncationFallback`, #2463) câblé en dernier recours : no-client / empty / exception / encore-trop-gros après retry — appliqué au **plus petit candidat** vu.

## Séparation des responsabilités (mandate user)

> « la condensation de message avec MAJ de statut ne doit pas se préoccuper de la croissance du statut, c'est le 2è mécanisme de condensation de statut trop gros qui y est consacré et ne fait que ça »

- **Mécanisme 1** (`generateStatusUpdate`) — la **croissance** du statut (héritage + last-known-state-wins #1502, zéro perte d'info). **NON touché.**
- **Mécanisme 2** (`condenseTextIfTooLarge`) — la **taille**, et rien d'autre. C'est le seul endroit modifié.
- **No-pendulum** : `MAX_STATUS_SIZE_BYTES` (15 KB) **inchangé** (mémoire stratégique légitime).

## Tests

Nouveau `condense-cap-enforcement.test.ts` (**10 tests**) — invariant `output ≤ cap` quand le LLM mocké renvoie : oversized / empty / throws / pas de client, + les chemins converge-attempt-1 et plus-petit-candidat. Plus tests purs de `truncateToMaxSize`.

## Validation locale

- `npm run build` (tsc) : **clean**.
- `npx vitest run --config vitest.config.ci.ts` : **9920 passed**, 2 skipped. Les 2 échecs `tests/unit/tools/search/*` (« semantic search successfully ») sont **pré-existants sur `origin/main`** (backend Qdrant/embedding local), **vérifiés par stash**, sans rapport avec ce changement. Zéro régression dashboard.

## Remède live (déjà appliqué, hors PR)

CoursIA-2 (21→8.4 KB) et 2025-Epita-IS (15.4→9.3 KB) condensés à la main intelligemment en attendant le déploiement, append post-remède = `condensed:false`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>