### PR TITLE
fix(indexing): trend_report crash on schema-drifted snapshots (#2623)

### DIFF
--- a/servers/roo-state-manager/src/tools/indexing/__tests__/roosync-indexing.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/indexing/__tests__/roosync-indexing.tool.test.ts
@@ -6,7 +6,16 @@
  * @module tools/indexing/__tests__/roosync-indexing.tool
  */
 
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Mutable shared-state path so trend_report tests can point at a temp dir.
+// vi.mock is hoisted, so the factory must reference this hoisted holder.
+const { sharedStatePathHolder } = vi.hoisted(() => ({
+	sharedStatePathHolder: { value: '' as string },
+}));
 
 const { mockIndexHandler, mockResetHandler, mockDiagnoseHandler, mockRebuildHandler,
 	mockArchiveTask, mockArchiveClaudeCodeSessions, mockListArchivedTasks, mockFindConversationById,
@@ -24,6 +33,12 @@ const { mockIndexHandler, mockResetHandler, mockDiagnoseHandler, mockRebuildHand
 	mockFsReadDir: vi.fn(),
 	mockFsReadFile: vi.fn(),
 	mockFsStat: vi.fn()
+}));
+
+// Default mock for shared-state-path — returns '' unless a test sets the holder.
+vi.mock('../../../utils/shared-state-path.js', () => ({
+	getSharedStatePath: () => sharedStatePathHolder.value,
+	tryGetSharedStatePath: () => sharedStatePathHolder.value,
 }));
 
 vi.mock('../../../services/task-archiver/index.js', () => ({
@@ -392,3 +407,100 @@ describe('roosync_indexing status action', () => {
 		expect(parsed.background_indexer.queue_size).toBe(1);
 	});
 });
+
+// ============================================================
+// trend_report action — #2623 schema-drift robustness
+// Older snapshots lack a `.tools` array; trend_report must not crash.
+// ============================================================
+
+describe('roosync_indexing trend_report action', () => {
+	const cache = new Map();
+	const ensureFresh = vi.fn().mockResolvedValue(true);
+	const saveSkeleton = vi.fn();
+	const setEnabled = vi.fn();
+	const mockRebuildHandler = vi.fn();
+
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rsm-trend-'));
+		sharedStatePathHolder.value = tmpDir;
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+		sharedStatePathHolder.value = '';
+	});
+
+	test('does not crash when previous snapshot has no .tools array (schema drift)', async () => {
+		const snapshotsDir = path.join(tmpDir, 'tool-usage-snapshots');
+		fs.mkdirSync(snapshotsDir, { recursive: true });
+
+		// Old-shape snapshot: no `.tools`, no `.weekly_trend` (pre per-tool breakdown).
+		const oldShape = {
+			action: 'tool_usage_stats', method: 'jsonl_scan',
+			date_range: { start: '2026-05-19', end: '2026-06-04', weeks: 2 },
+			files_scanned: 150, total_tool_calls: 25499, unique_tools: 38,
+			summary: '25499 calls across 38 tools',
+		};
+		// New-shape snapshot: has `.tools` + `.weekly_trend`.
+		const newShape = {
+			action: 'tool_usage_stats', method: 'jsonl_scan',
+			date_range: { start: '2026-05-19', end: '2026-06-17', weeks: 5 },
+			files_scanned: 194, total_tool_calls: 45181, unique_tools: 55,
+			tools: [
+				{ tool_name: 'Bash', calls: 15314, errors: 1042, error_rate: 6.8, retries: 11430, retry_rate: 74.6, downstream_actions: 9214, downstream_action_rate: 60.2 },
+				{ tool_name: 'Read', calls: 2808, errors: 44, error_rate: 1.6, retries: 874, retry_rate: 31.1, downstream_actions: 1836, downstream_action_rate: 65.4 },
+			],
+			weekly_trend: [],
+			summary: '45181 calls across 55 tools',
+		};
+		fs.writeFileSync(path.join(snapshotsDir, 'myia-po-2026-2026-06-04.json'), JSON.stringify(oldShape));
+		fs.writeFileSync(path.join(snapshotsDir, 'myia-po-2026-2026-06-17.json'), JSON.stringify(newShape));
+
+		const result: any = await handleRooSyncIndexing(
+			{ action: 'trend_report' },
+			cache, ensureFresh, saveSkeleton, new Set(), setEnabled, mockRebuildHandler
+		);
+
+		// Pre-#2623 this crashed with "Cannot read properties of undefined (reading 'map')".
+		expect(result.isError).toBe(false);
+		const text: string = result.content[0].text;
+		// Summary comparison still works (total_tool_calls present on both).
+		expect(text).toContain('| Total calls | 25499 | 45181');
+		// Schema-drift note surfaced.
+		expect(text).toContain('older schema');
+		// Latest per-tool table still rendered (baseline-only fallback).
+		expect(text).toContain('Bash');
+		expect(text).toContain('15314');
+	});
+
+	test('renders full per-tool trend when both snapshots have .tools', async () => {
+		const snapshotsDir = path.join(tmpDir, 'tool-usage-snapshots');
+		fs.mkdirSync(snapshotsDir, { recursive: true });
+
+		const prev = {
+			action: 'tool_usage_stats', total_tool_calls: 1000, unique_tools: 10, files_scanned: 50,
+			tools: [{ tool_name: 'Bash', calls: 500, errors: 10, error_rate: 2.0, retries: 50, retry_rate: 10.0, downstream_actions: 300, downstream_action_rate: 60.0 }],
+		};
+		const curr = {
+			action: 'tool_usage_stats', total_tool_calls: 2000, unique_tools: 12, files_scanned: 80,
+			tools: [{ tool_name: 'Bash', calls: 900, errors: 90, error_rate: 10.0, retries: 600, retry_rate: 66.7, downstream_actions: 600, downstream_action_rate: 66.7 }],
+		};
+		fs.writeFileSync(path.join(snapshotsDir, 'm-2026-06-10.json'), JSON.stringify(prev));
+		fs.writeFileSync(path.join(snapshotsDir, 'm-2026-06-17.json'), JSON.stringify(curr));
+
+		const result: any = await handleRooSyncIndexing(
+			{ action: 'trend_report' },
+			cache, ensureFresh, saveSkeleton, new Set(), setEnabled, mockRebuildHandler
+		);
+
+		expect(result.isError).toBe(false);
+		const text: string = result.content[0].text;
+		// Files-scanned row present (both have it).
+		expect(text).toContain('| Files scanned | 50 | 80');
+		// No schema-drift note.
+		expect(text).not.toContain('older schema');
+	});
+});
+

