### PR TITLE
fix(rsm): live Qdrant probe in health-view — stop masking 503 as OK (#2628)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/health-view.ts
+++ b/servers/roo-state-manager/src/tools/roosync/health-view.ts
@@ -69,6 +69,12 @@ export interface HealthViewResult {
      * `embeddings` above checks env-var presence only; this field reflects actual backend health.
      */
     embeddingsReachable?: boolean;
+    /**
+     * #2628: Same distinction for Qdrant. `qdrant` above checks env-var presence only;
+     * this field reflects an actual bounded authenticated GET /collections round-trip.
+     * Without it, a live 503/timeout was masked as "Qdrant: OK" (regression of #2547).
+     */
+    qdrantReachable?: boolean;
   };
   drift: {
     checked: boolean;
@@ -190,13 +196,14 @@ function collectCapabilities(): {
   qdrant: boolean;
   embeddings: boolean;
   embeddingsReachable?: boolean;
+  qdrantReachable?: boolean;
 } {
   const caps = getServerCapabilities();
   const embeddingsConfigured = caps.isAvailable('embeddings');
 
-  // #2547: embeddingsReachable is intentionally omitted here (undefined).
-  // It is populated asynchronously in roosyncHealthView() via probeEmbeddingBackend()
-  // to avoid blocking the synchronous capability check.
+  // #2547/#2628: *Reachable fields are intentionally omitted here (undefined).
+  // They are populated asynchronously in roosyncHealthView() via probeEmbeddingBackend()
+  // and probeQdrantBackend() to avoid blocking the synchronous capability check.
   return {
     sharedPath: caps.isAvailable('sharedPath'),
     qdrant: caps.isAvailable('qdrant'),
@@ -221,6 +228,42 @@ async function probeEmbeddingBackend(): Promise<boolean> {
     return result?.data?.[0]?.embedding?.length > 0;
   } catch {
     return false;
+  }
+}
+
+/**
+ * #2628: Async live probe of the Qdrant backend.
+ * Distinguishes "configured" (env vars present) from "reachable" (backend responds 2xx).
+ *
+ * Performs a bounded, authenticated `GET /collections`. ANY of the following → `false`:
+ * non-2xx (503/500/404), auth failure (401/403), timeout (AbortController), or a
+ * thrown network error (ECONNRESET / ENOTFOUND / CERT_HAS_EXPIRED / "fetch failed").
+ * This is precisely what makes a live outage flip the verdict to FAIL instead of being
+ * masked as `Qdrant: OK` because the env vars happen to be present (regression of #2547).
+ *
+ * Exported for unit testing (the regression suite asserts 503/401/timeout → false).
+ */
+export async function probeQdrantBackend(): Promise<boolean> {
+  const qdrantUrl = process.env.QDRANT_URL;
+  if (!qdrantUrl) return false;
+  const apiKey = process.env.QDRANT_API_KEY;
+  const timeoutMs = parseInt(process.env.QDRANT_HEALTH_PROBE_TIMEOUT_MS || '8000', 10);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (apiKey) headers['api-key'] = apiKey;
+    const resp = await fetch(`${qdrantUrl.replace(/\/+$/, '')}/collections`, {
+      method: 'GET',
+      headers,
+      signal: controller.signal,
+    });
+    return resp.ok; // 2xx only — 503/500/404/401/403 all resolve to false
+  } catch {
+    // AbortError (timeout) + TCP reset / DNS / TLS / "fetch failed" all land here → unreachable
+    return false;
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -293,7 +336,7 @@ function collectEnvCheck(): {
 function computeScore(
   onlineCount: number,
   totalCount: number,
-  capabilities: { sharedPath: boolean; qdrant: boolean; embeddings: boolean },
+  capabilities: { sharedPath: boolean; qdrant: boolean; embeddings: boolean; qdrantReachable?: boolean },
   drift: { critical: number; important: number; warning: number },
   criticalEnvMissing: number
 ): number {
@@ -307,7 +350,10 @@ function computeScore(
 
   // Capabilities (0-30 points)
   if (!capabilities.sharedPath) score -= 15;
-  if (!capabilities.qdrant) score -= 10;
+  // #2628: a configured-but-unreachable Qdrant is as bad as a missing one for scoring.
+  // Otherwise a live 503/timeout stays masked as HEALTHY (env vars present → qdrant=true,
+  // no deduction) — the exact false positive this fix removes.
+  if (!capabilities.qdrant || capabilities.qdrantReachable === false) score -= 10;
   if (!capabilities.embeddings) score -= 5;
 
   // Drift (0-30 points)
@@ -329,7 +375,7 @@ function determineStatus(score: number): 'HEALTHY' | 'WARNING' | 'CRITICAL' {
 function generateRecommendations(
   onlineCount: number,
   totalCount: number,
-  capabilities: { sharedPath: boolean; qdrant: boolean; embeddings: boolean },
+  capabilities: { sharedPath: boolean; qdrant: boolean; embeddings: boolean; qdrantReachable?: boolean },
   drift: { checked: boolean; critical: number; important: number; items: DriftItem[] },
   envMissing: Array<{ name: string; severity: string }>
 ): string[] {
@@ -339,7 +385,10 @@ function generateRecommendations(
     recs.push('ROOSYNC_SHARED_PATH not configured — RooSync features unavailable');
   }
   if (!capabilities.qdrant) {
-    recs.push('Qdrant not reachable — semantic search disabled');
+    recs.push('Qdrant not configured (QDRANT_URL / QDRANT_API_KEY / QDRANT_COLLECTION_NAME) — semantic search disabled');
+  } else if (capabilities.qdrantReachable === false) {
+    // #2628: configured but the live probe failed — a real outage, not a config gap.
+    recs.push('Qdrant configured but UNREACHABLE (live GET /collections failed) — semantic search degraded to text mode; check qdrant.myia.io / container / reverse proxy');
   }
   if (!capabilities.embeddings) {
     recs.push('Embedding service not configured — codebase_search disabled');
@@ -382,7 +431,12 @@ export function formatMarkdown(result: HealthViewResult): string {
 
   lines.push('## Capabilities');
   lines.push(`- SharedPath: ${result.capabilities.sharedPath ? 'OK' : 'MISSING'}`);
-  lines.push(`- Qdrant: ${result.capabilities.qdrant ? 'OK' : 'MISSING'}`);
+  // #2628: report FAIL (not OK) when configured but the live probe failed.
+  const qdrantStatus = !result.capabilities.qdrant ? 'MISSING (not configured)'
+    : result.capabilities.qdrantReachable === true ? 'OK (configured + reachable)'
+    : result.capabilities.qdrantReachable === false ? 'FAIL (configured but unreachable)'
+    : 'OK (configured)';
+  lines.push(`- Qdrant: ${qdrantStatus}`);
   const embStatus = !result.capabilities.embeddings ? 'MISSING (not configured)'
     : result.capabilities.embeddingsReachable === true ? 'OK (configured + reachable)'
     : result.capabilities.embeddingsReachable === false ? 'DEGRADED (configured but unreachable)'
@@ -435,8 +489,8 @@ export async function roosyncHealthView(args: HealthViewArgs): Promise<HealthVie
   // #2547: Collect sync capabilities first to decide whether to probe embeddings
   const capabilities = collectCapabilities();
 
-  // Collect all data sources in parallel (including optional embedding probe)
-  const [systemHealth, drift, envCheck, embeddingsReachable] = await Promise.all([
+  // Collect all data sources in parallel (including optional backend probes)
+  const [systemHealth, drift, envCheck, embeddingsReachable, qdrantReachable] = await Promise.all([
     collectSystemHealth(),
     collectDrift(targetMachine),
     args.includeEnvCheck !== false ? Promise.resolve(collectEnvCheck()) : Promise.resolve({
@@ -444,13 +498,23 @@ export async function roosyncHealthView(args: HealthViewArgs): Promise<HealthVie
     }),
     // #2547: Async live probe of embedding backend (only if configured)
     capabilities.embeddings ? probeEmbeddingBackend() : Promise.resolve(false as boolean),
+    // #2628: Async live probe of Qdrant backend (only if configured)
+    capabilities.qdrant ? probeQdrantBackend() : Promise.resolve(false as boolean),
   ]);
+
+  // #2547/#2628: Merge the async probe results into capabilities BEFORE scoring,
+  // so a configured-but-unreachable backend actually moves the score/verdict.
+  const enrichedCapabilities = {
+    ...capabilities,
+    embeddingsReachable: capabilities.embeddings ? embeddingsReachable : false,
+    qdrantReachable: capabilities.qdrant ? qdrantReachable : false,
+  };
 
   const criticalEnvMissing = envCheck.missing.filter(e => e.severity === 'critical').length;
   const score = computeScore(
     systemHealth.onlineCount,
     systemHealth.totalCount,
-    capabilities,
+    enrichedCapabilities,
     drift,
     criticalEnvMissing
   );
@@ -458,16 +522,10 @@ export async function roosyncHealthView(args: HealthViewArgs): Promise<HealthVie
   const recommendations = generateRecommendations(
     systemHealth.onlineCount,
     systemHealth.totalCount,
-    capabilities,
+    enrichedCapabilities,
     drift,
     envCheck.missing
   );
-
-  // #2547: Merge the async embedding probe result into capabilities
-  const enrichedCapabilities = {
-    ...capabilities,
-    embeddingsReachable: capabilities.embeddings ? embeddingsReachable : false,
-  };
 
   const result: HealthViewResult = {
     status,

--- a/servers/roo-state-manager/tests/unit/tools/roosync/health-view-qdrant-probe.test.ts
+++ b/servers/roo-state-manager/tests/unit/tools/roosync/health-view-qdrant-probe.test.ts
@@ -1,0 +1,122 @@
+/**
+ * #2628 regression suite — health-check masking Qdrant 503.
+ *
+ * Before this fix, `roosync_inventory(type: "health")` reported `Qdrant: OK` whenever
+ * the QDRANT_* env vars were merely present, even while qdrant.myia.io returned HTTP 503
+ * (or timed out / reset). The health verdict was derived from env-var PRESENCE, never a
+ * live round-trip. These tests pin the corrected behavior:
+ *
+ *  1. probeQdrantBackend() returns true ONLY on a 2xx; 503 / 401 / 404 / network error /
+ *     timeout / missing-URL all resolve to false.
+ *  2. formatMarkdown() renders `Qdrant: FAIL (configured but unreachable)` when the probe
+ *     failed — not `OK` — and `OK (configured + reachable)` when it succeeded.
+ *
+ * Regression of #2547 (same masking defect, previously only patched for embeddings).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { probeQdrantBackend, formatMarkdown, type HealthViewResult } from '../../../../src/tools/roosync/health-view.js';
+
+const OLD_ENV = { ...process.env };
+
+function mockFetch(impl: (url: string, init?: any) => Promise<any> | any) {
+  vi.stubGlobal('fetch', vi.fn(impl));
+}
+
+function jsonResponse(status: number) {
+  return { ok: status >= 200 && status < 300, status, json: async () => ({}) };
+}
+
+describe('#2628 probeQdrantBackend — live reachability, not env-var presence', () => {
+  beforeEach(() => {
+    process.env.QDRANT_URL = 'https://qdrant.myia.io';
+    process.env.QDRANT_API_KEY = 'test-key';
+    process.env.QDRANT_HEALTH_PROBE_TIMEOUT_MS = '500';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    process.env = { ...OLD_ENV };
+  });
+
+  it('returns true on HTTP 200', async () => {
+    mockFetch(() => jsonResponse(200));
+    await expect(probeQdrantBackend()).resolves.toBe(true);
+  });
+
+  it('returns FALSE on HTTP 503 (the masked-outage case)', async () => {
+    mockFetch(() => jsonResponse(503));
+    await expect(probeQdrantBackend()).resolves.toBe(false);
+  });
+
+  it('returns FALSE on HTTP 401 (auth failure)', async () => {
+    mockFetch(() => jsonResponse(401));
+    await expect(probeQdrantBackend()).resolves.toBe(false);
+  });
+
+  it('returns FALSE on HTTP 404', async () => {
+    mockFetch(() => jsonResponse(404));
+    await expect(probeQdrantBackend()).resolves.toBe(false);
+  });
+
+  it('returns FALSE on a thrown network error (ECONNRESET / fetch failed)', async () => {
+    mockFetch(() => { throw Object.assign(new Error('fetch failed'), { code: 'ECONNRESET' }); });
+    await expect(probeQdrantBackend()).resolves.toBe(false);
+  });
+
+  it('returns FALSE on timeout / abort', async () => {
+    mockFetch(() => Promise.reject(new DOMException('The operation was aborted', 'AbortError')));
+    await expect(probeQdrantBackend()).resolves.toBe(false);
+  });
+
+  it('returns FALSE when QDRANT_URL is unset, without calling fetch', async () => {
+    delete process.env.QDRANT_URL;
+    const f = vi.fn(() => jsonResponse(200));
+    vi.stubGlobal('fetch', f);
+    await expect(probeQdrantBackend()).resolves.toBe(false);
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it('sends the api-key header to GET /collections', async () => {
+    const f = vi.fn(() => jsonResponse(200));
+    vi.stubGlobal('fetch', f);
+    await probeQdrantBackend();
+    expect(f).toHaveBeenCalledTimes(1);
+    const [url, init] = f.mock.calls[0];
+    expect(url).toBe('https://qdrant.myia.io/collections');
+    expect(init.method).toBe('GET');
+    expect(init.headers['api-key']).toBe('test-key');
+  });
+});
+
+describe('#2628 formatMarkdown — Qdrant verdict reflects reachability', () => {
+  function baseResult(qdrant: boolean, qdrantReachable?: boolean): HealthViewResult {
+    return {
+      status: 'HEALTHY',
+      score: 100,
+      timestamp: '2026-06-20T00:00:00.000Z',
+      localMachine: 'myia-ai-01',
+      systemHealth: { machinesOnline: 6, machinesUnknown: 0, machinesTotal: 6, flags: [] },
+      capabilities: { sharedPath: true, qdrant, embeddings: true, embeddingsReachable: true, qdrantReachable },
+      drift: { checked: false, baselineSource: '', critical: 0, important: 0, warning: 0, info: 0, items: [] },
+      envCheck: { checked: false, missing: [], present: [] },
+      recommendations: [],
+    };
+  }
+
+  it('renders FAIL when configured but unreachable (probe false) — NOT OK', () => {
+    const md = formatMarkdown(baseResult(true, false));
+    expect(md).toContain('Qdrant: FAIL (configured but unreachable)');
+    expect(md).not.toContain('Qdrant: OK (configured + reachable)');
+  });
+
+  it('renders OK when configured and reachable (probe true)', () => {
+    const md = formatMarkdown(baseResult(true, true));
+    expect(md).toContain('Qdrant: OK (configured + reachable)');
+  });
+
+  it('renders MISSING when not configured', () => {
+    const md = formatMarkdown(baseResult(false, false));
+    expect(md).toContain('Qdrant: MISSING (not configured)');
+  });
+});


### PR DESCRIPTION
## Context

Resolves the **masking** half of roo-extensions#2628 (regression of #2547).

`roosync_inventory(type:"health")` reported **`Qdrant: OK`** whenever the `QDRANT_*` env vars were merely *present* — the verdict was derived from env-var presence, never a live round-trip. During the **2026-06-20 cluster-wide Qdrant 503** (VHDX disconnect on ai-01, now fixed), three machines independently confirmed the fleet health view + Hermes still said "Qdrant OK" while every endpoint returned 503 (po-2025/web1) or timeout/reset (po-2026).

Root cause was code-grounded by po-2026 to [`index.ts` L53-81](https://github.com/jsboige/roo-extensions/blob/main/mcps/internal/servers/roo-state-manager/src/index.ts) (capability set from env-var presence) + [`health-view.ts` L385](https://github.com/jsboige/roo-extensions/blob/main/mcps/internal/servers/roo-state-manager/src/tools/roosync/health-view.ts) (could only print `OK`/`MISSING`, never `FAIL`-on-unreachable).

## Fix

Mirrors the existing **#2547 embeddings reachability** pattern, applied to Qdrant:

- **`probeQdrantBackend()`** — bounded, authenticated `GET /collections` (`AbortController`, `QDRANT_HEALTH_PROBE_TIMEOUT_MS` default 8s). `2xx → true`; `503/500/404/401/403`, timeout, TCP reset, DNS/TLS error, `"fetch failed"` → `false`. Exported for unit testing.
- **`roosyncHealthView()`** runs the probe in parallel (only when configured) and merges `qdrantReachable` into capabilities **before** scoring.
- **`computeScore()`** — configured-but-unreachable Qdrant deducts the same **10 pts** as missing, so a live outage actually moves the score/verdict (no more `80/HEALTHY` during an outage).
- **`formatMarkdown()`** — renders `Qdrant: FAIL (configured but unreachable)` instead of `OK`.
- **`generateRecommendations()`** — distinct "configured but UNREACHABLE" guidance vs the "not configured" case.

### Scope / deliberately out

Health-view only (the masking defect this issue tracks). The `codebase_search` `collection_not_found`-vs-`qdrant_unreachable` surface mentioned in #2628 is left as a **separate follow-up** to keep the search hot path untouched (pendulum/blast-radius discipline). Embeddings score-weighting is unchanged (consistent with #2547's original choice).

## Acceptance criteria (#2628)

- [x] `roosync_inventory(type:"health")` performs an actual authenticated `GET /collections` and reports **`Qdrant: FAIL`** (not OK) when the round-trip is non-200.
- [x] Regression test covers 503 / 401 / 404 / timeout / network-error flipping the verdict to unhealthy.
- [x] Qdrant outage now moves the score (configured-but-unreachable == missing for scoring).

## Tests

`tests/unit/tools/roosync/health-view-qdrant-probe.test.ts` — **11 cases**: probe `200→true`; `503/401/404/network/timeout/missing-URL→false`; api-key header sent to `/collections`; markdown `FAIL/OK/MISSING`.

Local validation: `npm run build` clean (EXIT 0, 0 TS errors); full CI suite **504 files / 9977 tests passed, 0 failures** (`vitest.config.ci.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>