### PR TITLE
feat(compare-config): detect ROO_FLEET_ROSTER drift vs dashboard machines (#2570)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/compare-config.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/compare-config.test.ts
@@ -656,4 +656,95 @@ describe('compare-config', () => {
 			expect(result.summary.critical).toBe(1);
 		});
 	});
+
+	// ============================================================
+	// #2570 — ROO_FLEET_ROSTER consistency check
+	// ============================================================
+	describe('roosyncCompareConfig — fleet roster consistency (#2570)', () => {
+		const FLEET_6 = ['myia-ai-01', 'myia-po-2023', 'myia-po-2024', 'myia-po-2025', 'myia-po-2026', 'myia-web1'];
+		const FLEET_5_MISSING_2024 = ['myia-ai-01', 'myia-po-2023', 'myia-po-2025', 'myia-po-2026', 'myia-web1'];
+
+		function mockDashboard6() {
+			const machines: Record<string, { status: string }> = {};
+			for (const m of FLEET_6) machines[m] = { status: 'online' };
+			mockLoadDashboard.mockResolvedValue({ machines });
+		}
+
+		test('WARNING when ROO_FLEET_ROSTER unset (partitioning disabled)', async () => {
+			mockGetConfig.mockReturnValue({ machineId: 'myia-po-2024', sharedPath: '/shared', fleetRoster: null });
+			mockDashboard6();
+			mockCompareRealConfigurations.mockResolvedValue({
+				sourceMachine: 'myia-po-2024', targetMachine: 'myia-ai-01', hostId: 'myia-po-2024', differences: []
+			});
+
+			const result = await roosyncCompareConfig({ target: 'myia-ai-01' });
+
+			const rosterDiff = result.differences.find(d => d.path === 'env.ROO_FLEET_ROSTER');
+			expect(rosterDiff).toBeDefined();
+			expect(rosterDiff!.severity).toBe('WARNING');
+			expect(rosterDiff!.description).toContain('partitioning DÉSACTIVÉ');
+		});
+
+		test('CRITICAL when roster size mismatches dashboard (5 vs 6 → partition drift)', async () => {
+			mockGetConfig.mockReturnValue({ machineId: 'myia-po-2026', sharedPath: '/shared', fleetRoster: FLEET_5_MISSING_2024 });
+			mockDashboard6();
+			mockCompareRealConfigurations.mockResolvedValue({
+				sourceMachine: 'myia-po-2026', targetMachine: 'myia-ai-01', hostId: 'myia-po-2026', differences: []
+			});
+
+			const result = await roosyncCompareConfig({ target: 'myia-ai-01' });
+
+			const rosterDiff = result.differences.find(d => d.path === 'env.ROO_FLEET_ROSTER');
+			expect(rosterDiff).toBeDefined();
+			expect(rosterDiff!.severity).toBe('CRITICAL');
+			expect(rosterDiff!.description).toContain('Mismatch taille');
+			expect(rosterDiff!.description).toContain('myia-po-2024');
+		});
+
+		test('CRITICAL when roster content differs from dashboard (same size, different members)', async () => {
+			// Same size 6 but one member swapped
+			const swapped = [...FLEET_6];
+			swapped[swapped.indexOf('myia-po-2024')] = 'myia-phantom';
+			mockGetConfig.mockReturnValue({ machineId: 'myia-po-2024', sharedPath: '/shared', fleetRoster: swapped });
+			mockDashboard6();
+			mockCompareRealConfigurations.mockResolvedValue({
+				sourceMachine: 'myia-po-2024', targetMachine: 'myia-ai-01', hostId: 'myia-po-2024', differences: []
+			});
+
+			const result = await roosyncCompareConfig({ target: 'myia-ai-01' });
+
+			const rosterDiff = result.differences.find(d => d.path === 'env.ROO_FLEET_ROSTER');
+			expect(rosterDiff).toBeDefined();
+			expect(rosterDiff!.severity).toBe('CRITICAL');
+			expect(rosterDiff!.description).toContain('Mismatch contenu');
+		});
+
+		test('INFO when roster consistent with dashboard (6/6 canonical)', async () => {
+			mockGetConfig.mockReturnValue({ machineId: 'myia-po-2024', sharedPath: '/shared', fleetRoster: FLEET_6 });
+			mockDashboard6();
+			mockCompareRealConfigurations.mockResolvedValue({
+				sourceMachine: 'myia-po-2024', targetMachine: 'myia-ai-01', hostId: 'myia-po-2024', differences: []
+			});
+
+			const result = await roosyncCompareConfig({ target: 'myia-ai-01' });
+
+			const rosterDiff = result.differences.find(d => d.path === 'env.ROO_FLEET_ROSTER');
+			expect(rosterDiff).toBeDefined();
+			expect(rosterDiff!.severity).toBe('INFO');
+			expect(rosterDiff!.description).toContain('consistant');
+		});
+
+		test('no roster diff when dashboard load fails (never breaks compare_config)', async () => {
+			mockGetConfig.mockReturnValue({ machineId: 'myia-po-2024', sharedPath: '/shared', fleetRoster: null });
+			mockLoadDashboard.mockRejectedValue(new Error('GDrive offline'));
+			mockCompareRealConfigurations.mockResolvedValue({
+				sourceMachine: 'myia-po-2024', targetMachine: 'myia-ai-01', hostId: 'myia-po-2024', differences: []
+			});
+
+			const result = await roosyncCompareConfig({ target: 'myia-ai-01' });
+
+			const rosterDiff = result.differences.find(d => d.path === 'env.ROO_FLEET_ROSTER');
+			expect(rosterDiff).toBeUndefined(); // check silently skipped, compare_config still returns
+		});
+	});
 });

