### PR TITLE
feat(search): post-filter dead-path hits in codebase_search (#2609/#2554)

### DIFF
--- a/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
@@ -7,11 +7,19 @@
 
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const { mockGetQdrantClient, mockQdrant, mockEmbeddingCreate } = vi.hoisted(() => ({
+const { mockGetQdrantClient, mockQdrant, mockEmbeddingCreate, mockExistsSync } = vi.hoisted(() => ({
 	mockGetQdrantClient: vi.fn(),
 	mockQdrant: { getCollection: vi.fn(), query: vi.fn(), getCollections: vi.fn() },
-	mockEmbeddingCreate: vi.fn()
+	mockEmbeddingCreate: vi.fn(),
+	// #2609/#2554: mock existsSync so dead-path filtering is deterministic.
+	// Default true = all files reachable (preserves existing test expectations).
+	mockExistsSync: vi.fn(() => true)
 }));
+
+vi.mock('fs', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('fs')>();
+	return { ...actual, existsSync: mockExistsSync };
+});
 
 vi.mock('../../../services/qdrant.js', () => ({
 	getQdrantClient: mockGetQdrantClient
@@ -35,6 +43,8 @@ describe('search-codebase.tool', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockGetQdrantClient.mockReturnValue(mockQdrant);
+		// Default: all files reachable. Individual tests override to simulate dead paths.
+		mockExistsSync.mockReturnValue(true);
 	});
 
 	// ============================================================
@@ -386,6 +396,78 @@ describe('search-codebase.tool', () => {
 					filter: expect.objectContaining({ must: expect.any(Array) })
 				})
 			);
+		});
+
+		// ============================================================
+		// #2609/#2554 — dead-path post-filter (rename-GC gap mitigation)
+		// ============================================================
+
+		describe('handleCodebaseSearch - dead-path filtering (#2609/#2554)', () => {
+			beforeEach(() => {
+				process.env.EMBEDDING_API_KEY = 'test-key';
+				mockQdrant.getCollection.mockResolvedValue({ status: 'green' });
+				mockEmbeddingCreate.mockResolvedValue({
+					data: [{ embedding: new Array(8).fill(0.1) }]
+				});
+			});
+
+			afterEach(() => {
+				delete process.env.EMBEDDING_API_KEY;
+			});
+
+			test('filters out hits whose filePath no longer exists on disk', async () => {
+				// Simulate a renamed/archived doc: live hit + dead orphan (old path)
+				mockExistsSync.mockImplementation((p: string) =>
+					String(p).endsWith('live-doc.ts')
+				);
+				mockQdrant.query.mockResolvedValue({
+					points: [
+						{ score: 0.82, payload: { filePath: 'src/live-doc.ts', codeChunk: 'live code', startLine: 1, endLine: 5 } },
+						{ score: 0.78, payload: { filePath: 'docs/archive/dead-doc.ts', codeChunk: 'orphan', startLine: 1, endLine: 2 } }
+					]
+				});
+
+				const result = await handleCodebaseSearch({ query: 'doc', workspace: '/ws' });
+				const parsed = JSON.parse(result.content[0].text);
+				expect(parsed.results_count).toBe(1);
+				expect(parsed.results[0].file_path).toBe('src/live-doc.ts');
+				expect(parsed.dead_paths_filtered).toBe(1);
+				expect(parsed.warning).toBeUndefined();
+			});
+
+			test('returns raw hits with warning when ALL paths are dead (degenerate workspace root)', async () => {
+				// Every filePath unreachable → likely wrong workspace root or unmounted drive.
+				// Don't silently return 0; surface the raw hits + warning instead.
+				mockExistsSync.mockReturnValue(false);
+				mockQdrant.query.mockResolvedValue({
+					points: [
+						{ score: 0.8, payload: { filePath: 'src/a.ts', codeChunk: 'a', startLine: 1, endLine: 1 } },
+						{ score: 0.7, payload: { filePath: 'src/b.ts', codeChunk: 'b', startLine: 1, endLine: 1 } }
+					]
+				});
+
+				const result = await handleCodebaseSearch({ query: 'x', workspace: '/wrong-ws' });
+				const parsed = JSON.parse(result.content[0].text);
+				expect(parsed.results_count).toBe(2);
+				expect(parsed.dead_paths_filtered).toBeUndefined();
+				expect(parsed.warning).toMatch(/all hits resolved to dead paths/);
+			});
+
+			test('resolves relative filePath against the workspace root', async () => {
+				// existsSync receives the joined absolute path: workspaceRoot + relative filePath.
+				const seen: string[] = [];
+				mockExistsSync.mockImplementation((p: string) => {
+					seen.push(String(p));
+					return true;
+				});
+				mockQdrant.query.mockResolvedValue({
+					points: [{ score: 0.8, payload: { filePath: 'src/foo.ts', codeChunk: 'foo', startLine: 1, endLine: 1 } }]
+				});
+
+				await handleCodebaseSearch({ query: 'foo', workspace: '/my/ws' });
+				// The joined path must contain both the workspace root and the relative filePath.
+				expect(seen.some((p) => p.includes('my') && p.includes('foo.ts'))).toBe(true);
+			});
 		});
 	});
 

