### PR TITLE
fix(rsm): guard compareModelProfiles against non-array .profiles (fleet crash)

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/__tests__/compare-config.test.ts
+++ b/servers/roo-state-manager/src/tools/roosync/__tests__/compare-config.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 // Fix #636 timeout: Use static import instead of dynamic imports
-import { CompareConfigArgsSchema, CompareConfigResultSchema, roosyncCompareConfig } from '../compare-config.js';
+import { CompareConfigArgsSchema, CompareConfigResultSchema, roosyncCompareConfig, compareModelProfiles } from '../compare-config.js';
 
 // Mock dependencies
 const { mockGetConfig, mockCompareRealConfigurations, mockLoadDashboard, mockGetInventory } = vi.hoisted(() => ({
@@ -745,6 +745,58 @@ describe('compare-config', () => {
 
 			const rosterDiff = result.differences.find(d => d.path === 'env.ROO_FLEET_ROSTER');
 			expect(rosterDiff).toBeUndefined(); // check silently skipped, compare_config still returns
+		});
+	});
+
+	// ============================================================
+	// Non-array .profiles robustness (fleet crash 2026-06-21)
+	// ============================================================
+	describe('compareModelProfiles — non-array .profiles robustness', () => {
+		test('does not throw when modelProfile.profiles is a truthy non-array (degraded config sync)', () => {
+			// During a config-sync outage (reverse proxy down), the inventory can return
+			// modelProfile.profiles as a truthy non-array (keyed object / partial shape).
+			// The old `|| []` guard only caught falsy, so `.filter` threw
+			// `sourceProfiles.filter is not a function` — fleet-wide crash reproduced
+			// 2026-06-21 during the po-203 reverse-proxy outage (po-2024/web1/po-2026).
+			const sourceInventory = {
+				roo: { modelProfile: { hash: 'abc', profiles: { production: { id: 'production' } } } }
+			};
+			const targetInventory = {
+				roo: { modelProfile: { hash: 'abc', profiles: { production: { id: 'production' } } } }
+			};
+
+			// Must not throw, and must not emit a false "missing profiles" diff from
+			// the degraded (non-array) read.
+			const diffs = compareModelProfiles(sourceInventory, targetInventory);
+			const profilesDiff = diffs.find(d => d.path === 'roo.modelProfile.profiles');
+			expect(profilesDiff).toBeUndefined();
+		});
+
+		test('still detects missing profiles when .profiles are proper arrays', () => {
+			const sourceInventory = {
+				roo: { modelProfile: { hash: 'abc', profiles: ['production', 'dev'] } }
+			};
+			const targetInventory = {
+				roo: { modelProfile: { hash: 'abc', profiles: ['production'] } }
+			};
+
+			const diffs = compareModelProfiles(sourceInventory, targetInventory);
+			const profilesDiff = diffs.find(d => d.path === 'roo.modelProfile.profiles');
+			expect(profilesDiff).toBeDefined();
+			expect(profilesDiff!.severity).toBe('WARNING');
+			expect(profilesDiff!.description).toContain('dev');
+		});
+
+		test('does not throw when one side has a non-array .profiles and the other an array', () => {
+			// Mixed degraded/healthy reads across the two machines must not crash either.
+			const sourceInventory = {
+				roo: { modelProfile: { hash: 'abc', profiles: { production: {} } } }
+			};
+			const targetInventory = {
+				roo: { modelProfile: { hash: 'abc', profiles: ['production'] } }
+			};
+
+			expect(() => compareModelProfiles(sourceInventory, targetInventory)).not.toThrow();
 		});
 	});
 });

