### PR TITLE
fix(search): unified-store JOIN must enrich, not gate semantic results (fleet-wide recall regression)

### DIFF
--- a/servers/roo-state-manager/src/tools/search/__tests__/search-semantic.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-semantic.tool.test.ts
@@ -36,6 +36,17 @@ const { mockGetHostIdentifier } = vi.hoisted(() => ({
 	mockGetHostIdentifier: vi.fn().mockReturnValue('test-host-01')
 }));
 
+// #2426 follow-up: the unified-store reader was NEVER mocked, so every test ran
+// with Postgres OFF (NullUnifiedStoreReader) — the opposite of production, where
+// dual-write is ON and the JOIN executes. We mock it here so the deployed code
+// path can actually be exercised. Default = OFF (matches prior test behavior).
+const { mockUnifiedStoreReader } = vi.hoisted(() => ({
+	mockUnifiedStoreReader: {
+		isNull: vi.fn().mockReturnValue(true),
+		joinFromQdrant: vi.fn(async () => [] as Array<{ task_id: string; score: number }>)
+	}
+}));
+
 vi.mock('../../../services/qdrant.js', () => ({
 	getQdrantClient: () => mockQdrantClient,
 	resetQdrantClient: vi.fn(),
@@ -59,6 +70,10 @@ vi.mock('../../../services/task-indexer/ChunkExtractor.js', () => ({
 
 vi.mock('../search-fallback.tool.js', () => ({
 	handleSearchTasksSemanticFallback: mockFallbackHandler
+}));
+
+vi.mock('../../../services/unified-store/reader-factory.js', () => ({
+	getUnifiedStoreReader: () => mockUnifiedStoreReader
 }));
 
 import { searchTasksByContentTool, SearchTasksByContentArgs, _resetEmbeddingCircuitBreaker } from '../search-semantic.tool.js';
@@ -88,6 +103,11 @@ beforeEach(() => {
 	_resetEmbeddingCircuitBreaker();
 	mockGetEmbeddingModel.mockReturnValue('test-model');
 	mockGetHostIdentifier.mockReturnValue('test-host-01');
+	// #2426 follow-up: default unified store OFF every test; the regression
+	// describe-block below flips it ON explicitly. clearAllMocks() does not reset
+	// return values, so reassert defaults here to prevent cross-test leakage.
+	mockUnifiedStoreReader.isNull.mockReturnValue(true);
+	mockUnifiedStoreReader.joinFromQdrant.mockResolvedValue([]);
 	delete process.env.QDRANT_COLLECTION_NAME;
 });
 
@@ -789,6 +809,83 @@ describe('helper functions (indirect via handler)', () => {
 		expect(parsed.results[1].taskId).toBe('task-b');
 		expect(parsed.results[1].chunks).toHaveLength(2);
 		expect(parsed.results[1].best_score).toBe(0.7);
+	});
+
+	// ============================================================
+	// #2426 follow-up: unified-store Postgres JOIN must ENRICH, not GATE.
+	// These tests exercise the DEPLOYED config (dual-write ON), which the rest of
+	// the suite never did. The first one fails on the pre-fix code (results: []),
+	// which is exactly the fleet-wide "semantic search returns nothing" symptom.
+	// ============================================================
+
+	describe('#2426 unified-store JOIN (production config)', () => {
+		beforeEach(() => {
+			mockOpenAIClient.embeddings.create.mockResolvedValue({ data: [{ embedding: [0.1] }] });
+		});
+
+		test('keeps Qdrant results when the store is active but empty (backfill gap)', async () => {
+			// Reader active (dual-write ON) but Postgres returns no rows.
+			mockUnifiedStoreReader.isNull.mockReturnValue(false);
+			mockUnifiedStoreReader.joinFromQdrant.mockResolvedValue([]);
+			mockQdrantClient.search.mockResolvedValue([
+				{ score: 0.82, payload: { task_id: 'task-1', content: 'yesterday debrief', host_os: 'win32' } },
+				{ score: 0.71, payload: { task_id: 'task-2', content: 'coordination notes', host_os: 'win32' } },
+			]);
+
+			const result = await searchTasksByContentTool.handler(
+				{ search_query: 'debrief' },
+				makeCache(),
+				mockEnsureCache,
+				defaultFallback
+			);
+
+			const parsed = JSON.parse(getTextContent(result));
+			// Pre-fix: results: [] and unique_tasks: 0 (the bug). Post-fix: hits survive.
+			expect(parsed.results.length).toBe(2);
+			expect(parsed.current_machine.unique_tasks).toBe(2);
+			expect(parsed.results.map((r: any) => r.taskId)).toEqual(['task-1', 'task-2']);
+		});
+
+		test('applies Postgres ranking when the store DOES return rows', async () => {
+			// When Postgres is populated, the JOIN still filters + re-ranks (intended #2426 behavior).
+			mockUnifiedStoreReader.isNull.mockReturnValue(false);
+			mockUnifiedStoreReader.joinFromQdrant.mockResolvedValue([
+				{ task_id: 'task-2', score: 0.99 },
+				{ task_id: 'task-1', score: 0.50 },
+			]);
+			mockQdrantClient.search.mockResolvedValue([
+				{ score: 0.82, payload: { task_id: 'task-1', content: 'a', host_os: 'win32' } },
+				{ score: 0.71, payload: { task_id: 'task-2', content: 'b', host_os: 'win32' } },
+			]);
+
+			const result = await searchTasksByContentTool.handler(
+				{ search_query: 'x' },
+				makeCache(),
+				mockEnsureCache,
+				defaultFallback
+			);
+
+			const parsed = JSON.parse(getTextContent(result));
+			expect(parsed.results.map((r: any) => r.taskId)).toEqual(['task-2', 'task-1']);
+		});
+
+		test('requests host_os in the Qdrant payload include (machines_found populated)', async () => {
+			// Real Qdrant honours the include whitelist; omitting host_os made
+			// machines_found always ['unknown']. Assert the field is requested.
+			mockQdrantClient.search.mockResolvedValue([
+				{ score: 0.8, payload: { task_id: 't1', content: 'x', host_os: 'win32' } },
+			]);
+
+			await searchTasksByContentTool.handler(
+				{ search_query: 'x' },
+				makeCache(),
+				mockEnsureCache,
+				defaultFallback
+			);
+
+			const searchCall = mockQdrantClient.search.mock.calls[0][1] as any;
+			expect(searchCall.with_payload.include).toContain('host_os');
+		});
 	});
 
 	// ============================================================

--- a/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
@@ -651,7 +651,10 @@ export const searchTasksByContentTool = {
                     quantization: { rescore: true }
                 },
                 with_payload: {
-                    include: ['task_id', 'timestamp', 'chunk_type', 'content', 'content_summary', 'workspace', 'workspace_name', 'source', 'chunk_id', 'task_title', 'role', 'model', 'tool_name', 'has_error']
+                    // #2426 follow-up: 'host_os' must be in the include whitelist, otherwise
+                    // cross_machine_analysis.machines_found is always ['unknown'] (the payload
+                    // field exists but is never retrieved).
+                    include: ['task_id', 'timestamp', 'chunk_type', 'content', 'content_summary', 'workspace', 'workspace_name', 'source', 'chunk_id', 'task_title', 'role', 'model', 'tool_name', 'has_error', 'host_os']
                 },
                 timeout: searchTimeoutSec,
             }));
@@ -730,14 +733,26 @@ export const searchTasksByContentTool = {
                     if (tool_name) pgFilters.tool_name = tool_name;
 
                     const pgHits = await unifiedStoreReader.joinFromQdrant(qdrantHits, pgFilters);
-                    const pgTaskIds = new Set(pgHits.map(h => h.task_id));
 
-                    // Filter groupedResults to only those confirmed by Postgres
-                    // Re-order by ANN score (pgHits is already sorted by score DESC)
-                    const pgScoreMap = new Map(pgHits.map(h => [h.task_id, h.score]));
-                    groupedResults = groupedResults
-                        .filter(g => pgTaskIds.has(g.taskId))
-                        .sort((a, b) => (pgScoreMap.get(b.taskId) ?? 0) - (pgScoreMap.get(a.taskId) ?? 0));
+                    // #2426 follow-up (semantic-recall regression, 2026-06-16): the unified
+                    // Postgres store is a DERIVED index that may be incomplete (dual-write
+                    // backfill gap). Treat it as ENRICHMENT, not a gate: only apply the
+                    // inner-join filter when Postgres actually returned rows; otherwise keep
+                    // the Qdrant-only ANN ranking. Without this guard an empty/un-backfilled
+                    // Postgres silently nuked every semantic result fleet-wide (the tool
+                    // reported results_count > 0 but unique_tasks: 0, results: []).
+                    // tool_name filtering is already enforced upstream in the Qdrant filter
+                    // (see filterConditions above), so falling back to Qdrant-only when
+                    // Postgres has no rows loses no correctness.
+                    if (pgHits.length > 0) {
+                        const pgTaskIds = new Set(pgHits.map(h => h.task_id));
+                        // Filter groupedResults to only those confirmed by Postgres,
+                        // re-ordered by ANN score (pgHits is already sorted by score DESC)
+                        const pgScoreMap = new Map(pgHits.map(h => [h.task_id, h.score]));
+                        groupedResults = groupedResults
+                            .filter(g => pgTaskIds.has(g.taskId))
+                            .sort((a, b) => (pgScoreMap.get(b.taskId) ?? 0) - (pgScoreMap.get(a.taskId) ?? 0));
+                    }
                 } catch (err) {
                     // Postgres enrichment failed — fall back to Qdrant-only results (non-blocking)
                     console.warn('[WARN] #2426: Unified-store Postgres JOIN failed, using Qdrant-only results:', err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Symptom
Semantic conversation search — `roosync_search(action:"semantic")` and the semantic discovery path behind `conversation_browser` — returns **`results: []` with `unique_tasks: 0` fleet-wide**, even though the index is healthy (810k pts) and the vector search returns hits (`results_count: N > 0`). A coordinator trying to find *yesterday's debrief conversation* gets nothing.

## Root cause (code-grounded)
`#2426 Phase C+` added a Postgres unified-store JOIN in [`search-semantic.tool.ts`](servers/roo-state-manager/src/tools/search/search-semantic.tool.ts). When the reader is active (`UNIFIED_STORE_DUAL_WRITE=1`, the deployed config), the tool inner-joins the Qdrant ANN hits against Postgres and keeps **only** Postgres-confirmed `task_id`s:

```js
groupedResults = groupedResults.filter(g => pgTaskIds.has(g.taskId)).sort(...)
```

`pg.myia.io` is deployed but the dual-write **backfill never ran (0 rows)**, so `joinFromQdrant()` returns `[]` → `pgTaskIds` is empty → the filter **silently nukes every result**. `results_count` is computed pre-filter (stays `N`); `unique_tasks`/`results` are post-filter (→ 0 / `[]`). The `try/catch` only catches *thrown* errors, not an empty-but-successful join.

## Fix
Treat Postgres as **enrichment, not a gate**: apply the inner-join filter only when `pgHits.length > 0`; otherwise fall back to the Qdrant-only ANN ranking. `tool_name` is already enforced in the Qdrant filter, so no correctness is lost. Also added `host_os` to the Qdrant payload `include` whitelist — it was omitted, so `cross_machine_analysis.machines_found` was always `['unknown']`.

## Tests — the real point
The 1498-line unit suite mocked qdrant/openai/task-indexer but **not** the unified-store reader, so every test ran with Postgres **OFF** — the opposite of production. The pieces were green; the assembled tool was broken. Added:
- `vi.mock` for `reader-factory.js` (default OFF, preserving prior behavior)
- a `#2426 production config` block: **empty store keeps Qdrant hits** (RED on pre-fix: `0 ≠ 2`), populated store still filters + re-ranks, host_os requested in include.

Verified red→green by temporarily restoring the always-filter behavior (test fails `expected +0 to be 2` — the exact production symptom), then restoring the guard.

Build green; **71/71** tests pass locally and under `vitest.config.ci.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)