### PR TITLE
fix(search): extend content-match to empty-but-existing collections (#2609/#2554)

### DIFF
--- a/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
@@ -681,6 +681,90 @@ describe('search-codebase.tool', () => {
 				expect(parsed.collection).toBe('ws-biased');
 				expect(parsed.collection_resolved_by).toBe('content-match');
 			});
+
+			// ─── Follow-up to #644: blind-spot "collection exists but is EMPTY" ─────────
+			// Convergent finding (web1 c.N+4 + po-2026 c.46): the hash resolves to a real
+			// collection that was never populated (points_count == 0). Phase B must trigger
+			// in this sub-case too, not only when no hash variant matches at all.
+			test('hash matches an EMPTY collection (points_count=0) → content-match fallback finds the populated one', async () => {
+				mockReaddirSync.mockReturnValue([
+					{ name: 'roo-code', isDirectory: () => true },
+					{ name: 'mcps', isDirectory: () => true },
+					{ name: 'roo-config', isDirectory: () => true },
+					{ name: 'docs', isDirectory: () => true }
+				]);
+				// Compute the REAL hash variant for this workspace so the hash loop actually
+				// matches it — this is what reproduces the blind-spot (a hash that resolves
+				// to an existing-but-empty collection). Without this, the test would only
+				// exercise the generic hash-miss path, not the empty-collection sub-case.
+				const emptyCollectionName = getWorkspaceCollectionVariants('/empty-hash-ws')[0];
+				mockQdrant.getCollections.mockResolvedValue({
+					collections: [
+						{ name: emptyCollectionName },
+						{ name: 'ws-populated' }
+					]
+				});
+				mockQdrant.getCollection.mockImplementation(async (name: string) => {
+					if (name === emptyCollectionName) return { points_count: 0, status: 'green' };
+					if (name === 'ws-populated') return { points_count: 446000, status: 'green' };
+					throw new Error('not found');
+				});
+				mockQdrant.scroll.mockImplementation(async (name: string) => {
+					if (name === 'ws-populated') {
+						return { points: [
+							{ payload: { pathSegments: { '0': 'mcps' } } },
+							{ payload: { pathSegments: { '0': 'roo-code' } } },
+							{ payload: { pathSegments: { '0': 'roo-config' } } },
+							{ payload: { pathSegments: { '0': 'docs' } } }
+						] };
+					}
+					// Empty collection → scroll returns no points.
+					return { points: [] };
+				});
+				mockQdrant.query.mockResolvedValue({
+					points: [{ score: 0.8, payload: { filePath: 'mcps/internal/bar.ts', codeChunk: 'export const bar = 2', startLine: 1, endLine: 2 } }]
+				});
+
+				const result = await handleCodebaseSearch({ query: 'bar', workspace: '/empty-hash-ws' });
+				const parsed = JSON.parse(result.content[0].text);
+				// Must serve the populated collection, NOT return 0 results on the empty one.
+				expect(parsed.status).toBe('success');
+				expect(parsed.collection).toBe('ws-populated');
+				expect(parsed.collection_resolved_by).toBe('content-match');
+				expect(parsed.results[0].file_path).toBe('mcps/internal/bar.ts');
+			});
+
+			test('hash matches an EMPTY collection + no strict content-match → diagnostic with hash_matched_empty=true', async () => {
+				// Same blind-spot trigger, but no candidate collection matches by content
+				// → honest diagnostic must report hash_matched_empty=true so the caller
+				// understands the empty-collection nuance (not just "collection not found").
+				mockReaddirSync.mockReturnValue([
+					{ name: 'roo-code', isDirectory: () => true },
+					{ name: 'mcps', isDirectory: () => true }
+				]);
+				const emptyCollectionName = getWorkspaceCollectionVariants('/empty-hash-ws2')[0];
+				mockQdrant.getCollections.mockResolvedValue({
+					collections: [
+						{ name: emptyCollectionName },
+						{ name: 'ws-unrelated' }
+					]
+				});
+				mockQdrant.getCollection.mockImplementation(async (name: string) => {
+					if (name === emptyCollectionName) return { points_count: 0, status: 'green' };
+					if (name === 'ws-unrelated') return { points_count: 100, status: 'green' };
+					throw new Error('not found');
+				});
+				// The only non-empty candidate has unrelated dirs → strict gate fails.
+				mockQdrant.scroll.mockResolvedValue({
+					points: [{ payload: { pathSegments: { '0': 'wp-content' } } }]
+				});
+
+				const result = await handleCodebaseSearch({ query: 'x', workspace: '/empty-hash-ws2' });
+				const parsed = JSON.parse(result.content[0].text);
+				expect(parsed.status).toBe('collection_not_found');
+				expect(parsed.hash_matched_empty).toBe(true);
+				expect(parsed.content_match_attempted).toBe(true);
+			});
 		});
 	});
 

--- a/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
@@ -448,12 +448,20 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 		// Tracks how the collection was resolved — 'hash' (normal) or 'content-match' (L1 fallback).
 		let collectionResolvedBy: 'hash' | 'content-match' = 'hash';
 		let contentMatchDetails: { jaccard: number; jaccard_threshold: number } | undefined;
