### PR TITLE
chore(build): wipe build/ before tsc to stop orphan artefact accumulation

### DIFF
--- a/servers/roo-state-manager/package.json
+++ b/servers/roo-state-manager/package.json
@@ -6,7 +6,9 @@
   "type": "module",
   "scripts": {
     "prebuild": "npm install",
-    "build": "tsc",
+    "clean:build": "node scripts/clean-build.mjs",
+    "build": "npm run clean:build && tsc",
+    "build:noclean": "tsc",
     "build:tests": "tsc -p tests/tsconfig.json",
     "start": "npm run build && node --env-file=.env build/index.js",
     "dev": "tsc -w",

--- a/servers/roo-state-manager/scripts/clean-build.mjs
+++ b/servers/roo-state-manager/scripts/clean-build.mjs
@@ -1,0 +1,33 @@
+/**
+ * Clean the TypeScript build output directory before recompiling.
+ *
+ * Why: `tsc` does not delete emitted files whose source `.ts` was removed or
+ * consolidated. Over time, dead `.js`/`.d.ts`/`.map` artefacts accumulate in
+ * `build/` (orphans) — they pollute audits, can shadow real files, and risk
+ * being loaded by residual dynamic imports. Found by idle-task I8 (cycle 43):
+ * 35 orphans (e.g. ServiceRegistry, CommitLogService, SmartCleanerService) from
+ * past CONS-X consolidations whose source was removed but whose compiled
+ * output persisted.
+ *
+ * This is safe because `build` is a plain `tsc` (full recompile, no
+ * `--incremental`/tsBuildInfoFile) and `build/` is gitignored — wiping it only
+ * costs the one-time full recompile tsc does anyway.
+ *
+ * Usage: invoked from the `build` npm script before `tsc`.
+ * Keeps `dev` (`tsc -w`) untouched for fast incremental watch-mode dev.
+ *
+ * @version 1.0.0 — issue #2609/#2554 follow-up (idle-task I8 c.43 friction)
+ */
+import { rmSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const buildDir = join(__dirname, '..', 'build');
+
+if (existsSync(buildDir)) {
+	rmSync(buildDir, { recursive: true, force: true });
+	console.log(`[clean-build] removed ${buildDir}`);
+} else {
+	console.log('[clean-build] build/ absent — nothing to clean');
+}


### PR DESCRIPTION
## Summary

Fix for the **FRICTION** reported in [idle-task I8 (po-2024 cycle 43)](https://github.com/jsboige/roo-extensions/issues) and dispatched by ai-01 (cycle 52): `tsc` does not delete emitted files when their source `.ts` is removed/consolidated, so dead `.js`/`.d.ts`/`.map` artefacts accumulate in `build/` across CONS-X consolidations.

### Evidence (35 orphans, empirically confirmed)
Build files whose `src/` counterpart no longer exists:
- `services/ServiceRegistry.js`, `services/roosync/CommitLogService.js`, `services/SmartCleanerService.js`, `services/TwoLevelProcessingOrchestrator.js`
- `tools/roosync/heartbeat.js` (+ 30 more legacy roosync tools, types, services)

All 5 spot-checked manually: `build/X.js` exists, `src/X.ts` missing. None imported by live `src/` code (only by archived tests under `__tests__/_archives/`).

### Risks of leaving them
- Polluted `build/` audits (false positives — the initial I8 check returned 318 false hits before correction)
- Shadowed real files / confusing debugging
- Residual dynamic-import loading of dead modules

## The fix (zero new dependencies)

**`scripts/clean-build.mjs`** — wipes `build/` via Node-native `fs.rmSync` (Node 14.14+, cross-platform, no `rimraf` dep needed). The `build` script runs it before `tsc`.

### Why a prebuild clean is acceptable here (per ai-01 dispatch mandate)
The ai-01 dispatch said: *"SI le build est déjà full-recompile (plain tsc sans --incremental/.tsbuildinfo), un prebuild clean est acceptable — vérifie d'abord le setup réel."*

Verified setup:
- `build` = plain `tsc` (no `--incremental`, no `tsBuildInfoFile`, no `.tsbuildinfo` file, no `composite`)
- `outDir: ./build` is gitignored

→ It's a full recompile anyway. Wiping `build/` first only costs the one-time full recompile tsc does regardless. The dev path (`tsc -w`) is **left untouched** for fast incremental watch-mode dev (token-economy / dev-speed mandate respected).

### Scripts
| Script | Before | After |
|--------|--------|-------|
| `build` | `tsc` | `npm run clean:build && tsc` |
| `clean:build` | — | `node scripts/clean-build.mjs` (new, standalone for CI/periodic audits) |
| `build:noclean` | — | `tsc` (escape hatch, skip clean) |
| `dev` | `tsc -w` | `tsc -w` (unchanged) |

## Validation
- `npm run clean:build` → removes `build/`, idempotent ("nothing to clean" when absent)
- `npm run build` → orphans **35 → 0** after clean build (5 spot-checked all GONE)
- Full CI suite (`vitest.config.ci.ts`): **9966 passed, 23 skipped, 0 failed** — no regression
- `dev` (watch mode) untouched

## Related
- Idle-task I8 finding: po-2024 cycle 43 (roo-extensions dashboard)
- Dispatch: ai-01 cycle 52 → po-2024
- Note: po-2026 cycle 52 reported "I8 = 0 orphans" but used a check comparing `build/X.js` vs `build/X.ts` (the corrected check vs `src/X.ts` finds the real 35). This PR confirms the orphans are real and eliminates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)