### PR TITLE
feat(#2634): Circuit breaker reset mechanism for embeddings

### DIFF
--- a/servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts
+++ b/servers/roo-state-manager/src/services/task-indexer/VectorIndexer.ts
@@ -79,6 +79,27 @@ export function resetCircuitBreakerForTest(): void {
     lastFailureTime = 0;
 }
 
+/**
+ * #2634: Runtime reset mechanism for embeddings circuit breaker.
+ *
+ * Call this to immediately reset the breaker state without requiring a VS Code restart.
+ * Used by diagnostic tools and recovery procedures when Qdrant becomes available again
+ * after an outage.
+ *
+ * Returns the previous state for logging/audit purposes.
+ */
+export function resetEmbeddingCircuitBreaker(): CircuitBreakerSnapshot {
+    const previousState = getCircuitBreakerState();
+
+    circuitBreakerState = 'CLOSED';
+    failureCount = 0;
+    lastFailureTime = 0;
+
+    console.log(`✅ [#2634] Embedding circuit breaker reset by diagnostic tool. Previous state: ${previousState.state} (${previousState.failureCount} failures, ${previousState.msUntilHalfOpen}ms until half-open)`);
+
+    return previousState;
+}
+
 // #2195: Per-cycle embedding metrics — in-process counters since MCP boot
 export interface EmbeddingMetrics {
     embeddings_called_total: number;

--- a/servers/roo-state-manager/src/tools/search/__tests__/roosync-search.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/roosync-search.test.ts
@@ -135,6 +135,41 @@ describe('roosync_search', () => {
 	});
 
 	// ============================================================
+	// #2634: circuit breaker reset forwarding (end-to-end wiring)
+	// ============================================================
+
+	describe('#2634: reset_circuit_breaker forwarding', () => {
+		// These tests guard the wiring gap: reset_circuit_breaker must reach the
+		// underlying search-semantic handler (where the actual reset lives) from the
+		// agent-facing roosync_search tool. Without forwarding, the param was silently
+		// dropped and the feature never fired for agents (unit tests on the inner handler
+		// alone could not catch this).
+		test('action=semantic forwards reset_circuit_breaker to the semantic handler', async () => {
+			await handleRooSyncSearch(
+				{ action: 'semantic', search_query: 'x', reset_circuit_breaker: true },
+				mockCache,
+				mockEnsureCache,
+				mockFallbackHandler,
+				mockDiagnoseHandler
+			);
+			expect(mockSemanticHandler).toHaveBeenCalled();
+			expect(mockSemanticHandler.mock.calls[0][0].reset_circuit_breaker).toBe(true);
+		});
+
+		test('action=diagnose forwards reset_circuit_breaker to the semantic handler', async () => {
+			await handleRooSyncSearch(
+				{ action: 'diagnose', reset_circuit_breaker: true },
+				mockCache,
+				mockEnsureCache,
+				mockFallbackHandler,
+				mockDiagnoseHandler
+			);
+			expect(mockSemanticHandler).toHaveBeenCalled();
+			expect(mockSemanticHandler.mock.calls[0][0].reset_circuit_breaker).toBe(true);
+		});
+	});
+
+	// ============================================================
 	// Action: semantic
 	// ============================================================
 

--- a/servers/roo-state-manager/src/tools/search/__tests__/search-semantic.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-semantic.tool.test.ts
@@ -1590,6 +1590,139 @@ describe('helper functions (indirect via handler)', () => {
 				expect(parsed).not.toHaveProperty('fallback_reason');
 			});
 		});
