### PR TITLE
test(#2642): cover ProfileApplicabilityHelper + EnvRotationService (0->51 tests)

### DIFF
--- a/servers/roo-state-manager/src/services/__tests__/EnvRotationService.test.ts
+++ b/servers/roo-state-manager/src/services/__tests__/EnvRotationService.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Tests for EnvRotationService.ts
+ * Issue #2642 — test coverage audit gap (0 tests, security-critical live prod code)
+ * Issue #2410 — VibeSync Epic #2406 Phase 2 (env secret rotation)
+ *
+ * Uses REAL crypto (scrypt + AES-256-GCM) — mocks only fs + logger.
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const {
+  mockExistsSync,
+  mockMkdirSync,
+  mockReadFile,
+  mockWriteFile,
+  mockReaddir,
+  mockAppendFile,
+  mockCopyFile,
+} = vi.hoisted(() => ({
+  mockExistsSync: vi.fn(),
+  mockMkdirSync: vi.fn(),
+  mockReadFile: vi.fn(),
+  mockWriteFile: vi.fn(),
+  mockReaddir: vi.fn(),
+  mockAppendFile: vi.fn(),
+  mockCopyFile: vi.fn(),
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: actual,
+    existsSync: mockExistsSync,
+    mkdirSync: mockMkdirSync,
+    promises: {
+      readFile: mockReadFile,
+      writeFile: mockWriteFile,
+      readdir: mockReaddir,
+      appendFile: mockAppendFile,
+      copyFile: mockCopyFile,
+    },
+  };
+});
+
+vi.mock('../../utils/logger.js', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { EnvRotationService, ALLOWED_SERVICES } from '../EnvRotationService.js';
+
+const ENV_KEY = 'x'.repeat(48); // 48 chars — above the 32-char minimum
+
+describe('EnvRotationService', () => {
+  let service: EnvRotationService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ROOSYNC_ENV_KEY = ENV_KEY;
+    mockExistsSync.mockReturnValue(false);
+    mockMkdirSync.mockReturnValue(undefined);
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+    mockWriteFile.mockResolvedValue(undefined);
+    mockReaddir.mockResolvedValue([]);
+    mockAppendFile.mockResolvedValue(undefined);
+    mockCopyFile.mockResolvedValue(undefined);
+    service = new EnvRotationService();
+  });
+
+  afterEach(() => {
+    delete process.env.ROOSYNC_ENV_KEY;
+  });
+
+  // ============================================================
+  // ALLOWED_SERVICES (security allowlist)
+  // ============================================================
+  describe('ALLOWED_SERVICES', () => {
+    test('contains exactly the 4 permitted services', () => {
+      expect([...ALLOWED_SERVICES]).toEqual(['rsm', 'sk-agent', 'embedding', 'mcp-auth']);
+    });
+  });
+
+  // ============================================================
+  // encrypt / decrypt (real AES-256-GCM)
+  // ============================================================
+  describe('encrypt / decrypt', () => {
+    test('decrypt(encrypt(plaintext)) round-trips to the original', () => {
+      const plaintext = Buffer.from('API_KEY=secret123\nOTHER=value\n', 'utf-8');
+      const enc = service.encrypt(plaintext);
+      const dec = service.decrypt(enc.ciphertext, enc.iv, enc.tag, enc.salt);
+      expect(dec.equals(plaintext)).toBe(true);
+    });
+
+    test('encrypt produces different ciphertext + iv + salt for the same plaintext (randomness)', () => {
+      const plaintext = Buffer.from('KEY=val\n', 'utf-8');
+      const a = service.encrypt(plaintext);
+      const b = service.encrypt(plaintext);
+      expect(a.ciphertext.equals(b.ciphertext)).toBe(false);
+      expect(a.iv.equals(b.iv)).toBe(false);
+      expect(a.salt.equals(b.salt)).toBe(false);
+    });
+
+    test('encrypt throws if ROOSYNC_ENV_KEY is missing', () => {
+      delete process.env.ROOSYNC_ENV_KEY;
+      expect(() => service.encrypt(Buffer.from('KEY=val\n'))).toThrow(/ROOSYNC_ENV_KEY/);
+    });
+
+    test('encrypt throws if ROOSYNC_ENV_KEY is shorter than 32 chars', () => {
+      process.env.ROOSYNC_ENV_KEY = 'shortkey'; // 8 chars
+      expect(() => service.encrypt(Buffer.from('KEY=val\n'))).toThrow(/too short/i);
+    });
+
+    test('decrypt with a wrong key fails (GCM auth tag verification)', () => {
+      const enc = service.encrypt(Buffer.from('KEY=val\n', 'utf-8'));
+      process.env.ROOSYNC_ENV_KEY = 'y'.repeat(48); // different key
+      expect(() => service.decrypt(enc.ciphertext, enc.iv, enc.tag, enc.salt)).toThrow();
+    });
+  });
+
+  // ============================================================
+  // serializeEncrypted / deserializeEncrypted (wire format)
+  // ============================================================
+  describe('serializeEncrypted / deserializeEncrypted', () => {
+    test('round-trip preserves salt, iv, tag, ciphertext', () => {
+      const enc = service.encrypt(Buffer.from('KEY=val\n', 'utf-8'));
+      const wire = service.serializeEncrypted(enc);
+      const back = service.deserializeEncrypted(wire);
+      expect(back.salt.equals(enc.salt)).toBe(true);
+      expect(back.iv.equals(enc.iv)).toBe(true);
+      expect(back.tag.equals(enc.tag)).toBe(true);
+      expect(back.ciphertext.equals(enc.ciphertext)).toBe(true);
+    });
+
+    test('deserialize throws on input shorter than the header', () => {
+      expect(() => service.deserializeEncrypted(Buffer.from('too-short'))).toThrow(/too short/i);
+    });
+  });
+
+  // ============================================================
+  // publish
+  // ============================================================
+  describe('publish', () => {
+    test('rejects a service not in the allowlist', async () => {
+      await expect(
+        service.publish({
+          service: 'evil-service',
+          envPath: '/x/.env',
+          sharedStatePath: '/s',
+          version: '1',
+          machineId: 'm1',
+        })
+      ).rejects.toThrow(/not in the env rotation allowlist/);
+    });
+
+    test('returns error when the source .env does not exist', async () => {
+      mockExistsSync.mockReturnValue(false); // envPath missing
+      const res = await service.publish({
+        service: 'rsm',
+        envPath: '/x/.env',
+        sharedStatePath: '/s',
+        version: '1',
+        machineId: 'm1',
+      });
+      expect(res.status).toBe('error');
+      expect(res.message).toMatch(/not found/);
+    });
+
+    test('returns warning when the source .env is empty', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue('   \n  '); // whitespace-only
+      const res = await service.publish({
+        service: 'rsm',
+        envPath: '/x/.env',
+        sharedStatePath: '/s',
+        version: '1',
+        machineId: 'm1',
+      });
+      expect(res.status).toBe('warning');
+      expect(res.message).toMatch(/empty/);
+    });
+
+    test('success: encrypts and writes .enc + metadata .json + audit log', async () => {
+      mockExistsSync.mockReturnValue(true); // envPath exists
+      const content = 'API_KEY=secret\nOTHER=val\n';
+      mockReadFile.mockResolvedValue(content);
+
+      const res = await service.publish({
+        service: 'rsm',
+        envPath: '/x/.env',
+        sharedStatePath: '/s',
+        version: '1',
+        machineId: 'm1',
+      });
+
+      expect(res.status).toBe('success');
+      expect(res.size).toBe(Buffer.byteLength(content, 'utf-8'));
+      expect(mockWriteFile).toHaveBeenCalled(); // .enc + metadata .json
+      expect(mockAppendFile).toHaveBeenCalled(); // audit log
+    });
+
+    test('dryRun: reports success without writing the encrypted artifact', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue('API_KEY=secret\n');
+
+      const res = await service.publish({
+        service: 'rsm',
+        envPath: '/x/.env',
+        sharedStatePath: '/s',
+        version: '1',
+        machineId: 'm1',
+        dryRun: true,
+      });
+
+      expect(res.status).toBe('success');
+      expect(res.message).toMatch(/DRY RUN/);
+      expect(mockWriteFile).not.toHaveBeenCalled();
+      expect(mockAppendFile).not.toHaveBeenCalled();
+    });
+  });
+
+  // ============================================================
+  // apply
+  // ============================================================
+  describe('apply', () => {
+    test('rejects a service not in the allowlist', async () => {
+      await expect(
+        service.apply({ service: 'evil', targetEnvPath: '/x/.env', sharedStatePath: '/s' })
+      ).rejects.toThrow(/not in the env rotation allowlist/);
+    });
+
+    test('returns error when no env has been published for the service', async () => {
+      mockExistsSync.mockReturnValue(false); // envDir missing
+      const res = await service.apply({
+        service: 'rsm',
+        targetEnvPath: '/x/.env',
+        sharedStatePath: '/s',
+      });
+      expect(res.status).toBe('error');
+      expect(res.message).toMatch(/No env published/);
+    });
+
+    test('success: decrypts latest version, backs up existing target, writes new .env', async () => {
+      const plaintext = Buffer.from('API_KEY=secret\nOTHER=val\n', 'utf-8');
+      const enc = service.encrypt(plaintext);
+      const wire = service.serializeEncrypted(enc);
+      const metadata = {
+        service: 'rsm',
+        version: '1',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        size: plaintext.length,
+        algorithm: 'aes-256-gcm',
+      };
+
+      mockExistsSync.mockReturnValue(true); // envDir + encPath + existing target (backup)
+      mockReaddir.mockResolvedValue(['1.json'] as never);
+      mockReadFile.mockImplementation(async (p: { toString: () => string }) => {
+        const ps = p.toString();
+        if (ps.endsWith('1.json')) return JSON.stringify(metadata);
+        if (ps.endsWith('1.enc')) return wire;
+        throw new Error('ENOENT');
+      });
+
+      const res = await service.apply({
+        service: 'rsm',
+        targetEnvPath: '/x/.env',
+        sharedStatePath: '/s',
+      });
+
+      expect(res.status).toBe('success');
+      expect(res.keysWritten).toBeGreaterThan(0);
+      expect(mockCopyFile).toHaveBeenCalled(); // backup of existing target
+      expect(mockWriteFile).toHaveBeenCalled(); // new .env write
+    });
+
+    test('error when decrypted content has no KEY=VALUE line (corruption / key mismatch)', async () => {
+      const plaintext = Buffer.from('this is just prose, not an env file at all\n', 'utf-8');
+      const enc = service.encrypt(plaintext);
+      const wire = service.serializeEncrypted(enc);
+      const metadata = {
+        service: 'rsm',
+        version: '1',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        size: plaintext.length,
+      };
+
+      mockExistsSync.mockReturnValue(true);
+      mockReaddir.mockResolvedValue(['1.json'] as never);
+      mockReadFile.mockImplementation(async (p: { toString: () => string }) => {
+        const ps = p.toString();
+        if (ps.endsWith('1.json')) return JSON.stringify(metadata);
+        if (ps.endsWith('1.enc')) return wire;
+        throw new Error('ENOENT');
+      });
+
+      const res = await service.apply({
+        service: 'rsm',
+        targetEnvPath: '/x/.env',
+        sharedStatePath: '/s',
+      });
+
+      expect(res.status).toBe('error');
+      expect(res.message).toMatch(/does not appear to be a valid/);
+    });
+
+    test('dryRun: reports success without writing the target', async () => {
+      const plaintext = Buffer.from('API_KEY=secret\n', 'utf-8');
+      const enc = service.encrypt(plaintext);
+      const wire = service.serializeEncrypted(enc);
+      const metadata = {
+        service: 'rsm',
+        version: '1',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        size: plaintext.length,
+      };
+
+      mockExistsSync.mockReturnValue(true);
+      mockReaddir.mockResolvedValue(['1.json'] as never);
+      mockReadFile.mockImplementation(async (p: { toString: () => string }) => {
+        const ps = p.toString();
+        if (ps.endsWith('1.json')) return JSON.stringify(metadata);
+        if (ps.endsWith('1.enc')) return wire;
+        throw new Error('ENOENT');
+      });
+
+      const res = await service.apply({
+        service: 'rsm',
+        targetEnvPath: '/x/.env',
+        sharedStatePath: '/s',
+        dryRun: true,
+      });
+
+      expect(res.status).toBe('success');
+      expect(res.message).toMatch(/DRY RUN/);
+      expect(mockWriteFile).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/servers/roo-state-manager/src/services/roosync/__tests__/ProfileApplicabilityHelper.test.ts
+++ b/servers/roo-state-manager/src/services/roosync/__tests__/ProfileApplicabilityHelper.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for ProfileApplicabilityHelper.ts
+ * Issue #2642 — test coverage audit gap (0 tests, live prod code wired via NonNominativeBaselineService #1843)
+ *
+ * Pure-function class: category-based profile applicability matching.
+ * No side effects, no mocks required.
+ */
+
+import { describe, test, expect } from 'vitest';
+import {
+  ProfileApplicabilityHelper,
+  ALL_CATEGORIES,
+} from '../ProfileApplicabilityHelper.js';
+import type {
+  ConfigurationProfile,
+  ConfigurationCategory,
+  MachineInventory,
+} from '../../../../types/non-nominative-baseline.js';
+
+/** Minimal profile fixture — only `.category` is read by the helper. */
+function makeProfile(category: ConfigurationCategory): ConfigurationProfile {
+  return {
+    profileId: `profile-${category}`,
+    category,
+    name: category,
+    description: 'test profile',
+    configuration: {},
+    priority: 1,
+    compatibility: { requiredProfiles: [], conflictingProfiles: [], optionalProfiles: [] },
+    metadata: {
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      version: '1.0.0',
+      tags: [],
+      stability: 'stable',
+    },
+  } as ConfigurationProfile;
+}
+
+/** Inventory with no GPU and no detected software — the "bare" baseline. */
+function bareInventory(): MachineInventory {
+  return { machineId: 'test-machine' };
+}
+
+describe('ProfileApplicabilityHelper', () => {
+  // ============================================================
+  // isApplicable — always-true categories
+  // ============================================================
+  describe('isApplicable — always-applicable categories', () => {
+    test.each(['roo-core', 'roo-advanced'] as ConfigurationCategory[])(
+      '%s is always applicable',
+      (category) => {
+        expect(ProfileApplicabilityHelper.isApplicable(makeProfile(category), bareInventory())).toBe(true);
+      }
+    );
+
+    test.each(['hardware-cpu', 'hardware-memory', 'hardware-storage'] as ConfigurationCategory[])(
+      '%s is always applicable (no detection needed)',
+      (category) => {
+        expect(ProfileApplicabilityHelper.isApplicable(makeProfile(category), bareInventory())).toBe(true);
+      }
+    );
+
+    test.each(['system-os', 'system-architecture'] as ConfigurationCategory[])(
+      '%s is always applicable',
+      (category) => {
+        expect(ProfileApplicabilityHelper.isApplicable(makeProfile(category), bareInventory())).toBe(true);
+      }
+    );
+  });
+
+  // ============================================================
+  // isApplicable — hardware-gpu (conditional on GPU presence)
+  // ============================================================
+  describe('isApplicable — hardware-gpu', () => {
+    test('not applicable when machine has no GPU (bare inventory)', () => {
+      expect(
+        ProfileApplicabilityHelper.isApplicable(makeProfile('hardware-gpu'), bareInventory())
+      ).toBe(false);
+    });
+
+    test('applicable via config.hardware.gpu', () => {
+      const inv = { ...bareInventory(), config: { hardware: { gpu: 'NVIDIA RTX 4090' } } };
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('hardware-gpu'), inv)).toBe(true);
+    });
+
+    test('applicable via inventory.systemInfo.gpu array (non-empty)', () => {
+      const inv = {
+        ...bareInventory(),
+        inventory: { systemInfo: { gpu: [{ name: 'NVIDIA RTX 4090' }] } },
+      } as MachineInventory;
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('hardware-gpu'), inv)).toBe(true);
+    });
+
+    test('NOT applicable via empty systemInfo.gpu array', () => {
+      const inv = {
+        ...bareInventory(),
+        inventory: { systemInfo: { gpu: [] } },
+      } as MachineInventory;
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('hardware-gpu'), inv)).toBe(false);
+    });
+
+    test('applicable via inventory.gpuDetails (nvidia-smi) array (non-empty)', () => {
+      const inv = {
+        ...bareInventory(),
+        inventory: {
+          gpuDetails: [{ index: 0, name: 'RTX 4090', memoryTotal: 24576, memoryFree: 24000, memoryUsed: 576, source: 'nvidia-smi' }],
+        },
+      } as MachineInventory;
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('hardware-gpu'), inv)).toBe(true);
+    });
+  });
+
+  // ============================================================
+  // isApplicable — software-* (conditional on detection)
+  // ============================================================
+  describe('isApplicable — software-powershell', () => {
+    test('not applicable when not detected (bare inventory)', () => {
+      expect(
+        ProfileApplicabilityHelper.isApplicable(makeProfile('software-powershell'), bareInventory())
+      ).toBe(false);
+    });
+
+    test('applicable via systemInfo.powershellVersion', () => {
+      const inv = { ...bareInventory(), inventory: { systemInfo: { powershellVersion: '7.4.0' } } } as MachineInventory;
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('software-powershell'), inv)).toBe(true);
+    });
+
+    test('applicable via tools.powershell.version', () => {
+      const inv = { ...bareInventory(), inventory: { tools: { powershell: { version: '7.4.0' } } } } as MachineInventory;
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('software-powershell'), inv)).toBe(true);
+    });
+
+    test('applicable via legacy config.software.powershell', () => {
+      const inv = { ...bareInventory(), config: { software: { powershell: '7.4.0' } } };
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('software-powershell'), inv)).toBe(true);
+    });
+
+    test('NOT applicable when only "Unknown" version is present', () => {
+      const inv = {
+        ...bareInventory(),
+        inventory: { systemInfo: { powershellVersion: 'Unknown' }, tools: { powershell: { version: 'Unknown' } } },
+        config: { software: { powershell: 'Unknown' } },
+      } as MachineInventory;
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('software-powershell'), inv)).toBe(false);
+    });
+
+    test('NOT applicable when only empty-string versions are present', () => {
+      const inv = {
+        ...bareInventory(),
+        inventory: { tools: { powershell: { version: '' } } },
+      } as MachineInventory;
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('software-powershell'), inv)).toBe(false);
+    });
+  });
+
+  describe('isApplicable — software-node', () => {
+    test('not applicable when not detected', () => {
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('software-node'), bareInventory())).toBe(false);
+    });
+
+    test('applicable via tools.node.version', () => {
+      const inv = { ...bareInventory(), inventory: { tools: { node: { version: '20.10.0' } } } } as MachineInventory;
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('software-node'), inv)).toBe(true);
+    });
+
+    test('applicable via legacy config.software.node', () => {
+      const inv = { ...bareInventory(), config: { software: { node: '20.10.0' } } };
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('software-node'), inv)).toBe(true);
+    });
+
+    test('NOT applicable when version is "Unknown"', () => {
+      const inv = { ...bareInventory(), inventory: { tools: { node: { version: 'Unknown' } } } } as MachineInventory;
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('software-node'), inv)).toBe(false);
+    });
+  });
+
+  describe('isApplicable — software-python', () => {
+    test('not applicable when not detected', () => {
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('software-python'), bareInventory())).toBe(false);
+    });
+
+    test('applicable via tools.python.version', () => {
+      const inv = { ...bareInventory(), inventory: { tools: { python: { version: '3.12.0' } } } } as MachineInventory;
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('software-python'), inv)).toBe(true);
+    });
+
+    test('NOT applicable when version is "Unknown"', () => {
+      const inv = { ...bareInventory(), inventory: { tools: { python: { version: 'Unknown' } } } } as MachineInventory;
+      expect(ProfileApplicabilityHelper.isApplicable(makeProfile('software-python'), inv)).toBe(false);
+    });
+  });
+
+  // ============================================================
+  // isApplicable — default branch
+  // ============================================================
+  describe('isApplicable — default branch', () => {
+    test('unknown category defaults to applicable (safe default)', () => {
+      const unknownProfile = makeProfile('system-os'); // valid but test the default path via cast
+      (unknownProfile as { category: string }).category = 'some-future-category';
+      expect(ProfileApplicabilityHelper.isApplicable(unknownProfile, bareInventory())).toBe(true);
+    });
+  });
+
+  // ============================================================
+  // filterApplicable — split + exclusion reasons
+  // ============================================================
+  describe('filterApplicable', () => {
+    test('splits a mixed list into applicable + excluded', () => {
+      const profiles = [
+        makeProfile('roo-core'),          // always true
+        makeProfile('hardware-gpu'),      // false (bare inventory)
+        makeProfile('software-node'),     // false (bare inventory)
+        makeProfile('system-os'),         // always true
+      ];
+      const result = ProfileApplicabilityHelper.filterApplicable(profiles, bareInventory());
+      expect(result.applicable).toHaveLength(2);
+      expect(result.applicable.map((p) => p.category)).toEqual(['roo-core', 'system-os']);
+      expect(result.excluded).toHaveLength(2);
+      expect(result.excluded.map((e) => e.profile.category)).toEqual(['hardware-gpu', 'software-node']);
+    });
+
+    test('exclusion reason for missing GPU is human-readable', () => {
+      const result = ProfileApplicabilityHelper.filterApplicable([makeProfile('hardware-gpu')], bareInventory());
+      expect(result.excluded[0].reason).toBe('Machine has no GPU');
+    });
+
+    test('exclusion reason for undetected software names the software', () => {
+      const result = ProfileApplicabilityHelper.filterApplicable(
+        [makeProfile('software-node'), makeProfile('software-python'), makeProfile('software-powershell')],
+        bareInventory()
+      );
+      expect(result.excluded[0].reason).toBe('Node.js not detected');
+      expect(result.excluded[1].reason).toBe('Python not detected');
+      expect(result.excluded[2].reason).toBe('PowerShell not detected');
+    });
+
+    test('empty input → empty applicable + empty excluded', () => {
+      const result = ProfileApplicabilityHelper.filterApplicable([], bareInventory());
+      expect(result.applicable).toEqual([]);
+      expect(result.excluded).toEqual([]);
+    });
+
+    test('all-applicable list → empty excluded', () => {
+      const profiles = [makeProfile('roo-core'), makeProfile('system-os')];
+      const result = ProfileApplicabilityHelper.filterApplicable(profiles, bareInventory());
+      expect(result.applicable).toHaveLength(2);
+      expect(result.excluded).toEqual([]);
+    });
+  });
+
+  // ============================================================
+  // ALL_CATEGORIES exhaustive — every category returns a boolean, no throw
+  // ============================================================
+  describe('ALL_CATEGORIES exhaustive coverage', () => {
+    test('every declared category is handled without throwing', () => {
+      for (const category of ALL_CATEGORIES) {
+        const result = ProfileApplicabilityHelper.isApplicable(makeProfile(category), bareInventory());
+        expect(typeof result).toBe('boolean');
+      }
+    });
+
+    test('ALL_CATEGORIES contains exactly the 11 known categories', () => {
+      expect(ALL_CATEGORIES).toHaveLength(11);
+      expect(ALL_CATEGORIES).toContain('hardware-gpu');
+      expect(ALL_CATEGORIES).toContain('software-powershell');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes part of the **roo-extensions#2642** test coverage audit gap. Two live, prod-exercised services in `roo-state-manager` had **0 dedicated unit tests** (verified via broad `grep` across all `*.test.ts` — no indirect coverage via their callers `NonNominativeBaselineService` / the `config` tool).

| Service | Wired into prod | Tests before | Tests after |
|---------|-----------------|--------------|-------------|
| `ProfileApplicabilityHelper` | `NonNominativeBaselineService` (#1843) | 0 | 33 |
| `EnvRotationService` | `tools/roosync/config` env-rotation (#2410) | 0 | 18 |

Non-crash defense-in-depth (crash-class `sourceProfiles.filter` already hardened by #649).

## What's covered

**ProfileApplicabilityHelper** (pure function):
- Category applicability switch (roo / hardware / software / system branches)
- GPU detection across 3 sources (`config.hardware.gpu`, `systemInfo.gpu[]`, `gpuDetails[]`) incl. empty-array negative
- Software detection — `'Unknown'` and empty-string treated as not-detected; powershell/node/python across systemInfo / tools / legacy-config sources
- `filterApplicable` split + human-readable exclusion reasons
- `ALL_CATEGORIES` exhaustive (no throw)

**EnvRotationService** (security-critical, AES-256-GCM — uses **real crypto**, not mocked):
- encrypt/decrypt round-trip; key guards (missing `ROOSYNC_ENV_KEY`, <32 chars, wrong-key GCM auth-tag failure)
- wire serialize/deserialize round-trip + too-short rejection
- `ALLOWED_SERVICES` allowlist (rsm, sk-agent, embedding, mcp-auth)
- publish/apply happy + error + dryRun paths

## Validation
- `npm run build` ✅ clean
- `npx vitest run --config vitest.config.ci.ts` ✅ **10035 passed | 0 failed** (509 files)
- Targeted run of the 2 new files: **51 passed, 5.15s**
- **Test-only — no source changes** (zero regression surface)

## Notes
- This PR touches the submodule only. A parent pointer-bump will follow **after merge** (anti-pointer-bump-premature #1799) — coordinator can bundle it.
- Deploy-lag: test-only change, no `build/` impact, no MCP host restart needed.

Refs: roo-extensions#2642 (audit), #1843 (ProfileApplicabilityHelper impl), #2410 (EnvRotationService / VibeSync Epic #2406).
