### PR TITLE
fix(rsm): guard compare-config profiles with Array.isArray to stop crash on degraded inventory

### DIFF
--- a/servers/roo-state-manager/src/tools/roosync/compare-config.ts
+++ b/servers/roo-state-manager/src/tools/roosync/compare-config.ts
@@ -997,8 +997,8 @@ function compareModelProfiles(
   }
 
   // Comparer les profils disponibles
-  const sourceProfiles = sourceProfile.profiles || [];
-  const targetProfiles = targetProfile.profiles || [];
+  const sourceProfiles = Array.isArray(sourceProfile.profiles) ? sourceProfile.profiles : [];
+  const targetProfiles = Array.isArray(targetProfile.profiles) ? targetProfile.profiles : [];
   const missingProfiles = sourceProfiles.filter((p: string) => !targetProfiles.includes(p));
 
   if (missingProfiles.length > 0) {


### PR DESCRIPTION
## Problem

`roosync_compare_config` (and the `roosync_inventory` health-view Config Drift section) crashes fleet-wide with:

```
sourceProfiles.filter is not a function
```

…whenever inventory collection is degraded. This surfaced across the fleet during the 2026-06-21 po-203 proxy outage (claudish + reverse proxies down → degraded config collection).

## Root cause

`compareModelProfiles` ([compare-config.ts:1000](servers/roo-state-manager/src/tools/roosync/compare-config.ts#L1000)):

```ts
const sourceProfiles = sourceProfile.profiles || [];   // L1000
const targetProfiles = targetProfile.profiles || [];   // L1001
const missingProfiles = sourceProfiles.filter(...)      // L1002 → crash
```

`modelProfile.profiles` is **typed `string[]`** ([InventoryCollector.ts:75](servers/roo-state-manager/src/services/InventoryCollector.ts#L75)), but during degraded inventory collection it arrives as a **truthy non-array**. The `|| []` fallback only guards *falsy* values — a truthy non-array (e.g. an object) passes straight through, so `sourceProfiles` becomes that object and `.filter` is not a function.

> Note: two distinct `profiles` fields exist — `config.profiles` (object, [types/inventory.ts:11](servers/roo-state-manager/src/types/inventory.ts#L11), used by ConfigSharingService) and `modelProfile.profiles` (string[]). The crash is on the latter; no confusion between them.

## Fix

Replace the falsy-guard with a type-guard at both sites (L1000-1001):

```ts
const sourceProfiles = Array.isArray(sourceProfile.profiles) ? sourceProfile.profiles : [];
const targetProfiles = Array.isArray(targetProfile.profiles) ? targetProfile.profiles : [];
```

The config-drift check now degrades gracefully (skips the missing-profiles comparison) instead of crashing the entire call. This is correct regardless of *why* the runtime shape is wrong: if `profiles` is genuinely supposed to be an array but isn't, the comparison can't meaningfully run anyway, so skipping it is the right behavior.

## Validation

- ✅ **No-regression**: 29/29 existing `compare-config` tests pass (`npx vitest run compare-config.test.ts`)
- ✅ **Build**: `npm run build` (clean + tsc) compiles clean, type `string[]` preserved
- ✅ **Surgical diff**: 1 file, 2 insertions / 2 deletions (CRLF preserved)

## Recurrence evidence

Confirmed on 2 machines during the po-203 outage:
- po-2024 (c.53, 2026-06-21) — flagged as PR candidate pending recurrence
- web1 (c.N+2, 2026-06-21) — confirmed 2nd reproduction

## Deferred

**Regression test**: `compareModelProfiles` is called at L749 (non-granularity path, fed by `mockCompareRealConfigurations`). Reaching it with a non-array `profiles` shape requires multi-mock orchestration that wasn't traced in this pass. The guard is pure defensive code validated by the existing 29-test suite (no regression). Follow-up: add a test constructing `sourceInventory.roo.modelProfile.profiles` as an object and asserting no crash.

## After merge

Parent pointer-bump to follow in `jsboige/roo-extensions` (deferred until this PR is merged — anti-pointer-bump-premature #1799). ai-01 (CODEOWNER) to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>