### PR TITLE
feat(search): warn on partial dead-path recall shrink in codebase_search (#2609/#2554)

### DIFF
--- a/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
@@ -416,7 +416,10 @@ describe('search-codebase.tool', () => {
 			});
 
 			test('filters out hits whose filePath no longer exists on disk', async () => {
-				// Simulate a renamed/archived doc: live hit + dead orphan (old path)
+				// Simulate a renamed/archived doc: live hit + dead orphan (old path).
+				// limit: 2 with 1 live + 1 dead → results_count=1 < limit=2 → the dead-path
+				// filter shrank recall below the requested limit, so a partial-shrink warning
+				// MUST be emitted (otherwise the caller gets no signal that recall was reduced).
 				mockExistsSync.mockImplementation((p: string) =>
 					String(p).endsWith('live-doc.ts')
 				);
@@ -427,10 +430,32 @@ describe('search-codebase.tool', () => {
 					]
 				});
 
-				const result = await handleCodebaseSearch({ query: 'doc', workspace: '/ws' });
+				const result = await handleCodebaseSearch({ query: 'doc', workspace: '/ws', limit: 2 });
 				const parsed = JSON.parse(result.content[0].text);
 				expect(parsed.results_count).toBe(1);
 				expect(parsed.results[0].file_path).toBe('src/live-doc.ts');
+				expect(parsed.dead_paths_filtered).toBe(1);
+				expect(parsed.warning).toMatch(/dead-path filter reduced recall/);
+			});
+
+			test('does NOT warn when dead paths exist but recall did not shrink below limit', async () => {
+				// Distinguishing test (anti-faux-positif): limit: 1 with 1 live + 1 dead →
+				// results_count=1 === limit=1 → recall was NOT shrunk below the limit, so no
+				// warning must be emitted. Proves the warning is gated on the recall shrink,
+				// not on the mere presence of dead paths.
+				mockExistsSync.mockImplementation((p: string) =>
+					String(p).endsWith('live-doc.ts')
+				);
+				mockQdrant.query.mockResolvedValue({
+					points: [
+						{ score: 0.82, payload: { filePath: 'src/live-doc.ts', codeChunk: 'live code', startLine: 1, endLine: 5 } },
+						{ score: 0.78, payload: { filePath: 'docs/archive/dead-doc.ts', codeChunk: 'orphan', startLine: 1, endLine: 2 } }
+					]
+				});
+
+				const result = await handleCodebaseSearch({ query: 'doc', workspace: '/ws', limit: 1 });
+				const parsed = JSON.parse(result.content[0].text);
+				expect(parsed.results_count).toBe(1);
 				expect(parsed.dead_paths_filtered).toBe(1);
 				expect(parsed.warning).toBeUndefined();
 			});

--- a/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
@@ -468,6 +468,15 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 				: undefined
 		}));
 
+		// #2609/#2554: warn when the dead-path filter shrank recall below the requested
+		// limit in the PARTIAL case (some hits live, some dead). Without this, a caller
+		// asking for `limit: 5` could silently receive 3 results with no signal that 2
+		// candidates were unreachable orphan vectors. Mutually exclusive with the allDead
+		// warning (allDead resets deadPathsFiltered to 0, so this guard never fires then).
+		const recallShrankBelowLimit = !allDead
+			&& deadPathsFiltered > 0
+			&& results.length < effectiveLimit;
+
 		// 7. Construire la réponse
 		const response = {
 			status: 'success',
@@ -480,6 +489,7 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 			// #2609/#2554: dead-path filtering observability
 			...(deadPathsFiltered > 0 ? { dead_paths_filtered: deadPathsFiltered } : {}),
 			...(allDead ? { warning: 'all hits resolved to dead paths — workspace root may be wrong or drive unmounted; returning raw results unfiltered' } : {}),
+			...(recallShrankBelowLimit ? { warning: `dead-path filter reduced recall: ${deadPathsFiltered} of ${rawHits.length} candidate hits unreachable, results_count=${results.length} < limit=${effectiveLimit} (run roosync_indexing cleanup_orphans to reclaim orphan budget)` } : {}),
 			results: results
 		};
 


### PR DESCRIPTION
## Context

Follow-up to PR #642 (dead-path post-filter, merged via `fc171789`). Cross-machine dogfood (web1 c.15/16, po-2023 c.22, po-2024 sprint 06-19) found a **gap in the partial case**: the `warning` field was only emitted in the degenerate `allDead` scenario (every hit unreachable → wrong workspace root / unmounted drive). When SOME hits were live and SOME dead (the common rename/archive case), the tool returned `dead_paths_filtered: N` but **no warning** — so a caller asking `limit: 5` could silently receive 3 results with no signal that 2 candidates were unreachable orphan vectors.

## Spec (by po-2024 sprint 06-19 handoff)

po-2024 diagnosed the gap code-grounded (`search-codebase.tool.ts:453-482`) and handed off an executable spec (fix + 2 tests) to the executor circuit (session-listener constraint = no worktree/PR). This PR implements that spec.

## Change

Add a **partial-shrink warning**, mutually exclusive with the `allDead` warning (`allDead` resets `deadPathsFiltered=0`, so the guard never fires then):

```typescript
const recallShrankBelowLimit = !allDead
    && deadPathsFiltered > 0
    && results.length < effectiveLimit;
// ...
...(recallShrankBelowLimit ? { warning: `dead-path filter reduced recall: ${deadPathsFiltered} of ${rawHits.length} candidate hits unreachable, results_count=${results.length} < limit=${effectiveLimit} (run roosync_indexing cleanup_orphans to reclaim orphan budget)` } : {}),
```

Gated on `results.length < effectiveLimit` so it **never fires when recall was not actually shrunk** below the requested limit.

## Tests

- **Update** existing partial-dead test: `limit: 2`, 1 live + 1 dead → `results_count=1 < limit=2` → asserts `warning` matches `/dead-path filter reduced recall/`.
- **Add** distinguishing anti-faux-positif test: `limit: 1`, 1 live + 1 dead → `results_count=1 === limit=1` → asserts `warning === undefined`. Proves the warning is gated on the recall shrink, not on the mere presence of dead paths.
- Existing 38 tests preserved (CI 503 files / 9959 passed, 0 failure).

## Scope

Minimal, surgical. +37/-2 across 2 files. No public signature change. The `warning` field is additive (conditional spread). No new deps.

## Post-merge

Pointer-bump parent (`mcps/internal` → squash SHA) created **only after this PR is merged** (anti pointer-bump premature #1799).

Refs #2609, #2554 (Cause 3 — rename-GC gap, partial-shrink observability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>