+		// points_count of the hash-matched collection (if any). Used to detect the
+		// "collection exists but is empty" blind-spot: the hash resolves to a real
+		// collection that was never populated (e.g. the indexer hashed a different path
+		// format → points went into another ws-* collection). (#2609/#2554 follow-up,
+		// convergent finding web1 c.N+4 + po-2026 c.46: po-2023 sees 15 results from a
+		// populated collection; web1/po-2026 get 0 from an empty one matched by hash.)
+		let hashMatchedPointsCount: number | null = null;
 
 		for (const variant of collectionVariants) {
 			try {
 				const collectionInfo = await qdrant.getCollection(variant);
 				if (collectionInfo.status !== undefined) {
 					collectionName = variant;
+					hashMatchedPointsCount = (collectionInfo as any)?.points_count ?? null;
 					break;
 				}
 			} catch {
@@ -469,6 +477,19 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 		// fragile cross-agent. Before returning an empty diagnostic, try matching the right
 		// ws-* collection by CONTENT (its indexed top-level pathSegments vs the workspace's
 		// actual directory structure on disk). If a strict match is found, serve it.
+		//
+		// TWO trigger conditions (follow-up to #644, finding web1 c.N+4 + po-2026 c.46):
+		//  (1) No hash variant matched at all (`!collectionName`) — original case.
+		//  (2) A hash variant matched a collection that EXISTS but is EMPTY
+		//      (`hashMatchedPointsCount === 0`). The points went into another ws-* collection
+		//      under a different hash; serving this empty one would return 0 results. Fall
+		//      back to content-matching to find the populated one. The matched-but-empty
+		//      collection is reset so the content-match can re-select the best candidate
+		//      (including itself, if it turns out non-empty under a re-read — rare).
+		const hashMatchedEmpty = collectionName !== '' && hashMatchedPointsCount === 0;
+		if (hashMatchedEmpty) {
+			collectionName = '';
+		}
 		if (!collectionName) {
 			const allWsCollections = await listWorkspaceCollections();
 
@@ -530,6 +551,7 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 							hint: 'The workspace hash differs from what the indexer used AND no collection\'s indexed top-level dirs match yours strictly. Inspect the collection signatures below to identify yours, then re-index the workspace from Roo Code / Zoo Code on this machine, or report the path-format mismatch.',
 							tried_variants: collectionVariants,
 							primary_hash: primaryCollectionName,
+							hash_matched_empty: hashMatchedEmpty,
 							workspace: workspace,
 							workspace_source: workspaceSource,
 							workspace_signature: workspaceSignature ? [...workspaceSignature] : null,


### PR DESCRIPTION
## Summary

Follow-up to #644 (content-based collection matching). Fixes a **blind-spot** discovered during fleet-wide deploy-validation of #644 (convergent finding: web1 + po-2026, [documented on roo-extensions#2554](https://github.com/jsboige/roo-extensions/issues/2554)).

### The blind-spot

The content-based fallback (Phase B) only triggered when **no** hash variant matched at all (`!collectionName`). But the hash can resolve to a collection that **exists yet is empty** (`points_count == 0`): the Roo/Zoo indexer hashed a different path format, so the points went into another `ws-*` collection under a different hash. The empty collection still answers `getCollection` with `status: green`, so `collectionName` gets set → Phase B skipped → query on empty collection → 0 results → empty `success` returned, **never entering content-match**.

### Reproduction (fleet telemetry)

| Machine | Hash matched | Collection state | content-match Phase B? | Results |
|---------|--------------|------------------|------------------------|---------|
| po-2023 | `ws-59e7574d` | **populated** (446k pts) | not triggered (hash works) | **15** ✅ |
| po-2026 | `ws-cced6a0374b91fe1` | **empty** (0 pts) | **not triggered** (hash \"matched\") | **0** ❌ |
| web1 | `ws-cced6a0374b91fe1` | **empty** (0 pts) | not triggered | **0** ❌ |

## The fix (~22 LOC, surgical)

- Capture the hash-matched collection's `points_count` in the variant loop.
- Trigger Phase B **also** when `collectionName` is set by hash but `points_count == 0`.
- Reset `collectionName = ''` so the content-match re-selects the best populated candidate (same strict Jaccard ≥ 0.6 + discriminant-dir gate — no false-positives).
- Diagnostic now reports `hash_matched_empty: true|false` for traceability of this sub-case.

No refactor of adjacent code (#1936 surgical changes rule). Same strict gate, same cost cap (≤10 candidates, payload-only scroll).

## Tests

+2 tests under the existing `content-based collection matching` describe block:
1. `hash matches an EMPTY collection (points_count=0) → content-match fallback finds the populated one` — asserts it serves the populated collection with `collection_resolved_by: 'content-match'`, not 0 results.
2. `hash matches an EMPTY collection + no strict content-match → diagnostic with hash_matched_empty=true` — asserts the honest diagnostic reports the empty-collection nuance.

Both tests compute the **real** hash variant for the test workspace (`getWorkspaceCollectionVariants`) so the hash loop actually matches the empty collection — without this the test would only exercise the generic hash-miss path, not the blind-spot sub-case.

### Validation
- `npm run build` — 0 TS errors
- search-codebase suite: **48/48** (45 prior + 1 hardening + 2 new)
- Full CI suite (`vitest.config.ci.ts`): **9966 passed, 23 skipped, 0 failed**

## Related
- Builds on #644 (L1 content-match), #643 (partial dead-path warning), #642 (dead-path filter)
- roo-extensions EPIC #2554 / #2609
- Finding report: https://github.com/jsboige/roo-extensions/issues/2554#issuecomment-4755782948

🤖 Generated with [Claude Code](https://claude.com/claude-code)