--- a/servers/roo-state-manager/src/tools/roosync/compare-config.ts
+++ b/servers/roo-state-manager/src/tools/roosync/compare-config.ts
@@ -237,7 +237,8 @@ export async function roosyncCompareConfig(args: CompareConfigArgs): Promise<Com
 
     // Settings comparison: uses RooSettingsService + GDrive published settings
     if (args.granularity === 'settings') {
-      return await compareSettings(sourceMachineId, targetMachineId, service, args.filter);
+      const settingsResult = await compareSettings(sourceMachineId, targetMachineId, service, args.filter);
+      return withRosterCheck(settingsResult, config, service);
     }
 
     // Si granularity est fourni, utiliser GranularDiffDetector
@@ -370,7 +371,11 @@ export async function roosyncCompareConfig(args: CompareConfigArgs): Promise<Com
       }
 
       // Convertir au format CompareConfigResult (avec comparaison model profiles #498)
-      return formatGranularReport(granularReport, filteredDiffs, sourceMachineId, targetMachineId, args.granularity, sourceInventory, targetInventory);
+      return withRosterCheck(
+        formatGranularReport(granularReport, filteredDiffs, sourceMachineId, targetMachineId, args.granularity, sourceInventory, targetInventory),
+        config,
+        service
+      );
     }
 
     // Comparaison standard (sans granularité)
@@ -388,7 +393,7 @@ export async function roosyncCompareConfig(args: CompareConfigArgs): Promise<Com
     }
 
     // Formatter le rapport pour l'affichage
