### PR TITLE
feat(search): content-based collection matching for codebase_search (#2609/#2554 L1)

### DIFF
--- a/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
@@ -621,6 +621,41 @@ describe('search-codebase.tool', () => {
 				expect(parsed.collection_resolved_by).toBe('content-match');
 				expect(parsed.collection).not.toBe('ws-low');
 			});
+
+			test('hash miss + discriminant dir is a minority in the sample → still matches (large-sample hardening)', async () => {
+				// web1 observation: scroll is insertion-ordered; a small biased sample could
+				// hide a discriminant dir. The 200-pt sample + Set union must capture the
+				// discriminant dir even if it appears rarely among the sampled points.
+				mockReaddirSync.mockReturnValue([
+					{ name: 'roo-code', isDirectory: () => true },
+					{ name: 'mcps', isDirectory: () => true },
+					{ name: 'docs', isDirectory: () => true }
+				]);
+				mockQdrant.getCollections.mockResolvedValue({
+					collections: [{ name: 'ws-biased' }]
+				});
+				mockQdrant.getCollection.mockImplementation(async (name: string) => {
+					if (name === 'ws-biased') return { points_count: 50000, status: 'green' };
+					throw new Error('not found');
+				});
+				// The sample is heavily dominated by 'docs' (generic) but contains a few
+				// 'mcps' + 'roo-code' (discriminant) points. The signature must include them.
+				const biasedSample = [
+					...Array.from({ length: 40 }, () => ({ payload: { pathSegments: { '0': 'docs' } } })),
+					{ payload: { pathSegments: { '0': 'mcps' } } },
+					{ payload: { pathSegments: { '0': 'roo-code' } } }
+				];
+				mockQdrant.scroll.mockResolvedValue({ points: biasedSample });
+				mockQdrant.query.mockResolvedValue({
+					points: [{ score: 0.75, payload: { filePath: 'roo-code/y.ts', codeChunk: 'y', startLine: 1, endLine: 1 } }]
+				});
+
+				const result = await handleCodebaseSearch({ query: 'y', workspace: '/biased-ws' });
+				const parsed = JSON.parse(result.content[0].text);
+				expect(parsed.status).toBe('success');
+				expect(parsed.collection).toBe('ws-biased');
+				expect(parsed.collection_resolved_by).toBe('content-match');
+			});
 		});
 	});
 

