### PR TITLE
fix(rsm): route codebase_search Qdrant outage to qdrant_unreachable (#2636)

### DIFF
--- a/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
+++ b/servers/roo-state-manager/src/tools/search/__tests__/search-codebase.tool.test.ts
@@ -176,10 +176,20 @@ describe('search-codebase.tool', () => {
 				expect(collections).toEqual(['ws-abc123', 'ws-def456']);
 			});
 
-			test('returns empty array on error', async () => {
+			test('returns empty array on a non-network error', async () => {
 				mockQdrant.getCollections.mockRejectedValue(new Error('connection failed'));
 				const collections = await listWorkspaceCollections();
 				expect(collections).toEqual([]);
+			});
+
+			// #2636: a network/TLS failure (Qdrant outage) must propagate so the codebase_search
+			// outer catch classifies it as qdrant_unreachable, instead of being swallowed into []
+			// (which the caller reports as collection_not_found — masking the outage).
+			test('rethrows network errors so a Qdrant outage reaches the classifier (#2636)', async () => {
+				mockQdrant.getCollections.mockRejectedValue(
+					Object.assign(new Error('fetch failed'), { code: 'ECONNREFUSED' })
+				);
+				await expect(listWorkspaceCollections()).rejects.toThrow();
 			});
 
 			test('returns empty array when no ws-* collections exist', async () => {
@@ -290,9 +300,13 @@ describe('search-codebase.tool', () => {
 			expect(parsed.workspace).toBe('/fake/workspace');
 		});
 
-		test('returns collection_not_found when getCollection rejects', async () => {
-			// All variant attempts reject, so it's treated as "not found"
-			mockQdrant.getCollection.mockRejectedValue(new Error('fetch failed'));
+		// #2636: a Qdrant *outage* in the variant loop must surface as qdrant_unreachable,
+		// NOT be folded into collection_not_found (which masks an outage as a missing index
+		// and steers callers toward a wrong "re-index" remediation).
+		test('returns qdrant_unreachable when getCollection fails with a network error (#2636)', async () => {
+			mockQdrant.getCollection.mockRejectedValue(
+				Object.assign(new Error('fetch failed'), { code: 'ECONNREFUSED' })
+			);
 
 			const result = await handleCodebaseSearch({
 				query: 'test',
@@ -300,8 +314,27 @@ describe('search-codebase.tool', () => {
 			});
 
 			const parsed = JSON.parse(result.content[0].text);
-			expect(parsed.status).toBe('collection_not_found');
-			expect(parsed.tried_variants.length).toBeGreaterThan(0);
+			expect(parsed.status).toBe('qdrant_unreachable');
+			expect((result as any).isError).toBe(true);
+		});
+
+		// #2636: a Qdrant outage reached via the listWorkspaceCollections() fallback
+		// (variant loop sees genuine 404s, then getCollections() is down) must also
+		// surface as qdrant_unreachable rather than collection_not_found.
+		test('returns qdrant_unreachable when getCollections fails with a network error (#2636)', async () => {
+			mockQdrant.getCollection.mockRejectedValue(new Error('Not found')); // genuine 404 per variant
+			mockQdrant.getCollections.mockRejectedValue(
+				Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:6333'), { code: 'ECONNREFUSED' })
+			);
+
+			const result = await handleCodebaseSearch({
+				query: 'test',
+				workspace: '/ws'
+			});
+
+			const parsed = JSON.parse(result.content[0].text);
+			expect(parsed.status).toBe('qdrant_unreachable');
+			expect((result as any).isError).toBe(true);
 		});
 	});
 

--- a/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
+++ b/servers/roo-state-manager/src/tools/search/search-codebase.tool.ts
@@ -8,7 +8,7 @@
 
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { classifySearchError, formatClassifiedError } from './search-error-classifier.js';
+import { classifySearchError, formatClassifiedError, isNetworkErrorLike } from './search-error-classifier.js';
 import { createHash } from 'crypto';
 import OpenAI from 'openai';
 import { getQdrantClient } from '../../services/qdrant.js';
@@ -105,7 +105,12 @@ export async function listWorkspaceCollections(): Promise<string[]> {
 		return response.collections
 			.map((c: any) => c.name)
 			.filter((name: string) => name.startsWith('ws-'));
-	} catch {
+	} catch (err) {
+		// #2636: a Qdrant *outage* (network/TLS) must surface as qdrant_unreachable
+		// via the outer classifier, not be folded into an empty list — which the caller
+		// then reports as collection_not_found, masking the outage as a missing index.
+		// A genuinely empty / 404 listing is still swallowed → [].
+		if (isNetworkErrorLike(err)) throw err;
 		return [];
 	}
 }
@@ -464,7 +469,11 @@ export async function handleCodebaseSearch(args: CodebaseSearchArgs): Promise<Ca
 					hashMatchedPointsCount = (collectionInfo as any)?.points_count ?? null;
 					break;
 				}
-			} catch {
+			} catch (err) {
+				// #2636: a 404 means "this variant doesn't exist" → try the next one;
+				// a network/TLS error means the backend is down → stop and propagate so
+				// the outer catch classifies it as qdrant_unreachable (not collection_not_found).
+				if (isNetworkErrorLike(err)) throw err;
 				// Cette variante n'existe pas, essayer la suivante
 			}
 		}

--- a/servers/roo-state-manager/src/tools/search/search-error-classifier.ts
+++ b/servers/roo-state-manager/src/tools/search/search-error-classifier.ts
@@ -44,6 +44,21 @@ function isNetworkError(errorCode: string, errorMsg: string): boolean {
 }
 
 /**
+ * #2636: Public predicate — true when an error looks like a backend connection
+ * failure (TCP/DNS/TLS reset, or a `fetch failed`), as opposed to a genuine 404.
+ * Lets callers (e.g. codebase_search's collection-listing swallow points) tell a
+ * Qdrant *outage* apart from a missing collection BEFORE they fold the error into
+ * an empty result — so the outage can still reach `classifySearchError` and surface
+ * as `qdrant_unreachable` instead of being masked as `collection_not_found`.
+ * Reuses NETWORK_ERROR_PATTERNS so the distinction is not reinvented.
+ */
+export function isNetworkErrorLike(error: unknown): boolean {
+	const errorMsg = error instanceof Error ? error.message : String(error);
+	const errorCode = (error as any)?.code || '';
+	return isNetworkError(errorCode, errorMsg) || errorMsg.includes('fetch failed');
+}
+
+/**
  * Quick health probe to distinguish proxy_drop from qdrant_unreachable.
  * Returns { ok, latencyMs, status } or throws.
  * Timeout: 5 seconds (short, for diagnostic only).


### PR DESCRIPTION
## What

`codebase_search` masked a Qdrant **outage** as `collection_not_found` — steering callers toward the wrong "re-index the workspace" remediation when the real cause was the backend being unreachable. Reported live during the 2026-06-20 cluster-wide Qdrant 503 (myia-po-2026) and re-surfaced by the 2026-06-21 po-2023 reverse-proxy outage.

Implements the deferred follow-up from #2628 (this repo's PR #647 / parent #2635), which explicitly excluded the `codebase_search` surface to keep the hot path untouched.

## Root cause

`classifySearchError(error, 'codebase_search')` is already wired in the outer catch ([search-codebase.tool.ts L711-727](../blob/main/src/tools/search/search-codebase.tool.ts)) and already maps network/TLS errors → `qdrant_unreachable`. But **two inner `catch {}` swallowed the connection failure before it reached the classifier**:

1. `listWorkspaceCollections()` — `catch { return []; }` folds an outage into an empty list (indistinguishable from "no `ws-*` collections indexed").
2. The hash-variant loop — `catch {}` treats a network error identically to a genuine "variant doesn't exist" 404.

The `@qdrant/js-client-rest` client rides on `fetch`, so an outage surfaces as `error.code ∈ {ECONNREFUSED, ENOTFOUND, ETIMEDOUT, …}` or a `fetch failed` message — exactly what the classifier's `isNetworkError` already matches. Only the **error propagation** was broken.

## Fix (reuse the classifier, don't reinvent)

- **Export** `isNetworkErrorLike(error)` from `search-error-classifier.ts` (reuses the existing `NETWORK_ERROR_PATTERNS`).
- **Rethrow at both swallow points** when the error is a network/TLS failure → propagates to the outer catch → `qdrant_unreachable` (with the `QDRANT_URL`/DNS/TLS hint the classifier already emits). A genuine 404 / empty listing still falls through to `collection_not_found` — the honest-empty diagnostic is preserved.

~20 LOC across 2 files + 3 regression tests.

## Tests

Both swallow points + both paths:
- Outage via the **variant loop** (`getCollection` → `ECONNREFUSED`/`fetch failed`) → `status: qdrant_unreachable`, `isError: true`.
- Outage via the **`listWorkspaceCollections()` fallback** (variant loop sees genuine 404s, then `getCollections()` is down) → `qdrant_unreachable`.
- **Honest-empty preserved**: genuine `Not found` / empty listing → `collection_not_found` (unchanged).
- Plus a unit test that `listWorkspaceCollections()` rethrows network errors but still swallows non-network ones.

**Validation:** `npm run build` (tsc 0 errors) ✅ · targeted `search-codebase.tool.test.ts` + `search-error-classifier.test.ts` = **79/79 pass** ✅ · full CI suite `vitest.config.ci.ts` = 10034 passed (3 unrelated pre-existing flaky timeouts in `roosync/read.edge-cases` + condensation, verified passing in isolation — not touched by this change).

## Refs

- Parent issue: jsboige/roo-extensions#2636 (user-approved 2026-06-22)
- Deferred from #2628 / #647 / #2635 · Part of #2554 (semantic indexing reliability) and #2307 (MCP tool audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)