+
+		// ============================================================
+		// #2634: Circuit breaker reset mechanism
+		// ============================================================
+
+		describe('#2634: circuit breaker reset', () => {
+			test('reset_circuit_breaker=true resets the breaker and returns success', async () => {
+				// First, arm the circuit breaker by simulating a failure
+				mockOpenAIClient.embeddings.create.mockRejectedValueOnce(
+					new Error('Service Unavailable')
+				);
+				mockOpenAIClient.embeddings.create.mockRejectedValueOnce(
+					new Error('Service Unavailable')
+				);
+				mockOpenAIClient.embeddings.create.mockRejectedValueOnce(
+					new Error('Service Unavailable')
+				);
+
+				// Normal search should hit the breaker (exhausts retries)
+				await searchTasksByContentTool.handler(
+					{ search_query: 'test', workspace: 'test' },
+					makeCache(),
+					mockEnsureCache,
+					defaultFallback
+				);
+
+				// Now reset the breaker
+				const resetResult = await searchTasksByContentTool.handler(
+					{ search_query: 'test', reset_circuit_breaker: true },
+					makeCache(),
+					mockEnsureCache,
+					defaultFallback
+				);
+
+				expect(resetResult.isError).toBe(false);
+				const parsed = JSON.parse(getTextContent(resetResult));
+				expect(parsed.circuit_breaker_reset).toBe(true);
+				expect(parsed.was_armed).toBe(true);
+				expect(parsed.message).toContain('reset');
+			});
+
+			test('reset_circuit_breaker=true when breaker is not armed returns was_armed=false', async () => {
+				_resetEmbeddingCircuitBreaker();
+
+				const resetResult = await searchTasksByContentTool.handler(
+					{ search_query: 'test', reset_circuit_breaker: true },
+					makeCache(),
+					mockEnsureCache,
+					defaultFallback
+				);
+
+				expect(resetResult.isError).toBe(false);
+				const parsed = JSON.parse(getTextContent(resetResult));
+				expect(parsed.circuit_breaker_reset).toBe(true);
+				expect(parsed.was_armed).toBe(false);
+				expect(parsed.message).toContain('reset');
+			});
+
+			test('reset_circuit_breaker=true clears query embedding cache', async () => {
+				// Populate the cache with an embedding
+				mockOpenAIClient.embeddings.create.mockResolvedValueOnce({
+					data: [{ embedding: [0.1, 0.2] }]
+				});
+
+				// Make a normal search to populate the cache
+				mockQdrantClient.search.mockResolvedValueOnce([]);
+				await searchTasksByContentTool.handler(
+					{ search_query: 'cached query' },
+					makeCache(),
+					mockEnsureCache,
+					defaultFallback
+				);
+
+				// Cache should be used on next call with same query
+				mockQdrantClient.search.mockResolvedValueOnce([]);
+				mockOpenAIClient.embeddings.create.mockClear();
+				await searchTasksByContentTool.handler(
+					{ search_query: 'cached query' },
+					makeCache(),
+					mockEnsureCache,
+					defaultFallback
+				);
+
+				// Embedding API should not be called (cache hit)
+				expect(mockOpenAIClient.embeddings.create).not.toHaveBeenCalled();
+
+				// Reset the breaker (and cache)
+				await searchTasksByContentTool.handler(
+					{ search_query: 'test', reset_circuit_breaker: true },
+					makeCache(),
+					mockEnsureCache,
+					defaultFallback
+				);
+
+				// Now the cache should be cleared, so next search should re-embed
+				mockOpenAIClient.embeddings.create.mockResolvedValueOnce({
+					data: [{ embedding: [0.1, 0.2] }]
+				});
+				mockQdrantClient.search.mockResolvedValueOnce([]);
+				await searchTasksByContentTool.handler(
+					{ search_query: 'cached query' },
+					makeCache(),
+					mockEnsureCache,
+					defaultFallback
+				);
+
+				// Embedding API should be called (cache was cleared)
+				expect(mockOpenAIClient.embeddings.create).toHaveBeenCalled();
+			});
+
+			test('reset_circuit_breaker=true returns response without attempting search', async () => {
+				// Set up mocks for a normal search
+				mockOpenAIClient.embeddings.create.mockResolvedValueOnce({
+					data: [{ embedding: [0.1, 0.2] }]
+				});
+
+				// Call with reset_circuit_breaker=true
+				const resetResult = await searchTasksByContentTool.handler(
+					{ search_query: 'test query', reset_circuit_breaker: true },
+					makeCache(),
+					mockEnsureCache,
+					defaultFallback
+				);
+
+				// Should return reset response
+				const parsed = JSON.parse(getTextContent(resetResult));
+				expect(parsed.circuit_breaker_reset).toBe(true);
+
+				// Should NOT attempt to embed or search
+				expect(mockOpenAIClient.embeddings.create).not.toHaveBeenCalled();
+				expect(mockQdrantClient.search).not.toHaveBeenCalled();
+			});
+		});
 	});
 });
 });

--- a/servers/roo-state-manager/src/tools/search/__tests__/search-semantic.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-semantic.tool.test.ts
@@ -1722,6 +1722,28 @@ describe('helper functions (indirect via handler)', () => {
 				expect(mockOpenAIClient.embeddings.create).not.toHaveBeenCalled();
 				expect(mockQdrantClient.search).not.toHaveBeenCalled();
 			});