--- a/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
@@ -7,18 +7,21 @@
 
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const { mockGetQdrantClient, mockQdrant, mockEmbeddingCreate, mockExistsSync } = vi.hoisted(() => ({
+const { mockGetQdrantClient, mockQdrant, mockEmbeddingCreate, mockExistsSync, mockReaddirSync } = vi.hoisted(() => ({
 	mockGetQdrantClient: vi.fn(),
-	mockQdrant: { getCollection: vi.fn(), query: vi.fn(), getCollections: vi.fn() },
+	mockQdrant: { getCollection: vi.fn(), query: vi.fn(), getCollections: vi.fn(), scroll: vi.fn() },
 	mockEmbeddingCreate: vi.fn(),
 	// #2609/#2554: mock existsSync so dead-path filtering is deterministic.
 	// Default true = all files reachable (preserves existing test expectations).
-	mockExistsSync: vi.fn(() => true)
+	mockExistsSync: vi.fn(() => true),
+	// #2609/#2554 L1: mock readdirSync so content-based collection matching is deterministic.
+	// Default: empty array = no workspace dirs = content-match skipped. Individual tests override.
+	mockReaddirSync: vi.fn(() => [])
 }));
 
 vi.mock('fs', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('fs')>();
-	return { ...actual, existsSync: mockExistsSync };
+	return { ...actual, existsSync: mockExistsSync, readdirSync: mockReaddirSync };
 });
 
 vi.mock('../../../services/qdrant.js', () => ({
@@ -467,6 +470,156 @@ describe('search-codebase.tool', () => {
 				await handleCodebaseSearch({ query: 'foo', workspace: '/my/ws' });
 				// The joined path must contain both the workspace root and the relative filePath.
 				expect(seen.some((p) => p.includes('my') && p.includes('foo.ts'))).toBe(true);
+			});
+		});
+
+		// ============================================================
+		// #2609/#2554 L1 — content-based collection matching (hash-mismatch fallback)
+		// Root cause: the workspace path hash is fragile cross-agent; when no hash variant
+		// matches, the right ws-* collection is identified by its indexed top-level dirs vs
+		// the workspace's actual directory structure on disk.
+		// ============================================================
+
+		describe('handleCodebaseSearch - content-based collection matching (#2609/#2554 L1)', () => {
+			beforeEach(() => {
+				process.env.EMBEDDING_API_KEY = 'test-key';
+				mockEmbeddingCreate.mockResolvedValue({
+					data: [{ embedding: new Array(8).fill(0.1) }]
+				});
+			});
+
+			afterEach(() => {
+				delete process.env.EMBEDDING_API_KEY;
+			});
+
+			test('hash miss + strict content-match found → serves results with collection_resolved_by=content-match', async () => {
+				// Workspace signature: real dirs on disk, incl. discriminant 'roo-code' + 'mcps'.
+				mockReaddirSync.mockReturnValue([
+					{ name: 'roo-code', isDirectory: () => true },
+					{ name: 'mcps', isDirectory: () => true },
+					{ name: 'roo-config', isDirectory: () => true },
+					{ name: 'docs', isDirectory: () => true },
+					{ name: 'a-file.txt', isDirectory: () => false }
+				]);
+				mockQdrant.getCollections.mockResolvedValue({
+					collections: [{ name: 'ws-contentmatched' }, { name: 'ws-unrelated' }]
+				});
+				mockQdrant.getCollection.mockImplementation(async (name: string) => {
+					if (name === 'ws-contentmatched') return { points_count: 9000, status: 'green' };
+					if (name === 'ws-unrelated') return { points_count: 100, status: 'green' };
+					throw new Error('not found');
+				});
+				mockQdrant.scroll.mockImplementation(async (name: string) => {
+					if (name === 'ws-contentmatched') {
+						// A real collection indexes many top-level dirs. Signature should overlap
+						// strongly with the workspace dirs (roo-code, mcps, roo-config, docs).
+						return { points: [
+							{ payload: { pathSegments: { '0': 'mcps' } } },
+							{ payload: { pathSegments: { '0': 'roo-code' } } },
+							{ payload: { pathSegments: { '0': 'roo-config' } } },
+							{ payload: { pathSegments: { '0': 'docs' } } },
+							{ payload: { pathSegments: { '0': 'mcps' } } }
+						] };
+					}
+					return { points: Array.from({ length: 5 }, () => ({
+						payload: { pathSegments: { '0': 'src', '1': 'lib' } }
+					})) };
+				});
+				mockQdrant.query.mockResolvedValue({
+					points: [{
+						score: 0.82,
+						payload: { filePath: 'mcps/internal/foo.ts', codeChunk: 'export const foo = 1', startLine: 1, endLine: 2 }
+					}]
+				});
+
+				const result = await handleCodebaseSearch({ query: 'foo', workspace: '/roo-ext' });
+				const parsed = JSON.parse(result.content[0].text);
+				expect(parsed.status).toBe('success');
+				expect(parsed.collection).toBe('ws-contentmatched');
+				expect(parsed.collection_resolved_by).toBe('content-match');
+				expect(parsed.content_match.jaccard).toBeGreaterThanOrEqual(0.6);
+				expect(parsed.results[0].file_path).toBe('mcps/internal/foo.ts');
+			});
+
+			test('hash miss + 0 strict content-match → honest diagnostic with collection_signatures', async () => {
+				// Workspace dirs all generic → no discriminant possible → strict gate fails.
+				mockReaddirSync.mockReturnValue([
+					{ name: 'src', isDirectory: () => true },
+					{ name: 'docs', isDirectory: () => true },
+					{ name: 'tests', isDirectory: () => true }
+				]);
+				mockQdrant.getCollections.mockResolvedValue({
+					collections: [{ name: 'ws-someone' }]
+				});
+				// Force hash miss: getCollection throws for hash variants, succeeds only for the real candidate.
+				mockQdrant.getCollection.mockImplementation(async (name: string) => {
+					if (name === 'ws-someone') return { points_count: 500, status: 'green' };
+					throw new Error('not found');
+				});
+				mockQdrant.scroll.mockResolvedValue({
+					points: [{ payload: { pathSegments: { '0': 'src' } } }]
+				});
+
+				const result = await handleCodebaseSearch({ query: 'x', workspace: '/generic-ws' });
+				const parsed = JSON.parse(result.content[0].text);
+				expect(parsed.status).toBe('collection_not_found');
+				expect(parsed.content_match_attempted).toBe(true);
+				expect(parsed.collection_signatures).toBeDefined();
+				// Discriminant gate: src/docs/tests all generic → must NOT serve a query.
+				expect(mockQdrant.query).not.toHaveBeenCalled();
+			});
+
+			test('hash miss + readdir fails (workspace unmounted) → skip content-match, no crash', async () => {
+				mockReaddirSync.mockImplementation(() => { throw new Error('ENOENT'); });
+				mockQdrant.getCollections.mockResolvedValue({
+					collections: [{ name: 'ws-anything' }]
+				});
+				// Force hash miss: getCollection throws for hash variants, succeeds only for the real candidate.
+				mockQdrant.getCollection.mockImplementation(async (name: string) => {
+					if (name === 'ws-anything') return { points_count: 50, status: 'green' };
+					throw new Error('not found');
+				});
+
+				const result = await handleCodebaseSearch({ query: 'x', workspace: '/unmounted' });
+				const parsed = JSON.parse(result.content[0].text);
+				expect(parsed.status).toBe('collection_not_found');
+				expect(parsed.workspace_signature).toBeNull();
+				expect(mockQdrant.scroll).not.toHaveBeenCalled();
+			});
+
+			test('hash miss + multiple candidates → strict match picks highest Jaccard, rejects low-overlap', async () => {
+				mockReaddirSync.mockReturnValue([
+					{ name: 'roo-code', isDirectory: () => true },
+					{ name: 'mcps', isDirectory: () => true },
+					{ name: 'docs', isDirectory: () => true }
+				]);
+				mockQdrant.getCollections.mockResolvedValue({
+					collections: [{ name: 'ws-high' }, { name: 'ws-low' }]
+				});
+				mockQdrant.getCollection.mockImplementation(async (name: string) => {
+					if (name === 'ws-high') return { points_count: 8000, status: 'green' };
+					if (name === 'ws-low') return { points_count: 200, status: 'green' };
+					throw new Error('not found');
+				});
+				mockQdrant.scroll.mockImplementation(async (name: string) => {
+					if (name === 'ws-high') {
+						return { points: [
+							{ payload: { pathSegments: { '0': 'roo-code' } } },
+							{ payload: { pathSegments: { '0': 'mcps' } } }
+						] };
+					}
+					return { points: [{ payload: { pathSegments: { '0': 'docs' } } }] };
+				});
+				mockQdrant.query.mockResolvedValue({
+					points: [{ score: 0.7, payload: { filePath: 'roo-code/x.ts', codeChunk: 'x', startLine: 1, endLine: 1 } }]
+				});
+
+				const result = await handleCodebaseSearch({ query: 'x', workspace: '/multi-ws' });
+				const parsed = JSON.parse(result.content[0].text);
+				expect(parsed.status).toBe('success');
+				expect(parsed.collection).toBe('ws-high');
+				expect(parsed.collection_resolved_by).toBe('content-match');
+				expect(parsed.collection).not.toBe('ws-low');
 			});
 		});
 	});

--- a/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
@@ -154,22 +154,30 @@ function getWorkspaceRootSignature(workspaceRoot: string): Set<string> | null {
 }
 
 /**
- * Query a ws-* collection for a small sample of points and extract the set of
+ * Query a ws-* collection for a sample of points and extract the set of
  * top-level pathSegments.0 observed = the collection's signature.
  *
  * Uses Qdrant's `scroll` API (no vector / no embedding needed) to cheaply sample
  * points — the same approach used in indexing/cleanup-orphans.ts and diagnose-index.
  * We only request the `pathSegments` payload field, keeping the response tiny.
  *
+ * Sample size is deliberately larger than minimal (200 vs 50) to mitigate the
+ * insertion-order bias of `scroll`: on a large heterogeneous collection the first
+ * N points may cluster in one sub-directory, under-representing other top-level dirs
+ * and producing a false-negative match. A 200-pt sample captures a much broader
+ * signature. Cost stays negligible (payload-only, and only on the hash-miss path).
+ * If false-negatives still appear in the wild, consider a second scroll from a
+ * hash-derived offset. (Hardening per web1 review observation.)
+ *
  * Returns the set of pathSegments.0 values, or null if the collection is unreadable.
  */
 async function getCollectionSignature(qdrant: any, collectionName: string): Promise<Set<string> | null> {
 	try {
-		// Sample 50 points: payload-only (no vector). pathSegments is always present
+		// Sample 200 points: payload-only (no vector). pathSegments is always present
 		// on indexed points (qdrant-client.ts:315-331). Robust to scroll's response
 		// shape variants (.points or .result.points).
 		const result = await qdrant.scroll(collectionName, {
-			limit: 50,
+			limit: 200,
 			with_payload: { include: ['pathSegments'] },
 			with_vector: false,
 		});

--- a/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
@@ -13,7 +13,7 @@ import { createHash } from 'crypto';
 import OpenAI from 'openai';
 import { getQdrantClient } from '../../services/qdrant.js';
 import { resolveWorkspace } from '../../utils/workspace-resolver.js';
-import { existsSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { isAbsolute, join } from 'path';
 
 /**
@@ -108,6 +108,139 @@ export async function listWorkspaceCollections(): Promise<string[]> {
 	} catch {
 		return [];
 	}
+}
+
+// ─── Content-based collection matching (L1 fix for #2609/#2554) ───────────────
+// Root cause (convergent po-2023 c.32 + po-2024 c.34, 2026-06-19): the workspace
+// path hash `ws-{sha256(path)[0:16]}` is fundamentally fragile cross-agent — the
+// exact path format the Roo/Zoo indexer hashed is not always reproducible by the
+// MCP (backslash vs forward slash, case, file:// vs raw, resolved vs raw). When no
+// hash variant matches, the MCP served an empty diagnostic even though the code IS
+// indexed (just under a different hash). This content-based fallback identifies the
+// right ws-* collection by matching its top-level pathSegments against the actual
+// directory structure of the workspace on disk — robust where the hash is not.
+
+/** Strict similarity threshold (Jaccard) below which we refuse to serve a content-matched collection. */
+const CONTENT_MATCH_MIN_JACCARD = 0.6;
+/** Generic directory names that are NOT discriminant — excluded from the "discriminant dir" requirement. */
+const GENERIC_DIRS = new Set([
+	'src', 'docs', 'tests', 'test', 'scripts', 'node_modules', '.git', 'config',
+	'examples', 'lib', 'libs', 'build', 'dist', 'out', 'public', 'static', 'resources',
+	'assets', 'data', 'utils', 'tools', 'vendor', '.vscode', '.idea'
+]);
+/** Max ws-* collections scanned by the content fallback (cost cap). */
+const CONTENT_MATCH_MAX_CANDIDATES = 10;
+
+/**
+ * Build the "signature" of a workspace = the set of top-level directory names on disk.
+ * Used to match against a ws-* collection's indexed pathSegments.0.
+ * Best-effort: returns null on any FS error (e.g. workspace not mounted) so the caller
+ * can skip content-matching rather than crash.
+ */
+function getWorkspaceRootSignature(workspaceRoot: string): Set<string> | null {
+	try {
+		const entries = readdirSync(workspaceRoot, { withFileTypes: true });
+		const dirs = new Set<string>();
+		for (const e of entries) {
+			// dirent.isDirectory() excludes files, symlinks-to-files. Symlinked dirs
+			// (e.g. submodule checkouts on some setups) are included if isDirectory().
+			if (e.isDirectory()) dirs.add(e.name);
+		}
+		return dirs;
+	} catch {
+		// Workspace root unreadable / unmounted / ENOENT — skip content-matching.
+		return null;
+	}
+}
+
+/**
+ * Query a ws-* collection for a small sample of points and extract the set of
+ * top-level pathSegments.0 observed = the collection's signature.
+ *
+ * Uses Qdrant's `scroll` API (no vector / no embedding needed) to cheaply sample
+ * points — the same approach used in indexing/cleanup-orphans.ts and diagnose-index.
+ * We only request the `pathSegments` payload field, keeping the response tiny.
+ *
+ * Returns the set of pathSegments.0 values, or null if the collection is unreadable.
+ */
+async function getCollectionSignature(qdrant: any, collectionName: string): Promise<Set<string> | null> {
+	try {
+		// Sample 50 points: payload-only (no vector). pathSegments is always present
+		// on indexed points (qdrant-client.ts:315-331). Robust to scroll's response
+		// shape variants (.points or .result.points).
+		const result = await qdrant.scroll(collectionName, {
+			limit: 50,
+			with_payload: { include: ['pathSegments'] },
+			with_vector: false,
+		});
+		const points = result?.points || result?.result?.points || [];
+		const sig = new Set<string>();
+		for (const p of points) {
+			const ps = p?.payload?.pathSegments;
+			if (ps && typeof ps === 'object') {
+				// pathSegments is keyed by index: { "0": "mcps", "1": "internal", ... }
+				const seg0 = ps['0'];
+				if (seg0) sig.add(String(seg0));
+			} else if (p?.payload?.filePath) {
+				// Fallback: derive from filePath (relative path, first segment).
+				const seg0 = String(p.payload.filePath).split(/[\\/]/)[0];
+				if (seg0) sig.add(seg0);
+			}
+		}
+		return sig;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Find the ws-* collection whose indexed top-level directories best match the workspace's
+ * actual directory structure. Content-based fallback when hash resolution fails.
+ *
+ * Returns the best-matching collection if it passes the STRICT threshold (Jaccard ≥ 0.6
+ * AND at least one discriminant / non-generic dir shared), else null. On null the caller
+ * keeps the honest diagnostic — we never serve a low-confidence guess.
+ *
+ * @param qdrant - Qdrant client
+ * @param candidates - ws-* collection names to probe (pre-sorted by points_count desc)
+ * @param workspaceSignature - top-level dirs of the workspace on disk (null = skip)
+ * @returns { name, jaccard } of the best strict match, or null
+ */
+export async function findCollectionByContent(
+	qdrant: any,
+	candidates: string[],
+	workspaceSignature: Set<string> | null
+): Promise<{ name: string; jaccard: number } | null> {
+	if (!workspaceSignature || workspaceSignature.size === 0 || candidates.length === 0) {
+		return null;
+	}
+
+	// Discriminant dirs = workspace dirs minus generic ones. At least one must be shared.
+	const discriminantDirs = new Set([...workspaceSignature].filter(d => !GENERIC_DIRS.has(d)));
+
+	let best: { name: string; jaccard: number } | null = null;
+	const scanned = Math.min(candidates.length, CONTENT_MATCH_MAX_CANDIDATES);
+
+	for (let i = 0; i < scanned; i++) {
+		const name = candidates[i];
+		const collSig = await getCollectionSignature(qdrant, name);
+		if (!collSig || collSig.size === 0) continue;
+
+		// Jaccard similarity between workspace dirs and collection's indexed dirs.
+		const intersection = [...workspaceSignature].filter(d => collSig.has(d)).length;
+		const union = new Set([...workspaceSignature, ...collSig]).size;
+		if (union === 0) continue;
+		const jaccard = intersection / union;
+
+		// STRICT gate (user choice): require both threshold AND a discriminant dir match.
+		const sharedDiscriminant = [...discriminantDirs].some(d => collSig.has(d));
+		if (jaccard >= CONTENT_MATCH_MIN_JACCARD && sharedDiscriminant) {
+			if (!best || jaccard > best.jaccard) {
+				best = { name, jaccard };
+			}
+		}
+	}
+	return best;
 }
 
 /**
@@ -304,6 +437,9 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 		// 2. Trouver la collection existante (essayer toutes les variantes)
 		const qdrant = getQdrantClient();
 		let collectionName = '';
+		// Tracks how the collection was resolved — 'hash' (normal) or 'content-match' (L1 fallback).
+		let collectionResolvedBy: 'hash' | 'content-match' = 'hash';
+		let contentMatchDetails: { jaccard: number; jaccard_threshold: number } | undefined;
 
 		for (const variant of collectionVariants) {
 			try {
@@ -318,55 +454,91 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 		}
 
 
-		// Phase B: Diagnostic fallback — no blind collection selection (#2455)
-		// #1085: Hash mismatches between Roo (Windows fsPath backslashes) and
-		// Claude Code (Git Bash forward slashes) produce different hashes.
-		// #2455: Previously, Phase B blindly took the first ws-* collection with
-		// points_count > 0, serving results from unrelated workspaces. Now it
-		// returns enriched diagnostic info to help the caller take action.
+		// Phase B: Content-based fallback, then diagnostic (#2609/#2554 L1 fix)
+		// #1085/#2455: Hash mismatches (backslash vs forward slash, case, file:// vs raw)
+		// make the hash resolution miss the real collection even though the code IS indexed.
+		// Convergent root-cause (po-2023 c.32 + po-2024 c.34): the hash is fundamentally
+		// fragile cross-agent. Before returning an empty diagnostic, try matching the right
+		// ws-* collection by CONTENT (its indexed top-level pathSegments vs the workspace's
+		// actual directory structure on disk). If a strict match is found, serve it.
 		if (!collectionName) {
-			// Collect diagnostic info about existing ws-* collections
 			const allWsCollections = await listWorkspaceCollections();
-			const collectionDiagnostics = [];
-			for (const wsCol of allWsCollections.slice(0, 10)) {
+
+			// Pre-sort candidates by points_count desc (heuristic: the indexed workspace is
+			// usually a large collection; also caps cost by probing the biggest first).
+			const ranked: { name: string; points: number }[] = [];
+			for (const wsCol of allWsCollections) {
 				try {
 					const info = await qdrant.getCollection(wsCol);
-					collectionDiagnostics.push({
-						collection: wsCol,
-						points_count: (info as any)?.points_count ?? 0,
-						status: info?.status ?? 'unknown'
-					});
+					ranked.push({ name: wsCol, points: (info as any)?.points_count ?? 0 });
 				} catch {
-					collectionDiagnostics.push({
-						collection: wsCol,
-						points_count: -1,
-						status: 'error'
-					});
+					ranked.push({ name: wsCol, points: -1 });
 				}
 			}
+			ranked.sort((a, b) => b.points - a.points);
+			const candidates = ranked.map(r => r.name);
 
-			return {
-				isError: false,
-				content: [{
-					type: 'text',
-					text: JSON.stringify({
-						status: 'collection_not_found',
-						message: `No Qdrant collection matching workspace "${workspace}" (primary hash: ${primaryCollectionName}). ${collectionVariants.length} hash variants tried, none matched.`,
-						hint: 'The workspace must be indexed by Roo Code before searching. If already indexed, the path format may differ from what the indexer used. Check the diagnostic info below for existing collections.',
-						tried_variants: collectionVariants,
-						primary_hash: primaryCollectionName,
-						workspace: workspace,
-						workspace_source: workspaceSource,
-						existing_collections: collectionDiagnostics,
-						fallback_list_tried: true,
-						troubleshooting: {
-							ripgrep_vscode_1122: 'VS Code 1.122+ renamed ripgrep package to @vscode/ripgrep-universal. Roo Code 3.54 cannot find rg.exe → indexing never starts → collection stays empty. Workaround: copy rg.exe from new path to old path.',
-							hash_mismatch: 'Path format differs between indexing (Roo Code fsPath) and search (Claude Code). Common on Windows: backslash vs forward slash, case differences, UNC prefixes.',
-							action: 'Re-index the workspace from this machine via Roo Code, or verify the ripgrep binary is accessible.'
-						}
-					}, null, 2)
-				}]
-			};
+			// Try content-based matching (STRICT threshold — never serve a low-confidence guess).
+			const workspaceSignature = getWorkspaceRootSignature(workspace);
+			const contentMatch = workspaceSignature
+				? await findCollectionByContent(qdrant, candidates, workspaceSignature)
+				: null;
+
+			if (contentMatch) {
+				// Strict content-match found — serve results from this collection.
+				collectionName = contentMatch.name;
+				collectionResolvedBy = 'content-match';
+				contentMatchDetails = { jaccard: contentMatch.jaccard, jaccard_threshold: CONTENT_MATCH_MIN_JACCARD };
+			} else {
+				// No strict content-match → honest diagnostic. Enrich with the collection
+				// signatures we probed so the caller can identify theirs visually.
+				const collectionDiagnostics = [];
+				for (const r of ranked.slice(0, 10)) {
+					collectionDiagnostics.push({
+						collection: r.name,
+						points_count: r.points,
+						status: r.points >= 0 ? 'green' : 'error'
+					});
+				}
+
+				// Build signature samples for the top candidates (helps the caller self-identify).
+				// Only when we could read the workspace dirs — otherwise signatures are moot
+				// (we can't compare them to anything) and we avoid the extra scroll calls.
+				const signatureSamples: Record<string, string[]> = {};
+				if (workspaceSignature) {
+					for (const r of ranked.slice(0, 5)) {
+						const sig = await getCollectionSignature(qdrant, r.name);
+						if (sig && sig.size > 0) signatureSamples[r.name] = [...sig].slice(0, 8);
+					}
+				}
+
+				return {
+					isError: false,
+					content: [{
+						type: 'text',
+						text: JSON.stringify({
+							status: 'collection_not_found',
+							message: `No Qdrant collection matching workspace "${workspace}" (primary hash: ${primaryCollectionName}). ${collectionVariants.length} hash variants tried + content-based fallback over ${candidates.length} ws-* collections, no strict match (Jaccard ≥ ${CONTENT_MATCH_MIN_JACCARD} with a discriminant dir required).`,
+							hint: 'The workspace hash differs from what the indexer used AND no collection\'s indexed top-level dirs match yours strictly. Inspect the collection signatures below to identify yours, then re-index the workspace from Roo Code / Zoo Code on this machine, or report the path-format mismatch.',
+							tried_variants: collectionVariants,
+							primary_hash: primaryCollectionName,
+							workspace: workspace,
+							workspace_source: workspaceSource,
+							workspace_signature: workspaceSignature ? [...workspaceSignature] : null,
+							content_match_attempted: true,
+							content_match_threshold: CONTENT_MATCH_MIN_JACCARD,
+							collection_signatures: signatureSamples,
+							existing_collections: collectionDiagnostics,
+							fallback_list_tried: true,
+							troubleshooting: {
+								ripgrep_vscode_1122: 'VS Code 1.122+ renamed ripgrep package to @vscode/ripgrep-universal. Roo Code 3.54 cannot find rg.exe → indexing never starts → collection stays empty. Workaround: copy rg.exe from new path to old path.',
+								hash_mismatch: 'Path format differs between indexing (Roo Code fsPath) and search (Claude Code). Common on Windows: backslash vs forward slash, case differences, UNC prefixes.',
+								action: 'Re-index the workspace from this machine via Roo Code, or verify the ripgrep binary is accessible.'
+							}
+						}, null, 2)
+					}]
+				};
+			}
 		}
 
 		// 3. Générer l'embedding de la requête (uses dedicated codebase embedding client)
@@ -475,6 +647,11 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 			workspace: workspace,
 			workspace_source: workspaceSource,
 			collection: collectionName,
+			// #2609/#2554 L1: how the collection was resolved. 'content-match' means the
+			// hash missed and we identified the right ws-* collection by its indexed
+			// top-level dirs vs the workspace's actual directory structure.
+			collection_resolved_by: collectionResolvedBy,
+			...(contentMatchDetails ? { content_match: contentMatchDetails } : {}),
 			results_count: results.length,
 			min_score_used: effectiveMinScore,
 			// #2609/#2554: dead-path filtering observability


### PR DESCRIPTION
## Context

`codebase_search` systematically returns `collection_not_found` / 0 hits for `roo-extensions` even though the code IS indexed. Two independent investigations (po-2023 c.32 + po-2024 c.34, 2026-06-19) **refuted** the earlier diagnoses and isolated the real root-cause: **workspace hash mismatch**.

- **submodule-blindness** = false. Submodules ARE indexed (`roo-code` 98k pts, `mcps/internal` 60k+81k pts in the real collections). The Roo/Zoo indexer (`roo-code/src/services/glob/list-files.ts:221`, ripgrep `--files --hidden --follow`) recurses into submodules like normal dirs.
- **proxy IIS drop POST** = false. po-2023 live-tested GET `/healthz` = 200/68ms and POST `search` = 400/5.7ms (valid Qdrant dimension error, not a proxy timeout).
- **Real root-cause**: the MCP resolves the collection via `ws-{sha256(path)[0:16]}`, but the exact path format the indexer hashed is not reproducible by the MCP. Preuve empirique: `c:\dev\roo-extensions` hashes to `ws-cced6a0374b91fe1` (empty, 0 points) while the real collections are `ws-d2ffdbaa832aed16` (226k pts) and `ws-59e7574de63c6e62` (446k pts) under an unreproducible path format (15 variants tested — none match). po-2023 called this a \"structural hole: irreversible hash\".

The dead-path filter (#642, merged) remains useful but only cleans orphans *after* the right collection is found — it does not solve this mismatch.

## Fix — content-based collection matching (L1)

When no hash variant matches (Phase B), identify the right `ws-*` collection by **content**: match its indexed top-level `pathSegments` against the workspace's actual directory structure on disk (`readdir`). Robust where the hash is fundamentally fragile cross-agent (#1085, #2455 extended).

### Strict gate (user-approved threshold)
A collection is served **only** if:
- `Jaccard(workspace_dirs, collection_indexed_dirs) >= 0.6`, **AND**
- at least one **discriminant** dir is shared (non-generic: excludes `src`/`docs`/`tests`/`scripts`/`node_modules`/`config`/`lib`/`build`/...).

Otherwise the **honest diagnostic** is returned, enriched with the signatures of the scanned collections so the caller can self-identify theirs. **Zero false-positives** — we never serve a low-confidence guess.

### Observability
Response gains:
- `collection_resolved_by: "hash" | "content-match"` (always present)
- `content_match: { jaccard, jaccard_threshold }` (when content-matched)
- diagnostic (on miss): `collection_signatures`, `workspace_signature`, `content_match_attempted`

## Changes

**`search-codebase.tool.ts` (+259/-45):**
- `getWorkspaceRootSignature()` — `readdir` workspace top-level dirs, best-effort (null on FS error)
- `getCollectionSignature()` — `scroll` a collection (no vector/embedding) to sample `pathSegments.0`
- `findCollectionByContent()` — iterate candidates, Jaccard + discriminant strict gate
- Phase B block — try content-match before diagnostic; enrich diagnostic with collection + workspace signatures on miss
- response — `collection_resolved_by` field

**`search-codebase.tool.test.ts` (+161):** 4 new scenarios:
1. hash miss + strict content-match found → serves results, `collection_resolved_by: content-match`
2. hash miss + 0 strict match → diagnostic with `collection_signatures`, no query served
3. hash miss + readdir fails → skip content-match, no crash
4. hash miss + multiple candidates → strict match picks highest Jaccard, rejects generic-only overlap

Mock gains `scroll` + `readdirSync`. One existing test (`codebase-search-execution.test.ts`) updated: the `hint` still guides to \"Roo Code / Zoo Code\" re-indexing (contract preserved).

## Validation
- `npm run build`: 0 TS errors
- `npx vitest run --config vitest.config.ci.ts`: **9962 passed, 23 skipped, 0 failed** (full CI suite, 0 regressions)
- File tests: 44/44

## Out of scope
- L2 (extend `getWorkspaceCollectionVariants` with UNC/resolved forms) — the exact hashed form is unknown; L1 is more robust
- L3 (patch the roo-code indexer to expose a canonical collection-name) — reference-only submodule, upstream, too costly
- `_workspace_registry` persistent hash→path map (po-23 reco point 1) — larger Qdrant schema change, separate validation

Refs: #2609, #2554, #1085, #2455, convergent investigations po-2023 c.32 + po-2024 c.34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)