### PR TITLE
docs: fix stale roo-state-manager tool count 34→15 in submodule overview docs (#2601/#2602 follow-up)

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -8,7 +8,7 @@ Active servers in this repository. See [README.md](README.md) for full details.
 
 The core RooSync multi-agent coordination server.
 
-- **34 MCP tools** — conversations, RooSync messaging, dashboards, semantic search, baselines, diagnostics
+- **15 MCP tools** — conversations, RooSync messaging, dashboards, semantic search, baselines, diagnostics
 - **Stack**: TypeScript, Node.js 20.18.0, Vitest (~7900 tests)
 - **Storage**: Qdrant (semantic index), GDrive (shared state)
 - **Doc**: [servers/roo-state-manager/README.md](servers/roo-state-manager/README.md)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Les serveurs MCP sont placés dans le répertoire `servers/`:
 
 Le composant central du système RooSync Multi-Agent:
 
-- **34 outils MCP** pour la coordination multi-machine
+- **15 outils MCP** pour la coordination multi-machine
 - **Conversations**: browse, view, tree, summarize (Roo + Claude Code)
 - **RooSync**: send, read, manage, heartbeat, compare_config
 - **Dashboards**: global, machine, workspace (cross-machine coordination)
@@ -113,7 +113,7 @@ pip install -r requirements.txt
 
 ```text
 servers/
-├── roo-state-manager/   # TypeScript — 34 tools, RooSync core
+├── roo-state-manager/   # TypeScript — 15 tools, RooSync core
 │   ├── src/tools/       # Tool definitions + handlers
 │   ├── src/services/    # Business logic (RooSync, Qdrant, heartbeat)
 │   ├── src/resources/   # MCP resources

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ Un serveur MCP est un service qui implémente le protocole MCP et expose des out
 
 Dans ce dépôt, les serveurs MCP sont placés directement dans le répertoire `servers/`:
 
-- **roo-state-manager**: 34 outils MCP pour la coordination multi-agent (RooSync)
+- **roo-state-manager**: 15 outils MCP pour la coordination multi-agent (RooSync)
 - **sk-agent**: LLM proxy multi-agent avec mémoire vectorielle
 
 ### 2. Outils (Tools)


### PR DESCRIPTION
## Context

Submodule counterpart of the parent-repo **#2601/#2602** sweep (po-2023 fixed 2 parent files, po-2026 swept 9 parent files). po-2026 explicitly excluded the submodule docs from #2602 as "needs separate workflow (submodule PR → pointer-bump)" — this is that submodule PR.

## Why 15 (not 34)

The live `tools/list` count is **15**, triangulated across 4 independent sessions this cycle (po-2025, ai-01, web1, po-2023) + the `tool-availability.md` fleet rule. The "34" was pre-consolidation (CONS-1…CONS-13 reduced 34→15). web1 (cycle 11) refuted the inverse claim ("15→26" = counting `tool-definitions.ts` legacy redirects instead of live tools/list).

## Scope — 4 SAFE overview-doc substitutions

| File | Line | Context |
|------|------|---------|
| `README.md` | 40 | "34 outils MCP pour la coordination multi-machine" (feature list = exposed surface) |
| `README.md` | 116 | "TypeScript — 34 tools, RooSync core" (architecture tree summary) |
| `INDEX.md` | 11 | "34 MCP tools" (exposed-surface summary) |
| `docs/architecture.md` | 42 | "roo-state-manager: 34 outils MCP" (overview) |

These 4 are pure stale **fleet-facing summary counts** of the exposed MCP surface — identical context to the parent-repo sweep. 0 scope creep, 0 code.

## INTENTIONALLY EXCLUDED — 5 occurrences need reconciliation (NOT blind 34→15)

Blindly substituting these would repeat the **po-2026 cycle-21 trap** (counting the wrong layer):

- **`servers/roo-state-manager/README.md:311,313,407`** — "Liste Complète des Outils MCP (34 outils)" actually **enumerates 44 legacy tool names** (`roosync_init`, `get_raw_conversation`, `export_tasks_xml`, `roosync_send_message`…) mislabeled as 34. This documents the **internal/legacy registry surface** (cf. `registry.ts` 46 case handlers, `tool-definitions.ts` 26 redirects), NOT the 15 exposed to the client. Needs a major rewrite: either document the 15 live tools, or relabel as "internal/legacy tool registry". Tracked for separate PR.
- **`servers/roo-state-manager/.claude/agents/workers/config-auditor.md:22,64`** — functional audit criteria on `alwaysAllow` ("contient les 34 outils roosync_*"). Must reflect the live per-machine `mcp_settings.json` alwaysAllow content, which differs across the fleet. Needs separate verification against actual config. Tracked for separate PR.

## Verification

- ✅ `git diff` = exactly 4 substitutions (4 insertions / 4 deletions), 3 files
- ✅ Doc-only, 0 build/test risk
- ✅ Pre-existing untracked files (`servers/roo-state-manager/D`, `sk_agent_config.json.bak`) NOT touched/staged

After merge → pointer-bump in parent repo `jsboige/roo-extensions` (per `.claude/rules/submod-pointer-safety.md`, pointer-bump only AFTER this submodule PR is merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)