-    return formatComparisonReport(report, 'full');
+    return withRosterCheck(formatComparisonReport(report, 'full'), config, service);
     
   } catch (error) {
     if (error instanceof RooSyncServiceError) {
@@ -772,6 +777,147 @@ function formatGranularReport(
     differences: allDifferences,
     summary
   };
+}
+
+/**
+ * Merge les diffs de cohérence roster (#2570) dans un CompareConfigResult déjà construit,
+ * puis recalcule le summary. Garde les formatters synchrones — l'appelant (async) await ce helper.
+ */
+async function withRosterCheck(
+  result: CompareConfigResult,
+  config: any,
+  service: any
+): Promise<CompareConfigResult> {
+  try {
+    const rosterDiffs = await checkRosterConsistency(config, service);
+    if (rosterDiffs.length === 0) return result;
+
+    // Éviter le doublon si un diff roster existe déjà (path env.ROO_FLEET_ROSTER)
+    const existingPaths = new Set(result.differences.map(d => d.path));
+    const newDiffs = rosterDiffs.filter(d => !existingPaths.has(d.path));
+
+    const allDifferences = [...result.differences, ...newDiffs];
+    return {
+      ...result,
+      differences: allDifferences,
+      summary: {
+        total: allDifferences.length,
+        critical: allDifferences.filter(d => d.severity === 'CRITICAL').length,
+        important: allDifferences.filter(d => d.severity === 'IMPORTANT').length,
+        warning: allDifferences.filter(d => d.severity === 'WARNING').length,
+        info: allDifferences.filter(d => d.severity === 'INFO').length
+      }
+    };
+  } catch {
+    // Le check roster ne doit JAMAIS casser compare_config — c'est un diagnostic additionnel
+    return result;
+  }
+}
+
+/**
+ * Check la cohérence du ROO_FLEET_ROSTER local contre les machines connues du dashboard (#2570).
+ *
+ * Le roster (env var) drive le hash-based task-space partitioning (task-partition.ts).
+ * Il n'a aucune source-of-truth dans le repo ni dans les inventory snapshots GDrive,
+ * donc le drift entre machines passe silencieusement (certaines 5-machine, d'autres unset).
+ * Le dashboard partagé est la seule source canonique des machines vivantes de la flotte.
+ *
+ * @param config Config RooSync (contient fleetRoster parsé + machineId)
+ * @param service RooSyncService (pour loadDashboard)
+ * @returns Diff(s) si le roster local diverge des machines du dashboard, [] sinon
+ */
+async function checkRosterConsistency(
+  config: any,
+  service: any
+): Promise<Array<{
+  category: string;
+  severity: string;
+  path: string;
+  description: string;
+  action?: string;
+}>> {
+  const diffs: Array<{
+    category: string;
+    severity: string;
+    path: string;
+    description: string;
+    action?: string;
+  }> = [];
+
+  const localRoster: string[] | null = config?.fleetRoster ?? null;
+
+  // Charger les machines connues du dashboard (source canonique flotte)
+  let dashboardMachines: string[] = [];
+  try {
+    const dashboard = await service.loadDashboard();
+    dashboardMachines = Object.keys(dashboard.machines || {}).sort();
+  } catch {
+    // Dashboard injoignable (GDrive offline) — on ne peut pas comparer, skip silencieux
+    return diffs;
+  }
+
+  if (dashboardMachines.length === 0) {
+    return diffs; // Pas de machines de référence → rien à comparer
+  }
+
+  const dashSet = new Set(dashboardMachines);
+
+  if (!localRoster) {
+    // Roster unset → partitioning DISABLED (cette machine indexe tout l'espace)
+    diffs.push({
+      category: 'environment',
+      severity: 'WARNING',
+      path: 'env.ROO_FLEET_ROSTER',
+      description: `ROO_FLEET_ROSTER non défini — partitioning DÉSACTIVÉ. Cette machine indexe la totalité du task-space (pas de shard filtering), tandis que le dashboard voit ${dashboardMachines.length} machines (${dashboardMachines.join(', ')}). Contributeur de redondance d'indexation silencieuse (#2570).`,
+      action: `Définir ROO_FLEET_ROSTER="${dashboardMachines.join(',')}" dans ~/.claude.json mcpServers.roo-state-manager.env, puis restart MCP + roosync_indexing(rebuild)`
+    });
+    return diffs;
+  }
+
+  const rosterSet = new Set(localRoster);
+  const rosterSorted = [...localRoster].sort();
+
+  // Mismatch de taille (5 vs 6 décale ~tous les buckets — hash % size)
+  if (rosterSorted.length !== dashboardMachines.length) {
+    const missingFromRoster = dashboardMachines.filter(m => !rosterSet.has(m));
+    const extraInRoster = rosterSorted.filter(m => !dashSet.has(m));
+    const detail: string[] = [`roster=${rosterSorted.length} (${rosterSorted.join(', ')})`, `dashboard=${dashboardMachines.length} (${dashboardMachines.join(', ')})`];
+    if (missingFromRoster.length) detail.push(`manquantes du roster: ${missingFromRoster.join(', ')}`);
+    if (extraInRoster.length) detail.push(`absentes du dashboard: ${extraInRoster.join(', ')}`);
+    diffs.push({
+      category: 'environment',
+      severity: 'CRITICAL',
+      path: 'env.ROO_FLEET_ROSTER',
+      description: `Mismatch taille ROO_FLEET_ROSTER — partition drift. ${detail.join(' | ')}. Un écart de taille (hash % roster.length) décale ~TOUS les buckets, pas seulement le shard de la machine manquante → recall/precision dégradés silencieusement (#2570).`,
+      action: `Aligner sur le roster canonique "${dashboardMachines.join(',')}" sur TOUTES les machines simultanément, puis restart MCP + roosync_indexing(rebuild) sur chacune (migration task-partition.ts)`
+    });
+    return diffs;
+  }
+
+  // Même taille mais contenu diffère
+  const sameContent = rosterSorted.every((m, i) => m === dashboardMachines[i]);
+  if (!sameContent) {
+    const missingFromRoster = dashboardMachines.filter(m => !rosterSet.has(m));
+    const extraInRoster = rosterSorted.filter(m => !dashSet.has(m));
+    diffs.push({
+      category: 'environment',
+      severity: 'CRITICAL',
+      path: 'env.ROO_FLEET_ROSTER',
+      description: `Mismatch contenu ROO_FLEET_ROSTER (même taille, membres différents). roster=${rosterSorted.join(', ')} vs dashboard=${dashboardMachines.join(', ')}. Manquantes du roster: ${missingFromRoster.join(',') || 'none'}. Absentes du dashboard: ${extraInRoster.join(',') || 'none'}. → partition drift (#2570).`,
+      action: `Aligner sur le roster canonique "${dashboardMachines.join(',')}"`
+    });
+    return diffs;
+  }
+
+  // Roster consistant — signal positif INFO (utile pour l'audit flotte)
+  diffs.push({
+    category: 'environment',
+    severity: 'INFO',
+    path: 'env.ROO_FLEET_ROSTER',
+    description: `ROO_FLEET_ROSTER consistant avec le dashboard flotte (${rosterSorted.length} machines: ${rosterSorted.join(', ')}). Partitioning sain.`
+  });
+
+  return diffs;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes detection gap for **#2570** — `ROO_FLEET_ROSTER` drift between fleet machines was invisible to every supervision tool.

### Root cause (confirmed by code)
`ROO_FLEET_ROSTER` drives hash-based task-space partitioning ([`task-partition.ts:54-58`](servers/roo-state-manager/src/services/task-partition.ts#L54-L58): `hash % roster.length`). It has:
- **No source-of-truth** in the repo (`git grep` = 0 hits outside docs)
- **Not captured** in GDrive inventory snapshots (`InventoryCollector` doesn't read `mcpServers.env`)
- **Not compared** by `compare_config(mcp)` (reads Roo `mcp_settings.json`, not Claude `~/.claude.json`)

So when po-2024 joined the fleet, its config got the 6-machine roster but propagation to siblings was incomplete → silent drift (some 5-machine, web1 unset). #2570 documented the drift manually; this PR makes it **detectable**.

### Change

Adds `checkRosterConsistency(config, service)` in [`compare-config.ts`](servers/roo-state-manager/src/tools/roosync/compare-config.ts): compares the local effective `fleetRoster` (env var, already parsed at startup in `roosync-config.ts:202`) against `dashboard.machines` keys — the canonical source of live fleet machines (no GDrive inventory dependency).

Surfaces 4 states:

| State | Severity | Meaning |
|-------|----------|---------|
| unset | WARNING | Partitioning disabled — this machine indexes the full task-space (no shard filtering) |
| size mismatch | CRITICAL | 5 vs 6 shifts **~all** buckets (`hash % 5 ≠ hash % 6`), not just the missing machine's shard → recall/precision degraded silently |
| content mismatch (same size) | CRITICAL | Members differ → partition drift |
| consistent | INFO | Roster matches dashboard — positive audit signal for fleet-wide rollout tracking |

Wrapped via `withRosterCheck(result, config, service)` at all 3 return paths (granular / standard / settings). The check is **best-effort**: dashboard load failures (GDrive offline) are caught and skipped silently — `compare_config` never breaks because of it.

### Tests
5 new tests in [`compare-config.test.ts`](servers/roo-state-manager/src/tools/roosync/__tests__/compare-config.test.ts) under `#2570 — fleet roster consistency`:
- WARNING on unset roster
- CRITICAL on size mismatch (verifies the missing machine name appears in the description)
- CRITICAL on content mismatch (same size, swapped member)
- INFO on consistent 6/6
- No diff when dashboard load fails (never breaks compare_config)

Build: `tsc` ✅. Existing 342 tool tests still pass (no regression).

### Usage

Each executor machine now gets fleet-roster visibility by running:
```
roosync_compare_config(granularity: "mcp")
```
A CRITICAL/WARNING `env.ROO_FLEET_ROSTER` diff surfaces the local drift. Coordinated rollout (set canonical 6 + restart + rebuild) remains [INTERACTIVE-ONLY] coordinator orchestration — but the detection is now automated instead of requiring manual I4 patrol.

### Out of scope (deliberate, #1936)
- No canonical-roster template file created (would be a separate decision — where it lives, deploy mechanism)
- No inventory-snapshot capture of the roster (separate `InventoryCollector` change)
- No auto-fix (roster change requires fleet-wide simultaneous rollout per migration docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
