### PR TITLE
fix(indexer): key leader-election lock machine-local, not per-storage-path (#2352)

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/leader-election.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/leader-election.test.ts
@@ -10,6 +10,10 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'fs';
+import path from 'path';
+import * as os from 'os';
+import { getLeaderLockPath } from '../background-services.js';
+import { RooStorageDetector } from '../../utils/roo-storage-detector.js';
 
 // Mock fs
 vi.mock('fs', async () => {
@@ -24,8 +28,10 @@ vi.mock('fs', async () => {
   };
 });
 
-// Mock RooStorageDetector to return a deterministic path
-const MOCK_STORAGE_PATH = '/mock/storage';
+// Mock RooStorageDetector to return a deterministic path.
+// vi.hoisted() makes MOCK_STORAGE_PATH available to the hoisted vi.mock factory
+// (vi.mock is hoisted above top-level const initialization).
+const { MOCK_STORAGE_PATH } = vi.hoisted(() => ({ MOCK_STORAGE_PATH: '/mock/storage' }));
 vi.mock('../../utils/roo-storage-detector.js', () => ({
   RooStorageDetector: {
     detectStorageLocations: vi.fn().mockResolvedValue([MOCK_STORAGE_PATH]),
@@ -192,5 +198,53 @@ describe('Leader-election (#2352)', () => {
     expect(writtenData.pid).toBe(process.pid);
     expect(writtenData.timestamp).toBeGreaterThanOrEqual(before);
     expect(writtenData.timestamp).toBeLessThanOrEqual(Date.now());
+  });
+});
+
+// --- #2352 fix regression: path-resolution contract (production code, not a copy) ---
+// The describe above tests the lock CONTENTION algorithm via a local reimplementation
+// (path-agnostic). These tests exercise the REAL getLeaderLockPath export to prove the
+// fleet-storm fix: the lock path is machine-local and INVARIANT to detected storage.
+describe('getLeaderLockPath — #2352 machine-local keying (regression)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a path under os.tmpdir() (machine-local, not a storage path)', async () => {
+    const p = await getLeaderLockPath('myia-po-2026');
+    expect(p.startsWith(os.tmpdir())).toBe(true);
+    expect(p.endsWith('roosync-indexer-leader-myia-po-2026.lock')).toBe(true);
+  });
+
+  it('is INVARIANT to detected storage locations (the exact #2352 bug)', async () => {
+    // Pre-fix: path = locations[0]/tasks/.skeletons/.indexer-leader.lock → different
+    // storages = different locks = N concurrent leaders on the shared collection.
+    // Post-fix: storage detection must NOT affect the path at all.
+    (RooStorageDetector.detectStorageLocations as any).mockResolvedValue(['/roo/globalStorage']);
+    const p1 = await getLeaderLockPath('myia-po-2026');
+    (RooStorageDetector.detectStorageLocations as any).mockResolvedValue(['/roo/globalStorage', '/zoo/globalStorage']);
+    const p2 = await getLeaderLockPath('myia-po-2026');
+    (RooStorageDetector.detectStorageLocations as any).mockResolvedValue([]); // zero storage locations
+    const p3 = await getLeaderLockPath('myia-po-2026');
+    expect(p1).toBe(p2);
+    expect(p2).toBe(p3);
+  });
+
+  it('gives each machine its own lock (machineId-keyed)', async () => {
+    const a = await getLeaderLockPath('myia-ai-01');
+    const b = await getLeaderLockPath('myia-po-2026');
+    expect(a).not.toBe(b);
+    expect(a.endsWith('roosync-indexer-leader-myia-ai-01.lock')).toBe(true);
+    expect(b.endsWith('roosync-indexer-leader-myia-po-2026.lock')).toBe(true);
+  });
+
+  it('sanitizes unsafe machineId chars for filesystem safety', async () => {
+    const p = await getLeaderLockPath('My_Bad Machine/01');
+    expect(p.endsWith('roosync-indexer-leader-my-bad-machine-01.lock')).toBe(true);
+  });
+
+  it('falls back to "local" when machineId is empty', async () => {
+    const p = await getLeaderLockPath('');
+    expect(p.endsWith('roosync-indexer-leader-local.lock')).toBe(true);
   });
 });

--- a/servers/roo-state-manager/src/services/background-services.ts
+++ b/servers/roo-state-manager/src/services/background-services.ts
@@ -760,7 +760,7 @@ async function initializeQdrantIndexingService(state: ServerState): Promise<void
 
         // Phase 3: Start background process (always safe - doesn't contact Qdrant immediately)
         // #2352: Attempt leader-election at startup
-        state.isIndexLeader = await tryAcquireLeaderLock();
+        state.isIndexLeader = await tryAcquireLeaderLock(state.machineId);
         if (state.isIndexLeader) {
             console.log(`🔑 [Leader-Election] PID ${process.pid} is indexing leader at startup`);
         } else {
@@ -944,25 +944,37 @@ export const QDRANT_INDEX_BATCH_SIZE = 5;
 /**
  * #2352: Leader-election for Qdrant indexing.
  * Only one MCP instance per machine runs embeddings at a time.
- * Lock is a file in the skeletons directory containing { pid, timestamp }.
+ * Lock is a machine-local file under os.tmpdir() (keyed by machineId) containing { pid, timestamp }.
  * Stale after LEADER_LOCK_STALE_MS — allows takeover if leader process crashes.
  */
-const LEADER_LOCK_FILENAME = '.indexer-leader.lock';
 const LEADER_LOCK_STALE_MS = 15 * 60 * 1000; // 15 min (3× the 5-min indexing interval)
 
-async function getLeaderLockPath(): Promise<string | null> {
-    const locations = await RooStorageDetector.detectStorageLocations();
-    if (locations.length === 0) return null;
-    return path.join(locations[0], 'tasks', '.skeletons', LEADER_LOCK_FILENAME);
+/**
+ * #2352: Returns the MACHINE-LOCAL leader-lock path for Qdrant indexing.
+ *
+ * Fix (fleet consensus 2026-06-17, ai-01 sign-off): keyed on `machineId` under
+ * `os.tmpdir()`, NOT on `RooStorageDetector.detectStorageLocations()[0]`. The old
+ * per-storage-path keying meant every MCP host that detected a DIFFERENT storage
+ * location (Roo globalStorage vs Zoo globalStorage, or different client builds)
+ * elected itself leader of its own lock file → N concurrent indexers on the ONE
+ * shared `roo_tasks_semantic_index` collection → Qdrant congestion collapse.
+ * `os.tmpdir()` is machine-local and never GDrive-synced (unlike ROOSYNC_SHARED_PATH,
+ * which would replicate the lock cross-machine and re-split leaders) → all hosts on a
+ * machine compete for a SINGLE lock regardless of detected storage → exactly one
+ * indexing leader per machine (with ROO_FLEET_ROSTER partitioning = one leader per
+ * ~1/6 shard fleet-wide, the #2352 intent).
+ */
+export async function getLeaderLockPath(machineId: string): Promise<string> {
+    const safeId = (machineId || 'local').replace(/[^a-z0-9-]/gi, '-').toLowerCase();
+    return path.join(os.tmpdir(), `roosync-indexer-leader-${safeId}.lock`);
 }
 
 /**
  * Try to acquire or renew the leader lock. Non-blocking (single attempt).
  * Returns true if this process is the leader.
  */
-async function tryAcquireLeaderLock(): Promise<boolean> {
-    const lockPath = await getLeaderLockPath();
-    if (!lockPath) return true; // No storage → single-instance, assume leader
+async function tryAcquireLeaderLock(machineId: string): Promise<boolean> {
+    const lockPath = await getLeaderLockPath(machineId);
 
     const lockData = { pid: process.pid, timestamp: Date.now() };
 
@@ -1037,7 +1049,7 @@ export function startQdrantIndexingBackgroundProcess(state: ServerState): void {
         // #2352: Leader-election — only the leader does indexing
         if (!state.isIndexLeader) {
             // Try to become leader (non-blocking)
-            const won = await tryAcquireLeaderLock();
+            const won = await tryAcquireLeaderLock(state.machineId);
             if (won) {
                 state.isIndexLeader = true;
                 console.log(`🔑 [Leader-Election] PID ${process.pid} became indexing leader`);
@@ -1046,7 +1058,7 @@ export function startQdrantIndexingBackgroundProcess(state: ServerState): void {
             }
         } else {
             // Already leader — renew lock
-            const renewed = await tryAcquireLeaderLock();
+            const renewed = await tryAcquireLeaderLock(state.machineId);
             if (!renewed) {
                 state.isIndexLeader = false;
                 console.warn(`⚠️ [Leader-Election] PID ${process.pid} lost leadership (lock stolen). Stepping down.`);


### PR DESCRIPTION
## Summary

Fixes the structural driver of the fleet-degrading Qdrant storm: the `#2352` leader-election lock was keyed on `RooStorageDetector.detectStorageLocations()[0]` (**per-detected-storage-path**).

Machines with multiple detected storage locations — **Roo globalStorage (`RooVeterinaryInc.roo-cline`) + Zoo globalStorage (`ZooCodeOrganization.zoo-code`)**, or different client builds (qdrant-js 1.16.2 + 1.17.0) — each elected their own indexing leader. All N leaders indexed the **ONE shared `roo_tasks_semantic_index` collection** (~837k points) → `points/scroll` congestion collapse → sustained ~1200% Qdrant CPU fleet-wide.

## Fix

Key the lock on `machineId` under `os.tmpdir()`:

- `getLeaderLockPath(machineId)` / `tryAcquireLeaderLock(machineId)` → `os.tmpdir()/roosync-indexer-leader-<machineId>.lock` (machineId sanitized)
- Thread `state.machineId` through the 3 call-sites (startup L763 + Worker B attempt/renew L1049/L1058)
- Export `getLeaderLockPath` so the contract is testable

**Why `os.tmpdir()` not `ROOSYNC_SHARED_PATH`:** `ROOSYNC_SHARED_PATH` is GDrive-synced → the lock would replicate cross-machine and **re-split leaders** (the footgun re-armed). `os.tmpdir()` is machine-local (house convention — already used in `RooSettingsService` / `SchtasksConfigService`), stable cross-reboot, and the existing 15-min stale-takeover covers OS temp cleanup.

Combined with the existing `ROO_FLEET_ROSTER` task-space partitioning → one indexing leader per machine (~1/6 shard fleet-wide), the original #2352 intent.

## Validation
- `npm run build` (tsc) — clean, 0 errors
- `npx vitest run --config vitest.config.ci.ts` — **9948 passed, 23 skipped** (baseline 9943 + 5 new regression tests, 0 regressions)
- New regression tests prove the lock path is **invariant to detected storage locations** (`[rooPath]`, `[rooPath, zooPath]`, `[]` all yield the same machine-local path) — the exact bug scenario that shipped undetected

## Fleet grounding (cross-machine consensus, ai-01 sign-off)
- **po-2026** — root cause: `getLeaderLockPath()` keyed on `locations[0]` + shared-collection linchpin
- **po-2024** — adversarial verify + **correction**: rejected `ROOSYNC_SHARED_PATH` (GDrive) → machine-local
- **po-2025** — test gap: original tests mocked single-location only
- **po-2023** — impl feasibility: `state.machineId` in scope at all 3 call-sites; `os.tmpdir()` is house convention
- **ai-01** — sign-off: bug-fix of shipped feature → coordinator authority

## Known limitation
Effect only at next MCP host restart (rebuild ≠ hot-swap) → prevents **recurrence** of the storm class. Clearing the in-flight storm requires the user to close abandoned VS Code/Claude windows on ai-01 (19-33h stale hosts) — `[INTERACTIVE-ONLY]`.

## Parent repo
**No parent pointer-bump in `roo-extensions` until this PR merges** (anti-pointer-bump-premature #1799). Pointer-bump is a separate follow-up after merge.

Tracking: jsboige/roo-extensions#2352

🤖 Generated with [Claude Code](https://claude.com/claude-code)