--- a/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
+++ b/servers/roo-state-manager/src/tools/indexing/roosync-indexing.tool.ts
@@ -1193,6 +1193,9 @@ export async function handleRooSyncIndexing(
 
                 const latest = snapshots[snapshots.length - 1];
                 const previous = snapshots.length > 1 ? snapshots[snapshots.length - 2] : null;
+                // #2623: older snapshots (pre per-tool shape) may lack `.tools`/`.weekly_trend`/`.files_scanned`.
+                // Defend against schema drift instead of crashing on undefined.map().
+                const previousHasTools = !!(previous && Array.isArray(previous.tools));
 
                 // Build trend report as markdown
                 const lines: string[] = [];
@@ -1213,7 +1216,14 @@ export async function handleRooSyncIndexing(
                     lines.push(`|--------|----------|--------|--------|`);
                     lines.push(`| Total calls | ${previous.total_tool_calls} | ${latest.total_tool_calls} | ${arrow(callsDiff)} |`);
                     lines.push(`| Unique tools | ${previous.unique_tools} | ${latest.unique_tools} | ${arrow(toolsDiff)} |`);
-                    lines.push(`| Files scanned | ${previous.files_scanned} | ${latest.files_scanned} | ${arrow(latest.files_scanned - previous.files_scanned)} |`);
+                    // #2623: files_scanned may be absent on older snapshots — show only when both present.
+                    if (typeof previous.files_scanned === 'number' && typeof latest.files_scanned === 'number') {
+                        lines.push(`| Files scanned | ${previous.files_scanned} | ${latest.files_scanned} | ${arrow(latest.files_scanned - previous.files_scanned)} |`);
+                    }
+                    if (!previousHasTools) {
+                        lines.push(``);
+                        lines.push(`> Note: previous snapshot has no per-tool breakdown (older schema). Per-tool trend shows latest only.`);
+                    }
                 } else {
                     lines.push(`Baseline snapshot only — no comparison available yet.`);
                     lines.push(`- Total calls: ${latest.total_tool_calls}`);
@@ -1222,10 +1232,10 @@ export async function handleRooSyncIndexing(
                 }
                 lines.push(``);
 
-                // Per-tool trend (top 20)
+                // Per-tool trend (top 20) — requires both snapshots to have a `.tools` array (#2623 schema drift guard).
                 lines.push(`## Per-Tool Trend (Top 20)`);
                 lines.push(``);
-                if (previous) {
+                if (previousHasTools) {
                     const prevMap: Map<string, any> = new Map(previous.tools.map((t: any) => [t.tool_name, t]));
                     const rows = latest.tools.slice(0, 20).map((t: any) => {
                         const p: any = prevMap.get(t.tool_name);


### PR DESCRIPTION
## Problem

`roosync_indexing(action: "trend_report")` crashed with:
```
Error during trend_report: Cannot read properties of undefined (reading 'map')
```

## Root cause (verified)

`trend_report` loads the 2 most recent snapshots from `<shared>/tool-usage-snapshots/` and assumes every snapshot carries a `.tools` array:

```ts
const prevMap = new Map(previous.tools.map((t) => [t.tool_name, t]));
```

But snapshots produced by earlier `tool_usage_stats` versions only carry an aggregate `.summary` — no `.tools`, no `.weekly_trend`, no `.files_scanned`. On po-2026 the dir contained:
- `myia-po-2026-2026-06-04.json` — old shape, **no `.tools`**
- `myia-po-2026-2026-06-17.json` — new shape, has `.tools`

Comparing the two → `previous.tools` is `undefined` → `undefined.map()` → crash.

This blocks **#2336 D4** (the recurring `save_snapshot` → `trend_report` loop the user mandate requires: *"voir usage↑/utilité↑ vs cycle précédent"*). The infra exists (`save_snapshot` + `trend_report`, both tagged `#2336 D3`) but `trend_report` was unusable as soon as a single legacy snapshot was present.

## Fix

- Derive `previousHasTools` from `Array.isArray(previous.tools)`; gate the per-tool trend section on it.
- When the previous snapshot lacks the breakdown, render a baseline-only per-tool table (latest) instead of crashing.
- Summary comparison degrades gracefully: `files_scanned` row omitted when absent on either side; a note surfaces the schema drift.
- No behavior change when both snapshots are well-formed.

## Tests

2 regression cases added in `roosync-indexing.tool.test.ts`:
1. **Previous snapshot without `.tools`** — no longer crashes; summary comparison + latest per-tool table still render; schema-drift note present.
2. **Two well-formed snapshots** — full per-tool trend still renders; no drift note.

All 22 tests in the file pass; full indexing suite (11 files, 150 tests) green. Build clean.

## Scope

Chirurgical (rule #1936) — 16 LOC in handler + 114 LOC tests. Only the `trend_report` action touched.

## Activation

Source fix. Live activation requires MCP host restart (`[INTERACTIVE-ONLY]`) — same gating as the pending fleet storm-fix restart.

Closes #2623. Unblocks #2336 D4 automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>