--- a/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
@@ -13,6 +13,29 @@ import { createHash } from 'crypto';
 import OpenAI from 'openai';
 import { getQdrantClient } from '../../services/qdrant.js';
 import { resolveWorkspace } from '../../utils/workspace-resolver.js';
+import { existsSync } from 'fs';
+import { isAbsolute, join } from 'path';
+
+/**
+ * #2609/#2554 (rename-GC gap): the Roo/Zoo Code indexer (reference-only submodule
+ * roo-code) lacks reliable garbage-collection of vectors whose source file was
+ * renamed/moved/deleted. Surviving orphans make codebase_search return dead paths
+ * (e.g. docs archived via `git mv`). Since the MCP only reads the ws-* collections,
+ * we post-filter hits whose resolved filePath no longer exists on disk.
+ *
+ * Returns true if the file is reachable (keep the hit), false if it is a dead path
+ * (filter out). Resolves relative payloads against the workspace root; absolute
+ * payloads are checked as-is.
+ */
+function isFilePathReachable(filePath: string, workspaceRoot: string): boolean {
+	try {
+		const resolved = isAbsolute(filePath) ? filePath : join(workspaceRoot, filePath);
+		return existsSync(resolved);
+	} catch {
+		// On any FS error, be permissive (don't nuke legitimate hits on edge cases).
+		return true;
+	}
+}
 
 /**
  * Génère le nom de collection Qdrant pour un workspace (même convention que Roo)
@@ -407,19 +430,43 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 		});
 
 		// 6. Formater les résultats
-		const results = searchResults.points
-			.filter((p: any) => p.payload?.filePath && p.payload?.codeChunk)
-			.map((point: any) => ({
-				file_path: point.payload.filePath,
-				score: point.score,
-				relevance: interpretScore(point.score),
-				snippet: extractSnippet(point.payload.codeChunk || '', query),
-				start_line: point.payload.startLine,
-				end_line: point.payload.endLine,
-				lines: point.payload.startLine && point.payload.endLine
-					? `${point.payload.startLine}-${point.payload.endLine}`
-					: undefined
-			}));
+		// #2609/#2554: post-filter dead paths (orphans from rename/delete that the
+		// roo-code indexer failed to GC). Filter only AFTER building the full candidate
+		// list so we can detect the degenerate case where every hit is dead (e.g. wrong
+		// workspace root, unmounted drive) and avoid silently returning 0 results.
+		const rawHits: any[] = (searchResults.points || [])
+			.filter((p: any) => p.payload?.filePath && p.payload?.codeChunk);
+
+		const liveHits: any[] = [];
+		let deadPathsFiltered = 0;
+		for (const point of rawHits) {
+			if (isFilePathReachable(point.payload.filePath, workspace)) {
+				liveHits.push(point);
+			} else {
+				deadPathsFiltered++;
+			}
+		}
+
+		// Safety: if filtering killed ALL hits, the workspace root is likely wrong or
+		// the drive is unmounted — return the raw hits with a warning instead of an
+		// empty list, so the caller gets a signal rather than a silent zero.
+		const allDead = rawHits.length > 0 && liveHits.length === 0;
+		const finalHits = allDead ? rawHits : liveHits;
+		if (allDead) {
+			deadPathsFiltered = 0; // rawHits returned as-is, nothing actually filtered out
+		}
+
+		const results = finalHits.map((point: any) => ({
+			file_path: point.payload.filePath,
+			score: point.score,
+			relevance: interpretScore(point.score),
+			snippet: extractSnippet(point.payload.codeChunk || '', query),
+			start_line: point.payload.startLine,
+			end_line: point.payload.endLine,
+			lines: point.payload.startLine && point.payload.endLine
+				? `${point.payload.startLine}-${point.payload.endLine}`
+				: undefined
+		}));
 
 		// 7. Construire la réponse
 		const response = {
@@ -430,6 +477,9 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 			collection: collectionName,
 			results_count: results.length,
 			min_score_used: effectiveMinScore,
+			// #2609/#2554: dead-path filtering observability
+			...(deadPathsFiltered > 0 ? { dead_paths_filtered: deadPathsFiltered } : {}),
+			...(allDead ? { warning: 'all hits resolved to dead paths — workspace root may be wrong or drive unmounted; returning raw results unfiltered' } : {}),
 			results: results
 		};
 


### PR DESCRIPTION
## Context

Cross-machine finding (web1 c.15/16, po-2023 c.21/22, po-2026): `codebase_search` returns vectors for files that have been renamed/moved/deleted — e.g. `worktree-cleanup-protocol.md` archived to `docs/archive/` via #2617 still appears under its old path.

## Root cause (investigated, code-grounded)

The codebase indexer lives in the **roo-code submodule** (reference-only, `roo-code/src/services/code-index/`), NOT in this MCP. This MCP only **reads** the `ws-*` collections. The indexer DOES have GC (3 paths: startup-scan orphan GC, pre-upsert delete, live file-watcher), but orphans survive due to reachability gaps:

- GC keys off `processedFiles` from the mutable cache file. If the cache was cleared (collection-create, mid-scan failure), `getAllHashes()` no longer lists the old path → its vectors become permanent orphans.
- No `onDidRename` handler; rename-while-VS-Code-closed is only caught on next startup IF the cache still holds the old absolute path.
- Point ID = content hash; a renamed file creates new points, old points only removable by path-based delete.

**True root-cause fix belongs upstream** in `roo-code/src/services/code-index/processors/scanner.ts:332-376` (reconcile GC against Qdrant itself, not the cache). That's a separate upstream effort (reference-only submodule).

## This PR — read-side mitigation

Post-filter hits in `codebase_search` whose resolved `filePath` no longer exists on disk, so the tool returns exploitable results per **#2554 exit criteria** (`codebase_search` returns pertinent results).

- Resolve relative `filePath` payloads against the workspace root; absolute payloads checked as-is.
- `dead_paths_filtered` counter in the response (only when > 0) for observability.
- **Safety net:** if ALL hits resolve to dead paths (wrong workspace root / unmounted drive), return raw hits + `warning` instead of silently returning 0 results.
- Permissive on any FS error (don't nuke legitimate hits on edge cases).

## Tests

- 3 new tests under `dead-path filtering (#2609/#2554)`: filters dead path + reports counter, all-dead degenerate case returns raw + warning, relative-path resolution.
- Existing 37 tests preserved via mocked `existsSync` (default `true`).
- Full CI suite: **503 files / 9958 tests passed, 0 failure** (3 new tests).

## Scope

Minimal, surgical. No signature change to the public handler. No new deps. The `warning`/`dead_paths_filtered` fields are additive (conditional spread).

Refs #2609, #2554 (Cause 3 — rename-GC gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)