--- a/servers/roo-state-manager/src/tools/roosync/compare-config.ts
+++ b/servers/roo-state-manager/src/tools/roosync/compare-config.ts
@@ -924,7 +924,7 @@ async function checkRosterConsistency(
  * Compare les profils de modèle entre deux machines (#498)
  * Détecte les différences dans model-configs.json
  */
-function compareModelProfiles(
+export function compareModelProfiles(
   sourceInventory: any,
   targetInventory: any
 ): Array<{
@@ -997,8 +997,14 @@ function compareModelProfiles(
   }
 
   // Comparer les profils disponibles
-  const sourceProfiles = sourceProfile.profiles || [];
-  const targetProfiles = targetProfile.profiles || [];
+  // Robustness: `.profiles` can be a truthy non-array (keyed object / partial
+  // shape) when config sync is degraded (e.g. reverse-proxy outage). The `|| []`
+  // fallback only guards against falsy, which made `.filter` below throw
+  // `sourceProfiles.filter is not a function`. Array.isArray guards both falsy
+  // and non-array shapes. (Crash reproduced fleet-wide 2026-06-21 during the
+  // po-203 reverse-proxy outage on po-2024 / web1 / po-2026.)
+  const sourceProfiles = Array.isArray(sourceProfile.profiles) ? sourceProfile.profiles : [];
+  const targetProfiles = Array.isArray(targetProfile.profiles) ? targetProfile.profiles : [];
   const missingProfiles = sourceProfiles.filter((p: string) => !targetProfiles.includes(p));
 
   if (missingProfiles.length > 0) {


### PR DESCRIPTION
## Summary

`roosync_compare_config` crashed fleet-wide with `sourceProfiles.filter is not a function` whenever the inventory returned `modelProfile.profiles` as a truthy non-array — which happens when config sync is degraded (e.g. a reverse-proxy outage). This surfaces during exactly the kind of incident where operators lean on `compare_config` to diagnose drift.

## Root cause

`compareModelProfiles()` ([compare-config.ts:1000-1002](https://github.com/jsboige/jsboige-mcp-servers/blob/main/servers/roo-state-manager/src/tools/roosync/compare-config.ts#L1000)):

```ts
const sourceProfiles = sourceProfile.profiles || [];   // only guards falsy
const targetProfiles = targetProfile.profiles || [];
const missingProfiles = sourceProfiles.filter(...)      // → crash if .profiles is a truthy object
```

The `|| []` fallback only catches *falsy* values. When `.profiles` is a truthy non-array (keyed object / partial shape, returned during degraded config sync), `sourceProfiles` becomes that object and `.filter` throws. The guards at L949/L963 only check the truthiness of the whole `modelProfile` object, not that `.profiles` is an array.

The function is reached via the granular path: `roosyncCompareConfig` → `formatGranularReport` (L749) → `compareModelProfiles`, so any `granularity` (incl. `mcp`) triggers it.

## Fix

Replace `|| []` with `Array.isArray(...)` guards at both sites. This guards against both falsy and non-array shapes, so a degraded read degrades gracefully (no false "missing profiles" diff, no crash) instead of throwing.

```ts
const sourceProfiles = Array.isArray(sourceProfile.profiles) ? sourceProfile.profiles : [];
const targetProfiles = Array.isArray(targetProfile.profiles) ? targetProfile.profiles : [];
```

Also exports `compareModelProfiles` so it can be unit-tested directly (matches the existing pattern in `search-codebase.tool.ts`, which exports its internals).

> Note: web1's report suggested `profileThresholds` (L1015) might need the same guard — it does **not**: that path uses `Object.entries()`, which works on both arrays and objects. Left untouched (no speculative changes, #1936).

## Reproduction

```
roosync_compare_config(granularity: "mcp")
→ Error: [RooSync Service] Erreur lors de la comparaison: sourceProfiles.filter is not a function
```

Reproduced live on po-2026 during the 2026-06-21 po-203 reverse-proxy outage. Previously hit on po-2024 (c.52) and web1 (c.N+2).

## Tests

3 regression cases added to `compare-config.test.ts`:
1. truthy non-array `.profiles` (keyed object) on both sides → does **not** throw, no false "missing profiles" diff (the regression).
2. proper arrays with a real difference → missing-profile `WARNING` diff still emitted (detection preserved).
3. mixed sides (one non-array, one array) → does not throw.

## Validation

- `npm run build` (tsc): OK
- `npx vitest run --config vitest.config.ci.ts`: **9984 passed / 23 skipped / 0 failed** (135s)

## Coordination

First `[CLAIMED]` on this bug (po-2026 c.63). Grounding (root cause + fix sketch) came from web1 c.N+2; independently verified by po-2026 (crash reproduced live + root cause confirmed in source). Author-account cannot self-approve → merge by another machine (po-2024 / ai-01). Parent pointer-bump deferred until this merges (anti-premature-pointer-bump rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