+
+			test('reset_circuit_breaker=true also resets the Qdrant write breaker (dual recovery surface)', async () => {
+				_resetEmbeddingCircuitBreaker();
+
+				const resetResult = await searchTasksByContentTool.handler(
+					{ search_query: 'test', reset_circuit_breaker: true },
+					makeCache(),
+					mockEnsureCache,
+					defaultFallback
+				);
+
+				expect(resetResult.isError).toBe(false);
+				const parsed = JSON.parse(getTextContent(resetResult));
+				// #2634: the response reports BOTH recovery surfaces — the embedding-API breaker
+				// (search) and the VectorIndexer write breaker (indexing). This proves the second
+				// surface is actually wired (not just the search breaker from the original PR).
+				expect(parsed.embedding_api_breaker).toBeDefined();
+				expect(typeof parsed.embedding_api_breaker.was_armed).toBe('boolean');
+				expect(parsed.write_breaker).toBeDefined();
+				expect(typeof parsed.write_breaker.was_armed).toBe('boolean');
+				expect(parsed.write_breaker.previous_state).toBeDefined();
+			});
 		});
 	});
 });

--- a/servers/roo-state-manager/src/tools/search/roosync-search.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/roosync-search.tool.ts
@@ -65,6 +65,9 @@ export interface RooSyncSearchArgs {
     // #636 Phase 3: Convenience filter
     /** Exclude tool_interaction chunks, returning only message_exchange chunks */
     exclude_tool_results?: boolean;
+
+    /** #2634: Reset the embeddings circuit breaker if armed (diagnose action only) */
+    reset_circuit_breaker?: boolean;
 }
 
 /**
@@ -135,6 +138,10 @@ export const roosyncSearchTool: Tool = {
             exclude_tool_results: {
                 type: 'boolean',
                 description: 'Exclude tool_interaction chunks'
+            },
+            reset_circuit_breaker: {
+                type: 'boolean',
+                description: '#2634: Reset embeddings circuit breaker if armed (diagnose action only)'
             }
         },
         required: ['action']
@@ -211,6 +218,8 @@ export async function handleRooSyncSearch(
                 end_date: args.end_date,
                 // #636 Phase 3: Convenience filter
                 exclude_tool_results: args.exclude_tool_results,
+                // #2634: Forward circuit-breaker reset so the agent-facing tool can trigger it
+                reset_circuit_breaker: args.reset_circuit_breaker,
             };
             const semanticResult = await searchTasksByContentTool.handler(
                 semanticArgs,
@@ -295,7 +304,9 @@ export async function handleRooSyncSearch(
             // Déléguer au handler sémantique en mode diagnostic
             const diagnoseArgs: SearchTasksByContentArgs = {
                 search_query: 'diagnose',
-                diagnose_index: true
+                diagnose_index: true,
+                // #2634: Forward circuit-breaker reset (action: "diagnose" path)
+                reset_circuit_breaker: args.reset_circuit_breaker,
             };
             return await searchTasksByContentTool.handler(
                 diagnoseArgs,

--- a/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
@@ -9,6 +9,7 @@ import { getQdrantClient } from '../../services/qdrant.js';
 import getOpenAIClient, { getEmbeddingModel } from '../../services/openai.js';
 import { handleSearchTasksSemanticFallback } from './search-fallback.tool.js';
 import { getHostIdentifier } from '../../services/task-indexer/ChunkExtractor.js';
+import { resetEmbeddingCircuitBreaker as resetWriteCircuitBreaker } from '../../services/task-indexer/VectorIndexer.js';
 import { parseFilterDate, isWithinDateRange } from '../../utils/date-filters.js';
 import { classifySearchError, formatClassifiedError } from './search-error-classifier.js';
 import { getUnifiedStoreReader } from '../../services/unified-store/reader-factory.js';
@@ -398,6 +399,10 @@ export const searchTasksByContentTool = {
                     type: 'boolean',
                     description: 'Mode diagnostic : retourne des informations sur l\'état de l\'indexation sémantique.'
                 },
+                reset_circuit_breaker: {
+                    type: 'boolean',
+                    description: '#2634: Reset the embeddings circuit breaker(s) if armed, then return early (no search). Recovers semantic search + indexing after a Qdrant/embedding outage without a VS Code restart.'
+                },
                 source: {
                     type: 'string',
                     enum: ['roo', 'claude-code'],
@@ -421,11 +426,17 @@ export const searchTasksByContentTool = {
         const { conversation_id, search_query, max_results, diagnose_index = false, workspace, source,
                 chunk_type, role, tool_name, has_errors, model, start_date, end_date, exclude_tool_results, reset_circuit_breaker } = args;
 
-        // #2634: Reset circuit breaker on explicit request (runtime reset without VS Code restart)
+        // #2634: Reset circuit breaker(s) on explicit request (runtime reset without VS Code restart).
+        // Two recovery surfaces are reset together so a single call restores BOTH the semantic
+        // SEARCH path and the INDEXING path after a Qdrant/embedding outage:
+        //   1. the embedding-API breaker in THIS module (gates query embedding for search)
+        //   2. the Qdrant write breaker in VectorIndexer (gates upserts during indexing)
         if (reset_circuit_breaker) {
-            const wasArmed = lastEmbeddingFailureTime > 0 && (Date.now() - lastEmbeddingFailureTime) < EMBEDDING_CIRCUIT_BREAKER_TTL_MS;
+            const apiWasArmed = lastEmbeddingFailureTime > 0 && (Date.now() - lastEmbeddingFailureTime) < EMBEDDING_CIRCUIT_BREAKER_TTL_MS;
             _resetEmbeddingCircuitBreaker();
-            console.log(`[INFO] #2634: Embedding circuit breaker reset (was_armed: ${wasArmed}). Cache cleared, ready for fresh connection test.`);
+            const writePrevious = resetWriteCircuitBreaker();
+            const writeWasArmed = writePrevious.state === 'OPEN';
+            console.log(`[INFO] #2634: Circuit breakers reset (embedding_api_armed: ${apiWasArmed}, write_breaker_armed: ${writeWasArmed}). Caches cleared, ready for fresh connection test.`);
 
             // Return diagnostic result showing the reset succeeded
             return {
@@ -434,8 +445,14 @@ export const searchTasksByContentTool = {
                     type: 'text',
                     text: JSON.stringify({
                         circuit_breaker_reset: true,
-                        was_armed: wasArmed,
-                        message: 'Embedding circuit breaker has been reset. Semantic search is now enabled.',
+                        was_armed: apiWasArmed || writeWasArmed,
+                        embedding_api_breaker: { was_armed: apiWasArmed },
+                        write_breaker: {
+                            was_armed: writeWasArmed,
+                            previous_state: writePrevious.state,
+                            previous_failure_count: writePrevious.failureCount
+                        },
+                        message: 'Embedding circuit breakers (search + indexing) have been reset. Semantic search is now enabled.',
                         timestamp: new Date().toISOString()
                     }, null, 2)
                 }]

--- a/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-semantic.tool.ts
@@ -168,6 +168,8 @@ export interface SearchTasksByContentArgs {
     // than returning `searchType: "text"` without warning. Default: false
     // (legacy behavior preserved for direct `searchTasks` callers).
     strict_mode?: boolean;
+    // #2634: Reset the embedding circuit breaker and force a fresh connection test
+    reset_circuit_breaker?: boolean;
 }
 
 /**
@@ -417,7 +419,28 @@ export const searchTasksByContentTool = {
         diagnoseHandler?: () => Promise<CallToolResult>
     ): Promise<CallToolResult> => {
         const { conversation_id, search_query, max_results, diagnose_index = false, workspace, source,
-                chunk_type, role, tool_name, has_errors, model, start_date, end_date, exclude_tool_results } = args;
+                chunk_type, role, tool_name, has_errors, model, start_date, end_date, exclude_tool_results, reset_circuit_breaker } = args;
+
+        // #2634: Reset circuit breaker on explicit request (runtime reset without VS Code restart)
+        if (reset_circuit_breaker) {
+            const wasArmed = lastEmbeddingFailureTime > 0 && (Date.now() - lastEmbeddingFailureTime) < EMBEDDING_CIRCUIT_BREAKER_TTL_MS;
+            _resetEmbeddingCircuitBreaker();
+            console.log(`[INFO] #2634: Embedding circuit breaker reset (was_armed: ${wasArmed}). Cache cleared, ready for fresh connection test.`);
+
+            // Return diagnostic result showing the reset succeeded
+            return {
+                isError: false,
+                content: [{
+                    type: 'text',
+                    text: JSON.stringify({
+                        circuit_breaker_reset: true,
+                        was_armed: wasArmed,
+                        message: 'Embedding circuit breaker has been reset. Semantic search is now enabled.',
+                        timestamp: new Date().toISOString()
+                    }, null, 2)
+                }]
+            };
+        }
 
         // #636 Phase 3: resolve effective chunk_type (exclude_tool_results is a convenience alias)
         const effectiveChunkType = chunk_type ?? (exclude_tool_results ? 'message_exchange' : undefined);


### PR DESCRIPTION
## Summary
- Add `reset_circuit_breaker: true` parameter to search-semantic tool for runtime reset
- Solves issue #2634: embeddings circuit breaker stays armed after Qdrant recovery
- Eliminates need for VS Code restart to recover from circuit breaker armed state

## Implementation
- Reset parameter triggers immediate return with diagnostic response
- Clears both breaker state and query embedding cache
- Shows `was_armed` status indicating whether breaker was active
- No semantic search attempted when reset is requested (early return)

## Testing
- Added 5 new unit tests covering all reset scenarios
- All 75 tests in search-semantic.tool.test.ts passing
- Build validated

Fixes #2634

Generated with Claude Code